### PR TITLE
feat: add cc-broker Tool Router MCP Server (Part 2/3)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,6 +97,8 @@ services:
       CCBROKER_PORT: "8085"
       CCBROKER_JWT_SECRET: "dev-secret-change-in-production-32chars"
       CCBROKER_LOG_LEVEL: "info"
+      CCBROKER_EXECUTOR_REGISTRY_URL: "http://executor-registry:8084"
+      CCBROKER_AGENTSERVER_URL: "http://server:8080"
     ports:
       - "8085:8085"
     depends_on:

--- a/internal/ccbroker/config.go
+++ b/internal/ccbroker/config.go
@@ -8,10 +8,12 @@ import (
 )
 
 type Config struct {
-	Port        string
-	DatabaseURL string
-	JWTSecret   []byte
-	LogLevel    slog.Level
+	Port                string
+	DatabaseURL         string
+	JWTSecret           []byte
+	LogLevel            slog.Level
+	ExecutorRegistryURL string
+	AgentserverURL      string
 }
 
 func LoadConfigFromEnv() (Config, error) {
@@ -28,6 +30,8 @@ func LoadConfigFromEnv() (Config, error) {
 		return cfg, fmt.Errorf("CCBROKER_JWT_SECRET is required (32+ chars)")
 	}
 	cfg.JWTSecret = []byte(secret)
+	cfg.ExecutorRegistryURL = envOr("CCBROKER_EXECUTOR_REGISTRY_URL", "http://localhost:8084")
+	cfg.AgentserverURL = envOr("CCBROKER_AGENTSERVER_URL", "http://localhost:8080")
 	if v := os.Getenv("CCBROKER_LOG_LEVEL"); v != "" {
 		switch strings.ToLower(v) {
 		case "debug":

--- a/internal/ccbroker/mcp_router.go
+++ b/internal/ccbroker/mcp_router.go
@@ -1,0 +1,227 @@
+package ccbroker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// ToolRouter dispatches MCP tool calls to the appropriate backend:
+// executor-registry, local workspace, IM, or scheduler.
+type ToolRouter struct {
+	executorRegistryURL string
+	agentserverURL      string
+	workspaceDir        string // set per-worker, local temp dir
+	sessionID           string
+	workspaceID         string
+	httpClient          *http.Client
+	logger              *slog.Logger
+}
+
+// ToolRouterConfig holds the configuration for creating a ToolRouter.
+type ToolRouterConfig struct {
+	ExecutorRegistryURL string
+	AgentserverURL      string
+	WorkspaceDir        string
+	SessionID           string
+	WorkspaceID         string
+}
+
+// NewToolRouter creates a ToolRouter with the given configuration.
+func NewToolRouter(cfg ToolRouterConfig, logger *slog.Logger) *ToolRouter {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &ToolRouter{
+		executorRegistryURL: cfg.ExecutorRegistryURL,
+		agentserverURL:      cfg.AgentserverURL,
+		workspaceDir:        cfg.WorkspaceDir,
+		sessionID:           cfg.SessionID,
+		workspaceID:         cfg.WorkspaceID,
+		httpClient: &http.Client{
+			Timeout: 120 * time.Second,
+		},
+		logger: logger,
+	}
+}
+
+// Route dispatches a tool call to the appropriate handler based on tool name.
+func (r *ToolRouter) Route(ctx context.Context, toolName string, args map[string]interface{}) (*MCPToolResult, error) {
+	switch {
+	case strings.HasPrefix(toolName, "remote_"):
+		return r.routeToExecutor(ctx, toolName, args)
+	case strings.HasPrefix(toolName, "workspace_"):
+		return r.routeToWorkspace(ctx, toolName, args)
+	case toolName == "list_executors":
+		return r.routeListExecutors(ctx, args)
+	case toolName == "send_message" || toolName == "send_image" || toolName == "send_file":
+		return r.routeToIM(ctx, toolName, args)
+	case strings.Contains(toolName, "_scheduled_"):
+		return r.routeToScheduler(ctx, toolName, args)
+	default:
+		return nil, fmt.Errorf("unknown tool: %s", toolName)
+	}
+}
+
+// routeToExecutor forwards remote_* tool calls to executor-registry.
+func (r *ToolRouter) routeToExecutor(ctx context.Context, toolName string, args map[string]interface{}) (*MCPToolResult, error) {
+	executorID, _ := args["executor_id"].(string)
+	if executorID == "" {
+		return textError("executor_id is required"), nil
+	}
+
+	// Strip remote_ prefix: remote_bash -> Bash, remote_read -> Read, etc.
+	tool := strings.TrimPrefix(toolName, "remote_")
+	tool = strings.ToUpper(tool[:1]) + tool[1:] // capitalize first letter
+
+	// Remove executor_id from args (executor-registry doesn't need it in arguments).
+	cleanArgs := make(map[string]interface{})
+	for k, v := range args {
+		if k != "executor_id" {
+			cleanArgs[k] = v
+		}
+	}
+	argsJSON, _ := json.Marshal(cleanArgs)
+
+	// POST to executor-registry /api/execute.
+	reqBody, _ := json.Marshal(map[string]interface{}{
+		"executor_id": executorID,
+		"tool":        tool,
+		"arguments":   json.RawMessage(argsJSON),
+	})
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, r.executorRegistryURL+"/api/execute", bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("executor-registry request creation failed: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+
+	resp, err := r.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("executor-registry request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var execResp struct {
+		Output   string `json:"output"`
+		ExitCode int    `json:"exit_code"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&execResp); err != nil {
+		return nil, fmt.Errorf("executor-registry response decode failed: %w", err)
+	}
+
+	return &MCPToolResult{
+		Content: []MCPContentBlock{{Type: "text", Text: execResp.Output}},
+		IsError: execResp.ExitCode != 0,
+	}, nil
+}
+
+// routeToWorkspace handles workspace_* tool calls against the local workspace directory.
+func (r *ToolRouter) routeToWorkspace(ctx context.Context, toolName string, args map[string]interface{}) (*MCPToolResult, error) {
+	switch toolName {
+	case "workspace_write":
+		path, _ := args["path"].(string)
+		content, _ := args["content"].(string)
+		if path == "" {
+			return textError("path is required"), nil
+		}
+		fullPath := filepath.Join(r.workspaceDir, filepath.Clean(path))
+		// Security: ensure path doesn't escape workspaceDir.
+		if !strings.HasPrefix(fullPath, r.workspaceDir) {
+			return textError("path escapes workspace directory"), nil
+		}
+		if err := os.MkdirAll(filepath.Dir(fullPath), 0755); err != nil {
+			return textError("mkdir failed: " + err.Error()), nil
+		}
+		if err := os.WriteFile(fullPath, []byte(content), 0644); err != nil {
+			return textError("write failed: " + err.Error()), nil
+		}
+		return textResult("Written successfully: " + path), nil
+
+	case "workspace_read":
+		path, _ := args["path"].(string)
+		if path == "" {
+			return textError("path is required"), nil
+		}
+		fullPath := filepath.Join(r.workspaceDir, filepath.Clean(path))
+		if !strings.HasPrefix(fullPath, r.workspaceDir) {
+			return textError("path escapes workspace directory"), nil
+		}
+		data, err := os.ReadFile(fullPath)
+		if err != nil {
+			return textError("read failed: " + err.Error()), nil
+		}
+		return textResult(string(data)), nil
+
+	case "workspace_ls":
+		path, _ := args["path"].(string)
+		fullPath := filepath.Join(r.workspaceDir, filepath.Clean(path))
+		if !strings.HasPrefix(fullPath, r.workspaceDir) {
+			return textError("path escapes workspace directory"), nil
+		}
+		entries, err := os.ReadDir(fullPath)
+		if err != nil {
+			return textError("ls failed: " + err.Error()), nil
+		}
+		var lines []string
+		for _, e := range entries {
+			suffix := ""
+			if e.IsDir() {
+				suffix = "/"
+			}
+			lines = append(lines, e.Name()+suffix)
+		}
+		return textResult(strings.Join(lines, "\n")), nil
+	}
+
+	return nil, fmt.Errorf("unknown workspace tool: %s", toolName)
+}
+
+// routeListExecutors queries executor-registry for available executors.
+func (r *ToolRouter) routeListExecutors(ctx context.Context, args map[string]interface{}) (*MCPToolResult, error) {
+	url := r.executorRegistryURL + "/api/executors?workspace_id=" + r.workspaceID
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("executor-registry request creation failed: %w", err)
+	}
+
+	resp, err := r.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, fmt.Errorf("executor-registry request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, _ := io.ReadAll(resp.Body)
+	return textResult(string(body)), nil
+}
+
+// routeToIM handles IM-related tools (send_message, send_image, send_file).
+// This is a placeholder until the IM integration is connected.
+func (r *ToolRouter) routeToIM(ctx context.Context, toolName string, args map[string]interface{}) (*MCPToolResult, error) {
+	return textResult("IM tool " + toolName + " is not yet connected to agentserver"), nil
+}
+
+// routeToScheduler handles scheduling-related tools (*_scheduled_*).
+// This is a placeholder until the scheduler integration is connected.
+func (r *ToolRouter) routeToScheduler(ctx context.Context, toolName string, args map[string]interface{}) (*MCPToolResult, error) {
+	return textResult("Scheduling tool " + toolName + " is not yet connected to agentserver"), nil
+}
+
+// textResult creates a successful MCPToolResult with text content.
+func textResult(text string) *MCPToolResult {
+	return &MCPToolResult{Content: []MCPContentBlock{{Type: "text", Text: text}}}
+}
+
+// textError creates an error MCPToolResult with text content.
+func textError(text string) *MCPToolResult {
+	return &MCPToolResult{Content: []MCPContentBlock{{Type: "text", Text: text}}, IsError: true}
+}

--- a/internal/ccbroker/mcp_server.go
+++ b/internal/ccbroker/mcp_server.go
@@ -66,11 +66,6 @@ func (r *ToolRouter) Route(ctx context.Context, toolName string, args map[string
 	return &MCPToolResult{Content: []MCPContentBlock{{Type: "text", Text: "not implemented"}}}, nil
 }
 
-// Stub tool definitions — will be replaced in Task 2.
-func buildToolDefinitions() []MCPToolDef {
-	return []MCPToolDef{}
-}
-
 // MCPServer implements http.Handler and speaks JSON-RPC 2.0 / MCP.
 type MCPServer struct {
 	router *ToolRouter

--- a/internal/ccbroker/mcp_server.go
+++ b/internal/ccbroker/mcp_server.go
@@ -1,0 +1,201 @@
+package ccbroker
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// JSON-RPC 2.0 types
+
+type JSONRPCRequest struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      *json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params,omitempty"`
+}
+
+type JSONRPCResponse struct {
+	JSONRPC string           `json:"jsonrpc"`
+	ID      *json.RawMessage `json:"id,omitempty"`
+	Result  interface{}      `json:"result,omitempty"`
+	Error   *RPCError        `json:"error,omitempty"`
+}
+
+type RPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// Standard JSON-RPC 2.0 error codes.
+const (
+	rpcParseError     = -32700
+	rpcInvalidRequest = -32600
+	rpcMethodNotFound = -32601
+	rpcInvalidParams  = -32602
+	rpcInternalError  = -32603
+)
+
+// MCP types
+
+type MCPToolDef struct {
+	Name        string      `json:"name"`
+	Description string      `json:"description,omitempty"`
+	InputSchema interface{} `json:"inputSchema"`
+}
+
+type MCPToolCallParams struct {
+	Name      string                 `json:"name"`
+	Arguments map[string]interface{} `json:"arguments,omitempty"`
+}
+
+type MCPContentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text,omitempty"`
+}
+
+type MCPToolResult struct {
+	Content []MCPContentBlock `json:"content"`
+	IsError bool              `json:"isError,omitempty"`
+}
+
+// Stub ToolRouter — will be replaced in Task 3.
+type ToolRouter struct{}
+
+func (r *ToolRouter) Route(ctx context.Context, toolName string, args map[string]interface{}) (*MCPToolResult, error) {
+	return &MCPToolResult{Content: []MCPContentBlock{{Type: "text", Text: "not implemented"}}}, nil
+}
+
+// Stub tool definitions — will be replaced in Task 2.
+func buildToolDefinitions() []MCPToolDef {
+	return []MCPToolDef{}
+}
+
+// MCPServer implements http.Handler and speaks JSON-RPC 2.0 / MCP.
+type MCPServer struct {
+	router *ToolRouter
+}
+
+func NewMCPServer(router *ToolRouter) *MCPServer {
+	return &MCPServer{router: router}
+}
+
+func (s *MCPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req JSONRPCRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSONRPC(w, http.StatusOK, &JSONRPCResponse{
+			JSONRPC: "2.0",
+			Error:   &RPCError{Code: rpcParseError, Message: "parse error: " + err.Error()},
+		})
+		return
+	}
+
+	if req.JSONRPC != "2.0" {
+		writeJSONRPC(w, http.StatusOK, &JSONRPCResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &RPCError{Code: rpcInvalidRequest, Message: "invalid JSON-RPC version"},
+		})
+		return
+	}
+
+	// Notifications (no id) that require no response body.
+	if req.Method == "notifications/initialized" {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	switch req.Method {
+	case "initialize":
+		s.handleInitialize(w, r, &req)
+	case "tools/list":
+		s.handleToolsList(w, r, &req)
+	case "tools/call":
+		s.handleToolsCall(w, r, &req)
+	default:
+		writeJSONRPC(w, http.StatusOK, &JSONRPCResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &RPCError{Code: rpcMethodNotFound, Message: "method not found: " + req.Method},
+		})
+	}
+}
+
+func (s *MCPServer) handleInitialize(w http.ResponseWriter, r *http.Request, req *JSONRPCRequest) {
+	result := map[string]interface{}{
+		"protocolVersion": "2025-03-26",
+		"capabilities": map[string]interface{}{
+			"tools": map[string]interface{}{},
+		},
+		"serverInfo": map[string]interface{}{
+			"name":    "cc-broker",
+			"version": "0.1.0",
+		},
+	}
+	writeJSONRPC(w, http.StatusOK, &JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      req.ID,
+		Result:  result,
+	})
+}
+
+func (s *MCPServer) handleToolsList(w http.ResponseWriter, r *http.Request, req *JSONRPCRequest) {
+	tools := buildToolDefinitions()
+	result := map[string]interface{}{
+		"tools": tools,
+	}
+	writeJSONRPC(w, http.StatusOK, &JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      req.ID,
+		Result:  result,
+	})
+}
+
+func (s *MCPServer) handleToolsCall(w http.ResponseWriter, r *http.Request, req *JSONRPCRequest) {
+	var params MCPToolCallParams
+	if err := json.Unmarshal(req.Params, &params); err != nil {
+		writeJSONRPC(w, http.StatusOK, &JSONRPCResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &RPCError{Code: rpcInvalidParams, Message: "invalid params: " + err.Error()},
+		})
+		return
+	}
+
+	if params.Name == "" {
+		writeJSONRPC(w, http.StatusOK, &JSONRPCResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &RPCError{Code: rpcInvalidParams, Message: "params.name is required"},
+		})
+		return
+	}
+
+	result, err := s.router.Route(r.Context(), params.Name, params.Arguments)
+	if err != nil {
+		writeJSONRPC(w, http.StatusOK, &JSONRPCResponse{
+			JSONRPC: "2.0",
+			ID:      req.ID,
+			Error:   &RPCError{Code: rpcInternalError, Message: err.Error()},
+		})
+		return
+	}
+
+	writeJSONRPC(w, http.StatusOK, &JSONRPCResponse{
+		JSONRPC: "2.0",
+		ID:      req.ID,
+		Result:  result,
+	})
+}
+
+// writeJSONRPC writes a JSON-RPC 2.0 response with the given HTTP status code.
+func writeJSONRPC(w http.ResponseWriter, status int, resp *JSONRPCResponse) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(resp)
+}

--- a/internal/ccbroker/mcp_server.go
+++ b/internal/ccbroker/mcp_server.go
@@ -1,7 +1,6 @@
 package ccbroker
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 )
@@ -57,13 +56,6 @@ type MCPContentBlock struct {
 type MCPToolResult struct {
 	Content []MCPContentBlock `json:"content"`
 	IsError bool              `json:"isError,omitempty"`
-}
-
-// Stub ToolRouter — will be replaced in Task 3.
-type ToolRouter struct{}
-
-func (r *ToolRouter) Route(ctx context.Context, toolName string, args map[string]interface{}) (*MCPToolResult, error) {
-	return &MCPToolResult{Content: []MCPContentBlock{{Type: "text", Text: "not implemented"}}}, nil
 }
 
 // MCPServer implements http.Handler and speaks JSON-RPC 2.0 / MCP.

--- a/internal/ccbroker/mcp_server.go
+++ b/internal/ccbroker/mcp_server.go
@@ -2,6 +2,7 @@ package ccbroker
 
 import (
 	"encoding/json"
+	"log/slog"
 	"net/http"
 )
 
@@ -61,10 +62,14 @@ type MCPToolResult struct {
 // MCPServer implements http.Handler and speaks JSON-RPC 2.0 / MCP.
 type MCPServer struct {
 	router *ToolRouter
+	logger *slog.Logger
 }
 
-func NewMCPServer(router *ToolRouter) *MCPServer {
-	return &MCPServer{router: router}
+func NewMCPServer(router *ToolRouter, logger *slog.Logger) *MCPServer {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &MCPServer{router: router, logger: logger}
 }
 
 func (s *MCPServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {

--- a/internal/ccbroker/mcp_server_test.go
+++ b/internal/ccbroker/mcp_server_test.go
@@ -1,0 +1,240 @@
+package ccbroker
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func newTestMCPServer(t *testing.T) (*MCPServer, string) {
+	t.Helper()
+	tmpDir := t.TempDir()
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	router := NewToolRouter(ToolRouterConfig{
+		ExecutorRegistryURL: "http://localhost:9999", // won't be called in workspace tests
+		AgentserverURL:      "http://localhost:9999",
+		WorkspaceDir:        tmpDir,
+		SessionID:           "test-session",
+		WorkspaceID:         "test-workspace",
+	}, logger)
+	return NewMCPServer(router, logger), tmpDir
+}
+
+func mcpRequest(t *testing.T, srv http.Handler, method string, params interface{}) JSONRPCResponse {
+	t.Helper()
+	paramsJSON, err := json.Marshal(params)
+	if err != nil {
+		t.Fatalf("marshal params: %v", err)
+	}
+	rawParams := json.RawMessage(paramsJSON)
+	rawID := json.RawMessage(`1`)
+	body, err := json.Marshal(JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      &rawID,
+		Method:  method,
+		Params:  rawParams,
+	})
+	if err != nil {
+		t.Fatalf("marshal request: %v", err)
+	}
+	req := httptest.NewRequest("POST", "/", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	var resp JSONRPCResponse
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return resp
+}
+
+func TestMCPInitialize(t *testing.T) {
+	srv, _ := newTestMCPServer(t)
+	resp := mcpRequest(t, srv, "initialize", map[string]interface{}{
+		"protocolVersion": "2025-03-26",
+		"clientInfo":      map[string]string{"name": "test"},
+	})
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %+v", resp.Error)
+	}
+	result, ok := resp.Result.(map[string]interface{})
+	if !ok {
+		t.Fatal("result is not a map")
+	}
+	if result["protocolVersion"] != "2025-03-26" {
+		t.Errorf("wrong protocol version: %v", result["protocolVersion"])
+	}
+	caps, ok := result["capabilities"].(map[string]interface{})
+	if !ok {
+		t.Error("capabilities is not a map")
+	} else if _, hasTool := caps["tools"]; !hasTool {
+		t.Error("capabilities missing tools key")
+	}
+}
+
+func TestMCPToolsList(t *testing.T) {
+	srv, _ := newTestMCPServer(t)
+	resp := mcpRequest(t, srv, "tools/list", map[string]interface{}{})
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %+v", resp.Error)
+	}
+	result, ok := resp.Result.(map[string]interface{})
+	if !ok {
+		t.Fatal("result is not a map")
+	}
+	tools, ok := result["tools"].([]interface{})
+	if !ok {
+		t.Fatal("tools is not a slice")
+	}
+	if len(tools) < 10 {
+		t.Errorf("expected at least 10 tools, got %d", len(tools))
+	}
+	// Check specific tools exist.
+	toolNames := make(map[string]bool)
+	for _, tool := range tools {
+		m, ok := tool.(map[string]interface{})
+		if !ok {
+			t.Fatal("tool entry is not a map")
+		}
+		name, _ := m["name"].(string)
+		toolNames[name] = true
+	}
+	for _, expected := range []string{"remote_bash", "list_executors", "workspace_write", "send_message", "create_scheduled_task"} {
+		if !toolNames[expected] {
+			t.Errorf("missing tool: %s", expected)
+		}
+	}
+}
+
+func TestMCPWorkspaceTools(t *testing.T) {
+	srv, tmpDir := newTestMCPServer(t)
+
+	// Write a file.
+	resp := mcpRequest(t, srv, "tools/call", MCPToolCallParams{
+		Name: "workspace_write",
+		Arguments: map[string]interface{}{
+			"path":    "test.txt",
+			"content": "hello world",
+		},
+	})
+	if resp.Error != nil {
+		t.Fatalf("workspace_write error: %+v", resp.Error)
+	}
+	result, ok := resp.Result.(map[string]interface{})
+	if !ok {
+		t.Fatal("workspace_write result is not a map")
+	}
+	if isErr, _ := result["isError"].(bool); isErr {
+		t.Errorf("workspace_write returned isError=true")
+	}
+
+	// Check the file exists on disk.
+	data, err := os.ReadFile(filepath.Join(tmpDir, "test.txt"))
+	if err != nil {
+		t.Fatalf("file not created: %v", err)
+	}
+	if string(data) != "hello world" {
+		t.Errorf("wrong content: %s", data)
+	}
+
+	// Read the file back via workspace_read.
+	resp = mcpRequest(t, srv, "tools/call", MCPToolCallParams{
+		Name:      "workspace_read",
+		Arguments: map[string]interface{}{"path": "test.txt"},
+	})
+	if resp.Error != nil {
+		t.Fatalf("workspace_read error: %+v", resp.Error)
+	}
+	result, ok = resp.Result.(map[string]interface{})
+	if !ok {
+		t.Fatal("workspace_read result is not a map")
+	}
+	content, _ := result["content"].([]interface{})
+	if len(content) == 0 {
+		t.Fatal("workspace_read returned no content blocks")
+	}
+	block, _ := content[0].(map[string]interface{})
+	text, _ := block["text"].(string)
+	if text != "hello world" {
+		t.Errorf("workspace_read returned wrong text: %q", text)
+	}
+
+	// List files via workspace_ls.
+	resp = mcpRequest(t, srv, "tools/call", MCPToolCallParams{
+		Name:      "workspace_ls",
+		Arguments: map[string]interface{}{"path": ""},
+	})
+	if resp.Error != nil {
+		t.Fatalf("workspace_ls error: %+v", resp.Error)
+	}
+	result, ok = resp.Result.(map[string]interface{})
+	if !ok {
+		t.Fatal("workspace_ls result is not a map")
+	}
+	lsContent, _ := result["content"].([]interface{})
+	if len(lsContent) == 0 {
+		t.Fatal("workspace_ls returned no content blocks")
+	}
+	lsBlock, _ := lsContent[0].(map[string]interface{})
+	lsText, _ := lsBlock["text"].(string)
+	if !strings.Contains(lsText, "test.txt") {
+		t.Errorf("workspace_ls output doesn't contain test.txt: %q", lsText)
+	}
+}
+
+func TestMCPUnknownTool(t *testing.T) {
+	srv, _ := newTestMCPServer(t)
+	resp := mcpRequest(t, srv, "tools/call", MCPToolCallParams{
+		Name:      "nonexistent_tool",
+		Arguments: map[string]interface{}{},
+	})
+	// Router returns error for unknown tool, which the server maps to an RPC error.
+	// Check for either RPC-level error or isError in result.
+	if resp.Error != nil {
+		// Acceptable: server returned an RPC-level error.
+		return
+	}
+	result, ok := resp.Result.(map[string]interface{})
+	if !ok {
+		t.Fatal("result is neither error nor map")
+	}
+	if isErr, ok := result["isError"].(bool); !ok || !isErr {
+		t.Error("expected isError=true for unknown tool")
+	}
+}
+
+func TestMCPUnknownMethod(t *testing.T) {
+	srv, _ := newTestMCPServer(t)
+	resp := mcpRequest(t, srv, "unknown/method", map[string]interface{}{})
+	if resp.Error == nil {
+		t.Error("expected RPC error for unknown method")
+	}
+	if resp.Error.Code != rpcMethodNotFound {
+		t.Errorf("expected code %d, got %d", rpcMethodNotFound, resp.Error.Code)
+	}
+}
+
+func TestMCPNotInitializedNotification(t *testing.T) {
+	srv, _ := newTestMCPServer(t)
+	// notifications/initialized should return 200 with no body error.
+	rawID := json.RawMessage(`null`)
+	body, _ := json.Marshal(JSONRPCRequest{
+		JSONRPC: "2.0",
+		ID:      &rawID,
+		Method:  "notifications/initialized",
+	})
+	req := httptest.NewRequest("POST", "/", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected 200, got %d", rr.Code)
+	}
+}

--- a/internal/ccbroker/mcp_tools.go
+++ b/internal/ccbroker/mcp_tools.go
@@ -1,0 +1,349 @@
+package ccbroker
+
+func buildToolDefinitions() []MCPToolDef {
+	return []MCPToolDef{
+		{
+			Name:        "remote_bash",
+			Description: "Execute a shell command on a remote executor. Use list_executors to discover available executors and obtain executor_id.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"executor_id": map[string]interface{}{
+						"type":        "string",
+						"description": "Target executor ID. Use list_executors to discover available executors.",
+					},
+					"command": map[string]interface{}{
+						"type":        "string",
+						"description": "Shell command to execute on the remote executor.",
+					},
+					"timeout": map[string]interface{}{
+						"type":        "integer",
+						"description": "Optional timeout in milliseconds for the command execution.",
+					},
+					"description": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional human-readable description of what this command does.",
+					},
+				},
+				"required": []string{"executor_id", "command"},
+			},
+		},
+		{
+			Name:        "remote_read",
+			Description: "Read the contents of a file on a remote executor. Use list_executors to discover available executors and obtain executor_id.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"executor_id": map[string]interface{}{
+						"type":        "string",
+						"description": "Target executor ID. Use list_executors to discover available executors.",
+					},
+					"file_path": map[string]interface{}{
+						"type":        "string",
+						"description": "Absolute path to the file to read on the remote executor.",
+					},
+					"offset": map[string]interface{}{
+						"type":        "integer",
+						"description": "Optional line number offset to start reading from (0-based).",
+					},
+					"limit": map[string]interface{}{
+						"type":        "integer",
+						"description": "Optional maximum number of lines to read.",
+					},
+				},
+				"required": []string{"executor_id", "file_path"},
+			},
+		},
+		{
+			Name:        "remote_edit",
+			Description: "Edit a file on a remote executor by replacing a specific string with a new string. Use list_executors to discover available executors and obtain executor_id.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"executor_id": map[string]interface{}{
+						"type":        "string",
+						"description": "Target executor ID. Use list_executors to discover available executors.",
+					},
+					"file_path": map[string]interface{}{
+						"type":        "string",
+						"description": "Absolute path to the file to edit on the remote executor.",
+					},
+					"old_string": map[string]interface{}{
+						"type":        "string",
+						"description": "The exact string to find and replace in the file.",
+					},
+					"new_string": map[string]interface{}{
+						"type":        "string",
+						"description": "The replacement string to substitute for old_string.",
+					},
+					"replace_all": map[string]interface{}{
+						"type":        "boolean",
+						"description": "If true, replace all occurrences of old_string. Defaults to false (replace only the first occurrence).",
+					},
+				},
+				"required": []string{"executor_id", "file_path", "old_string", "new_string"},
+			},
+		},
+		{
+			Name:        "remote_write",
+			Description: "Write content to a file on a remote executor, creating or overwriting it. Use list_executors to discover available executors and obtain executor_id.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"executor_id": map[string]interface{}{
+						"type":        "string",
+						"description": "Target executor ID. Use list_executors to discover available executors.",
+					},
+					"file_path": map[string]interface{}{
+						"type":        "string",
+						"description": "Absolute path to the file to write on the remote executor.",
+					},
+					"content": map[string]interface{}{
+						"type":        "string",
+						"description": "The content to write to the file.",
+					},
+				},
+				"required": []string{"executor_id", "file_path", "content"},
+			},
+		},
+		{
+			Name:        "remote_glob",
+			Description: "Find files matching a glob pattern on a remote executor. Use list_executors to discover available executors and obtain executor_id.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"executor_id": map[string]interface{}{
+						"type":        "string",
+						"description": "Target executor ID. Use list_executors to discover available executors.",
+					},
+					"pattern": map[string]interface{}{
+						"type":        "string",
+						"description": "Glob pattern to match files against (e.g. '**/*.go', 'src/**/*.ts').",
+					},
+					"path": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional directory path to search within. Defaults to the current working directory.",
+					},
+				},
+				"required": []string{"executor_id", "pattern"},
+			},
+		},
+		{
+			Name:        "remote_grep",
+			Description: "Search for a pattern in files on a remote executor using ripgrep. Use list_executors to discover available executors and obtain executor_id.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"executor_id": map[string]interface{}{
+						"type":        "string",
+						"description": "Target executor ID. Use list_executors to discover available executors.",
+					},
+					"pattern": map[string]interface{}{
+						"type":        "string",
+						"description": "Regular expression pattern to search for in file contents.",
+					},
+					"path": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional file or directory path to search in. Defaults to the current working directory.",
+					},
+					"glob": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional glob pattern to filter files (e.g. '*.go', '**/*.ts').",
+					},
+				},
+				"required": []string{"executor_id", "pattern"},
+			},
+		},
+		{
+			Name:        "remote_ls",
+			Description: "List directory contents on a remote executor. Use list_executors to discover available executors and obtain executor_id.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"executor_id": map[string]interface{}{
+						"type":        "string",
+						"description": "Target executor ID. Use list_executors to discover available executors.",
+					},
+					"path": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional directory path to list. Defaults to the current working directory.",
+					},
+				},
+				"required": []string{"executor_id"},
+			},
+		},
+		{
+			Name:        "list_executors",
+			Description: "List available remote executors that can be used with remote_* tools. Returns executor IDs, status, and metadata.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"status_filter": map[string]interface{}{
+						"type":        "string",
+						"enum":        []string{"online", "all"},
+						"description": "Filter executors by status. 'online' returns only currently connected executors (default). 'all' returns all executors including offline ones.",
+						"default":     "online",
+					},
+				},
+			},
+		},
+		{
+			Name:        "workspace_write",
+			Description: "Write content to a file in the broker's shared workspace. The workspace is accessible across sessions and can be used to share data between tools.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"path": map[string]interface{}{
+						"type":        "string",
+						"description": "Relative path within the workspace where the file should be written.",
+					},
+					"content": map[string]interface{}{
+						"type":        "string",
+						"description": "The content to write to the workspace file.",
+					},
+				},
+				"required": []string{"path", "content"},
+			},
+		},
+		{
+			Name:        "workspace_read",
+			Description: "Read the contents of a file from the broker's shared workspace.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"path": map[string]interface{}{
+						"type":        "string",
+						"description": "Relative path within the workspace of the file to read.",
+					},
+				},
+				"required": []string{"path"},
+			},
+		},
+		{
+			Name:        "workspace_ls",
+			Description: "List files and directories in the broker's shared workspace.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"path": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional relative path within the workspace to list. Defaults to the workspace root.",
+						"default":     "",
+					},
+				},
+			},
+		},
+		{
+			Name:        "send_message",
+			Description: "Send a text message to the human operator monitoring this agent session.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"text": map[string]interface{}{
+						"type":        "string",
+						"description": "The text message to send to the operator.",
+					},
+					"sender": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional display name identifying who is sending the message.",
+					},
+				},
+				"required": []string{"text"},
+			},
+		},
+		{
+			Name:        "send_image",
+			Description: "Send an image to the human operator monitoring this agent session.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"source": map[string]interface{}{
+						"type":        "string",
+						"description": "The image source — either a URL or a base64-encoded data string.",
+					},
+					"format": map[string]interface{}{
+						"type":        "string",
+						"enum":        []string{"png", "jpeg", "gif", "webp"},
+						"description": "Optional image format. Defaults to png if not specified.",
+					},
+					"caption": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional caption text to accompany the image.",
+					},
+				},
+				"required": []string{"source"},
+			},
+		},
+		{
+			Name:        "send_file",
+			Description: "Send a file to the human operator monitoring this agent session.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"source": map[string]interface{}{
+						"type":        "string",
+						"description": "The file source — either a URL or a base64-encoded data string.",
+					},
+					"filename": map[string]interface{}{
+						"type":        "string",
+						"description": "The filename to use when presenting the file to the operator.",
+					},
+					"caption": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional caption or description text to accompany the file.",
+					},
+				},
+				"required": []string{"source", "filename"},
+			},
+		},
+		{
+			Name:        "create_scheduled_task",
+			Description: "Schedule a prompt to run on a cron schedule. The scheduled task will invoke the agent with the given prompt at each scheduled time.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"cron": map[string]interface{}{
+						"type":        "string",
+						"description": "Standard 5-field cron expression specifying when to run (e.g. '0 9 * * 1-5' for weekdays at 9am, '*/15 * * * *' for every 15 minutes).",
+					},
+					"prompt": map[string]interface{}{
+						"type":        "string",
+						"description": "The prompt text to send to the agent when the scheduled task fires.",
+					},
+					"recurring": map[string]interface{}{
+						"type":        "boolean",
+						"description": "If true (default), the task repeats on every cron match. If false, it fires once and is automatically removed.",
+						"default":     true,
+					},
+					"description": map[string]interface{}{
+						"type":        "string",
+						"description": "Optional human-readable description of what this scheduled task does.",
+					},
+				},
+				"required": []string{"cron", "prompt"},
+			},
+		},
+		{
+			Name:        "list_scheduled_tasks",
+			Description: "List all currently scheduled tasks managed by the broker.",
+			InputSchema: map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
+			},
+		},
+		{
+			Name:        "cancel_scheduled_task",
+			Description: "Cancel and remove a scheduled task by its ID. Use list_scheduled_tasks to find task IDs.",
+			InputSchema: map[string]interface{}{
+				"type": "object",
+				"properties": map[string]interface{}{
+					"task_id": map[string]interface{}{
+						"type":        "string",
+						"description": "The ID of the scheduled task to cancel. Use list_scheduled_tasks to discover task IDs.",
+					},
+				},
+				"required": []string{"task_id"},
+			},
+		},
+	}
+}

--- a/internal/ccbroker/server.go
+++ b/internal/ccbroker/server.go
@@ -2,7 +2,9 @@ package ccbroker
 
 import (
 	"encoding/json"
+	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 
@@ -55,6 +57,31 @@ func (s *Server) Routes() http.Handler {
 	})
 
 	return r
+}
+
+// CreateMCPServer creates a per-worker MCP server and returns (server, port, closer, error).
+// The caller should call closer() to stop the MCP server when done.
+func (s *Server) CreateMCPServer(sessionID, workspaceID, workspaceDir string) (*MCPServer, int, func(), error) {
+	router := NewToolRouter(ToolRouterConfig{
+		ExecutorRegistryURL: s.config.ExecutorRegistryURL,
+		AgentserverURL:      s.config.AgentserverURL,
+		WorkspaceDir:        workspaceDir,
+		SessionID:           sessionID,
+		WorkspaceID:         workspaceID,
+	}, s.logger)
+
+	mcpSrv := NewMCPServer(router, s.logger)
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, 0, nil, fmt.Errorf("listen: %w", err)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+
+	go http.Serve(listener, mcpSrv) //nolint:errcheck
+
+	closer := func() { listener.Close() }
+	return mcpSrv, port, closer, nil
 }
 
 // Helpers


### PR DESCRIPTION
## Summary

Add the Tool Router MCP Server to cc-broker — an HTTP MCP server (JSON-RPC 2.0) that CC workers connect to via `--mcp-config` for tool execution.

This is **Part 2 of 3** for cc-broker:
- Part 1: Bridge API (merged in #30)
- Part 2 (this PR): Tool Router MCP Server
- Part 3: Worker Management + External API

## MCP Tools (17 total)

| Category | Tools |
|----------|-------|
| Executor (`remote_*`) | `remote_bash`, `remote_read`, `remote_edit`, `remote_write`, `remote_glob`, `remote_grep`, `remote_ls` |
| Discovery | `list_executors` |
| Workspace | `workspace_write`, `workspace_read`, `workspace_ls` |
| IM | `send_message`, `send_image`, `send_file` |
| Scheduling | `create_scheduled_task`, `list_scheduled_tasks`, `cancel_scheduled_task` |

## Architecture

- MCP server implements JSON-RPC 2.0 over HTTP (initialize, tools/list, tools/call)
- Tool Router classifies calls by prefix and routes to appropriate backend
- Per-worker MCP server instances on dynamic ports (created via `Server.CreateMCPServer()`)
- Executor tools route to executor-registry `/api/execute`
- Workspace tools operate on local filesystem (with path traversal protection)
- IM + scheduling tools are placeholder stubs (agentserver endpoints not yet built)

## Impact

- New files: 4 Go files in `internal/ccbroker/` (mcp_server.go, mcp_tools.go, mcp_router.go, mcp_server_test.go)
- Modified: config.go (2 new env vars), server.go (CreateMCPServer factory), docker-compose.yml (2 env vars added)
- Zero impact on existing code

## Test Plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] Unit tests pass: initialize, tools/list, workspace tools, error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)