### PR TITLE
feat: add cc-broker Worker Management + External API (Part 3/3)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,9 @@ services:
       CCBROKER_LOG_LEVEL: "info"
       CCBROKER_EXECUTOR_REGISTRY_URL: "http://executor-registry:8084"
       CCBROKER_AGENTSERVER_URL: "http://server:8080"
+      CCBROKER_OPENVIKING_URL: "http://openviking:1933"
+      CCBROKER_OPENVIKING_API_KEY: ""
+      ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}"
     ports:
       - "8085:8085"
     depends_on:

--- a/internal/ccbroker/config.go
+++ b/internal/ccbroker/config.go
@@ -14,6 +14,8 @@ type Config struct {
 	LogLevel            slog.Level
 	ExecutorRegistryURL string
 	AgentserverURL      string
+	OpenVikingURL       string
+	OpenVikingAPIKey    string
 }
 
 func LoadConfigFromEnv() (Config, error) {
@@ -32,6 +34,8 @@ func LoadConfigFromEnv() (Config, error) {
 	cfg.JWTSecret = []byte(secret)
 	cfg.ExecutorRegistryURL = envOr("CCBROKER_EXECUTOR_REGISTRY_URL", "http://localhost:8084")
 	cfg.AgentserverURL = envOr("CCBROKER_AGENTSERVER_URL", "http://localhost:8080")
+	cfg.OpenVikingURL = envOr("CCBROKER_OPENVIKING_URL", "http://localhost:1933")
+	cfg.OpenVikingAPIKey = os.Getenv("CCBROKER_OPENVIKING_API_KEY")
 	if v := os.Getenv("CCBROKER_LOG_LEVEL"); v != "" {
 		switch strings.ToLower(v) {
 		case "debug":

--- a/internal/ccbroker/handler_turns.go
+++ b/internal/ccbroker/handler_turns.go
@@ -1,0 +1,155 @@
+package ccbroker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// ProcessTurnRequest is the external API request body for POST /api/turns.
+type ProcessTurnRequest struct {
+	SessionID   string `json:"session_id"`
+	WorkspaceID string `json:"workspace_id"`
+	UserMessage string `json:"user_message"`
+}
+
+// handleProcessTurn handles POST /api/turns. It acquires the turn lock for
+// the session, ensures the session exists, inserts the user message, spawns
+// a CC worker, and streams SSE events back to the caller until the worker
+// exits or the client disconnects.
+func (s *Server) handleProcessTurn(w http.ResponseWriter, r *http.Request) {
+	var req ProcessTurnRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	if req.SessionID == "" || req.WorkspaceID == "" || req.UserMessage == "" {
+		writeError(w, http.StatusBadRequest, "session_id, workspace_id, and user_message are required")
+		return
+	}
+
+	// Acquire turn lock so only one turn runs per session at a time.
+	s.turnLock.Acquire(req.SessionID)
+	defer s.turnLock.Release(req.SessionID)
+
+	// Ensure session exists.
+	sess, err := s.store.GetSession(r.Context(), req.SessionID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to check session")
+		return
+	}
+	if sess == nil {
+		if err := s.store.CreateSession(r.Context(), req.SessionID, req.WorkspaceID, "", "api", nil); err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to create session")
+			return
+		}
+	}
+
+	// Get current epoch for event insertion.
+	epoch, err := s.store.GetSessionEpoch(r.Context(), req.SessionID)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to get session epoch")
+		return
+	}
+
+	// Insert user message as an event.
+	eventUUID := uuid.NewString()
+	payload, _ := json.Marshal(map[string]string{
+		"uuid":    eventUUID,
+		"type":    "user",
+		"content": req.UserMessage,
+	})
+	_, err = s.store.InsertEvents(r.Context(), req.SessionID, epoch, []EventInput{
+		{
+			EventID:   eventUUID,
+			Payload:   payload,
+			Ephemeral: false,
+		},
+	})
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to insert user message")
+		return
+	}
+
+	// Spawn CC worker.
+	worker, err := s.SpawnWorker(r.Context(), req.SessionID, req.WorkspaceID)
+	if err != nil {
+		s.logger.Error("spawn worker failed", "session_id", req.SessionID, "error", err)
+		writeError(w, http.StatusInternalServerError, "failed to spawn worker")
+		return
+	}
+
+	// Set SSE response headers.
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming not supported", http.StatusInternalServerError)
+		return
+	}
+
+	// Subscribe to session SSE events.
+	sub := s.sse.Subscribe(req.SessionID)
+	defer s.sse.Unsubscribe(req.SessionID, sub)
+
+	// Wait for CC process to exit in a background goroutine.
+	done := make(chan struct{})
+	go func() {
+		worker.Process.Wait() //nolint:errcheck
+		close(done)
+	}()
+
+	keepalive := time.NewTicker(15 * time.Second)
+	defer keepalive.Stop()
+
+	for {
+		select {
+		case <-r.Context().Done():
+			// Client disconnected. Kill the CC process and clean up in background.
+			worker.Process.Process.Kill() //nolint:errcheck
+			go s.CleanupWorker(context.Background(), worker)
+			return
+
+		case evt := <-sub.Ch:
+			data, _ := json.Marshal(evt)
+			fmt.Fprintf(w, "data: %s\n\n", data)
+			flusher.Flush()
+
+		case <-sub.Done():
+			// Subscriber was closed (e.g. channel overflow). Clean up.
+			go s.CleanupWorker(context.Background(), worker)
+			return
+
+		case <-done:
+			// CC process exited. Drain remaining buffered events.
+			for {
+				select {
+				case evt := <-sub.Ch:
+					data, _ := json.Marshal(evt)
+					fmt.Fprintf(w, "data: %s\n\n", data)
+					flusher.Flush()
+				default:
+					goto drained
+				}
+			}
+		drained:
+			// Send done sentinel.
+			fmt.Fprintf(w, "data: {\"event_type\":\"done\"}\n\n")
+			flusher.Flush()
+			// Clean up in background (r.Context may be cancelled).
+			go s.CleanupWorker(context.Background(), worker)
+			return
+
+		case <-keepalive.C:
+			fmt.Fprintf(w, ":keepalive\n\n")
+			flusher.Flush()
+		}
+	}
+}

--- a/internal/ccbroker/server.go
+++ b/internal/ccbroker/server.go
@@ -45,6 +45,9 @@ func (s *Server) Routes() http.Handler {
 		w.Write([]byte("ok"))
 	})
 
+	// External API
+	r.Post("/api/turns", s.handleProcessTurn)
+
 	// Session lifecycle
 	r.Post("/v1/sessions", s.handleCreateSession)
 	r.Post("/v1/sessions/{sessionId}/bridge", s.handleBridge)

--- a/internal/ccbroker/server.go
+++ b/internal/ccbroker/server.go
@@ -15,21 +15,23 @@ import (
 )
 
 type Server struct {
-	config Config
-	store  *Store
-	sse    *SSEBroker
-	dedup  *DedupRegistry
-	logger *slog.Logger
+	config   Config
+	store    *Store
+	sse      *SSEBroker
+	dedup    *DedupRegistry
+	turnLock *TurnLock
+	logger   *slog.Logger
 }
 
 func NewServer(cfg Config, store *Store) *Server {
 	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: cfg.LogLevel}))
 	return &Server{
-		config: cfg,
-		store:  store,
-		sse:    NewSSEBroker(),
-		dedup:  NewDedupRegistry(),
-		logger: logger,
+		config:   cfg,
+		store:    store,
+		sse:      NewSSEBroker(),
+		dedup:    NewDedupRegistry(),
+		turnLock: NewTurnLock(),
+		logger:   logger,
 	}
 }
 

--- a/internal/ccbroker/turn_lock.go
+++ b/internal/ccbroker/turn_lock.go
@@ -1,0 +1,31 @@
+package ccbroker
+
+import "sync"
+
+type TurnLock struct {
+	mu    sync.Mutex
+	locks map[string]chan struct{}
+}
+
+func NewTurnLock() *TurnLock {
+	return &TurnLock{locks: make(map[string]chan struct{})}
+}
+
+func (t *TurnLock) Acquire(sessionID string) {
+	t.mu.Lock()
+	ch, exists := t.locks[sessionID]
+	if !exists {
+		ch = make(chan struct{}, 1)
+		t.locks[sessionID] = ch
+	}
+	t.mu.Unlock()
+	ch <- struct{}{}
+}
+
+func (t *TurnLock) Release(sessionID string) {
+	t.mu.Lock()
+	if ch, exists := t.locks[sessionID]; exists {
+		<-ch
+	}
+	t.mu.Unlock()
+}

--- a/internal/ccbroker/viking_client.go
+++ b/internal/ccbroker/viking_client.go
@@ -1,0 +1,180 @@
+package ccbroker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+type VikingClient struct {
+	baseURL    string
+	apiKey     string
+	httpClient *http.Client
+}
+
+func NewVikingClient(baseURL, apiKey string) *VikingClient {
+	return &VikingClient{
+		baseURL:    baseURL,
+		apiKey:     apiKey,
+		httpClient: &http.Client{Timeout: 120 * time.Second},
+	}
+}
+
+// vikingResponse is the generic OpenViking API response wrapper
+type vikingResponse struct {
+	Status string          `json:"status"`
+	Result json.RawMessage `json:"result"`
+}
+
+type vikingFileEntry struct {
+	Name    string `json:"name"`
+	IsDir   bool   `json:"isDir"`
+	URI     string `json:"uri"`
+	RelPath string `json:"rel_path"`
+}
+
+func (v *VikingClient) doRequest(ctx context.Context, method, path string, body io.Reader, contentType string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(ctx, method, v.baseURL+path, body)
+	if err != nil {
+		return nil, err
+	}
+	if v.apiKey != "" {
+		req.Header.Set("X-API-Key", v.apiKey)
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+	return v.httpClient.Do(req)
+}
+
+// DownloadTree recursively downloads files from a Viking URI to a local directory.
+func (v *VikingClient) DownloadTree(ctx context.Context, vikingURI, localDir string) error {
+	// 1. List files recursively
+	listURL := fmt.Sprintf("/api/v1/fs/ls?uri=%s&recursive=true", url.QueryEscape(vikingURI))
+	resp, err := v.doRequest(ctx, "GET", listURL, nil, "")
+	if err != nil {
+		return fmt.Errorf("list files: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		// Directory might not exist yet — that's OK for first-time workspaces
+		return nil
+	}
+
+	var vresp vikingResponse
+	if err := json.NewDecoder(resp.Body).Decode(&vresp); err != nil {
+		return fmt.Errorf("decode list response: %w", err)
+	}
+
+	var entries []vikingFileEntry
+	if err := json.Unmarshal(vresp.Result, &entries); err != nil {
+		return fmt.Errorf("unmarshal entries: %w", err)
+	}
+
+	// 2. Create directories and download files
+	for _, entry := range entries {
+		localPath := filepath.Join(localDir, entry.RelPath)
+		if entry.IsDir {
+			os.MkdirAll(localPath, 0755)
+			continue
+		}
+
+		// Download file content
+		readURL := fmt.Sprintf("/api/v1/content/read?uri=%s", url.QueryEscape(entry.URI))
+		fresp, err := v.doRequest(ctx, "GET", readURL, nil, "")
+		if err != nil {
+			continue // skip failed files
+		}
+
+		var fvresp vikingResponse
+		json.NewDecoder(fresp.Body).Decode(&fvresp)
+		fresp.Body.Close()
+
+		// Result is the file content as a JSON string
+		var content string
+		json.Unmarshal(fvresp.Result, &content)
+
+		os.MkdirAll(filepath.Dir(localPath), 0755)
+		os.WriteFile(localPath, []byte(content), 0644)
+	}
+
+	return nil
+}
+
+// UploadFile writes content to an existing file in OpenViking.
+func (v *VikingClient) UploadFile(ctx context.Context, vikingURI, content string) error {
+	body, _ := json.Marshal(map[string]interface{}{
+		"uri":     vikingURI,
+		"content": content,
+		"mode":    "replace",
+		"wait":    false,
+	})
+	resp, err := v.doRequest(ctx, "POST", "/api/v1/content/write", bytes.NewReader(body), "application/json")
+	if err != nil {
+		return fmt.Errorf("upload file: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("upload failed (status %d): %s", resp.StatusCode, respBody)
+	}
+	return nil
+}
+
+// CreateFile creates a new file in OpenViking using temp_upload + add_resource.
+func (v *VikingClient) CreateFile(ctx context.Context, vikingURI string, content []byte) error {
+	// Step 1: temp_upload
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	part, err := writer.CreateFormFile("file", "upload.dat")
+	if err != nil {
+		return err
+	}
+	part.Write(content)
+	writer.Close()
+
+	resp, err := v.doRequest(ctx, "POST", "/api/v1/resources/temp_upload", &buf, writer.FormDataContentType())
+	if err != nil {
+		return fmt.Errorf("temp upload: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var uploadResp vikingResponse
+	json.NewDecoder(resp.Body).Decode(&uploadResp)
+
+	var uploadResult struct {
+		TempFileID string `json:"temp_file_id"`
+	}
+	json.Unmarshal(uploadResp.Result, &uploadResult)
+
+	if uploadResult.TempFileID == "" {
+		return fmt.Errorf("temp upload returned no file ID")
+	}
+
+	// Step 2: add_resource
+	addBody, _ := json.Marshal(map[string]interface{}{
+		"temp_file_id": uploadResult.TempFileID,
+		"to":           vikingURI,
+		"wait":         false,
+	})
+	resp2, err := v.doRequest(ctx, "POST", "/api/v1/resources", bytes.NewReader(addBody), "application/json")
+	if err != nil {
+		return fmt.Errorf("add resource: %w", err)
+	}
+	defer resp2.Body.Close()
+
+	if resp2.StatusCode != 200 {
+		respBody, _ := io.ReadAll(resp2.Body)
+		return fmt.Errorf("add resource failed (status %d): %s", resp2.StatusCode, respBody)
+	}
+	return nil
+}

--- a/internal/ccbroker/worker.go
+++ b/internal/ccbroker/worker.go
@@ -1,0 +1,242 @@
+package ccbroker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+)
+
+// CCWorker represents a running Claude Code worker process.
+type CCWorker struct {
+	ID          string
+	Process     *exec.Cmd
+	SessionID   string
+	WorkspaceID string
+	Status      string // "running" | "done" | "failed"
+	StartedAt   time.Time
+	mcpCloser   func()
+	tempDir     string
+	snapshot    map[string]fileInfo
+}
+
+// fileInfo records the size and modification time of a file for snapshot diffing.
+type fileInfo struct {
+	Size    int64
+	ModTime time.Time
+}
+
+// fileChange describes a file that was added or modified since the snapshot.
+type fileChange struct {
+	Path    string
+	RelPath string
+	IsNew   bool
+}
+
+// takeFileSnapshot walks dir and records size + modtime for each regular file.
+// The returned map is keyed by path relative to dir.
+func takeFileSnapshot(dir string) map[string]fileInfo {
+	snap := make(map[string]fileInfo)
+	filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return nil
+		}
+		snap[rel] = fileInfo{Size: info.Size(), ModTime: info.ModTime()}
+		return nil
+	})
+	return snap
+}
+
+// diffSnapshot walks dir again and compares against old. It returns files that
+// are new (not in old) or modified (size or modtime changed).
+func diffSnapshot(dir string, old map[string]fileInfo) []fileChange {
+	var changes []fileChange
+	filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return nil
+		}
+		prev, exists := old[rel]
+		if !exists {
+			changes = append(changes, fileChange{Path: path, RelPath: rel, IsNew: true})
+		} else if info.Size() != prev.Size || !info.ModTime().Equal(prev.ModTime) {
+			changes = append(changes, fileChange{Path: path, RelPath: rel, IsNew: false})
+		}
+		return nil
+	})
+	return changes
+}
+
+// SpawnWorker sets up a temporary workspace, downloads files from OpenViking,
+// starts an MCP server, and launches a Claude Code worker process.
+func (s *Server) SpawnWorker(ctx context.Context, sessionID, workspaceID string) (*CCWorker, error) {
+	// 1. Create temp dir structure.
+	tempDir, err := os.MkdirTemp("", "cc-worker-")
+	if err != nil {
+		return nil, fmt.Errorf("create temp dir: %w", err)
+	}
+
+	claudeDir := filepath.Join(tempDir, "claude-config")
+	projectDir := filepath.Join(tempDir, "project")
+	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+		os.RemoveAll(tempDir)
+		return nil, fmt.Errorf("create claude-config dir: %w", err)
+	}
+	if err := os.MkdirAll(projectDir, 0755); err != nil {
+		os.RemoveAll(tempDir)
+		return nil, fmt.Errorf("create project dir: %w", err)
+	}
+
+	// 2. Download from OpenViking.
+	vc := NewVikingClient(s.config.OpenVikingURL, s.config.OpenVikingAPIKey)
+	homeURI := fmt.Sprintf("viking://resources/workspace_%s/claude-home/", workspaceID)
+	if err := vc.DownloadTree(ctx, homeURI, claudeDir); err != nil {
+		os.RemoveAll(tempDir)
+		return nil, fmt.Errorf("download claude-home: %w", err)
+	}
+	projURI := fmt.Sprintf("viking://resources/workspace_%s/project/", workspaceID)
+	if err := vc.DownloadTree(ctx, projURI, projectDir); err != nil {
+		os.RemoveAll(tempDir)
+		return nil, fmt.Errorf("download project: %w", err)
+	}
+
+	// 3. Create auto-memory directory.
+	memoryDir := filepath.Join(claudeDir, "projects", fmt.Sprintf("ws_%s", workspaceID), "memory")
+	if err := os.MkdirAll(memoryDir, 0755); err != nil {
+		os.RemoveAll(tempDir)
+		return nil, fmt.Errorf("create memory dir: %w", err)
+	}
+
+	// 4. Take file snapshot of claude-config dir.
+	snapshot := takeFileSnapshot(claudeDir)
+
+	// 5. Start MCP server.
+	_, mcpPort, mcpCloser, err := s.CreateMCPServer(sessionID, workspaceID, claudeDir)
+	if err != nil {
+		os.RemoveAll(tempDir)
+		return nil, fmt.Errorf("create MCP server: %w", err)
+	}
+
+	// 6. Write MCP config JSON to a temp file.
+	mcpConfig := map[string]interface{}{
+		"mcpServers": map[string]interface{}{
+			"cc-broker": map[string]interface{}{
+				"url": fmt.Sprintf("http://127.0.0.1:%d", mcpPort),
+			},
+		},
+	}
+	mcpConfigBytes, err := json.Marshal(mcpConfig)
+	if err != nil {
+		mcpCloser()
+		os.RemoveAll(tempDir)
+		return nil, fmt.Errorf("marshal MCP config: %w", err)
+	}
+	mcpConfigPath := filepath.Join(tempDir, "mcp-config.json")
+	if err := os.WriteFile(mcpConfigPath, mcpConfigBytes, 0644); err != nil {
+		mcpCloser()
+		os.RemoveAll(tempDir)
+		return nil, fmt.Errorf("write MCP config: %w", err)
+	}
+
+	// 7. Build Claude Code command.
+	sdkURL := fmt.Sprintf("http://127.0.0.1:%s/v1/sessions/%s", s.config.Port, sessionID)
+	cmd := exec.CommandContext(ctx, "claude",
+		"--print",
+		"--sdk-url", sdkURL,
+		"--tools", "WebSearch,WebFetch",
+		"--mcp-config", mcpConfigPath,
+		"--permission-mode", "bypassPermissions",
+		"--dangerously-skip-permissions",
+		"--no-session-persistence",
+	)
+	cmd.Dir = projectDir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	// 8. Set environment variables.
+	cmd.Env = []string{
+		"CLAUDE_CONFIG_DIR=" + claudeDir,
+		"CLAUDE_COWORK_MEMORY_PATH_OVERRIDE=" + memoryDir,
+		"ANTHROPIC_API_KEY=" + os.Getenv("ANTHROPIC_API_KEY"),
+		"CLAUDE_CODE_DISABLE_FILE_CHECKPOINTING=1",
+		"CLAUDE_CODE_AUTO_COMPACT_WINDOW=165000",
+		"HOME=" + tempDir,
+		"PATH=" + os.Getenv("PATH"),
+		"TERM=xterm-256color",
+	}
+
+	// 9. Start the process.
+	if err := cmd.Start(); err != nil {
+		mcpCloser()
+		os.RemoveAll(tempDir)
+		return nil, fmt.Errorf("start claude process: %w", err)
+	}
+
+	worker := &CCWorker{
+		ID:          sessionID,
+		Process:     cmd,
+		SessionID:   sessionID,
+		WorkspaceID: workspaceID,
+		Status:      "running",
+		StartedAt:   time.Now(),
+		mcpCloser:   mcpCloser,
+		tempDir:     tempDir,
+		snapshot:    snapshot,
+	}
+
+	return worker, nil
+}
+
+// CleanupWorker diffs the claude-config directory against the initial snapshot,
+// uploads changed/new files back to OpenViking, then tears down the MCP server
+// and removes the temporary directory.
+func (s *Server) CleanupWorker(ctx context.Context, worker *CCWorker) {
+	// 1. Diff files against the initial snapshot.
+	claudeDir := filepath.Join(worker.tempDir, "claude-config")
+	changes := diffSnapshot(claudeDir, worker.snapshot)
+
+	// 2. Upload changed/new files to OpenViking.
+	if len(changes) > 0 {
+		vc := NewVikingClient(s.config.OpenVikingURL, s.config.OpenVikingAPIKey)
+		for _, ch := range changes {
+			content, err := os.ReadFile(ch.Path)
+			if err != nil {
+				s.logger.Warn("cleanup: failed to read changed file",
+					"path", ch.Path, "error", err)
+				continue
+			}
+			vikingURI := fmt.Sprintf("viking://resources/workspace_%s/claude-home/%s",
+				worker.WorkspaceID, ch.RelPath)
+
+			if ch.IsNew {
+				if err := vc.CreateFile(ctx, vikingURI, content); err != nil {
+					s.logger.Warn("cleanup: failed to create file in OpenViking",
+						"uri", vikingURI, "error", err)
+				}
+			} else {
+				if err := vc.UploadFile(ctx, vikingURI, string(content)); err != nil {
+					s.logger.Warn("cleanup: failed to upload file to OpenViking",
+						"uri", vikingURI, "error", err)
+				}
+			}
+		}
+	}
+
+	// 3. Close MCP server.
+	if worker.mcpCloser != nil {
+		worker.mcpCloser()
+	}
+
+	// 4. Remove temp dir.
+	os.RemoveAll(worker.tempDir)
+}

--- a/internal/ccbroker/worker_test.go
+++ b/internal/ccbroker/worker_test.go
@@ -1,0 +1,106 @@
+package ccbroker
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestTurnLock(t *testing.T) {
+	tl := NewTurnLock()
+
+	// Acquire for session A
+	tl.Acquire("session-a")
+
+	// Try to acquire in goroutine — should block
+	acquired := make(chan struct{})
+	go func() {
+		tl.Acquire("session-a")
+		close(acquired)
+		tl.Release("session-a")
+	}()
+
+	// Should not acquire within 100ms
+	select {
+	case <-acquired:
+		t.Fatal("second acquire should block")
+	case <-time.After(100 * time.Millisecond):
+		// expected
+	}
+
+	// Release — goroutine should unblock
+	tl.Release("session-a")
+
+	select {
+	case <-acquired:
+		// expected
+	case <-time.After(time.Second):
+		t.Fatal("second acquire should have unblocked after release")
+	}
+}
+
+func TestTurnLock_DifferentSessions(t *testing.T) {
+	tl := NewTurnLock()
+
+	tl.Acquire("session-a")
+
+	// Acquiring for a different session should NOT block
+	acquired := make(chan struct{})
+	go func() {
+		tl.Acquire("session-b")
+		close(acquired)
+		tl.Release("session-b")
+	}()
+
+	select {
+	case <-acquired:
+		// expected — different sessions don't block
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("different session should not block")
+	}
+
+	tl.Release("session-a")
+}
+
+func TestFileSnapshot(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create initial files
+	os.WriteFile(filepath.Join(dir, "file1.txt"), []byte("hello"), 0644)
+	os.MkdirAll(filepath.Join(dir, "sub"), 0755)
+	os.WriteFile(filepath.Join(dir, "sub", "file2.txt"), []byte("world"), 0644)
+
+	// Take snapshot
+	snap := takeFileSnapshot(dir)
+	if len(snap) != 2 {
+		t.Fatalf("expected 2 files in snapshot, got %d", len(snap))
+	}
+
+	// Wait a moment (modtime resolution)
+	time.Sleep(10 * time.Millisecond)
+
+	// Modify file1, add file3
+	os.WriteFile(filepath.Join(dir, "file1.txt"), []byte("hello modified"), 0644)
+	os.WriteFile(filepath.Join(dir, "file3.txt"), []byte("new file"), 0644)
+
+	// Diff
+	changes := diffSnapshot(dir, snap)
+
+	// Should have 2 changes: file1.txt modified, file3.txt new
+	if len(changes) != 2 {
+		t.Fatalf("expected 2 changes, got %d: %+v", len(changes), changes)
+	}
+
+	changeMap := make(map[string]fileChange)
+	for _, c := range changes {
+		changeMap[c.RelPath] = c
+	}
+
+	if _, ok := changeMap["file1.txt"]; !ok {
+		t.Error("missing change for file1.txt")
+	}
+	if c, ok := changeMap["file3.txt"]; !ok || !c.IsNew {
+		t.Error("file3.txt should be new")
+	}
+}


### PR DESCRIPTION
## Summary

Complete cc-broker by adding CC worker process management, OpenViking context integration, and the external `/api/turns` endpoint. This is **Part 3 of 3** — cc-broker is now fully functional.

## What This Adds

- **Turn Lock**: Per-session serialization prevents concurrent turn processing
- **OpenViking Client**: Download workspace context (CLAUDE.md, Memory, Skills) before CC starts, upload changes after CC exits
- **CC Worker Lifecycle**: Spawn CC process with `--sdk-url` + `--mcp-config`, manage temp dirs, cleanup
- **POST /api/turns**: External API that agentserver calls — returns SSE stream of CC events

## End-to-End Flow

```
agentserver → POST /api/turns {session_id, workspace_id, user_message}
  → cc-broker acquires turn lock
  → downloads workspace context from OpenViking
  → inserts user message into bridge event log
  → starts MCP server on dynamic port
  → spawns CC: claude --print --sdk-url ... --tools WebSearch,WebFetch --mcp-config ...
  → streams events back via SSE
  → CC exits → diff files → upload changes to OpenViking → cleanup
```

## Files

- `internal/ccbroker/turn_lock.go` — Per-session mutex
- `internal/ccbroker/viking_client.go` — OpenViking REST API client
- `internal/ccbroker/worker.go` — CC process spawn + cleanup
- `internal/ccbroker/handler_turns.go` — POST /api/turns with SSE
- `internal/ccbroker/worker_test.go` — Turn lock + file snapshot tests
- `docker-compose.yml` — Added OpenViking + ANTHROPIC_API_KEY env vars

## Impact

Zero impact on existing code. Only additive changes to cc-broker and docker-compose.yml.

## Test Plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] Turn lock tests pass
- [x] File snapshot tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)