### PR TITLE
feat: add cc-broker bridge API (Part 1/3)

### DIFF
--- a/Dockerfile.cc-broker
+++ b/Dockerfile.cc-broker
@@ -1,0 +1,15 @@
+# Build Go binary
+FROM golang:1.26-trixie AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -o cc-broker ./cmd/cc-broker
+
+# Runtime image (minimal — no Docker CLI, no frontend)
+FROM debian:trixie-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/cc-broker /usr/local/bin/cc-broker
+EXPOSE 8085
+ENTRYPOINT ["cc-broker"]

--- a/cmd/cc-broker/main.go
+++ b/cmd/cc-broker/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"context"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/agentserver/agentserver/internal/ccbroker"
+)
+
+func main() {
+	cfg, err := ccbroker.LoadConfigFromEnv()
+	if err != nil {
+		log.Fatalf("config: %v", err)
+	}
+
+	srv := ccbroker.NewServer(cfg, nil)
+	httpServer := &http.Server{
+		Addr:    ":" + cfg.Port,
+		Handler: srv.Routes(),
+	}
+
+	go func() {
+		sigCh := make(chan os.Signal, 1)
+		signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+		<-sigCh
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		httpServer.Shutdown(ctx)
+	}()
+
+	log.Printf("cc-broker listening on :%s", cfg.Port)
+	if err := httpServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		log.Fatal(err)
+	}
+}

--- a/cmd/cc-broker/main.go
+++ b/cmd/cc-broker/main.go
@@ -18,7 +18,13 @@ func main() {
 		log.Fatalf("config: %v", err)
 	}
 
-	srv := ccbroker.NewServer(cfg, nil)
+	store, err := ccbroker.NewStore(cfg.DatabaseURL)
+	if err != nil {
+		log.Fatalf("database: %v", err)
+	}
+	defer store.Close()
+
+	srv := ccbroker.NewServer(cfg, store)
 	httpServer := &http.Server{
 		Addr:    ":" + cfg.Port,
 		Handler: srv.Routes(),

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,5 +88,20 @@ services:
       - postgres
     restart: unless-stopped
 
+  cc-broker:
+    build:
+      context: .
+      dockerfile: Dockerfile.cc-broker
+    environment:
+      CCBROKER_DATABASE_URL: "postgres://agentserver:agentserver@postgres:5432/agentserver?sslmode=disable"
+      CCBROKER_PORT: "8085"
+      CCBROKER_JWT_SECRET: "dev-secret-change-in-production-32chars"
+      CCBROKER_LOG_LEVEL: "info"
+    ports:
+      - "8085:8085"
+    depends_on:
+      - postgres
+    restart: unless-stopped
+
 volumes:
   pgdata:

--- a/internal/ccbroker/config.go
+++ b/internal/ccbroker/config.go
@@ -1,0 +1,49 @@
+package ccbroker
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+)
+
+type Config struct {
+	Port        string
+	DatabaseURL string
+	JWTSecret   []byte
+	LogLevel    slog.Level
+}
+
+func LoadConfigFromEnv() (Config, error) {
+	cfg := Config{
+		Port:        envOr("CCBROKER_PORT", "8085"),
+		DatabaseURL: os.Getenv("CCBROKER_DATABASE_URL"),
+		LogLevel:    slog.LevelInfo,
+	}
+	if cfg.DatabaseURL == "" {
+		return cfg, fmt.Errorf("CCBROKER_DATABASE_URL is required")
+	}
+	secret := os.Getenv("CCBROKER_JWT_SECRET")
+	if secret == "" {
+		return cfg, fmt.Errorf("CCBROKER_JWT_SECRET is required (32+ chars)")
+	}
+	cfg.JWTSecret = []byte(secret)
+	if v := os.Getenv("CCBROKER_LOG_LEVEL"); v != "" {
+		switch strings.ToLower(v) {
+		case "debug":
+			cfg.LogLevel = slog.LevelDebug
+		case "warn":
+			cfg.LogLevel = slog.LevelWarn
+		case "error":
+			cfg.LogLevel = slog.LevelError
+		}
+	}
+	return cfg, nil
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}

--- a/internal/ccbroker/dedup.go
+++ b/internal/ccbroker/dedup.go
@@ -1,0 +1,68 @@
+package ccbroker
+
+import "sync"
+
+// BoundedUUIDSet is a fixed-capacity set with FIFO eviction.
+// Used for echo/replay deduplication, matching CC's BoundedUUIDSet (capacity 2000).
+// Thread-safe.
+type BoundedUUIDSet struct {
+	mu       sync.Mutex
+	capacity int
+	set      map[string]struct{}
+	ring     []string
+	idx      int
+	count    int
+}
+
+// NewBoundedUUIDSet creates a new bounded set with the given capacity.
+func NewBoundedUUIDSet(capacity int) *BoundedUUIDSet {
+	return &BoundedUUIDSet{
+		capacity: capacity,
+		set:      make(map[string]struct{}, capacity),
+		ring:     make([]string, capacity),
+	}
+}
+
+// Add inserts a UUID. Returns false if already present (duplicate).
+func (s *BoundedUUIDSet) Add(uuid string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, exists := s.set[uuid]; exists {
+		return false
+	}
+	if s.count >= s.capacity {
+		old := s.ring[s.idx]
+		delete(s.set, old)
+	} else {
+		s.count++
+	}
+	s.ring[s.idx] = uuid
+	s.set[uuid] = struct{}{}
+	s.idx = (s.idx + 1) % s.capacity
+	return true
+}
+
+// DedupRegistry maintains per-session deduplication sets.
+type DedupRegistry struct {
+	mu       sync.Mutex
+	sessions map[string]*BoundedUUIDSet
+}
+
+// NewDedupRegistry creates a new dedup registry.
+func NewDedupRegistry() *DedupRegistry {
+	return &DedupRegistry{
+		sessions: make(map[string]*BoundedUUIDSet),
+	}
+}
+
+// GetOrCreate returns the dedup set for a session, creating one if needed.
+func (r *DedupRegistry) GetOrCreate(sessionID string) *BoundedUUIDSet {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if s, ok := r.sessions[sessionID]; ok {
+		return s
+	}
+	s := NewBoundedUUIDSet(2000)
+	r.sessions[sessionID] = s
+	return s
+}

--- a/internal/ccbroker/handler_bridge.go
+++ b/internal/ccbroker/handler_bridge.go
@@ -55,7 +55,7 @@ func (s *Server) handleBridge(w http.ResponseWriter, r *http.Request) {
 	if r.TLS != nil {
 		scheme = "https"
 	}
-	if fwd := r.Header.Get("X-Forwarded-Proto"); fwd != "" {
+	if fwd := r.Header.Get("X-Forwarded-Proto"); fwd == "https" || fwd == "http" {
 		scheme = fwd
 	}
 	apiBaseURL := fmt.Sprintf("%s://%s/v1/sessions/%s", scheme, r.Host, sessionID)

--- a/internal/ccbroker/handler_bridge.go
+++ b/internal/ccbroker/handler_bridge.go
@@ -1,0 +1,70 @@
+package ccbroker
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func (s *Server) handleBridge(w http.ResponseWriter, r *http.Request) {
+	sessionID := chi.URLParam(r, "sessionId")
+
+	// 1. Get session, return 404 if not found
+	session, err := s.store.GetSession(r.Context(), sessionID)
+	if err != nil {
+		s.logger.Error("get session failed", "error", err, "session_id", sessionID)
+		writeError(w, http.StatusInternalServerError, "failed to get session")
+		return
+	}
+	if session == nil {
+		writeError(w, http.StatusNotFound, "session not found")
+		return
+	}
+
+	// 2. Bump epoch atomically
+	newEpoch, err := s.store.BumpSessionEpoch(r.Context(), sessionID)
+	if err != nil {
+		s.logger.Error("bump session epoch failed", "error", err, "session_id", sessionID)
+		writeError(w, http.StatusInternalServerError, "failed to bump session epoch")
+		return
+	}
+
+	// 3. Upsert worker record
+	if err := s.store.UpsertWorker(r.Context(), sessionID, newEpoch); err != nil {
+		s.logger.Error("upsert worker failed", "error", err, "session_id", sessionID)
+		writeError(w, http.StatusInternalServerError, "failed to register worker")
+		return
+	}
+
+	// 4. Issue JWT
+	claims := WorkerJWTClaims{
+		SessionID:   sessionID,
+		WorkspaceID: session.WorkspaceID,
+		Epoch:       newEpoch,
+	}
+	jwt, err := IssueWorkerJWT(s.config.JWTSecret, claims)
+	if err != nil {
+		s.logger.Error("issue worker jwt failed", "error", err, "session_id", sessionID)
+		writeError(w, http.StatusInternalServerError, "failed to issue worker JWT")
+		return
+	}
+
+	// 5. Build api_base_url
+	scheme := "http"
+	if r.TLS != nil {
+		scheme = "https"
+	}
+	if fwd := r.Header.Get("X-Forwarded-Proto"); fwd != "" {
+		scheme = fwd
+	}
+	apiBaseURL := fmt.Sprintf("%s://%s/v1/sessions/%s", scheme, r.Host, sessionID)
+
+	// 6. Return BridgeResponse
+	writeJSON(w, http.StatusOK, BridgeResponse{
+		WorkerJWT:   jwt,
+		APIBaseURL:  apiBaseURL,
+		ExpiresIn:   86400,
+		WorkerEpoch: newEpoch,
+	})
+}

--- a/internal/ccbroker/handler_events.go
+++ b/internal/ccbroker/handler_events.go
@@ -35,7 +35,11 @@ func (s *Server) handleWorkerEventStream(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	// 1. Replay persisted events from DB.
+	// 1. Subscribe FIRST (before replay) to capture events during replay.
+	sub := s.sse.Subscribe(sessionID)
+	defer s.sse.Unsubscribe(sessionID, sub)
+
+	// 2. Replay persisted events from DB.
 	events, err := s.store.GetEventsSince(r.Context(), sessionID, fromSeq, 1000)
 	if err != nil {
 		s.logger.Error("replay events failed", "error", err)
@@ -58,11 +62,7 @@ func (s *Server) handleWorkerEventStream(w http.ResponseWriter, r *http.Request)
 		lastSeq = evt.ID
 	}
 
-	// 2. Subscribe to live events via SSE broker.
-	sub := s.sse.Subscribe(sessionID)
-	defer s.sse.Unsubscribe(sessionID, sub)
-
-	// 3. Stream loop: live events + keepalive.
+	// 3. Stream loop: live events + keepalive (lastSeq guard filters already-replayed events).
 	keepalive := time.NewTicker(15 * time.Second)
 	defer keepalive.Stop()
 
@@ -70,10 +70,7 @@ func (s *Server) handleWorkerEventStream(w http.ResponseWriter, r *http.Request)
 		select {
 		case <-r.Context().Done():
 			return
-		case evt, ok := <-sub.Ch:
-			if !ok {
-				return // subscriber closed (backpressure)
-			}
+		case evt := <-sub.Ch:
 			if evt.SequenceNum <= lastSeq {
 				continue // already replayed
 			}
@@ -158,14 +155,18 @@ func (s *Server) handleWorkerEvents(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Publish to SSE subscribers.
-	for i, ins := range inserted {
+	// Build eventID → payload map for correct lookup
+	payloadByID := make(map[string]json.RawMessage, len(inputs))
+	for _, inp := range inputs {
+		payloadByID[inp.EventID] = inp.Payload
+	}
+	for _, ins := range inserted {
 		s.sse.Publish(sessionID, &StreamClientEvent{
 			EventID:     ins.EventID,
 			SequenceNum: ins.SeqNum,
 			EventType:   "client_event",
 			Source:      "worker",
-			Payload:     inputs[i].Payload,
+			Payload:     payloadByID[ins.EventID],
 			CreatedAt:   time.Now().Format(time.RFC3339Nano),
 		})
 	}

--- a/internal/ccbroker/handler_events.go
+++ b/internal/ccbroker/handler_events.go
@@ -1,0 +1,174 @@
+package ccbroker
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// handleWorkerEventStream serves the SSE endpoint that CC workers connect to
+// for conversation history replay and live event streaming.
+func (s *Server) handleWorkerEventStream(w http.ResponseWriter, r *http.Request) {
+	sessionID := SessionIDFromContext(r.Context())
+
+	// Parse from_sequence_num (query param or Last-Event-ID header).
+	var fromSeq int64
+	if v := r.URL.Query().Get("from_sequence_num"); v != "" {
+		fromSeq, _ = strconv.ParseInt(v, 10, 64)
+	} else if v := r.Header.Get("Last-Event-ID"); v != "" {
+		fromSeq, _ = strconv.ParseInt(v, 10, 64)
+	}
+
+	// Set SSE headers.
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	// 1. Replay persisted events from DB.
+	events, err := s.store.GetEventsSince(r.Context(), sessionID, fromSeq, 1000)
+	if err != nil {
+		s.logger.Error("replay events failed", "error", err)
+		return
+	}
+
+	lastSeq := fromSeq
+	for _, evt := range events {
+		sce := StreamClientEvent{
+			EventID:     evt.EventID,
+			SequenceNum: evt.ID,
+			EventType:   evt.EventType,
+			Source:      evt.Source,
+			Payload:     evt.Payload,
+			CreatedAt:   evt.CreatedAt.Format(time.RFC3339Nano),
+		}
+		data, _ := json.Marshal(sce)
+		fmt.Fprintf(w, "event: %s\nid: %d\ndata: %s\n\n", evt.EventType, evt.ID, data)
+		flusher.Flush()
+		lastSeq = evt.ID
+	}
+
+	// 2. Subscribe to live events via SSE broker.
+	sub := s.sse.Subscribe(sessionID)
+	defer s.sse.Unsubscribe(sessionID, sub)
+
+	// 3. Stream loop: live events + keepalive.
+	keepalive := time.NewTicker(15 * time.Second)
+	defer keepalive.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			return
+		case evt, ok := <-sub.Ch:
+			if !ok {
+				return // subscriber closed (backpressure)
+			}
+			if evt.SequenceNum <= lastSeq {
+				continue // already replayed
+			}
+			data, _ := json.Marshal(evt)
+			fmt.Fprintf(w, "event: %s\nid: %d\ndata: %s\n\n", evt.EventType, evt.SequenceNum, data)
+			flusher.Flush()
+			lastSeq = evt.SequenceNum
+		case <-sub.Done():
+			return
+		case <-keepalive.C:
+			fmt.Fprintf(w, ":keepalive\n\n")
+			flusher.Flush()
+		}
+	}
+}
+
+// handleWorkerEvents accepts a batch of events from a CC worker, validates the
+// epoch, deduplicates, persists to DB, and publishes to SSE subscribers.
+func (s *Server) handleWorkerEvents(w http.ResponseWriter, r *http.Request) {
+	sessionID := SessionIDFromContext(r.Context())
+
+	var req EventBatchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	// Limit batch size.
+	if len(req.Events) > 100 {
+		writeError(w, http.StatusBadRequest, "max 100 events per batch")
+		return
+	}
+
+	// Validate epoch.
+	currentEpoch, err := s.store.GetSessionEpoch(r.Context(), sessionID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to check epoch")
+		return
+	}
+	if req.WorkerEpoch != currentEpoch {
+		writeError(w, http.StatusConflict, fmt.Sprintf("epoch mismatch: got %d, current %d", req.WorkerEpoch, currentEpoch))
+		return
+	}
+
+	// Build EventInput list with dedup.
+	dedupSet := s.dedup.GetOrCreate(sessionID)
+	var inputs []EventInput
+	for _, evt := range req.Events {
+		// Extract uuid from payload, or generate one.
+		var payloadMap map[string]interface{}
+		json.Unmarshal(evt.Payload, &payloadMap)
+
+		eventUUID := ""
+		if u, ok := payloadMap["uuid"].(string); ok {
+			eventUUID = u
+		} else {
+			eventUUID = uuid.NewString()
+		}
+
+		// Dedup check.
+		if !dedupSet.Add(eventUUID) {
+			continue // duplicate, skip
+		}
+
+		inputs = append(inputs, EventInput{
+			EventID:   eventUUID,
+			Payload:   evt.Payload,
+			Ephemeral: evt.Ephemeral,
+		})
+	}
+
+	if len(inputs) == 0 {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	// Insert into DB.
+	inserted, err := s.store.InsertEvents(r.Context(), sessionID, req.WorkerEpoch, inputs)
+	if err != nil {
+		s.logger.Error("insert events failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to persist events")
+		return
+	}
+
+	// Publish to SSE subscribers.
+	for i, ins := range inserted {
+		s.sse.Publish(sessionID, &StreamClientEvent{
+			EventID:     ins.EventID,
+			SequenceNum: ins.SeqNum,
+			EventType:   "client_event",
+			Source:      "worker",
+			Payload:     inputs[i].Payload,
+			CreatedAt:   time.Now().Format(time.RFC3339Nano),
+		})
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/internal/ccbroker/handler_internal_events.go
+++ b/internal/ccbroker/handler_internal_events.go
@@ -1,0 +1,89 @@
+package ccbroker
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+)
+
+// handleWorkerInternalEvents handles POST .../worker/internal-events — persists a batch of internal events.
+func (s *Server) handleWorkerInternalEvents(w http.ResponseWriter, r *http.Request) {
+	sessionID := SessionIDFromContext(r.Context())
+
+	var req InternalEventBatchRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	// Validate epoch.
+	currentEpoch, err := s.store.GetSessionEpoch(r.Context(), sessionID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to check epoch")
+		return
+	}
+	if req.WorkerEpoch != currentEpoch {
+		writeError(w, http.StatusConflict, fmt.Sprintf("epoch mismatch: got %d, current %d", req.WorkerEpoch, currentEpoch))
+		return
+	}
+
+	// Build InternalEventInput list, extracting event_type from each payload.
+	inputs := make([]InternalEventInput, 0, len(req.Events))
+	for _, item := range req.Events {
+		// Extract "type" field from payload JSON.
+		var payloadMap map[string]json.RawMessage
+		eventType := ""
+		if err := json.Unmarshal(item.Payload, &payloadMap); err == nil {
+			if typeRaw, ok := payloadMap["type"]; ok {
+				var t string
+				if err := json.Unmarshal(typeRaw, &t); err == nil {
+					eventType = t
+				}
+			}
+		}
+
+		inputs = append(inputs, InternalEventInput{
+			EventType:    eventType,
+			Payload:      item.Payload,
+			IsCompaction: item.IsCompaction,
+			AgentID:      item.AgentID,
+		})
+	}
+
+	if err := s.store.InsertInternalEvents(r.Context(), sessionID, inputs); err != nil {
+		s.logger.Error("insert internal events failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to persist internal events")
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// handleGetInternalEvents handles GET .../worker/internal-events — returns internal events since a sequence number.
+func (s *Server) handleGetInternalEvents(w http.ResponseWriter, r *http.Request) {
+	sessionID := SessionIDFromContext(r.Context())
+
+	var fromSeq int64
+	if v := r.URL.Query().Get("from_sequence_num"); v != "" {
+		parsed, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid from_sequence_num")
+			return
+		}
+		fromSeq = parsed
+	}
+
+	events, err := s.store.GetInternalEventsSince(r.Context(), sessionID, fromSeq, 1000)
+	if err != nil {
+		s.logger.Error("get internal events failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to retrieve internal events")
+		return
+	}
+
+	if events == nil {
+		events = []SessionEvent{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"data": events})
+}

--- a/internal/ccbroker/handler_session.go
+++ b/internal/ccbroker/handler_session.go
@@ -1,0 +1,45 @@
+package ccbroker
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/google/uuid"
+)
+
+func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		WorkspaceID string  `json:"workspace_id"`
+		Title       string  `json:"title"`
+		Source      string  `json:"source"`
+		ExternalID  *string `json:"external_id"`
+	}
+
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	if req.WorkspaceID == "" {
+		writeError(w, http.StatusBadRequest, "workspace_id is required")
+		return
+	}
+
+	if req.Source == "" {
+		req.Source = "stateless_cc"
+	}
+
+	sessionID := "cse_" + uuid.NewString()
+
+	if err := s.store.CreateSession(r.Context(), sessionID, req.WorkspaceID, req.Title, req.Source, req.ExternalID); err != nil {
+		s.logger.Error("create session failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to create session")
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"session": map[string]string{
+			"id": sessionID,
+		},
+	})
+}

--- a/internal/ccbroker/handler_worker.go
+++ b/internal/ccbroker/handler_worker.go
@@ -1,0 +1,73 @@
+package ccbroker
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// handleWorkerState handles PUT .../worker — updates the worker state and metadata.
+func (s *Server) handleWorkerState(w http.ResponseWriter, r *http.Request) {
+	sessionID := SessionIDFromContext(r.Context())
+
+	var req WorkerStateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	// Validate epoch.
+	currentEpoch, err := s.store.GetSessionEpoch(r.Context(), sessionID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to check epoch")
+		return
+	}
+	if req.WorkerEpoch != currentEpoch {
+		writeError(w, http.StatusConflict, fmt.Sprintf("epoch mismatch: got %d, current %d", req.WorkerEpoch, currentEpoch))
+		return
+	}
+
+	if err := s.store.UpdateWorkerState(r.Context(), sessionID, req.WorkerEpoch, req.WorkerStatus, req.ExternalMetadata, req.RequiresActionDetails); err != nil {
+		s.logger.Error("update worker state failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to update worker state")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+// handleWorkerHeartbeat handles POST .../worker/heartbeat — updates the worker heartbeat timestamp.
+func (s *Server) handleWorkerHeartbeat(w http.ResponseWriter, r *http.Request) {
+	sessionID := SessionIDFromContext(r.Context())
+
+	var req HeartbeatRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+
+	// Use req.WorkerEpoch if set, otherwise fall back to JWT epoch.
+	epoch := req.WorkerEpoch
+	if epoch == 0 {
+		epoch = EpochFromContext(r.Context())
+	}
+
+	// Validate epoch.
+	currentEpoch, err := s.store.GetSessionEpoch(r.Context(), sessionID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to check epoch")
+		return
+	}
+	if epoch != currentEpoch {
+		writeError(w, http.StatusConflict, fmt.Sprintf("epoch mismatch: got %d, current %d", epoch, currentEpoch))
+		return
+	}
+
+	if err := s.store.UpdateWorkerHeartbeat(r.Context(), sessionID, epoch); err != nil {
+		s.logger.Error("update worker heartbeat failed", "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to update heartbeat")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}

--- a/internal/ccbroker/integration_test.go
+++ b/internal/ccbroker/integration_test.go
@@ -1,0 +1,223 @@
+package ccbroker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+)
+
+const testJWTSecret = "test-secret-change-in-production-32chars"
+
+// setupTestServer creates a Store backed by TEST_DATABASE_URL and returns a
+// fully-wired Server. The test is skipped when TEST_DATABASE_URL is not set.
+// t.Cleanup truncates the cc-broker tables so each test starts with a clean slate.
+func setupTestServer(t *testing.T) *Server {
+	t.Helper()
+	dbURL := os.Getenv("TEST_DATABASE_URL")
+	if dbURL == "" {
+		t.Skip("TEST_DATABASE_URL not set")
+	}
+
+	store, err := NewStore(dbURL)
+	if err != nil {
+		t.Fatalf("NewStore: %v", err)
+	}
+
+	t.Cleanup(func() {
+		// Remove test data; order matters due to FK constraints.
+		store.Exec(`DELETE FROM agent_session_events`)
+		store.Exec(`DELETE FROM agent_session_internal_events`)
+		store.Exec(`DELETE FROM agent_session_workers`)
+		store.Exec(`DELETE FROM agent_sessions`)
+		store.Close()
+	})
+
+	cfg := Config{
+		Port:      "0",
+		JWTSecret: []byte(testJWTSecret),
+		LogLevel:  0, // LevelInfo
+	}
+	return NewServer(cfg, store)
+}
+
+// doRequest is a convenience helper that runs a request through the router and
+// returns the recorded response.
+func doRequest(t *testing.T, srv *Server, method, target string, body any, authToken string) *httptest.ResponseRecorder {
+	t.Helper()
+	var reqBody *bytes.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			t.Fatalf("marshal request body: %v", err)
+		}
+		reqBody = bytes.NewReader(b)
+	} else {
+		reqBody = bytes.NewReader(nil)
+	}
+
+	req := httptest.NewRequest(method, target, reqBody)
+	req.Header.Set("Content-Type", "application/json")
+	if authToken != "" {
+		req.Header.Set("Authorization", "Bearer "+authToken)
+	}
+
+	rr := httptest.NewRecorder()
+	srv.Routes().ServeHTTP(rr, req)
+	return rr
+}
+
+// createSession is a test helper that creates a session and returns the session ID.
+func createSession(t *testing.T, srv *Server, workspaceID, title string) string {
+	t.Helper()
+	rr := doRequest(t, srv, http.MethodPost, "/v1/sessions",
+		map[string]string{"workspace_id": workspaceID, "title": title}, "")
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("create session: want 201, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Session struct {
+			ID string `json:"id"`
+		} `json:"session"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode create session response: %v", err)
+	}
+	return resp.Session.ID
+}
+
+// attachBridge is a test helper that posts to /bridge and returns the BridgeResponse.
+func attachBridge(t *testing.T, srv *Server, sessionID string) BridgeResponse {
+	t.Helper()
+	rr := doRequest(t, srv, http.MethodPost, "/v1/sessions/"+sessionID+"/bridge", nil, "")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("attach bridge: want 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+	var resp BridgeResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode bridge response: %v", err)
+	}
+	return resp
+}
+
+// TestCreateSessionAndBridge creates a session, attaches a bridge, and verifies
+// that a second bridge call increments the epoch.
+func TestCreateSessionAndBridge(t *testing.T) {
+	srv := setupTestServer(t)
+
+	// 1. Create session
+	sessionID := createSession(t, srv, "ws_test", "Test")
+
+	// 2. Assert session ID starts with "cse_"
+	if !strings.HasPrefix(sessionID, "cse_") {
+		t.Errorf("session ID: want prefix cse_, got %q", sessionID)
+	}
+
+	// 3. Attach bridge (first time)
+	bridge1 := attachBridge(t, srv, sessionID)
+
+	// 4. Assert worker_jwt is non-empty and worker_epoch == 1
+	if bridge1.WorkerJWT == "" {
+		t.Error("worker_jwt is empty")
+	}
+	if bridge1.WorkerEpoch != 1 {
+		t.Errorf("worker_epoch: want 1, got %d", bridge1.WorkerEpoch)
+	}
+
+	// 5. Attach bridge again → worker_epoch should be 2
+	bridge2 := attachBridge(t, srv, sessionID)
+	if bridge2.WorkerEpoch != 2 {
+		t.Errorf("worker_epoch (second bridge): want 2, got %d", bridge2.WorkerEpoch)
+	}
+}
+
+// TestEventBatchAndReplay creates a session, attaches a bridge, posts events,
+// and verifies that the events are persisted in the database.
+func TestEventBatchAndReplay(t *testing.T) {
+	srv := setupTestServer(t)
+
+	// 1. Create session + attach bridge
+	sessionID := createSession(t, srv, "ws_test", "Event Test")
+	bridge := attachBridge(t, srv, sessionID)
+
+	// 2. POST events with JWT auth
+	eventsReq := map[string]any{
+		"worker_epoch": 1,
+		"events": []map[string]any{
+			{
+				"payload":   map[string]any{"uuid": "evt1", "type": "user", "content": "hello"},
+				"ephemeral": false,
+			},
+		},
+	}
+	rr := doRequest(t, srv, http.MethodPost, "/v1/sessions/"+sessionID+"/worker/events",
+		eventsReq, bridge.WorkerJWT)
+
+	// 3. Assert 200
+	if rr.Code != http.StatusOK {
+		t.Fatalf("post events: want 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+
+	// 4. Verify DB persistence via store.GetEventsSince
+	events, err := srv.store.GetEventsSince(context.Background(), sessionID, 0, 10)
+	if err != nil {
+		t.Fatalf("GetEventsSince: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("GetEventsSince: want 1 event, got %d", len(events))
+	}
+	if events[0].EventID != "evt1" {
+		t.Errorf("event_id: want evt1, got %q", events[0].EventID)
+	}
+}
+
+// TestEpochMismatch creates a session, attaches a bridge, then posts events
+// with a wrong epoch and verifies a 409 response.
+func TestEpochMismatch(t *testing.T) {
+	srv := setupTestServer(t)
+
+	// 1. Create session + bridge (epoch=1)
+	sessionID := createSession(t, srv, "ws_test", "Epoch Test")
+	bridge := attachBridge(t, srv, sessionID)
+
+	// 2. POST events with wrong epoch
+	eventsReq := map[string]any{
+		"worker_epoch": 99,
+		"events": []map[string]any{
+			{
+				"payload":   map[string]any{"uuid": "evt_wrong", "type": "user", "content": "oops"},
+				"ephemeral": false,
+			},
+		},
+	}
+	rr := doRequest(t, srv, http.MethodPost, "/v1/sessions/"+sessionID+"/worker/events",
+		eventsReq, bridge.WorkerJWT)
+
+	// 3. Assert 409
+	if rr.Code != http.StatusConflict {
+		t.Errorf("epoch mismatch: want 409, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+}
+
+// TestHeartbeat creates a session, attaches a bridge, and sends a heartbeat.
+func TestHeartbeat(t *testing.T) {
+	srv := setupTestServer(t)
+
+	// 1. Create session + bridge
+	sessionID := createSession(t, srv, "ws_test", "Heartbeat Test")
+	bridge := attachBridge(t, srv, sessionID)
+
+	// 2. POST heartbeat with JWT
+	heartbeatReq := HeartbeatRequest{WorkerEpoch: 1}
+	rr := doRequest(t, srv, http.MethodPost, "/v1/sessions/"+sessionID+"/worker/heartbeat",
+		heartbeatReq, bridge.WorkerJWT)
+
+	// 3. Assert 200
+	if rr.Code != http.StatusOK {
+		t.Errorf("heartbeat: want 200, got %d (body: %s)", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/ccbroker/jwt.go
+++ b/internal/ccbroker/jwt.go
@@ -1,0 +1,73 @@
+package ccbroker
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+)
+
+var (
+	ErrJWTExpired   = errors.New("jwt expired")
+	ErrJWTMalformed = errors.New("jwt malformed")
+	ErrJWTSignature = errors.New("jwt signature invalid")
+)
+
+var jwtHeader = base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+
+// IssueWorkerJWT creates an HMAC-SHA256 JWT with the given claims.
+// If claims.Exp is zero, it defaults to now + 24 hours.
+func IssueWorkerJWT(secret []byte, claims WorkerJWTClaims) (string, error) {
+	if claims.Exp == 0 {
+		claims.Exp = time.Now().Add(24 * time.Hour).Unix()
+	}
+	payload, err := json.Marshal(claims)
+	if err != nil {
+		return "", fmt.Errorf("marshal claims: %w", err)
+	}
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payload)
+	signingInput := jwtHeader + "." + payloadB64
+
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(signingInput))
+	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+
+	return signingInput + "." + sig, nil
+}
+
+// ValidateWorkerJWT validates an HMAC-SHA256 JWT and returns the claims.
+func ValidateWorkerJWT(secret []byte, token string) (*WorkerJWTClaims, error) {
+	parts := strings.SplitN(token, ".", 3)
+	if len(parts) != 3 {
+		return nil, ErrJWTMalformed
+	}
+
+	signingInput := parts[0] + "." + parts[1]
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(signingInput))
+	expectedSig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+
+	if !hmac.Equal([]byte(parts[2]), []byte(expectedSig)) {
+		return nil, ErrJWTSignature
+	}
+
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		return nil, ErrJWTMalformed
+	}
+
+	var claims WorkerJWTClaims
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return nil, ErrJWTMalformed
+	}
+
+	if time.Now().Unix() > claims.Exp {
+		return nil, ErrJWTExpired
+	}
+
+	return &claims, nil
+}

--- a/internal/ccbroker/middleware.go
+++ b/internal/ccbroker/middleware.go
@@ -1,0 +1,58 @@
+package ccbroker
+
+import (
+	"context"
+	"net/http"
+	"strings"
+)
+
+type contextKey string
+
+const (
+	ctxSessionID   contextKey = "sessionID"
+	ctxWorkspaceID contextKey = "workspaceID"
+	ctxEpoch       contextKey = "epoch"
+)
+
+// SessionIDFromContext extracts the session ID set by workerAuthMiddleware.
+func SessionIDFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(ctxSessionID).(string)
+	return v
+}
+
+// WorkspaceIDFromContext extracts the workspace ID set by workerAuthMiddleware.
+func WorkspaceIDFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(ctxWorkspaceID).(string)
+	return v
+}
+
+// EpochFromContext extracts the epoch set by workerAuthMiddleware.
+func EpochFromContext(ctx context.Context) int {
+	v, _ := ctx.Value(ctxEpoch).(int)
+	return v
+}
+
+// workerAuthMiddleware validates the Bearer JWT and injects session/workspace/epoch
+// into the request context.
+func (s *Server) workerAuthMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		auth := r.Header.Get("Authorization")
+		if !strings.HasPrefix(auth, "Bearer ") {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		token := strings.TrimPrefix(auth, "Bearer ")
+
+		claims, err := ValidateWorkerJWT(s.config.JWTSecret, token)
+		if err != nil {
+			http.Error(w, "unauthorized: "+err.Error(), http.StatusUnauthorized)
+			return
+		}
+
+		ctx := r.Context()
+		ctx = context.WithValue(ctx, ctxSessionID, claims.SessionID)
+		ctx = context.WithValue(ctx, ctxWorkspaceID, claims.WorkspaceID)
+		ctx = context.WithValue(ctx, ctxEpoch, claims.Epoch)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}

--- a/internal/ccbroker/migrations/001_initial.sql
+++ b/internal/ccbroker/migrations/001_initial.sql
@@ -1,0 +1,49 @@
+CREATE TABLE IF NOT EXISTS agent_sessions (
+    id            TEXT PRIMARY KEY,
+    sandbox_id    TEXT,
+    workspace_id  TEXT NOT NULL,
+    title         TEXT,
+    status        TEXT DEFAULT 'active',
+    epoch         INTEGER DEFAULT 0,
+    external_id   TEXT,
+    source        TEXT DEFAULT 'agent',
+    tags          TEXT[],
+    created_at    TIMESTAMPTZ DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ DEFAULT NOW(),
+    archived_at   TIMESTAMPTZ
+);
+
+CREATE TABLE IF NOT EXISTS agent_session_events (
+    id            BIGSERIAL PRIMARY KEY,
+    session_id    TEXT NOT NULL,
+    event_id      TEXT NOT NULL UNIQUE,
+    event_type    TEXT DEFAULT 'client_event',
+    source        TEXT DEFAULT 'client',
+    epoch         INTEGER,
+    payload       JSONB NOT NULL,
+    ephemeral     BOOLEAN DEFAULT FALSE,
+    created_at    TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_ase_session_id ON agent_session_events(session_id, id);
+
+CREATE TABLE IF NOT EXISTS agent_session_workers (
+    session_id              TEXT NOT NULL,
+    epoch                   INTEGER NOT NULL,
+    state                   TEXT DEFAULT 'idle',
+    external_metadata       JSONB,
+    requires_action_details JSONB,
+    last_heartbeat_at       TIMESTAMPTZ,
+    registered_at           TIMESTAMPTZ DEFAULT NOW(),
+    PRIMARY KEY (session_id, epoch)
+);
+
+CREATE TABLE IF NOT EXISTS agent_session_internal_events (
+    id            BIGSERIAL PRIMARY KEY,
+    session_id    TEXT NOT NULL,
+    event_type    TEXT,
+    payload       JSONB,
+    is_compaction BOOLEAN DEFAULT FALSE,
+    agent_id      TEXT,
+    created_at    TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_asie_session ON agent_session_internal_events(session_id, id);

--- a/internal/ccbroker/models.go
+++ b/internal/ccbroker/models.go
@@ -1,0 +1,112 @@
+package ccbroker
+
+import (
+	"encoding/json"
+	"time"
+)
+
+type Session struct {
+	ID          string    `json:"id"`
+	WorkspaceID string    `json:"workspace_id"`
+	Title       string    `json:"title,omitempty"`
+	Status      string    `json:"status"`
+	Epoch       int       `json:"epoch"`
+	ExternalID  *string   `json:"external_id,omitempty"`
+	Source      string    `json:"source,omitempty"`
+	CreatedAt   time.Time `json:"created_at"`
+}
+
+type SessionEvent struct {
+	ID        int64           `json:"id"`
+	SessionID string          `json:"session_id"`
+	EventID   string          `json:"event_id"`
+	EventType string          `json:"event_type"`
+	Source    string          `json:"source"`
+	Epoch     int             `json:"epoch"`
+	Payload   json.RawMessage `json:"payload"`
+	Ephemeral bool            `json:"ephemeral"`
+	CreatedAt time.Time       `json:"created_at"`
+}
+
+type StreamClientEvent struct {
+	EventID     string          `json:"event_id"`
+	SequenceNum int64           `json:"sequence_num"`
+	EventType   string          `json:"event_type"`
+	Source      string          `json:"source"`
+	Payload     json.RawMessage `json:"payload"`
+	CreatedAt   string          `json:"created_at"`
+}
+
+type WorkerJWTClaims struct {
+	SessionID   string `json:"sid"`
+	WorkspaceID string `json:"wid"`
+	Epoch       int    `json:"epoch"`
+	Exp         int64  `json:"exp"`
+}
+
+type BridgeResponse struct {
+	WorkerJWT   string `json:"worker_jwt"`
+	APIBaseURL  string `json:"api_base_url"`
+	ExpiresIn   int    `json:"expires_in"`
+	WorkerEpoch int    `json:"worker_epoch"`
+}
+
+type EventBatchRequest struct {
+	WorkerEpoch int              `json:"worker_epoch"`
+	Events      []EventBatchItem `json:"events"`
+}
+
+type EventBatchItem struct {
+	Payload   json.RawMessage `json:"payload"`
+	Ephemeral bool            `json:"ephemeral"`
+}
+
+type InternalEventBatchRequest struct {
+	WorkerEpoch int                      `json:"worker_epoch"`
+	Events      []InternalEventBatchItem `json:"events"`
+}
+
+type InternalEventBatchItem struct {
+	Payload      json.RawMessage `json:"payload"`
+	IsCompaction bool            `json:"is_compaction"`
+	AgentID      string          `json:"agent_id,omitempty"`
+}
+
+type WorkerStateRequest struct {
+	WorkerStatus          string          `json:"worker_status"`
+	WorkerEpoch           int             `json:"worker_epoch"`
+	ExternalMetadata      json.RawMessage `json:"external_metadata,omitempty"`
+	RequiresActionDetails json.RawMessage `json:"requires_action_details,omitempty"`
+}
+
+type HeartbeatRequest struct {
+	WorkerEpoch int `json:"worker_epoch"`
+}
+
+type EventInput struct {
+	EventID   string
+	Payload   json.RawMessage
+	Ephemeral bool
+}
+
+type InternalEventInput struct {
+	EventType    string
+	Payload      json.RawMessage
+	IsCompaction bool
+	AgentID      string
+}
+
+type InsertedEvent struct {
+	SeqNum  int64
+	EventID string
+}
+
+type Worker struct {
+	SessionID             string
+	Epoch                 int
+	State                 string
+	ExternalMetadata      json.RawMessage
+	RequiresActionDetails json.RawMessage
+	LastHeartbeatAt       *time.Time
+	RegisteredAt          time.Time
+}

--- a/internal/ccbroker/server.go
+++ b/internal/ccbroker/server.go
@@ -2,7 +2,6 @@ package ccbroker
 
 import (
 	"encoding/json"
-	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -11,8 +10,7 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 )
 
-// Temporary stubs -- replaced in Tasks 2-3
-type Store struct{ io.Closer }
+// Temporary stubs -- replaced in Task 3
 type SSEBroker struct{}
 
 func NewSSEBroker() *SSEBroker { return &SSEBroker{} }

--- a/internal/ccbroker/server.go
+++ b/internal/ccbroker/server.go
@@ -1,0 +1,93 @@
+package ccbroker
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+// Temporary stubs -- replaced in Tasks 2-3
+type Store struct{ io.Closer }
+type SSEBroker struct{}
+
+func NewSSEBroker() *SSEBroker { return &SSEBroker{} }
+
+type DedupRegistry struct{}
+
+func NewDedupRegistry() *DedupRegistry { return &DedupRegistry{} }
+
+type Server struct {
+	config Config
+	store  *Store
+	sse    *SSEBroker
+	dedup  *DedupRegistry
+	logger *slog.Logger
+}
+
+func NewServer(cfg Config, store *Store) *Server {
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: cfg.LogLevel}))
+	return &Server{
+		config: cfg,
+		store:  store,
+		sse:    NewSSEBroker(),
+		dedup:  NewDedupRegistry(),
+		logger: logger,
+	}
+}
+
+func (s *Server) Routes() http.Handler {
+	r := chi.NewRouter()
+	r.Use(middleware.Logger)
+	r.Use(middleware.Recoverer)
+
+	r.Get("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok"))
+	})
+
+	// Session lifecycle
+	r.Post("/v1/sessions", s.handleCreateSession)
+	r.Post("/v1/sessions/{sessionId}/bridge", s.handleBridge)
+
+	// Worker endpoints (JWT auth)
+	r.Route("/v1/sessions/{sessionId}/worker", func(r chi.Router) {
+		r.Use(s.workerAuthMiddleware)
+		r.Get("/events/stream", s.handleWorkerEventStream)
+		r.Post("/events", s.handleWorkerEvents)
+		r.Post("/internal-events", s.handleWorkerInternalEvents)
+		r.Get("/internal-events", s.handleGetInternalEvents)
+		r.Put("/", s.handleWorkerState)
+		r.Post("/heartbeat", s.handleWorkerHeartbeat)
+	})
+
+	return r
+}
+
+// Stub handlers -- replaced in Tasks 4-6
+func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request)       { w.WriteHeader(501) }
+func (s *Server) handleBridge(w http.ResponseWriter, r *http.Request)              { w.WriteHeader(501) }
+func (s *Server) handleWorkerEventStream(w http.ResponseWriter, r *http.Request)   { w.WriteHeader(501) }
+func (s *Server) handleWorkerEvents(w http.ResponseWriter, r *http.Request)        { w.WriteHeader(501) }
+func (s *Server) handleWorkerInternalEvents(w http.ResponseWriter, r *http.Request) { w.WriteHeader(501) }
+func (s *Server) handleGetInternalEvents(w http.ResponseWriter, r *http.Request)   { w.WriteHeader(501) }
+func (s *Server) handleWorkerState(w http.ResponseWriter, r *http.Request)         { w.WriteHeader(501) }
+func (s *Server) handleWorkerHeartbeat(w http.ResponseWriter, r *http.Request)     { w.WriteHeader(501) }
+func (s *Server) workerAuthMiddleware(next http.Handler) http.Handler              { return next }
+
+// Helpers
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v)
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(map[string]string{"error": msg})
+}

--- a/internal/ccbroker/server.go
+++ b/internal/ccbroker/server.go
@@ -57,12 +57,6 @@ func (s *Server) Routes() http.Handler {
 	return r
 }
 
-// Stub handlers -- replaced in Task 6
-func (s *Server) handleWorkerInternalEvents(w http.ResponseWriter, r *http.Request) { w.WriteHeader(501) }
-func (s *Server) handleGetInternalEvents(w http.ResponseWriter, r *http.Request)   { w.WriteHeader(501) }
-func (s *Server) handleWorkerState(w http.ResponseWriter, r *http.Request)         { w.WriteHeader(501) }
-func (s *Server) handleWorkerHeartbeat(w http.ResponseWriter, r *http.Request)     { w.WriteHeader(501) }
-
 // Helpers
 func writeJSON(w http.ResponseWriter, status int, v any) {
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/ccbroker/server.go
+++ b/internal/ccbroker/server.go
@@ -10,15 +10,6 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 )
 
-// Temporary stubs -- replaced in Task 3
-type SSEBroker struct{}
-
-func NewSSEBroker() *SSEBroker { return &SSEBroker{} }
-
-type DedupRegistry struct{}
-
-func NewDedupRegistry() *DedupRegistry { return &DedupRegistry{} }
-
 type Server struct {
 	config Config
 	store  *Store

--- a/internal/ccbroker/server.go
+++ b/internal/ccbroker/server.go
@@ -57,9 +57,7 @@ func (s *Server) Routes() http.Handler {
 	return r
 }
 
-// Stub handlers -- replaced in Tasks 4-6
-func (s *Server) handleCreateSession(w http.ResponseWriter, r *http.Request)       { w.WriteHeader(501) }
-func (s *Server) handleBridge(w http.ResponseWriter, r *http.Request)              { w.WriteHeader(501) }
+// Stub handlers -- replaced in Tasks 5-6
 func (s *Server) handleWorkerEventStream(w http.ResponseWriter, r *http.Request)   { w.WriteHeader(501) }
 func (s *Server) handleWorkerEvents(w http.ResponseWriter, r *http.Request)        { w.WriteHeader(501) }
 func (s *Server) handleWorkerInternalEvents(w http.ResponseWriter, r *http.Request) { w.WriteHeader(501) }

--- a/internal/ccbroker/server.go
+++ b/internal/ccbroker/server.go
@@ -57,14 +57,11 @@ func (s *Server) Routes() http.Handler {
 	return r
 }
 
-// Stub handlers -- replaced in Tasks 5-6
-func (s *Server) handleWorkerEventStream(w http.ResponseWriter, r *http.Request)   { w.WriteHeader(501) }
-func (s *Server) handleWorkerEvents(w http.ResponseWriter, r *http.Request)        { w.WriteHeader(501) }
+// Stub handlers -- replaced in Task 6
 func (s *Server) handleWorkerInternalEvents(w http.ResponseWriter, r *http.Request) { w.WriteHeader(501) }
 func (s *Server) handleGetInternalEvents(w http.ResponseWriter, r *http.Request)   { w.WriteHeader(501) }
 func (s *Server) handleWorkerState(w http.ResponseWriter, r *http.Request)         { w.WriteHeader(501) }
 func (s *Server) handleWorkerHeartbeat(w http.ResponseWriter, r *http.Request)     { w.WriteHeader(501) }
-func (s *Server) workerAuthMiddleware(next http.Handler) http.Handler              { return next }
 
 // Helpers
 func writeJSON(w http.ResponseWriter, status int, v any) {

--- a/internal/ccbroker/sse.go
+++ b/internal/ccbroker/sse.go
@@ -1,0 +1,91 @@
+package ccbroker
+
+import "sync"
+
+// SSESubscriber receives events for a single session.
+type SSESubscriber struct {
+	Ch   chan *StreamClientEvent
+	done chan struct{}
+	once sync.Once
+}
+
+func newSSESubscriber() *SSESubscriber {
+	return &SSESubscriber{
+		Ch:   make(chan *StreamClientEvent, 256),
+		done: make(chan struct{}),
+	}
+}
+
+// Close marks the subscriber as done.
+func (s *SSESubscriber) Close() {
+	s.once.Do(func() { close(s.done) })
+}
+
+// Done returns a channel closed when the subscriber is removed.
+func (s *SSESubscriber) Done() <-chan struct{} {
+	return s.done
+}
+
+// SSEBroker fans out events to per-session subscribers.
+type SSEBroker struct {
+	mu          sync.RWMutex
+	subscribers map[string]map[*SSESubscriber]struct{}
+}
+
+// NewSSEBroker creates a new SSE broker.
+func NewSSEBroker() *SSEBroker {
+	return &SSEBroker{
+		subscribers: make(map[string]map[*SSESubscriber]struct{}),
+	}
+}
+
+// Subscribe creates a new subscriber for a session.
+func (b *SSEBroker) Subscribe(sessionID string) *SSESubscriber {
+	sub := newSSESubscriber()
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.subscribers[sessionID] == nil {
+		b.subscribers[sessionID] = make(map[*SSESubscriber]struct{})
+	}
+	b.subscribers[sessionID][sub] = struct{}{}
+	return sub
+}
+
+// Unsubscribe removes a subscriber.
+func (b *SSEBroker) Unsubscribe(sessionID string, sub *SSESubscriber) {
+	sub.Close()
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if subs, ok := b.subscribers[sessionID]; ok {
+		delete(subs, sub)
+		if len(subs) == 0 {
+			delete(b.subscribers, sessionID)
+		}
+	}
+}
+
+// Publish sends an event to all subscribers of a session.
+// If a subscriber's channel is full, it is closed (force reconnect).
+func (b *SSEBroker) Publish(sessionID string, event *StreamClientEvent) {
+	b.mu.RLock()
+	subs, ok := b.subscribers[sessionID]
+	if !ok {
+		b.mu.RUnlock()
+		return
+	}
+	// Snapshot subscriber list to avoid holding lock during send.
+	snapshot := make([]*SSESubscriber, 0, len(subs))
+	for sub := range subs {
+		snapshot = append(snapshot, sub)
+	}
+	b.mu.RUnlock()
+
+	for _, sub := range snapshot {
+		select {
+		case sub.Ch <- event:
+		default:
+			// Channel full — force reconnect.
+			sub.Close()
+		}
+	}
+}

--- a/internal/ccbroker/store.go
+++ b/internal/ccbroker/store.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"embed"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"sort"
@@ -113,7 +114,7 @@ func (s *Store) GetSession(ctx context.Context, id string) (*Session, error) {
 		`SELECT id, workspace_id, title, status, epoch, external_id, source, created_at
 		 FROM agent_sessions WHERE id = $1`, id,
 	).Scan(&sess.ID, &sess.WorkspaceID, &sess.Title, &sess.Status, &sess.Epoch, &externalID, &sess.Source, &sess.CreatedAt)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	if err != nil {
@@ -132,7 +133,7 @@ func (s *Store) BumpSessionEpoch(ctx context.Context, id string) (int, error) {
 		`UPDATE agent_sessions SET epoch = epoch + 1, updated_at = NOW()
 		 WHERE id = $1 RETURNING epoch`, id,
 	).Scan(&epoch)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return 0, fmt.Errorf("session not found: %s", id)
 	}
 	if err != nil {
@@ -147,7 +148,7 @@ func (s *Store) GetSessionEpoch(ctx context.Context, sessionID string) (int, err
 	err := s.QueryRowContext(ctx,
 		`SELECT epoch FROM agent_sessions WHERE id = $1`, sessionID,
 	).Scan(&epoch)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return 0, fmt.Errorf("session not found: %s", sessionID)
 	}
 	if err != nil {
@@ -180,7 +181,7 @@ func (s *Store) InsertEvents(ctx context.Context, sessionID string, epoch int, e
 	for _, e := range events {
 		var seqNum int64
 		err := stmt.QueryRowContext(ctx, sessionID, e.EventID, epoch, e.Payload, e.Ephemeral).Scan(&seqNum)
-		if err == sql.ErrNoRows {
+		if errors.Is(err, sql.ErrNoRows) {
 			continue // duplicate event_id — skip
 		}
 		if err != nil {

--- a/internal/ccbroker/store.go
+++ b/internal/ccbroker/store.go
@@ -1,0 +1,319 @@
+package ccbroker
+
+import (
+	"context"
+	"database/sql"
+	"embed"
+	"encoding/json"
+	"fmt"
+	"log"
+	"sort"
+
+	_ "github.com/lib/pq"
+)
+
+//go:embed migrations/*.sql
+var migrationsFS embed.FS
+
+// Store provides database access for the cc-broker.
+type Store struct {
+	*sql.DB
+}
+
+// NewStore opens a database connection and runs migrations.
+func NewStore(databaseURL string) (*Store, error) {
+	db, err := sql.Open("postgres", databaseURL)
+	if err != nil {
+		return nil, fmt.Errorf("open database: %w", err)
+	}
+	if err := db.Ping(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("ping database: %w", err)
+	}
+	s := &Store{DB: db}
+	if err := s.migrate(); err != nil {
+		db.Close()
+		return nil, fmt.Errorf("run migrations: %w", err)
+	}
+	return s, nil
+}
+
+func (s *Store) migrate() error {
+	_, err := s.Exec(`CREATE TABLE IF NOT EXISTS schema_migrations (
+		version TEXT PRIMARY KEY,
+		applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+	)`)
+	if err != nil {
+		return fmt.Errorf("create migrations table: %w", err)
+	}
+
+	entries, err := migrationsFS.ReadDir("migrations")
+	if err != nil {
+		return fmt.Errorf("read migrations dir: %w", err)
+	}
+
+	sort.Slice(entries, func(i, j int) bool {
+		return entries[i].Name() < entries[j].Name()
+	})
+
+	for _, entry := range entries {
+		name := entry.Name()
+		var exists bool
+		if err := s.QueryRow("SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE version = $1)", name).Scan(&exists); err != nil {
+			return fmt.Errorf("check migration %s: %w", name, err)
+		}
+		if exists {
+			continue
+		}
+
+		content, err := migrationsFS.ReadFile("migrations/" + name)
+		if err != nil {
+			return fmt.Errorf("read migration %s: %w", name, err)
+		}
+
+		tx, err := s.Begin()
+		if err != nil {
+			return fmt.Errorf("begin tx for %s: %w", name, err)
+		}
+		if _, err := tx.Exec(string(content)); err != nil {
+			tx.Rollback()
+			return fmt.Errorf("execute migration %s: %w", name, err)
+		}
+		if _, err := tx.Exec("INSERT INTO schema_migrations (version) VALUES ($1)", name); err != nil {
+			tx.Rollback()
+			return fmt.Errorf("record migration %s: %w", name, err)
+		}
+		if err := tx.Commit(); err != nil {
+			return fmt.Errorf("commit migration %s: %w", name, err)
+		}
+		log.Printf("Applied migration: %s", name)
+	}
+
+	return nil
+}
+
+// CreateSession inserts a new session.
+func (s *Store) CreateSession(ctx context.Context, id, workspaceID, title, source string, externalID *string) error {
+	_, err := s.ExecContext(ctx,
+		`INSERT INTO agent_sessions (id, workspace_id, title, source, external_id, status, epoch)
+		 VALUES ($1, $2, $3, $4, $5, 'active', 0)`,
+		id, workspaceID, title, source, externalID,
+	)
+	if err != nil {
+		return fmt.Errorf("create session: %w", err)
+	}
+	return nil
+}
+
+// GetSession retrieves a session by ID. Returns nil if not found.
+func (s *Store) GetSession(ctx context.Context, id string) (*Session, error) {
+	sess := &Session{}
+	var externalID sql.NullString
+	err := s.QueryRowContext(ctx,
+		`SELECT id, workspace_id, title, status, epoch, external_id, source, created_at
+		 FROM agent_sessions WHERE id = $1`, id,
+	).Scan(&sess.ID, &sess.WorkspaceID, &sess.Title, &sess.Status, &sess.Epoch, &externalID, &sess.Source, &sess.CreatedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get session: %w", err)
+	}
+	if externalID.Valid {
+		sess.ExternalID = &externalID.String
+	}
+	return sess, nil
+}
+
+// BumpSessionEpoch atomically increments the epoch and returns the new value.
+func (s *Store) BumpSessionEpoch(ctx context.Context, id string) (int, error) {
+	var epoch int
+	err := s.QueryRowContext(ctx,
+		`UPDATE agent_sessions SET epoch = epoch + 1, updated_at = NOW()
+		 WHERE id = $1 RETURNING epoch`, id,
+	).Scan(&epoch)
+	if err == sql.ErrNoRows {
+		return 0, fmt.Errorf("session not found: %s", id)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("bump session epoch: %w", err)
+	}
+	return epoch, nil
+}
+
+// GetSessionEpoch returns the current epoch for a session.
+func (s *Store) GetSessionEpoch(ctx context.Context, sessionID string) (int, error) {
+	var epoch int
+	err := s.QueryRowContext(ctx,
+		`SELECT epoch FROM agent_sessions WHERE id = $1`, sessionID,
+	).Scan(&epoch)
+	if err == sql.ErrNoRows {
+		return 0, fmt.Errorf("session not found: %s", sessionID)
+	}
+	if err != nil {
+		return 0, fmt.Errorf("get session epoch: %w", err)
+	}
+	return epoch, nil
+}
+
+// InsertEvents inserts a batch of events, skipping duplicates.
+// Returns only the successfully inserted events with their sequence numbers.
+func (s *Store) InsertEvents(ctx context.Context, sessionID string, epoch int, events []EventInput) ([]InsertedEvent, error) {
+	tx, err := s.BeginTx(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.PrepareContext(ctx,
+		`INSERT INTO agent_session_events (session_id, event_id, event_type, source, epoch, payload, ephemeral)
+		 VALUES ($1, $2, 'client_event', 'worker', $3, $4, $5)
+		 ON CONFLICT (event_id) DO NOTHING
+		 RETURNING id`,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("prepare insert events: %w", err)
+	}
+	defer stmt.Close()
+
+	var inserted []InsertedEvent
+	for _, e := range events {
+		var seqNum int64
+		err := stmt.QueryRowContext(ctx, sessionID, e.EventID, epoch, e.Payload, e.Ephemeral).Scan(&seqNum)
+		if err == sql.ErrNoRows {
+			continue // duplicate event_id — skip
+		}
+		if err != nil {
+			return nil, fmt.Errorf("insert event %s: %w", e.EventID, err)
+		}
+		inserted = append(inserted, InsertedEvent{SeqNum: seqNum, EventID: e.EventID})
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit insert events: %w", err)
+	}
+	return inserted, nil
+}
+
+// GetEventsSince returns events with sequence number > sinceSeqNum.
+func (s *Store) GetEventsSince(ctx context.Context, sessionID string, sinceSeqNum int64, limit int) ([]SessionEvent, error) {
+	rows, err := s.QueryContext(ctx,
+		`SELECT id, session_id, event_id, event_type, source, epoch, payload, ephemeral, created_at
+		 FROM agent_session_events
+		 WHERE session_id = $1 AND id > $2
+		 ORDER BY id ASC
+		 LIMIT $3`,
+		sessionID, sinceSeqNum, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get events since: %w", err)
+	}
+	defer rows.Close()
+
+	var events []SessionEvent
+	for rows.Next() {
+		var e SessionEvent
+		if err := rows.Scan(&e.ID, &e.SessionID, &e.EventID, &e.EventType, &e.Source, &e.Epoch, &e.Payload, &e.Ephemeral, &e.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan event: %w", err)
+		}
+		events = append(events, e)
+	}
+	return events, rows.Err()
+}
+
+// InsertInternalEvents inserts a batch of internal events.
+func (s *Store) InsertInternalEvents(ctx context.Context, sessionID string, events []InternalEventInput) error {
+	tx, err := s.BeginTx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	stmt, err := tx.PrepareContext(ctx,
+		`INSERT INTO agent_session_internal_events (session_id, event_type, payload, is_compaction, agent_id)
+		 VALUES ($1, $2, $3, $4, $5)`,
+	)
+	if err != nil {
+		return fmt.Errorf("prepare insert internal events: %w", err)
+	}
+	defer stmt.Close()
+
+	for _, e := range events {
+		agentID := sql.NullString{String: e.AgentID, Valid: e.AgentID != ""}
+		if _, err := stmt.ExecContext(ctx, sessionID, e.EventType, e.Payload, e.IsCompaction, agentID); err != nil {
+			return fmt.Errorf("insert internal event: %w", err)
+		}
+	}
+
+	return tx.Commit()
+}
+
+// GetInternalEventsSince returns internal events with id > sinceID.
+func (s *Store) GetInternalEventsSince(ctx context.Context, sessionID string, sinceID int64, limit int) ([]SessionEvent, error) {
+	rows, err := s.QueryContext(ctx,
+		`SELECT id, event_type, payload, is_compaction, COALESCE(agent_id, ''), created_at
+		 FROM agent_session_internal_events
+		 WHERE session_id = $1 AND id > $2
+		 ORDER BY id ASC LIMIT $3`,
+		sessionID, sinceID, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("get internal events since: %w", err)
+	}
+	defer rows.Close()
+
+	var events []SessionEvent
+	for rows.Next() {
+		var e SessionEvent
+		var isCompaction bool
+		var agentID string
+		if err := rows.Scan(&e.ID, &e.EventType, &e.Payload, &isCompaction, &agentID, &e.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scan internal event: %w", err)
+		}
+		e.SessionID = sessionID
+		e.Source = "internal"
+		events = append(events, e)
+	}
+	return events, rows.Err()
+}
+
+// UpsertWorker inserts or updates a worker registration.
+func (s *Store) UpsertWorker(ctx context.Context, sessionID string, epoch int) error {
+	_, err := s.ExecContext(ctx,
+		`INSERT INTO agent_session_workers (session_id, epoch)
+		 VALUES ($1, $2)
+		 ON CONFLICT (session_id, epoch) DO UPDATE SET registered_at = NOW()`,
+		sessionID, epoch,
+	)
+	if err != nil {
+		return fmt.Errorf("upsert worker: %w", err)
+	}
+	return nil
+}
+
+// UpdateWorkerState updates the state and metadata for a worker.
+func (s *Store) UpdateWorkerState(ctx context.Context, sessionID string, epoch int, state string, metadata, actionDetails json.RawMessage) error {
+	_, err := s.ExecContext(ctx,
+		`UPDATE agent_session_workers
+		 SET state = $3, external_metadata = $4, requires_action_details = $5, last_heartbeat_at = NOW()
+		 WHERE session_id = $1 AND epoch = $2`,
+		sessionID, epoch, state, metadata, actionDetails,
+	)
+	if err != nil {
+		return fmt.Errorf("update worker state: %w", err)
+	}
+	return nil
+}
+
+// UpdateWorkerHeartbeat updates the heartbeat timestamp for a worker.
+func (s *Store) UpdateWorkerHeartbeat(ctx context.Context, sessionID string, epoch int) error {
+	_, err := s.ExecContext(ctx,
+		`UPDATE agent_session_workers SET last_heartbeat_at = NOW()
+		 WHERE session_id = $1 AND epoch = $2`,
+		sessionID, epoch,
+	)
+	if err != nil {
+		return fmt.Errorf("update worker heartbeat: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

Add cc-broker's CCR v2-compatible bridge API — the server that CC workers connect to via `--sdk-url` for session management, context replay, and event persistence.

This is **Part 1 of 3** for the cc-broker service:
- Part 1 (this PR): Bridge API — sessions, SSE replay, event persistence
- Part 2: Tool Router MCP Server
- Part 3: Worker Management + External API

## Bridge API Endpoints

| Method | Path | Description |
|--------|------|-------------|
| POST | `/v1/sessions` | Create session |
| POST | `/v1/sessions/{id}/bridge` | Worker attach (epoch bump + JWT) |
| GET | `.../worker/events/stream` | SSE event replay + live stream |
| POST | `.../worker/events` | Event batch write (dedup + epoch) |
| POST | `.../worker/internal-events` | Internal events (compaction) |
| GET | `.../worker/internal-events` | Get internal events |
| PUT | `.../worker` | Worker state update |
| POST | `.../worker/heartbeat` | Worker heartbeat |

## Key Components

- **JWT**: Custom HMAC-SHA256 worker tokens with epoch tracking
- **SSE Broker**: In-memory pub/sub with backpressure handling
- **Dedup**: Bounded UUID set (2000 capacity, FIFO eviction) per session
- **Store**: Shares PostgreSQL tables with agentserver (agent_sessions, agent_session_events, etc.)

## Impact on Existing Code

**Zero impact.** All changes are additive:
- New package `internal/ccbroker/` — no imports from existing code
- `docker-compose.yml` — only appended cc-broker service
- Shares existing DB tables via `CREATE TABLE IF NOT EXISTS`

## Test Plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] Integration tests with `TEST_DATABASE_URL`
- [ ] Manual: create session → bridge → write events → SSE replay

🤖 Generated with [Claude Code](https://claude.com/claude-code)