### PR TITLE
feat: Phase 4 — agentserver IM inbound + imbridge routing_mode

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -225,6 +225,7 @@ var serveCmd = &cobra.Command{
 		srv.ModelserverOAuthIntrospectURL = os.Getenv("MODELSERVER_OAUTH_INTROSPECT_URL")
 		srv.ModelserverOAuthRedirectURI = os.Getenv("MODELSERVER_OAUTH_REDIRECT_URI")
 		srv.ModelserverProxyURL = os.Getenv("MODELSERVER_PROXY_URL")
+		srv.CCBrokerURL = os.Getenv("CC_BROKER_URL")
 
 		// Hydra OAuth2 for agent Device Flow.
 		hydraAdminURL := os.Getenv("HYDRA_ADMIN_URL")

--- a/internal/bridge/server.go
+++ b/internal/bridge/server.go
@@ -85,13 +85,19 @@ func (h *Handler) HandleCreateSession(w http.ResponseWriter, r *http.Request) {
 	if sandboxID == "" {
 		sandboxID = req.SandboxID
 	}
-	if sandboxID == "" {
-		http.Error(w, "sandbox_id required", http.StatusBadRequest)
-		return
+
+	// Resolve sandboxID to a pointer (nil when empty for stateless CC sessions).
+	var sandboxIDPtr *string
+	if sandboxID != "" {
+		sandboxIDPtr = &sandboxID
 	}
 
 	workspaceID := WorkspaceIDFromContext(r.Context())
 	if workspaceID == "" {
+		if sandboxID == "" {
+			http.Error(w, "workspace_id or sandbox_id required", http.StatusBadRequest)
+			return
+		}
 		// Look up workspace from sandbox.
 		sbx, err := h.DB.GetSandbox(sandboxID)
 		if err != nil || sbx == nil {
@@ -102,7 +108,7 @@ func (h *Handler) HandleCreateSession(w http.ResponseWriter, r *http.Request) {
 	}
 
 	sessionID := "cse_" + uuid.New().String()
-	if err := h.DB.CreateAgentSession(sessionID, sandboxID, workspaceID, req.Title, req.Tags); err != nil {
+	if err := h.DB.CreateAgentSession(sessionID, sandboxIDPtr, workspaceID, req.Title, req.Tags); err != nil {
 		log.Printf("bridge: create session error: %v", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
@@ -130,7 +136,7 @@ func (h *Handler) HandleBridge(w http.ResponseWriter, r *http.Request) {
 
 	// Verify caller owns this session's sandbox.
 	callerSandbox := SandboxIDFromContext(r.Context())
-	if callerSandbox != "" && callerSandbox != session.SandboxID {
+	if callerSandbox != "" && (session.SandboxID == nil || callerSandbox != *session.SandboxID) {
 		http.Error(w, "forbidden", http.StatusForbidden)
 		return
 	}
@@ -150,7 +156,11 @@ func (h *Handler) HandleBridge(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Issue worker JWT.
-	token, err := IssueWorkerJWT(h.JWTSecret, sessionID, session.SandboxID, session.WorkspaceID, newEpoch, jwtTTL)
+	sandboxIDStr := ""
+	if session.SandboxID != nil {
+		sandboxIDStr = *session.SandboxID
+	}
+	token, err := IssueWorkerJWT(h.JWTSecret, sessionID, sandboxIDStr, session.WorkspaceID, newEpoch, jwtTTL)
 	if err != nil {
 		log.Printf("bridge: issue jwt error: %v", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)
@@ -189,7 +199,7 @@ func (h *Handler) HandleArchive(w http.ResponseWriter, r *http.Request) {
 
 	// Verify caller owns this session.
 	callerSandbox := SandboxIDFromContext(r.Context())
-	if callerSandbox != "" && callerSandbox != session.SandboxID {
+	if callerSandbox != "" && (session.SandboxID == nil || callerSandbox != *session.SandboxID) {
 		http.Error(w, "forbidden", http.StatusForbidden)
 		return
 	}

--- a/internal/db/agent_sessions.go
+++ b/internal/db/agent_sessions.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -12,7 +13,7 @@ import (
 // AgentSession represents a bridge session.
 type AgentSession struct {
 	ID          string
-	SandboxID   string
+	SandboxID   *string
 	WorkspaceID string
 	Title       string
 	Status      string
@@ -47,7 +48,7 @@ type AgentSessionWorker struct {
 	RegisteredAt          time.Time
 }
 
-func (db *DB) CreateAgentSession(id, sandboxID, workspaceID, title string, tags []string) error {
+func (db *DB) CreateAgentSession(id string, sandboxID *string, workspaceID, title string, tags []string) error {
 	if tags == nil {
 		tags = []string{}
 	}
@@ -62,16 +63,18 @@ func (db *DB) CreateAgentSession(id, sandboxID, workspaceID, title string, tags 
 func (db *DB) GetAgentSession(id string) (*AgentSession, error) {
 	s := &AgentSession{}
 	var tags pq.StringArray
+	var sandboxID *string
 	err := db.QueryRow(
 		`SELECT id, sandbox_id, workspace_id, title, status, epoch, tags, created_at, updated_at, archived_at
 		 FROM agent_sessions WHERE id = $1`, id,
-	).Scan(&s.ID, &s.SandboxID, &s.WorkspaceID, &s.Title, &s.Status, &s.Epoch, &tags, &s.CreatedAt, &s.UpdatedAt, &s.ArchivedAt)
+	).Scan(&s.ID, &sandboxID, &s.WorkspaceID, &s.Title, &s.Status, &s.Epoch, &tags, &s.CreatedAt, &s.UpdatedAt, &s.ArchivedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
 	if err != nil {
 		return nil, err
 	}
+	s.SandboxID = sandboxID
 	s.Tags = tags
 	return s, nil
 }
@@ -299,4 +302,34 @@ func (db *DB) GetAgentSessionInternalEventsSince(sessionID string, sinceID int64
 		result = append(result, e)
 	}
 	return result, rows.Err()
+}
+
+// GetSessionByExternalID looks up a session by workspace and external ID.
+func (db *DB) GetSessionByExternalID(ctx context.Context, workspaceID, externalID string) (*AgentSession, error) {
+	s := &AgentSession{}
+	var tags pq.StringArray
+	var sandboxID *string
+	err := db.QueryRowContext(ctx,
+		`SELECT id, sandbox_id, workspace_id, title, status, epoch, tags, created_at, updated_at, archived_at
+		 FROM agent_sessions WHERE workspace_id = $1 AND external_id = $2`,
+		workspaceID, externalID,
+	).Scan(&s.ID, &sandboxID, &s.WorkspaceID, &s.Title, &s.Status, &s.Epoch, &tags, &s.CreatedAt, &s.UpdatedAt, &s.ArchivedAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	s.SandboxID = sandboxID
+	s.Tags = tags
+	return s, nil
+}
+
+// SetSessionExternalID sets the external_id for a session.
+func (db *DB) SetSessionExternalID(ctx context.Context, sessionID, externalID string) error {
+	_, err := db.ExecContext(ctx,
+		`UPDATE agent_sessions SET external_id = $1 WHERE id = $2`,
+		externalID, sessionID,
+	)
+	return err
 }

--- a/internal/db/im_channels.go
+++ b/internal/db/im_channels.go
@@ -16,6 +16,7 @@ type IMChannel struct {
 	BaseURL        string
 	Cursor         string
 	RequireMention bool
+	RoutingMode    string
 	BoundAt        time.Time
 }
 
@@ -47,12 +48,12 @@ func (db *DB) SaveIMChannelCredentials(channelID, botToken, baseURL string) erro
 // GetIMChannel retrieves a single workspace IM channel by ID.
 func (db *DB) GetIMChannel(channelID string) (*IMChannel, error) {
 	c := &IMChannel{}
-	var botToken, baseURL, cursor *string
+	var botToken, baseURL, cursor, routingMode *string
 	err := db.QueryRow(
-		`SELECT id, workspace_id, provider, bot_id, user_id, bot_token, base_url, cursor, require_mention, bound_at
+		`SELECT id, workspace_id, provider, bot_id, user_id, bot_token, base_url, cursor, require_mention, routing_mode, bound_at
 		FROM workspace_im_channels WHERE id = $1`,
 		channelID,
-	).Scan(&c.ID, &c.WorkspaceID, &c.Provider, &c.BotID, &c.UserID, &botToken, &baseURL, &cursor, &c.RequireMention, &c.BoundAt)
+	).Scan(&c.ID, &c.WorkspaceID, &c.Provider, &c.BotID, &c.UserID, &botToken, &baseURL, &cursor, &c.RequireMention, &routingMode, &c.BoundAt)
 	if err != nil {
 		return nil, err
 	}
@@ -65,13 +66,16 @@ func (db *DB) GetIMChannel(channelID string) (*IMChannel, error) {
 	if cursor != nil {
 		c.Cursor = *cursor
 	}
+	if routingMode != nil {
+		c.RoutingMode = *routingMode
+	}
 	return c, nil
 }
 
 // ListIMChannels returns all IM channels for a workspace.
 func (db *DB) ListIMChannels(workspaceID string) ([]IMChannel, error) {
 	rows, err := db.Query(
-		`SELECT id, workspace_id, provider, bot_id, user_id, bot_token, base_url, cursor, require_mention, bound_at
+		`SELECT id, workspace_id, provider, bot_id, user_id, bot_token, base_url, cursor, require_mention, routing_mode, bound_at
 		FROM workspace_im_channels WHERE workspace_id = $1 ORDER BY bound_at`,
 		workspaceID,
 	)
@@ -83,8 +87,8 @@ func (db *DB) ListIMChannels(workspaceID string) ([]IMChannel, error) {
 	var channels []IMChannel
 	for rows.Next() {
 		var c IMChannel
-		var botToken, baseURL, cursor *string
-		if err := rows.Scan(&c.ID, &c.WorkspaceID, &c.Provider, &c.BotID, &c.UserID, &botToken, &baseURL, &cursor, &c.RequireMention, &c.BoundAt); err != nil {
+		var botToken, baseURL, cursor, routingMode *string
+		if err := rows.Scan(&c.ID, &c.WorkspaceID, &c.Provider, &c.BotID, &c.UserID, &botToken, &baseURL, &cursor, &c.RequireMention, &routingMode, &c.BoundAt); err != nil {
 			return nil, err
 		}
 		if botToken != nil {
@@ -96,6 +100,9 @@ func (db *DB) ListIMChannels(workspaceID string) ([]IMChannel, error) {
 		if cursor != nil {
 			c.Cursor = *cursor
 		}
+		if routingMode != nil {
+			c.RoutingMode = *routingMode
+		}
 		channels = append(channels, c)
 	}
 	return channels, rows.Err()
@@ -105,7 +112,7 @@ func (db *DB) ListIMChannels(workspaceID string) ([]IMChannel, error) {
 // Used by RestoreIMBridgePollers.
 func (db *DB) ListAllActiveChannels(provider string) ([]IMChannel, error) {
 	rows, err := db.Query(
-		`SELECT id, workspace_id, provider, bot_id, user_id, bot_token, base_url, cursor, require_mention, bound_at
+		`SELECT id, workspace_id, provider, bot_id, user_id, bot_token, base_url, cursor, require_mention, routing_mode, bound_at
 		FROM workspace_im_channels
 		WHERE provider = $1 AND bot_token IS NOT NULL`,
 		provider,
@@ -118,8 +125,8 @@ func (db *DB) ListAllActiveChannels(provider string) ([]IMChannel, error) {
 	var channels []IMChannel
 	for rows.Next() {
 		var c IMChannel
-		var botToken, baseURL, cursor *string
-		if err := rows.Scan(&c.ID, &c.WorkspaceID, &c.Provider, &c.BotID, &c.UserID, &botToken, &baseURL, &cursor, &c.RequireMention, &c.BoundAt); err != nil {
+		var botToken, baseURL, cursor, routingMode *string
+		if err := rows.Scan(&c.ID, &c.WorkspaceID, &c.Provider, &c.BotID, &c.UserID, &botToken, &baseURL, &cursor, &c.RequireMention, &routingMode, &c.BoundAt); err != nil {
 			return nil, err
 		}
 		if botToken != nil {
@@ -130,6 +137,9 @@ func (db *DB) ListAllActiveChannels(provider string) ([]IMChannel, error) {
 		}
 		if cursor != nil {
 			c.Cursor = *cursor
+		}
+		if routingMode != nil {
+			c.RoutingMode = *routingMode
 		}
 		channels = append(channels, c)
 	}
@@ -264,14 +274,14 @@ func (db *DB) GetSandboxForChannel(channelID string) (sandboxID, podIP, bridgeSe
 // Returns sql.ErrNoRows if the sandbox has no channel bound.
 func (db *DB) GetIMChannelForSandbox(sandboxID string) (*IMChannel, error) {
 	c := &IMChannel{}
-	var botToken, baseURL, cursor *string
+	var botToken, baseURL, cursor, routingMode *string
 	err := db.QueryRow(
-		`SELECT c.id, c.workspace_id, c.provider, c.bot_id, c.user_id, c.bot_token, c.base_url, c.cursor, c.require_mention, c.bound_at
+		`SELECT c.id, c.workspace_id, c.provider, c.bot_id, c.user_id, c.bot_token, c.base_url, c.cursor, c.require_mention, c.routing_mode, c.bound_at
 		FROM workspace_im_channels c
 		JOIN sandboxes s ON s.im_channel_id = c.id
 		WHERE s.id = $1`,
 		sandboxID,
-	).Scan(&c.ID, &c.WorkspaceID, &c.Provider, &c.BotID, &c.UserID, &botToken, &baseURL, &cursor, &c.RequireMention, &c.BoundAt)
+	).Scan(&c.ID, &c.WorkspaceID, &c.Provider, &c.BotID, &c.UserID, &botToken, &baseURL, &cursor, &c.RequireMention, &routingMode, &c.BoundAt)
 	if err != nil {
 		return nil, err
 	}
@@ -283,6 +293,9 @@ func (db *DB) GetIMChannelForSandbox(sandboxID string) (*IMChannel, error) {
 	}
 	if cursor != nil {
 		c.Cursor = *cursor
+	}
+	if routingMode != nil {
+		c.RoutingMode = *routingMode
 	}
 	return c, nil
 }

--- a/internal/db/migrations/018_im_routing_mode.sql
+++ b/internal/db/migrations/018_im_routing_mode.sql
@@ -1,0 +1,3 @@
+ALTER TABLE workspace_im_channels
+    ADD COLUMN IF NOT EXISTS routing_mode TEXT NOT NULL DEFAULT 'nanoclaw';
+-- Values: 'nanoclaw' (existing flow), 'stateless_cc' (new stateless CC flow)

--- a/internal/db/migrations/019_stateless_sessions.sql
+++ b/internal/db/migrations/019_stateless_sessions.sql
@@ -1,0 +1,10 @@
+-- Make sandbox_id nullable (stateless CC sessions have no sandbox)
+ALTER TABLE agent_sessions ALTER COLUMN sandbox_id DROP NOT NULL;
+
+-- Add external_id for IM session resolution (chat_jid → session mapping)
+ALTER TABLE agent_sessions ADD COLUMN IF NOT EXISTS external_id TEXT;
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_sessions_external_id
+    ON agent_sessions(workspace_id, external_id) WHERE external_id IS NOT NULL;
+
+-- Add source field to identify session origin
+ALTER TABLE agent_sessions ADD COLUMN IF NOT EXISTS source TEXT NOT NULL DEFAULT 'agent';

--- a/internal/imbridge/bridge.go
+++ b/internal/imbridge/bridge.go
@@ -6,8 +6,10 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -46,6 +48,8 @@ type BridgeBinding struct {
 	Credentials Credentials
 	ChannelID   string // workspace_im_channels.id
 	Cursor      string
+	WorkspaceID string // workspace that owns this channel
+	RoutingMode string // "nanoclaw" (default) or "stateless_cc"
 }
 
 // Bridge manages per-binding poll goroutines for all IM providers.
@@ -53,6 +57,7 @@ type Bridge struct {
 	db               BridgeDB
 	resolver         SandboxResolver
 	exec             ExecCommander
+	agentserverURL   string
 	providers        map[string]Provider
 	pollers          map[string]context.CancelFunc // key: channelID
 	registeredGroups map[string]string             // key: "sandboxID:chatJID" → cached settings hash
@@ -67,10 +72,15 @@ func NewBridge(db BridgeDB, resolver SandboxResolver, exec ExecCommander, provid
 	for _, p := range providers {
 		pm[p.Name()] = p
 	}
+	agentserverURL := os.Getenv("AGENTSERVER_URL")
+	if agentserverURL == "" {
+		agentserverURL = "http://localhost:8080"
+	}
 	return &Bridge{
 		db:               db,
 		resolver:         resolver,
 		exec:             exec,
+		agentserverURL:   agentserverURL,
 		providers:        pm,
 		pollers:          make(map[string]context.CancelFunc),
 		registeredGroups: make(map[string]string),
@@ -278,7 +288,7 @@ func (b *Bridge) pollLoop(ctx context.Context, binding BridgeBinding) {
 				}
 			}
 
-			forwarded, err := b.forwardToNanoClaw(ctx, binding, msg)
+			forwarded, err := b.forwardMessage(ctx, binding, msg)
 			if err != nil {
 				log.Printf("imbridge: forward failed channel=%s from=%s: %v (will retry next poll)",
 					channelID, msg.FromUserID, err)
@@ -301,6 +311,55 @@ func (b *Bridge) pollLoop(ctx context.Context, binding BridgeBinding) {
 			sleepCtx(ctx, bridgeRetryDelay)
 		}
 	}
+}
+
+// forwardMessage routes an inbound message based on the binding's RoutingMode.
+// "stateless_cc" forwards to the agentserver HTTP API; all other values
+// (including empty, for backward compatibility) forward to NanoClaw.
+func (b *Bridge) forwardMessage(ctx context.Context, binding BridgeBinding, msg InboundMessage) (bool, error) {
+	switch binding.RoutingMode {
+	case "stateless_cc":
+		return b.forwardToAgentserver(ctx, binding, msg)
+	default: // "nanoclaw" or empty (backward compatible)
+		return b.forwardToNanoClaw(ctx, binding, msg)
+	}
+}
+
+// forwardToAgentserver sends a message to the agentserver IM inbound endpoint.
+func (b *Bridge) forwardToAgentserver(ctx context.Context, binding BridgeBinding, msg InboundMessage) (bool, error) {
+	payload := map[string]interface{}{
+		"chat_jid":    msg.FromUserID,
+		"sender_name": msg.SenderName,
+		"content":     msg.Text,
+		"provider":    binding.Provider.Name(),
+		"channel_id":  binding.ChannelID,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return false, fmt.Errorf("marshal message: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/api/workspaces/%s/im/inbound", b.agentserverURL, binding.WorkspaceID)
+	ctx, cancel := context.WithTimeout(ctx, forwardTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("forward to agentserver: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusAccepted {
+		respBody, _ := io.ReadAll(resp.Body)
+		return false, fmt.Errorf("agentserver returned %d: %s", resp.StatusCode, respBody)
+	}
+	return true, nil
 }
 
 // forwardToNanoClaw sends a message to the NanoClaw pod's bridge HTTP endpoint.

--- a/internal/imbridgesvc/handlers.go
+++ b/internal/imbridgesvc/handlers.go
@@ -305,8 +305,9 @@ func (s *Server) saveWeixinCredentials(ctx context.Context, sandboxID string, re
 				BotToken:  result.Token,
 				BaseURL:   baseURL,
 			},
-			ChannelID: channelID,
-			Cursor:    "",
+			ChannelID:   channelID,
+			Cursor:      "",
+			WorkspaceID: sbx.WorkspaceID,
 		})
 		return nil
 	}
@@ -419,8 +420,9 @@ func (s *Server) handleIMTelegramConfigure(w http.ResponseWriter, r *http.Reques
 			BotToken:  req.BotToken,
 			BaseURL:   tgBaseURL,
 		},
-		ChannelID: channelID,
-		Cursor:    "",
+		ChannelID:   channelID,
+		Cursor:      "",
+		WorkspaceID: sbx.WorkspaceID,
 	})
 
 	w.Header().Set("Content-Type", "application/json")
@@ -545,8 +547,9 @@ func (s *Server) handleIMMatrixConfigure(w http.ResponseWriter, r *http.Request)
 			BotToken:  req.AccessToken,
 			BaseURL:   req.HomeserverURL,
 		},
-		ChannelID: channelID,
-		Cursor:    "",
+		ChannelID:   channelID,
+		Cursor:      "",
+		WorkspaceID: sbx.WorkspaceID,
 	})
 
 	w.Header().Set("Content-Type", "application/json")
@@ -847,6 +850,7 @@ func (s *Server) handleWorkspaceWeixinQRWait(w http.ResponseWriter, r *http.Requ
 			Provider:    provider,
 			Credentials: imbridge.Credentials{ChannelID: channelID, BotID: accountID, BotToken: result.Token, BaseURL: baseURL},
 			ChannelID:   channelID,
+			WorkspaceID: wsID,
 		})
 
 		w.Header().Set("Content-Type", "application/json")
@@ -930,6 +934,7 @@ func (s *Server) handleWorkspaceTelegramConfigure(w http.ResponseWriter, r *http
 		Provider:    provider,
 		Credentials: imbridge.Credentials{ChannelID: channelID, BotID: botID, BotToken: req.BotToken, BaseURL: baseURL},
 		ChannelID:   channelID,
+		WorkspaceID: wsID,
 	})
 
 	w.Header().Set("Content-Type", "application/json")
@@ -996,6 +1001,7 @@ func (s *Server) handleWorkspaceMatrixConfigure(w http.ResponseWriter, r *http.R
 		Provider:    provider,
 		Credentials: imbridge.Credentials{ChannelID: channelID, BotID: botID, BotToken: req.AccessToken, BaseURL: req.HomeserverURL},
 		ChannelID:   channelID,
+		WorkspaceID: wsID,
 	})
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/imbridgesvc/lifecycle.go
+++ b/internal/imbridgesvc/lifecycle.go
@@ -30,8 +30,10 @@ func (s *Server) RestorePollers() {
 					BotToken:  ch.BotToken,
 					BaseURL:   ch.BaseURL,
 				},
-				ChannelID: ch.ID,
-				Cursor:    ch.Cursor,
+				ChannelID:   ch.ID,
+				Cursor:      ch.Cursor,
+				WorkspaceID: ch.WorkspaceID,
+				RoutingMode: ch.RoutingMode,
 			})
 			restored++
 		}
@@ -60,8 +62,10 @@ func (s *Server) restorePollerForSandbox(sandboxID string) {
 			BotToken:  ch.BotToken,
 			BaseURL:   ch.BaseURL,
 		},
-		ChannelID: ch.ID,
-		Cursor:    ch.Cursor,
+		ChannelID:   ch.ID,
+		Cursor:      ch.Cursor,
+		WorkspaceID: ch.WorkspaceID,
+		RoutingMode: ch.RoutingMode,
 	})
 }
 

--- a/internal/server/agent_tasks.go
+++ b/internal/server/agent_tasks.go
@@ -89,7 +89,8 @@ func (s *Server) handleCreateTaskForWorkspace(w http.ResponseWriter, r *http.Req
 	var sessionID string
 	if s.BridgeHandler != nil {
 		sessionID = "cse_" + uuid.New().String()
-		if err := s.DB.CreateAgentSession(sessionID, req.TargetID, wid, fmt.Sprintf("Task: %s", taskID), nil); err != nil {
+		targetID := req.TargetID
+		if err := s.DB.CreateAgentSession(sessionID, &targetID, wid, fmt.Sprintf("Task: %s", taskID), nil); err != nil {
 			log.Printf("create task session: %v", err)
 		} else {
 			s.DB.Exec(`UPDATE agent_tasks SET session_id = $1 WHERE id = $2`, sessionID, taskID)

--- a/internal/server/im_inbound.go
+++ b/internal/server/im_inbound.go
@@ -1,0 +1,127 @@
+package server
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/agentserver/agentserver/internal/db"
+)
+
+// IMInboundMessage represents an inbound message from an IM channel.
+type IMInboundMessage struct {
+	ChatJID    string `json:"chat_jid"`
+	SenderName string `json:"sender_name"`
+	Content    string `json:"content"`
+	Provider   string `json:"provider"`
+	ChannelID  string `json:"channel_id"`
+}
+
+func (s *Server) handleIMInbound(w http.ResponseWriter, r *http.Request) {
+	workspaceID := chi.URLParam(r, "wid")
+
+	var msg IMInboundMessage
+	if err := json.NewDecoder(r.Body).Decode(&msg); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if msg.Content == "" {
+		http.Error(w, "content is required", http.StatusBadRequest)
+		return
+	}
+
+	// 1. Resolve session by chat_jid
+	session, err := s.DB.GetSessionByExternalID(r.Context(), workspaceID, msg.ChatJID)
+	if err != nil || session == nil {
+		// Create new session
+		sessionID := "cse_" + uuid.NewString()
+		title := fmt.Sprintf("IM: %s", msg.SenderName)
+		if createErr := s.DB.CreateAgentSession(sessionID, nil, workspaceID, title, nil); createErr != nil {
+			http.Error(w, "failed to create session", http.StatusInternalServerError)
+			return
+		}
+		if setErr := s.DB.SetSessionExternalID(r.Context(), sessionID, msg.ChatJID); setErr != nil {
+			http.Error(w, "failed to set external ID", http.StatusInternalServerError)
+			return
+		}
+		session, _ = s.DB.GetAgentSession(sessionID)
+	}
+
+	if session == nil {
+		http.Error(w, "failed to resolve session", http.StatusInternalServerError)
+		return
+	}
+
+	// 2. Async: call cc-broker
+	bgCtx := context.Background()
+	go s.processWithCCBroker(bgCtx, session, msg)
+
+	// 3. Return 202 immediately
+	w.WriteHeader(http.StatusAccepted)
+}
+
+func (s *Server) processWithCCBroker(_ context.Context, session *db.AgentSession, msg IMInboundMessage) {
+	if s.CCBrokerURL == "" {
+		return
+	}
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"session_id":   session.ID,
+		"workspace_id": session.WorkspaceID,
+		"user_message": msg.Content,
+	})
+
+	resp, err := http.Post(s.CCBrokerURL+"/api/turns", "application/json", bytes.NewReader(body))
+	if err != nil {
+		// Log error but don't crash — user already got 202
+		return
+	}
+	defer resp.Body.Close()
+
+	// Read SSE stream from cc-broker — events are persisted by cc-broker itself.
+	// We just need to wait for completion and extract the final text response.
+	var finalResponse string
+	scanner := bufio.NewScanner(resp.Body)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if !strings.HasPrefix(line, "data: ") {
+			continue
+		}
+		data := strings.TrimPrefix(line, "data: ")
+
+		var event map[string]interface{}
+		if err := json.Unmarshal([]byte(data), &event); err != nil {
+			continue
+		}
+
+		// Check for done event
+		if eventType, _ := event["event_type"].(string); eventType == "done" {
+			break
+		}
+
+		// Extract text from assistant messages for IM reply.
+		// CC events have nested payload; look for text content.
+		if payload, ok := event["payload"]; ok {
+			payloadMap, _ := payload.(map[string]interface{})
+			if payloadMap != nil {
+				// Look for assistant message with text content
+				if msgType, _ := payloadMap["type"].(string); msgType == "assistant" {
+					if content, ok := payloadMap["content"].(string); ok {
+						finalResponse = content
+					}
+				}
+			}
+		}
+	}
+
+	// Reply to IM via imbridge.
+	// For now, just capture — IM reply routing will be connected later.
+	_ = finalResponse
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -70,6 +70,10 @@ type Server struct {
 	// BridgeHandler provides CCR V2-compatible bridge API for agent sessions.
 	BridgeHandler *bridge.Handler
 
+	// CCBrokerURL is the base URL of the cc-broker service for stateless
+	// Claude Code sessions (e.g. "http://cc-broker:8090").
+	CCBrokerURL string
+
 	// Credential proxy
 	EncryptionKey    []byte // AES-256 key for credential_bindings auth_blob
 	CredproxyPublicURL string // URL sandboxes use to reach credentialproxy
@@ -331,6 +335,9 @@ func (s *Server) Router() http.Handler {
 			r.Post("/api/sandboxes/{id}/weixin/qr-start", imbridgeProxy)
 			r.Post("/api/sandboxes/{id}/weixin/qr-wait", imbridgeProxy)
 		}
+
+		// IM inbound handler (stateless CC sessions via cc-broker)
+		r.Post("/api/workspaces/{wid}/im/inbound", s.handleIMInbound)
 
 		// Agent discovery
 		r.Get("/api/workspaces/{wid}/agents", s.handleListAgentCards)


### PR DESCRIPTION
## Summary

Wire the stateless CC pipeline end-to-end by modifying existing agentserver and imbridge code:

1. **Schema migrations**: Add `routing_mode` to `workspace_im_channels`, make `agent_sessions.sandbox_id` nullable, add `external_id` and `source` columns
2. **Go type updates**: `IMChannel.RoutingMode`, `AgentSession.SandboxID *string` (nullable)
3. **Imbridge routing**: Per-channel `routing_mode` switch — "nanoclaw" (existing) or "stateless_cc" (new, forwards to agentserver)
4. **IM inbound handler**: `POST /api/workspaces/{wid}/im/inbound` in agentserver — resolves/creates session by chat_jid, calls cc-broker async

## End-to-End Flow (stateless_cc mode)

```
WeChat → iLink → imbridge poll → routing_mode check
  → "stateless_cc" → POST agentserver /api/workspaces/{wid}/im/inbound
  → agentserver resolves session (by chat_jid external_id)
  → POST cc-broker /api/turns (async, SSE response)
  → CC processes, results stream back
  → (IM reply routing TBD — plumbing is in place)
```

## Modified Existing Files

- `internal/db/im_channels.go` — RoutingMode field + query updates
- `internal/db/agent_sessions.go` — SandboxID nullable + new methods
- `internal/bridge/server.go` — Relaxed sandbox_id validation
- `internal/server/agent_tasks.go` — Updated CreateAgentSession caller
- `internal/imbridge/bridge.go` — forwardMessage routing switch
- `internal/imbridgesvc/lifecycle.go` — BridgeBinding with RoutingMode
- `internal/imbridgesvc/handlers.go` — BridgeBinding with WorkspaceID
- `internal/server/server.go` — CCBrokerURL + new route
- `cmd/serve.go` — CC_BROKER_URL env var

## New Files

- `internal/db/migrations/018_im_routing_mode.sql`
- `internal/db/migrations/019_stateless_sessions.sql`
- `internal/server/im_inbound.go`

## Backward Compatibility

- `routing_mode` defaults to "nanoclaw" — existing channels unaffected
- `sandbox_id` nullable with existing FK — existing sessions unaffected
- All existing routes and handlers preserved

## Test Plan

- [x] `go build ./...` passes (all existing code + new code compiles)
- [ ] Migration applies to existing DB without data loss
- [ ] Existing nanoclaw channels continue working (routing_mode='nanoclaw')
- [ ] New stateless_cc channels route to agentserver inbound handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)