### PR TITLE
feat: add agentserver MCP bridge to nanoclaw sandbox

### DIFF
--- a/Dockerfile.nanoclaw
+++ b/Dockerfile.nanoclaw
@@ -1,4 +1,13 @@
 ARG NANOCLAW_VERSION=v1.2.42
+
+# Stage 0: Build agentserver Go binary (for mcp-server subcommand)
+FROM golang:1.26-alpine AS go-builder
+WORKDIR /build
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -ldflags="-s -w" -o /agentserver ./cmd/agentserver-agent
+
 FROM node:20-slim AS builder
 
 WORKDIR /app
@@ -19,6 +28,9 @@ WORKDIR /app
 
 # Install Claude Code CLI
 RUN npm install -g @anthropic-ai/claude-code
+
+# agentserver binary (mcp-server subcommand for agent discovery + delegation)
+COPY --from=go-builder /agentserver /usr/local/bin/agentserver
 
 # Copy built NanoClaw
 COPY --from=builder /app /app

--- a/internal/sandbox/manager.go
+++ b/internal/sandbox/manager.go
@@ -451,6 +451,17 @@ fs.writeFileSync(path, JSON.stringify(existing, null, 2));
 		if m.cfg.NanoclawModel != "" {
 			containerEnv = append(containerEnv, corev1.EnvVar{Name: "ANTHROPIC_MODEL", Value: m.cfg.NanoclawModel})
 		}
+		// MCP bridge config: agentserver URL + auth for discover_agents/delegate_task
+		agentserverURL := m.cfg.AgentServerInternalURL
+		if agentserverURL == "" {
+			agentserverURL = "http://agentserver:8080"
+		}
+		containerEnv = append(containerEnv,
+			corev1.EnvVar{Name: "AGENTSERVER_URL", Value: agentserverURL},
+			corev1.EnvVar{Name: "AGENTSERVER_TOKEN", Value: opts.ProxyToken},
+			corev1.EnvVar{Name: "AGENTSERVER_WORKSPACE_ID", Value: opts.WorkspaceID},
+			corev1.EnvVar{Name: "AGENTSERVER_SANDBOX_ID", Value: opts.SandboxID},
+		)
 	default: // "opencode"
 		if opts.OpencodeToken != "" {
 			containerEnv = append(containerEnv, corev1.EnvVar{Name: "OPENCODE_SERVER_PASSWORD", Value: opts.OpencodeToken})

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1397,6 +1397,7 @@ func (s *Server) handleCreateSandbox(w http.ResponseWriter, r *http.Request) {
 	if sandboxType == "nanoclaw" {
 		startOpts.NanoclawBridgeSecret = sbx.NanoclawBridgeSecret
 		startOpts.SandboxID = id
+		startOpts.WorkspaceID = wsID
 		startOpts.AssistantName = sbx.MetadataString("assistant_name")
 	}
 	if sandboxType == "claudecode" {

--- a/nanoclaw-entrypoint.sh
+++ b/nanoclaw-entrypoint.sh
@@ -5,6 +5,27 @@ if [ -n "$NANOCLAW_CONFIG_CONTENT" ]; then
     echo "$NANOCLAW_CONFIG_CONTENT" > /app/.env
 fi
 
+# Write MCP config so Claude Code (spawned by NanoClaw) discovers agentserver
+# tools (discover_agents, delegate_task, check_task, send_message, read_inbox).
+if [ -n "$AGENTSERVER_URL" ]; then
+    cat > "$HOME/.mcp.json" <<MCPEOF
+{
+  "mcpServers": {
+    "agentserver": {
+      "command": "/usr/local/bin/agentserver",
+      "args": ["mcp-server"],
+      "env": {
+        "AGENTSERVER_URL": "${AGENTSERVER_URL}",
+        "AGENTSERVER_TOKEN": "${AGENTSERVER_TOKEN}",
+        "AGENTSERVER_WORKSPACE_ID": "${AGENTSERVER_WORKSPACE_ID}",
+        "AGENTSERVER_SANDBOX_ID": "${AGENTSERVER_SANDBOX_ID}"
+      }
+    }
+  }
+}
+MCPEOF
+fi
+
 # Ensure data directories exist and are writable (PVC may be mounted as root).
 for dir in /app/store /app/groups /app/data; do
     mkdir -p "$dir" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Add agentserver MCP tools (discover_agents, delegate_task, check_task, send_message, read_inbox) to nanoclaw sandboxes, matching the existing claude code sandbox setup
- Dockerfile.nanoclaw gains a Go builder stage to compile the agentserver binary into the image
- nanoclaw-entrypoint.sh writes `~/.mcp.json` when `AGENTSERVER_URL` is set so Claude Code (spawned by NanoClaw) auto-discovers the MCP server
- manager.go injects `AGENTSERVER_URL`, `AGENTSERVER_TOKEN`, `AGENTSERVER_WORKSPACE_ID`, `AGENTSERVER_SANDBOX_ID` env vars into nanoclaw pods

## Test plan
- [ ] Build nanoclaw image: `docker build -f Dockerfile.nanoclaw -t nanoclaw:test .`
- [ ] Verify agentserver binary exists at `/usr/local/bin/agentserver` inside the image
- [ ] Create a nanoclaw sandbox and verify AGENTSERVER_* env vars are present in the pod
- [ ] Verify `~/.mcp.json` is written on container startup
- [ ] Confirm Claude Code inside nanoclaw can use MCP tools (discover_agents, delegate_task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)