### PR TITLE
feat(agent): executor subcommand — local machines as tool executors

### DIFF
--- a/cmd/agentserver-agent/main.go
+++ b/cmd/agentserver-agent/main.go
@@ -27,6 +27,13 @@ var (
 	skipOpenBrowser bool
 	resumeID       string
 	continueFlag   bool
+
+	// Executor subcommand flags.
+	executorRegistryURL string
+	executorName        string
+	executorWorkspaceID string
+	executorSkipBrowser bool
+	executorWorkDir     string
 )
 
 var rootCmd = &cobra.Command{
@@ -270,8 +277,38 @@ var versionCmd = &cobra.Command{
 	},
 }
 
+var executorCmd = &cobra.Command{
+	Use:   "executor",
+	Short: "Run as a tool executor connected to executor-registry",
+	Long: `Registers with executor-registry and serves as a tool executor for
+stateless Claude Code. Workers in cc-broker dispatch remote_* tool calls
+to this machine via the executor-registry tunnel.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+		go func() {
+			sigCh := make(chan os.Signal, 1)
+			signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+			<-sigCh
+			cancel()
+		}()
+
+		err := agent.RunExecutor(ctx, agent.ExecutorOpts{
+			ServerURL:       executorRegistryURL,
+			Name:            executorName,
+			WorkspaceID:     executorWorkspaceID,
+			SkipOpenBrowser: executorSkipBrowser,
+			WorkDir:         executorWorkDir,
+		})
+		if err != nil && err != context.Canceled {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
 func init() {
-	rootCmd.AddCommand(claudecodeCmd, loginCmd, listCmd, removeCmd, taskWorkerCmd, mcpServerCmd, versionCmd)
+	rootCmd.AddCommand(claudecodeCmd, loginCmd, listCmd, removeCmd, taskWorkerCmd, mcpServerCmd, versionCmd, executorCmd)
 
 	// Root command flags (default: headless Claude Code agent).
 	rootCmd.Flags().StringVar(&server, "server", "https://agent.cs.ac.cn", "Agent server URL")
@@ -306,6 +343,14 @@ func init() {
 	removeCmd.Flags().String("workspace", "", "Workspace ID of the agent to remove")
 	removeCmd.Flags().String("dir", "", "Directory of the agent to remove")
 	removeCmd.Flags().BoolP("yes", "y", false, "Skip confirmation prompt")
+
+	// Executor subcommand flags.
+	defaultName, _ := os.Hostname()
+	executorCmd.Flags().StringVar(&executorRegistryURL, "registry", "https://agent.cs.ac.cn", "executor-registry URL")
+	executorCmd.Flags().StringVar(&executorName, "name", defaultName, "display name for this executor")
+	executorCmd.Flags().StringVar(&executorWorkspaceID, "workspace-id", "", "workspace ID to register this executor under (required)")
+	executorCmd.Flags().BoolVar(&executorSkipBrowser, "skip-open-browser", false, "don't auto-open browser during auth")
+	executorCmd.Flags().StringVar(&executorWorkDir, "work-dir", "", "working directory for tool executions (default: current directory)")
 }
 
 func truncID(id string, n int) string {

--- a/internal/agent/executor_client.go
+++ b/internal/agent/executor_client.go
@@ -1,0 +1,40 @@
+package agent
+
+import (
+	"context"
+	"log"
+	"time"
+)
+
+// ExecutorClient runs a tunnel to executor-registry and serves tool
+// execution requests from cc-broker workers.
+//
+// Task 1 skeleton — the real tunnel + heartbeat + dispatch logic is
+// filled in by Task 2 (tunnel) and Task 3 (tool dispatch).
+type ExecutorClient struct {
+	session *ExecutorSession
+	workDir string
+}
+
+// NewExecutorClient constructs a new executor client bound to the given
+// registry session and working directory.
+func NewExecutorClient(sess *ExecutorSession, workDir string) *ExecutorClient {
+	return &ExecutorClient{
+		session: sess,
+		workDir: workDir,
+	}
+}
+
+// Run blocks until the context is cancelled. Task 2 replaces this stub
+// with the real tunnel accept loop + heartbeat goroutine.
+func (c *ExecutorClient) Run(ctx context.Context) error {
+	log.Printf("executor client: tunnel/heartbeat not yet implemented; idling until Ctrl+C")
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(30 * time.Second):
+			log.Printf("executor client: idle (session=%s)", c.session.ExecutorID)
+		}
+	}
+}

--- a/internal/agent/executor_client.go
+++ b/internal/agent/executor_client.go
@@ -15,22 +15,25 @@ import (
 
 	"nhooyr.io/websocket"
 
+	"github.com/agentserver/agentserver/internal/agent/executortools"
 	"github.com/agentserver/agentserver/internal/tunnel"
 )
 
 // ExecutorClient runs a tunnel to executor-registry and serves tool
 // execution requests from cc-broker workers.
 type ExecutorClient struct {
-	session *ExecutorSession
-	workDir string
+	session  *ExecutorSession
+	workDir  string
+	executor *executortools.ToolExecutor
 }
 
 // NewExecutorClient constructs a new executor client bound to the given
 // registry session and working directory.
 func NewExecutorClient(sess *ExecutorSession, workDir string) *ExecutorClient {
 	return &ExecutorClient{
-		session: sess,
-		workDir: workDir,
+		session:  sess,
+		workDir:  workDir,
+		executor: executortools.New(workDir),
 	}
 }
 
@@ -124,14 +127,21 @@ func (c *ExecutorClient) handleStream(ctx context.Context, stream net.Conn) {
 		return
 	}
 
-	// Task 3 replaces this with real dispatch.
-	body, _ := io.ReadAll(req.Body)
-	log.Printf("received tool execution request (%d bytes); dispatcher not yet implemented", len(body))
-	resp, _ := json.Marshal(map[string]interface{}{
-		"output":    "tool executor not yet implemented",
-		"exit_code": 1,
-	})
-	writeHTTPResponse(stream, http.StatusOK, resp)
+	body, err := io.ReadAll(req.Body)
+	if err != nil {
+		writeHTTPResponse(stream, http.StatusBadRequest, []byte(`{"error":"read body"}`))
+		return
+	}
+
+	var execReq executortools.ExecuteRequest
+	if err := json.Unmarshal(body, &execReq); err != nil {
+		writeHTTPResponse(stream, http.StatusBadRequest, []byte(`{"error":"invalid body"}`))
+		return
+	}
+
+	resp := c.executor.Execute(ctx, execReq)
+	respBody, _ := json.Marshal(resp)
+	writeHTTPResponse(stream, http.StatusOK, respBody)
 }
 
 // heartbeatLoop sends a heartbeat every 20s (plus one immediately).

--- a/internal/agent/executor_client.go
+++ b/internal/agent/executor_client.go
@@ -11,12 +11,35 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 
+	"github.com/hashicorp/yamux"
 	"nhooyr.io/websocket"
 
 	"github.com/agentserver/agentserver/internal/agent/executortools"
 	"github.com/agentserver/agentserver/internal/tunnel"
+)
+
+const (
+	// maxRequestBodyBytes caps the size of an incoming tool-execute request.
+	// CC-side tool arguments are small JSON blobs; 16 MiB is generous.
+	maxRequestBodyBytes = 16 << 20
+
+	// streamReadTimeout bounds how long we wait for the request headers +
+	// body to arrive before giving up. Tool execution itself is bounded by
+	// ExecuteRequest.TimeoutMs (enforced in executortools).
+	streamReadTimeout = 60 * time.Second
+
+	// streamWriteTimeout bounds how long we wait to flush the response.
+	streamWriteTimeout = 30 * time.Second
+
+	// heartbeatInterval matches the registry's expected cadence.
+	heartbeatInterval = 20 * time.Second
+
+	// heartbeatHTTPTimeout prevents a stalled registry from piling up
+	// heartbeat goroutines / blocking reconnects.
+	heartbeatHTTPTimeout = 10 * time.Second
 )
 
 // ExecutorClient runs a tunnel to executor-registry and serves tool
@@ -25,6 +48,8 @@ type ExecutorClient struct {
 	session  *ExecutorSession
 	workDir  string
 	executor *executortools.ToolExecutor
+	hbClient *http.Client
+	stale    atomic.Bool
 }
 
 // NewExecutorClient constructs a new executor client bound to the given
@@ -34,16 +59,34 @@ func NewExecutorClient(sess *ExecutorSession, workDir string) *ExecutorClient {
 		session:  sess,
 		workDir:  workDir,
 		executor: executortools.New(workDir),
+		hbClient: &http.Client{Timeout: heartbeatHTTPTimeout},
 	}
 }
 
 // Run maintains a persistent tunnel to executor-registry and reconnects
-// with exponential backoff on disconnection.
+// with exponential backoff on disconnection. If the registry reports the
+// session as stale (unauthorized / not found) the saved credentials are
+// discarded and a new executor is registered before reconnecting.
 func (c *ExecutorClient) Run(ctx context.Context) error {
 	backoff := time.Second
 	const maxBackoff = 60 * time.Second
 
 	for {
+		if c.stale.Load() {
+			if err := c.reRegister(ctx); err != nil {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
+				log.Printf("re-register failed: %v; retrying in %s", err, backoff)
+				if !sleepCtx(ctx, backoff) {
+					return ctx.Err()
+				}
+				backoff = nextBackoff(backoff, maxBackoff)
+				continue
+			}
+			backoff = time.Second
+		}
+
 		connectedAt := time.Now()
 		err := c.connectAndServe(ctx)
 		if ctx.Err() != nil {
@@ -58,17 +101,32 @@ func (c *ExecutorClient) Run(ctx context.Context) error {
 		}
 
 		log.Printf("reconnecting in %s...", backoff)
-		select {
-		case <-ctx.Done():
+		if !sleepCtx(ctx, backoff) {
 			return ctx.Err()
-		case <-time.After(backoff):
 		}
-
-		backoff *= 2
-		if backoff > maxBackoff {
-			backoff = maxBackoff
-		}
+		backoff = nextBackoff(backoff, maxBackoff)
 	}
+}
+
+// reRegister wipes the stale session file and obtains a fresh executor
+// identity from the registry. Called from Run on the main loop goroutine
+// only, so no locking is needed on c.session.
+func (c *ExecutorClient) reRegister(ctx context.Context) error {
+	log.Printf("session stale; re-registering with %s", c.session.ServerURL)
+	if err := removeExecutorSession(c.session.ExecutorID); err != nil {
+		log.Printf("warning: failed to remove stale session file: %v", err)
+	}
+	newSess, err := registerExecutorWithRegistry(c.session.ServerURL, c.session.Name, c.session.WorkspaceID)
+	if err != nil {
+		return err
+	}
+	if err := saveExecutorSession(newSess); err != nil {
+		log.Printf("warning: failed to save new executor session: %v", err)
+	}
+	c.session = newSess
+	c.stale.Store(false)
+	log.Printf("re-registered: id=%s", newSess.ExecutorID)
+	return nil
 }
 
 func (c *ExecutorClient) connectAndServe(ctx context.Context) error {
@@ -76,8 +134,12 @@ func (c *ExecutorClient) connectAndServe(ctx context.Context) error {
 
 	log.Printf("connecting to %s", wsURL)
 
-	ws, _, err := websocket.Dial(ctx, wsURL, nil)
+	ws, resp, err := websocket.Dial(ctx, wsURL, nil)
 	if err != nil {
+		if resp != nil && (resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusNotFound) {
+			log.Printf("tunnel dial returned %d — marking session stale", resp.StatusCode)
+			c.stale.Store(true)
+		}
 		return fmt.Errorf("ws dial: %w", err)
 	}
 	defer ws.Close(websocket.StatusNormalClosure, "")
@@ -94,7 +156,7 @@ func (c *ExecutorClient) connectAndServe(ctx context.Context) error {
 
 	hbCtx, cancelHB := context.WithCancel(ctx)
 	defer cancelHB()
-	go c.heartbeatLoop(hbCtx)
+	go c.heartbeatLoop(hbCtx, session)
 
 	for {
 		stream, err := session.Accept()
@@ -108,10 +170,18 @@ func (c *ExecutorClient) connectAndServe(ctx context.Context) error {
 	}
 }
 
-// handleStream reads one HTTP request from the stream and responds.
-// Task 3 wires the real tool dispatcher; for now every request returns 501.
+// handleStream reads one HTTP request from the stream, dispatches it to the
+// local tool executor, and writes back the response. Panics in the tool
+// handler are caught so one malformed call can't take down the tunnel.
 func (c *ExecutorClient) handleStream(ctx context.Context, stream net.Conn) {
+	defer func() {
+		if r := recover(); r != nil {
+			log.Printf("panic in tool handler: %v", r)
+		}
+	}()
 	defer stream.Close()
+
+	_ = stream.SetReadDeadline(time.Now().Add(streamReadTimeout))
 
 	req, err := http.ReadRequest(bufio.NewReader(stream))
 	if err != nil {
@@ -122,48 +192,75 @@ func (c *ExecutorClient) handleStream(ctx context.Context, stream net.Conn) {
 	}
 	defer req.Body.Close()
 
+	reply := func(status int, body []byte) {
+		_ = stream.SetWriteDeadline(time.Now().Add(streamWriteTimeout))
+		writeHTTPResponse(stream, status, body)
+	}
+
 	if req.Method != http.MethodPost || req.URL.Path != "/tool/execute" {
-		writeHTTPResponse(stream, http.StatusNotFound, []byte(`{"error":"not found"}`))
+		reply(http.StatusNotFound, []byte(`{"error":"not found"}`))
 		return
 	}
 
-	body, err := io.ReadAll(req.Body)
+	body, err := io.ReadAll(io.LimitReader(req.Body, maxRequestBodyBytes+1))
 	if err != nil {
-		writeHTTPResponse(stream, http.StatusBadRequest, []byte(`{"error":"read body"}`))
+		reply(http.StatusBadRequest, []byte(`{"error":"read body"}`))
+		return
+	}
+	if len(body) > maxRequestBodyBytes {
+		reply(http.StatusRequestEntityTooLarge, []byte(`{"error":"request body too large"}`))
 		return
 	}
 
 	var execReq executortools.ExecuteRequest
 	if err := json.Unmarshal(body, &execReq); err != nil {
-		writeHTTPResponse(stream, http.StatusBadRequest, []byte(`{"error":"invalid body"}`))
+		reply(http.StatusBadRequest, []byte(`{"error":"invalid body"}`))
 		return
 	}
 
+	// Clear the read deadline: tool execution has its own timeout.
+	_ = stream.SetReadDeadline(time.Time{})
+
 	resp := c.executor.Execute(ctx, execReq)
-	respBody, _ := json.Marshal(resp)
-	writeHTTPResponse(stream, http.StatusOK, respBody)
+	respBody, err := json.Marshal(resp)
+	if err != nil {
+		log.Printf("marshal tool response: %v", err)
+		respBody = []byte(`{"output":"internal: failed to marshal response","exit_code":1}`)
+	}
+	reply(http.StatusOK, respBody)
 }
 
-// heartbeatLoop sends a heartbeat every 20s (plus one immediately).
-func (c *ExecutorClient) heartbeatLoop(ctx context.Context) {
-	c.sendHeartbeat(ctx)
-	ticker := time.NewTicker(20 * time.Second)
+// heartbeatLoop sends a heartbeat every heartbeatInterval (plus one
+// immediately). If the registry reports the executor as stale it flags
+// the client and closes the session so the accept loop unblocks.
+func (c *ExecutorClient) heartbeatLoop(ctx context.Context, session *yamux.Session) {
+	if c.sendHeartbeat(ctx, session) {
+		return
+	}
+	ticker := time.NewTicker(heartbeatInterval)
 	defer ticker.Stop()
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			c.sendHeartbeat(ctx)
+			if c.sendHeartbeat(ctx, session) {
+				return
+			}
 		}
 	}
 }
 
-func (c *ExecutorClient) sendHeartbeat(ctx context.Context) {
+// sendHeartbeat posts one heartbeat. Returns true if the caller should stop
+// the heartbeat loop (the session was deemed stale and closed).
+func (c *ExecutorClient) sendHeartbeat(ctx context.Context, session *yamux.Session) (stop bool) {
 	info := collectAgentInfo("", c.workDir)
-	infoJSON, _ := json.Marshal(info)
-
-	body, _ := json.Marshal(map[string]interface{}{
+	infoJSON, err := json.Marshal(info)
+	if err != nil {
+		log.Printf("heartbeat: marshal sysinfo: %v", err)
+		return false
+	}
+	body, err := json.Marshal(map[string]interface{}{
 		"status":      "online",
 		"system_info": json.RawMessage(infoJSON),
 		"capabilities": map[string]interface{}{
@@ -172,26 +269,39 @@ func (c *ExecutorClient) sendHeartbeat(ctx context.Context) {
 			"description": "Local machine executor",
 		},
 	})
+	if err != nil {
+		log.Printf("heartbeat: marshal body: %v", err)
+		return false
+	}
 
 	url := c.session.ServerURL + "/api/executors/" + c.session.ExecutorID + "/heartbeat"
 	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(body))
 	if err != nil {
-		log.Printf("heartbeat build request: %v", err)
-		return
+		log.Printf("heartbeat: build request: %v", err)
+		return false
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+c.session.RegistryToken)
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := c.hbClient.Do(req)
 	if err != nil {
 		log.Printf("heartbeat failed: %v", err)
-		return
+		return false
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
+	switch resp.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
+		log.Printf("heartbeat returned %d — marking session stale and tearing down tunnel", resp.StatusCode)
+		c.stale.Store(true)
+		_ = session.Close()
+		return true
+	case http.StatusOK:
+		return false
+	default:
 		respBody, _ := io.ReadAll(resp.Body)
 		log.Printf("heartbeat returned %d: %s", resp.StatusCode, respBody)
+		return false
 	}
 }
 
@@ -217,4 +327,21 @@ func httpToWS(u string) string {
 		return "ws://" + strings.TrimPrefix(u, "http://")
 	}
 	return u
+}
+
+func sleepCtx(ctx context.Context, d time.Duration) bool {
+	select {
+	case <-ctx.Done():
+		return false
+	case <-time.After(d):
+		return true
+	}
+}
+
+func nextBackoff(cur, max time.Duration) time.Duration {
+	cur *= 2
+	if cur > max {
+		cur = max
+	}
+	return cur
 }

--- a/internal/agent/executor_client.go
+++ b/internal/agent/executor_client.go
@@ -1,16 +1,25 @@
 package agent
 
 import (
+	"bufio"
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
+	"io"
 	"log"
+	"net"
+	"net/http"
+	"strings"
 	"time"
+
+	"nhooyr.io/websocket"
+
+	"github.com/agentserver/agentserver/internal/tunnel"
 )
 
 // ExecutorClient runs a tunnel to executor-registry and serves tool
 // execution requests from cc-broker workers.
-//
-// Task 1 skeleton — the real tunnel + heartbeat + dispatch logic is
-// filled in by Task 2 (tunnel) and Task 3 (tool dispatch).
 type ExecutorClient struct {
 	session *ExecutorSession
 	workDir string
@@ -25,16 +34,177 @@ func NewExecutorClient(sess *ExecutorSession, workDir string) *ExecutorClient {
 	}
 }
 
-// Run blocks until the context is cancelled. Task 2 replaces this stub
-// with the real tunnel accept loop + heartbeat goroutine.
+// Run maintains a persistent tunnel to executor-registry and reconnects
+// with exponential backoff on disconnection.
 func (c *ExecutorClient) Run(ctx context.Context) error {
-	log.Printf("executor client: tunnel/heartbeat not yet implemented; idling until Ctrl+C")
+	backoff := time.Second
+	const maxBackoff = 60 * time.Second
+
 	for {
+		connectedAt := time.Now()
+		err := c.connectAndServe(ctx)
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if err != nil {
+			log.Printf("tunnel disconnected: %v", err)
+		}
+
+		if time.Since(connectedAt) > 30*time.Second {
+			backoff = time.Second
+		}
+
+		log.Printf("reconnecting in %s...", backoff)
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case <-time.After(30 * time.Second):
-			log.Printf("executor client: idle (session=%s)", c.session.ExecutorID)
+		case <-time.After(backoff):
+		}
+
+		backoff *= 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
 		}
 	}
+}
+
+func (c *ExecutorClient) connectAndServe(ctx context.Context) error {
+	wsURL := httpToWS(c.session.ServerURL) + "/api/tunnel/" + c.session.ExecutorID + "?token=" + c.session.TunnelToken
+
+	log.Printf("connecting to %s", wsURL)
+
+	ws, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		return fmt.Errorf("ws dial: %w", err)
+	}
+	defer ws.Close(websocket.StatusNormalClosure, "")
+
+	log.Printf("tunnel connected (executor: %s)", c.session.ExecutorID)
+
+	conn := tunnel.NewWSConn(ctx, ws)
+	session, err := tunnel.ClientMux(conn)
+	if err != nil {
+		conn.Close()
+		return fmt.Errorf("yamux session: %w", err)
+	}
+	defer session.Close()
+
+	hbCtx, cancelHB := context.WithCancel(ctx)
+	defer cancelHB()
+	go c.heartbeatLoop(hbCtx)
+
+	for {
+		stream, err := session.Accept()
+		if err != nil {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
+			return fmt.Errorf("accept stream: %w", err)
+		}
+		go c.handleStream(ctx, stream)
+	}
+}
+
+// handleStream reads one HTTP request from the stream and responds.
+// Task 3 wires the real tool dispatcher; for now every request returns 501.
+func (c *ExecutorClient) handleStream(ctx context.Context, stream net.Conn) {
+	defer stream.Close()
+
+	req, err := http.ReadRequest(bufio.NewReader(stream))
+	if err != nil {
+		if err != io.EOF {
+			log.Printf("read request: %v", err)
+		}
+		return
+	}
+	defer req.Body.Close()
+
+	if req.Method != http.MethodPost || req.URL.Path != "/tool/execute" {
+		writeHTTPResponse(stream, http.StatusNotFound, []byte(`{"error":"not found"}`))
+		return
+	}
+
+	// Task 3 replaces this with real dispatch.
+	body, _ := io.ReadAll(req.Body)
+	log.Printf("received tool execution request (%d bytes); dispatcher not yet implemented", len(body))
+	resp, _ := json.Marshal(map[string]interface{}{
+		"output":    "tool executor not yet implemented",
+		"exit_code": 1,
+	})
+	writeHTTPResponse(stream, http.StatusOK, resp)
+}
+
+// heartbeatLoop sends a heartbeat every 20s (plus one immediately).
+func (c *ExecutorClient) heartbeatLoop(ctx context.Context) {
+	c.sendHeartbeat(ctx)
+	ticker := time.NewTicker(20 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			c.sendHeartbeat(ctx)
+		}
+	}
+}
+
+func (c *ExecutorClient) sendHeartbeat(ctx context.Context) {
+	info := collectAgentInfo("", c.workDir)
+	infoJSON, _ := json.Marshal(info)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"status":      "online",
+		"system_info": json.RawMessage(infoJSON),
+		"capabilities": map[string]interface{}{
+			"tools":       []string{"Bash", "Read", "Edit", "Write", "Glob", "Grep", "LS"},
+			"working_dir": c.workDir,
+			"description": "Local machine executor",
+		},
+	})
+
+	url := c.session.ServerURL + "/api/executors/" + c.session.ExecutorID + "/heartbeat"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(body))
+	if err != nil {
+		log.Printf("heartbeat build request: %v", err)
+		return
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.session.RegistryToken)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		log.Printf("heartbeat failed: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		log.Printf("heartbeat returned %d: %s", resp.StatusCode, respBody)
+	}
+}
+
+// writeHTTPResponse writes a minimal HTTP/1.1 response over the stream.
+func writeHTTPResponse(w io.Writer, status int, body []byte) {
+	resp := &http.Response{
+		StatusCode:    status,
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Header:        http.Header{"Content-Type": []string{"application/json"}},
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+	}
+	_ = resp.Write(w)
+}
+
+// httpToWS converts http(s):// → ws(s):// preserving the remainder.
+func httpToWS(u string) string {
+	if strings.HasPrefix(u, "https://") {
+		return "wss://" + strings.TrimPrefix(u, "https://")
+	}
+	if strings.HasPrefix(u, "http://") {
+		return "ws://" + strings.TrimPrefix(u, "http://")
+	}
+	return u
 }

--- a/internal/agent/executor_cmd.go
+++ b/internal/agent/executor_cmd.go
@@ -1,0 +1,50 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+)
+
+// ExecutorOpts holds configuration for the `executor` subcommand.
+type ExecutorOpts struct {
+	ServerURL       string
+	Name            string
+	WorkspaceID     string
+	SkipOpenBrowser bool
+	WorkDir         string
+}
+
+// RunExecutor registers with executor-registry (or reuses a saved session)
+// and runs the tunnel + heartbeat loop, serving tool execution requests
+// over a yamux tunnel.
+func RunExecutor(ctx context.Context, opts ExecutorOpts) error {
+	if opts.WorkspaceID == "" {
+		return fmt.Errorf("--workspace-id is required")
+	}
+	if opts.ServerURL == "" {
+		return fmt.Errorf("--registry is required")
+	}
+
+	workDir := opts.WorkDir
+	if workDir == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("get working directory: %w", err)
+		}
+		workDir = cwd
+	}
+
+	sess, err := LoadOrRegisterExecutor(opts)
+	if err != nil {
+		return fmt.Errorf("register executor: %w", err)
+	}
+
+	log.Printf("executor registered: id=%s name=%s", sess.ExecutorID, sess.Name)
+	log.Printf("registry URL: %s", sess.ServerURL)
+	log.Printf("working directory: %s", workDir)
+
+	client := NewExecutorClient(sess, workDir)
+	return client.Run(ctx)
+}

--- a/internal/agent/executor_session.go
+++ b/internal/agent/executor_session.go
@@ -1,0 +1,158 @@
+package agent
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+// ExecutorSession holds the credentials for a registered executor.
+// Persisted at ~/.agentserver/executors/{executor_id}.json so the local
+// machine can reconnect to executor-registry across restarts.
+type ExecutorSession struct {
+	ExecutorID    string    `json:"executor_id"`
+	Name          string    `json:"name"`
+	WorkspaceID   string    `json:"workspace_id"`
+	TunnelToken   string    `json:"tunnel_token"`
+	RegistryToken string    `json:"registry_token"`
+	ServerURL     string    `json:"server_url"`
+	CreatedAt     time.Time `json:"created_at"`
+}
+
+// executorSessionsDir returns the directory where executor sessions are stored.
+func executorSessionsDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".agentserver", "executors"), nil
+}
+
+// loadLatestExecutorSession loads the most recently created session
+// matching the given server URL + workspace ID. Returns nil if none found.
+func loadLatestExecutorSession(serverURL, workspaceID string) (*ExecutorSession, error) {
+	dir, err := executorSessionsDir()
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var sessions []*ExecutorSession
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		var sess ExecutorSession
+		if err := json.Unmarshal(data, &sess); err != nil {
+			continue
+		}
+		if sess.ServerURL == serverURL && sess.WorkspaceID == workspaceID {
+			sessions = append(sessions, &sess)
+		}
+	}
+
+	if len(sessions) == 0 {
+		return nil, nil
+	}
+	sort.Slice(sessions, func(i, j int) bool {
+		return sessions[i].CreatedAt.After(sessions[j].CreatedAt)
+	})
+	return sessions[0], nil
+}
+
+// saveExecutorSession writes the session JSON to disk.
+func saveExecutorSession(sess *ExecutorSession) error {
+	dir, err := executorSessionsDir()
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return err
+	}
+	path := filepath.Join(dir, sess.ExecutorID+".json")
+	data, err := json.MarshalIndent(sess, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0600)
+}
+
+// registerExecutorWithRegistry POSTs /api/executors/register and returns a session.
+// executor-registry is currently unauthenticated by design; name + workspace_id
+// are sufficient for the MVP.
+func registerExecutorWithRegistry(serverURL, name, workspaceID string) (*ExecutorSession, error) {
+	reqBody, _ := json.Marshal(map[string]string{
+		"name":         name,
+		"workspace_id": workspaceID,
+	})
+	resp, err := http.Post(serverURL+"/api/executors/register", "application/json", bytes.NewReader(reqBody))
+	if err != nil {
+		return nil, fmt.Errorf("register: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("register returned %d: %s", resp.StatusCode, body)
+	}
+
+	var regResp struct {
+		ExecutorID    string `json:"executor_id"`
+		TunnelToken   string `json:"tunnel_token"`
+		RegistryToken string `json:"registry_token"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&regResp); err != nil {
+		return nil, fmt.Errorf("decode response: %w", err)
+	}
+	if regResp.ExecutorID == "" || regResp.TunnelToken == "" || regResp.RegistryToken == "" {
+		return nil, fmt.Errorf("register response missing required fields")
+	}
+
+	return &ExecutorSession{
+		ExecutorID:    regResp.ExecutorID,
+		Name:          name,
+		WorkspaceID:   workspaceID,
+		TunnelToken:   regResp.TunnelToken,
+		RegistryToken: regResp.RegistryToken,
+		ServerURL:     serverURL,
+		CreatedAt:     time.Now().UTC(),
+	}, nil
+}
+
+// LoadOrRegisterExecutor reuses a saved session for the given serverURL +
+// workspaceID if one exists, otherwise registers a new executor with the
+// registry and persists the result.
+func LoadOrRegisterExecutor(opts ExecutorOpts) (*ExecutorSession, error) {
+	if opts.WorkspaceID == "" {
+		return nil, fmt.Errorf("workspace_id is required")
+	}
+	sess, err := loadLatestExecutorSession(opts.ServerURL, opts.WorkspaceID)
+	if err == nil && sess != nil {
+		return sess, nil
+	}
+	sess, err = registerExecutorWithRegistry(opts.ServerURL, opts.Name, opts.WorkspaceID)
+	if err != nil {
+		return nil, err
+	}
+	if err := saveExecutorSession(sess); err != nil {
+		// Non-fatal: we can still run, just won't persist across restarts.
+		fmt.Fprintf(os.Stderr, "warning: failed to save executor session: %v\n", err)
+	}
+	return sess, nil
+}

--- a/internal/agent/executor_session.go
+++ b/internal/agent/executor_session.go
@@ -76,6 +76,20 @@ func loadLatestExecutorSession(serverURL, workspaceID string) (*ExecutorSession,
 	return sessions[0], nil
 }
 
+// removeExecutorSession deletes the persisted session file for the given
+// executor ID. Missing files are not considered an error.
+func removeExecutorSession(executorID string) error {
+	dir, err := executorSessionsDir()
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(dir, executorID+".json")
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
 // saveExecutorSession writes the session JSON to disk.
 func saveExecutorSession(sess *ExecutorSession) error {
 	dir, err := executorSessionsDir()
@@ -137,13 +151,18 @@ func registerExecutorWithRegistry(serverURL, name, workspaceID string) (*Executo
 
 // LoadOrRegisterExecutor reuses a saved session for the given serverURL +
 // workspaceID if one exists, otherwise registers a new executor with the
-// registry and persists the result.
+// registry and persists the result. Read errors other than "sessions dir
+// doesn't exist" are surfaced to the caller rather than silently triggering
+// a re-registration.
 func LoadOrRegisterExecutor(opts ExecutorOpts) (*ExecutorSession, error) {
 	if opts.WorkspaceID == "" {
 		return nil, fmt.Errorf("workspace_id is required")
 	}
 	sess, err := loadLatestExecutorSession(opts.ServerURL, opts.WorkspaceID)
-	if err == nil && sess != nil {
+	if err != nil {
+		return nil, fmt.Errorf("load saved session: %w", err)
+	}
+	if sess != nil {
 		return sess, nil
 	}
 	sess, err = registerExecutorWithRegistry(opts.ServerURL, opts.Name, opts.WorkspaceID)

--- a/internal/agent/executortools/bash.go
+++ b/internal/agent/executortools/bash.go
@@ -1,0 +1,38 @@
+package executortools
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os/exec"
+)
+
+func (e *ToolExecutor) bash(ctx context.Context, rawArgs json.RawMessage) ExecuteResponse {
+	var args struct {
+		Command     string `json:"command"`
+		Timeout     int    `json:"timeout,omitempty"`
+		Description string `json:"description,omitempty"`
+	}
+	if err := json.Unmarshal(rawArgs, &args); err != nil {
+		return errResponse("invalid arguments: " + err.Error())
+	}
+	if args.Command == "" {
+		return errResponse("command is required")
+	}
+
+	cmd := exec.CommandContext(ctx, "bash", "-lc", args.Command)
+	cmd.Dir = e.WorkDir
+	out, err := cmd.CombinedOutput()
+
+	exitCode := 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			exitCode = 1
+			out = append(out, []byte("\n"+err.Error())...)
+		}
+	}
+	return ExecuteResponse{Output: string(out), ExitCode: exitCode}
+}

--- a/internal/agent/executortools/edit.go
+++ b/internal/agent/executortools/edit.go
@@ -3,9 +3,49 @@ package executortools
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
 )
 
-// edit is filled in by Task 4.
 func (e *ToolExecutor) edit(ctx context.Context, rawArgs json.RawMessage) ExecuteResponse {
-	return errResponse("Edit: not yet implemented")
+	var args struct {
+		FilePath   string `json:"file_path"`
+		OldString  string `json:"old_string"`
+		NewString  string `json:"new_string"`
+		ReplaceAll bool   `json:"replace_all,omitempty"`
+	}
+	if err := json.Unmarshal(rawArgs, &args); err != nil {
+		return errResponse("invalid arguments: " + err.Error())
+	}
+	if args.FilePath == "" || args.OldString == "" {
+		return errResponse("file_path and old_string are required")
+	}
+
+	p := resolvePath(e.WorkDir, args.FilePath)
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return errResponse("read failed: " + err.Error())
+	}
+	content := string(data)
+
+	count := strings.Count(content, args.OldString)
+	if count == 0 {
+		return errResponse("old_string not found in file")
+	}
+	if count > 1 && !args.ReplaceAll {
+		return errResponse(fmt.Sprintf("old_string appears %d times; set replace_all=true or provide more context", count))
+	}
+
+	var newContent string
+	if args.ReplaceAll {
+		newContent = strings.ReplaceAll(content, args.OldString, args.NewString)
+	} else {
+		newContent = strings.Replace(content, args.OldString, args.NewString, 1)
+	}
+
+	if err := os.WriteFile(p, []byte(newContent), 0644); err != nil {
+		return errResponse("write failed: " + err.Error())
+	}
+	return okResponse(fmt.Sprintf("edited %s (%d replacement(s))", args.FilePath, count))
 }

--- a/internal/agent/executortools/edit.go
+++ b/internal/agent/executortools/edit.go
@@ -1,0 +1,11 @@
+package executortools
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// edit is filled in by Task 4.
+func (e *ToolExecutor) edit(ctx context.Context, rawArgs json.RawMessage) ExecuteResponse {
+	return errResponse("Edit: not yet implemented")
+}

--- a/internal/agent/executortools/glob.go
+++ b/internal/agent/executortools/glob.go
@@ -3,9 +3,84 @@ package executortools
 import (
 	"context"
 	"encoding/json"
+	"io/fs"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
 )
 
-// glob is filled in by Task 4.
 func (e *ToolExecutor) glob(ctx context.Context, rawArgs json.RawMessage) ExecuteResponse {
-	return errResponse("Glob: not yet implemented")
+	var args struct {
+		Pattern string `json:"pattern"`
+		Path    string `json:"path,omitempty"`
+	}
+	if err := json.Unmarshal(rawArgs, &args); err != nil {
+		return errResponse("invalid arguments: " + err.Error())
+	}
+	if args.Pattern == "" {
+		return errResponse("pattern is required")
+	}
+
+	root := e.WorkDir
+	if args.Path != "" {
+		root = resolvePath(e.WorkDir, args.Path)
+	}
+
+	re, err := globToRegexp(args.Pattern)
+	if err != nil {
+		return errResponse("invalid pattern: " + err.Error())
+	}
+
+	var matches []string
+	err = filepath.WalkDir(root, func(p string, d fs.DirEntry, werr error) error {
+		if werr != nil {
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(root, p)
+		if relErr != nil {
+			return nil
+		}
+		if re.MatchString(rel) {
+			matches = append(matches, rel)
+		}
+		return nil
+	})
+	if err != nil {
+		return errResponse("glob failed: " + err.Error())
+	}
+
+	sort.Strings(matches)
+	return okResponse(strings.Join(matches, "\n"))
+}
+
+// globToRegexp translates a glob with ** (recursive) and * (single-segment)
+// wildcards into an anchored regular expression.
+func globToRegexp(pattern string) (*regexp.Regexp, error) {
+	var sb strings.Builder
+	sb.WriteString("^")
+	for i := 0; i < len(pattern); i++ {
+		c := pattern[i]
+		switch c {
+		case '*':
+			if i+1 < len(pattern) && pattern[i+1] == '*' {
+				sb.WriteString(".*")
+				i++
+			} else {
+				sb.WriteString("[^/]*")
+			}
+		case '?':
+			sb.WriteString("[^/]")
+		case '.', '+', '(', ')', '|', '^', '$', '{', '}', '[', ']', '\\':
+			sb.WriteByte('\\')
+			sb.WriteByte(c)
+		default:
+			sb.WriteByte(c)
+		}
+	}
+	sb.WriteString("$")
+	return regexp.Compile(sb.String())
 }

--- a/internal/agent/executortools/glob.go
+++ b/internal/agent/executortools/glob.go
@@ -1,0 +1,11 @@
+package executortools
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// glob is filled in by Task 4.
+func (e *ToolExecutor) glob(ctx context.Context, rawArgs json.RawMessage) ExecuteResponse {
+	return errResponse("Glob: not yet implemented")
+}

--- a/internal/agent/executortools/grep.go
+++ b/internal/agent/executortools/grep.go
@@ -1,11 +1,109 @@
 package executortools
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
 )
 
-// grep is filled in by Task 4.
 func (e *ToolExecutor) grep(ctx context.Context, rawArgs json.RawMessage) ExecuteResponse {
-	return errResponse("Grep: not yet implemented")
+	var args struct {
+		Pattern string `json:"pattern"`
+		Path    string `json:"path,omitempty"`
+		Glob    string `json:"glob,omitempty"`
+	}
+	if err := json.Unmarshal(rawArgs, &args); err != nil {
+		return errResponse("invalid arguments: " + err.Error())
+	}
+	if args.Pattern == "" {
+		return errResponse("pattern is required")
+	}
+
+	searchPath := e.WorkDir
+	if args.Path != "" {
+		searchPath = resolvePath(e.WorkDir, args.Path)
+	}
+
+	if _, err := exec.LookPath("rg"); err == nil {
+		return rgGrep(ctx, args.Pattern, args.Glob, searchPath)
+	}
+	return goGrep(args.Pattern, args.Glob, searchPath)
+}
+
+func rgGrep(ctx context.Context, pattern, glob, searchPath string) ExecuteResponse {
+	cmdArgs := []string{"-n", "--no-heading"}
+	if glob != "" {
+		cmdArgs = append(cmdArgs, "-g", glob)
+	}
+	cmdArgs = append(cmdArgs, pattern, searchPath)
+
+	cmd := exec.CommandContext(ctx, "rg", cmdArgs...)
+	out, err := cmd.CombinedOutput()
+
+	exitCode := 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			return errResponse("grep failed: " + err.Error())
+		}
+	}
+	// rg exit 1 means "no matches" — not an error for our callers.
+	if exitCode == 1 {
+		exitCode = 0
+	}
+	return ExecuteResponse{Output: string(out), ExitCode: exitCode}
+}
+
+func goGrep(pattern, glob, searchPath string) ExecuteResponse {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return errResponse("invalid pattern: " + err.Error())
+	}
+
+	var globRE *regexp.Regexp
+	if glob != "" {
+		globRE, err = globToRegexp(glob)
+		if err != nil {
+			return errResponse("invalid glob: " + err.Error())
+		}
+	}
+
+	var results []string
+	_ = filepath.WalkDir(searchPath, func(p string, d fs.DirEntry, werr error) error {
+		if werr != nil || d.IsDir() {
+			return nil
+		}
+		if globRE != nil && !globRE.MatchString(filepath.Base(p)) {
+			return nil
+		}
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return nil
+		}
+		// Skip likely-binary files — heuristic: a NUL byte in the first 8KB.
+		head := data
+		if len(head) > 8192 {
+			head = head[:8192]
+		}
+		if bytes.IndexByte(head, 0) >= 0 {
+			return nil
+		}
+		for i, line := range strings.Split(string(data), "\n") {
+			if re.MatchString(line) {
+				results = append(results, fmt.Sprintf("%s:%d:%s", p, i+1, line))
+			}
+		}
+		return nil
+	})
+	return okResponse(strings.Join(results, "\n"))
 }

--- a/internal/agent/executortools/grep.go
+++ b/internal/agent/executortools/grep.go
@@ -1,0 +1,11 @@
+package executortools
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// grep is filled in by Task 4.
+func (e *ToolExecutor) grep(ctx context.Context, rawArgs json.RawMessage) ExecuteResponse {
+	return errResponse("Grep: not yet implemented")
+}

--- a/internal/agent/executortools/grep.go
+++ b/internal/agent/executortools/grep.go
@@ -65,6 +65,9 @@ func rgGrep(ctx context.Context, pattern, glob, searchPath string) ExecuteRespon
 }
 
 func goGrep(pattern, glob, searchPath string) ExecuteResponse {
+	if _, err := os.Stat(searchPath); err != nil {
+		return errResponse("grep: " + err.Error())
+	}
 	re, err := regexp.Compile(pattern)
 	if err != nil {
 		return errResponse("invalid pattern: " + err.Error())

--- a/internal/agent/executortools/ls.go
+++ b/internal/agent/executortools/ls.go
@@ -1,0 +1,37 @@
+package executortools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+)
+
+func (e *ToolExecutor) ls(ctx context.Context, rawArgs json.RawMessage) ExecuteResponse {
+	var args struct {
+		Path string `json:"path,omitempty"`
+	}
+	if len(rawArgs) > 0 {
+		if err := json.Unmarshal(rawArgs, &args); err != nil {
+			return errResponse("invalid arguments: " + err.Error())
+		}
+	}
+	p := e.WorkDir
+	if args.Path != "" {
+		p = resolvePath(e.WorkDir, args.Path)
+	}
+
+	entries, err := os.ReadDir(p)
+	if err != nil {
+		return errResponse("ls failed: " + err.Error())
+	}
+	lines := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() {
+			name += "/"
+		}
+		lines = append(lines, name)
+	}
+	return okResponse(strings.Join(lines, "\n"))
+}

--- a/internal/agent/executortools/paths.go
+++ b/internal/agent/executortools/paths.go
@@ -1,0 +1,11 @@
+package executortools
+
+import "path/filepath"
+
+// resolvePath joins path against workDir if path is relative.
+func resolvePath(workDir, path string) string {
+	if filepath.IsAbs(path) {
+		return path
+	}
+	return filepath.Join(workDir, path)
+}

--- a/internal/agent/executortools/read.go
+++ b/internal/agent/executortools/read.go
@@ -1,0 +1,45 @@
+package executortools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"strings"
+)
+
+func (e *ToolExecutor) read(ctx context.Context, rawArgs json.RawMessage) ExecuteResponse {
+	var args struct {
+		FilePath string `json:"file_path"`
+		Offset   int    `json:"offset,omitempty"`
+		Limit    int    `json:"limit,omitempty"`
+	}
+	if err := json.Unmarshal(rawArgs, &args); err != nil {
+		return errResponse("invalid arguments: " + err.Error())
+	}
+	if args.FilePath == "" {
+		return errResponse("file_path is required")
+	}
+
+	data, err := os.ReadFile(resolvePath(e.WorkDir, args.FilePath))
+	if err != nil {
+		return errResponse("read failed: " + err.Error())
+	}
+
+	if args.Offset <= 0 && args.Limit <= 0 {
+		return okResponse(string(data))
+	}
+
+	lines := strings.Split(string(data), "\n")
+	start := args.Offset
+	if start < 0 {
+		start = 0
+	}
+	if start > len(lines) {
+		start = len(lines)
+	}
+	end := len(lines)
+	if args.Limit > 0 && start+args.Limit < end {
+		end = start + args.Limit
+	}
+	return okResponse(strings.Join(lines[start:end], "\n"))
+}

--- a/internal/agent/executortools/tools.go
+++ b/internal/agent/executortools/tools.go
@@ -1,0 +1,72 @@
+// Package executortools implements the tool set served by the local
+// executor over the executor-registry tunnel. Each tool is a pure Go
+// function receiving JSON arguments and returning an ExecuteResponse.
+package executortools
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+// ExecuteRequest mirrors the wire format that executor-registry forwards
+// over the yamux stream (body of POST /tool/execute).
+type ExecuteRequest struct {
+	ExecutorID string          `json:"executor_id"`
+	Tool       string          `json:"tool"`
+	Arguments  json.RawMessage `json:"arguments"`
+	TimeoutMs  int             `json:"timeout_ms,omitempty"`
+}
+
+// ExecuteResponse is the single unified response shape returned for every
+// tool call. Output is free-form text; ExitCode is 0 on success.
+type ExecuteResponse struct {
+	Output   string `json:"output"`
+	ExitCode int    `json:"exit_code"`
+}
+
+// ToolExecutor dispatches tool calls to per-tool handlers rooted at WorkDir.
+type ToolExecutor struct {
+	WorkDir string
+}
+
+// New returns a new ToolExecutor rooted at workDir.
+func New(workDir string) *ToolExecutor {
+	return &ToolExecutor{WorkDir: workDir}
+}
+
+// Execute dispatches to the per-tool handler. Unknown tools return exit 1.
+func (e *ToolExecutor) Execute(ctx context.Context, req ExecuteRequest) ExecuteResponse {
+	if req.TimeoutMs > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(req.TimeoutMs)*time.Millisecond)
+		defer cancel()
+	}
+
+	switch req.Tool {
+	case "Bash":
+		return e.bash(ctx, req.Arguments)
+	case "Read":
+		return e.read(ctx, req.Arguments)
+	case "Write":
+		return e.write(ctx, req.Arguments)
+	case "LS":
+		return e.ls(ctx, req.Arguments)
+	case "Edit":
+		return e.edit(ctx, req.Arguments)
+	case "Glob":
+		return e.glob(ctx, req.Arguments)
+	case "Grep":
+		return e.grep(ctx, req.Arguments)
+	default:
+		return errResponse("unknown tool: " + req.Tool)
+	}
+}
+
+func errResponse(msg string) ExecuteResponse {
+	return ExecuteResponse{Output: msg, ExitCode: 1}
+}
+
+func okResponse(output string) ExecuteResponse {
+	return ExecuteResponse{Output: output, ExitCode: 0}
+}

--- a/internal/agent/executortools/tools_test.go
+++ b/internal/agent/executortools/tools_test.go
@@ -1,0 +1,180 @@
+package executortools
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func run(t *testing.T, e *ToolExecutor, tool, argsJSON string) ExecuteResponse {
+	t.Helper()
+	return e.Execute(context.Background(), ExecuteRequest{
+		Tool:      tool,
+		Arguments: json.RawMessage(argsJSON),
+	})
+}
+
+func TestBash(t *testing.T) {
+	dir := t.TempDir()
+	e := New(dir)
+	resp := run(t, e, "Bash", `{"command":"echo hello"}`)
+	if resp.ExitCode != 0 {
+		t.Fatalf("expected exit 0, got %d; output=%s", resp.ExitCode, resp.Output)
+	}
+	if !strings.Contains(resp.Output, "hello") {
+		t.Fatalf("expected 'hello' in output, got %q", resp.Output)
+	}
+}
+
+func TestBashNonzeroExit(t *testing.T) {
+	e := New(t.TempDir())
+	resp := run(t, e, "Bash", `{"command":"exit 3"}`)
+	if resp.ExitCode != 3 {
+		t.Fatalf("expected exit 3, got %d", resp.ExitCode)
+	}
+}
+
+func TestWriteReadLS(t *testing.T) {
+	dir := t.TempDir()
+	e := New(dir)
+
+	if resp := run(t, e, "Write", `{"file_path":"test.txt","content":"hello world"}`); resp.ExitCode != 0 {
+		t.Fatalf("write failed: %s", resp.Output)
+	}
+
+	resp := run(t, e, "Read", `{"file_path":"test.txt"}`)
+	if resp.ExitCode != 0 {
+		t.Fatalf("read failed: %s", resp.Output)
+	}
+	if resp.Output != "hello world" {
+		t.Fatalf("read mismatch: got %q", resp.Output)
+	}
+
+	resp = run(t, e, "LS", `{}`)
+	if resp.ExitCode != 0 {
+		t.Fatalf("ls failed: %s", resp.Output)
+	}
+	if !strings.Contains(resp.Output, "test.txt") {
+		t.Fatalf("ls missing test.txt: %s", resp.Output)
+	}
+}
+
+func TestReadOffsetLimit(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "lines.txt"), []byte("a\nb\nc\nd\ne"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	e := New(dir)
+	resp := run(t, e, "Read", `{"file_path":"lines.txt","offset":1,"limit":2}`)
+	if resp.ExitCode != 0 {
+		t.Fatalf("read failed: %s", resp.Output)
+	}
+	if resp.Output != "b\nc" {
+		t.Fatalf("expected 'b\\nc', got %q", resp.Output)
+	}
+}
+
+func TestEdit(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(file, []byte("foo bar baz"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	e := New(dir)
+
+	if resp := run(t, e, "Edit", `{"file_path":"f.txt","old_string":"bar","new_string":"qux"}`); resp.ExitCode != 0 {
+		t.Fatalf("edit failed: %s", resp.Output)
+	}
+	data, _ := os.ReadFile(file)
+	if string(data) != "foo qux baz" {
+		t.Fatalf("edit result: got %q", data)
+	}
+}
+
+func TestEditMissingString(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "f.txt"), []byte("abc"), 0644)
+	e := New(dir)
+	resp := run(t, e, "Edit", `{"file_path":"f.txt","old_string":"xyz","new_string":"q"}`)
+	if resp.ExitCode == 0 {
+		t.Fatalf("expected failure when old_string missing, got success: %s", resp.Output)
+	}
+}
+
+func TestEditNonUniqueRequiresReplaceAll(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "f.txt"), []byte("x x x"), 0644)
+	e := New(dir)
+
+	resp := run(t, e, "Edit", `{"file_path":"f.txt","old_string":"x","new_string":"y"}`)
+	if resp.ExitCode == 0 {
+		t.Fatalf("expected failure on non-unique match without replace_all")
+	}
+
+	resp = run(t, e, "Edit", `{"file_path":"f.txt","old_string":"x","new_string":"y","replace_all":true}`)
+	if resp.ExitCode != 0 {
+		t.Fatalf("replace_all failed: %s", resp.Output)
+	}
+	data, _ := os.ReadFile(filepath.Join(dir, "f.txt"))
+	if string(data) != "y y y" {
+		t.Fatalf("replace_all result: got %q", data)
+	}
+}
+
+func TestGlob(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "a.go"), []byte("package main"), 0644)
+	os.WriteFile(filepath.Join(dir, "b.go"), []byte("package main"), 0644)
+	os.WriteFile(filepath.Join(dir, "c.txt"), []byte("not go"), 0644)
+	os.MkdirAll(filepath.Join(dir, "sub"), 0755)
+	os.WriteFile(filepath.Join(dir, "sub", "d.go"), []byte("package sub"), 0644)
+	e := New(dir)
+
+	resp := run(t, e, "Glob", `{"pattern":"*.go"}`)
+	if resp.ExitCode != 0 {
+		t.Fatalf("glob failed: %s", resp.Output)
+	}
+	if !strings.Contains(resp.Output, "a.go") || !strings.Contains(resp.Output, "b.go") {
+		t.Fatalf("glob missing top-level go files: %s", resp.Output)
+	}
+	if strings.Contains(resp.Output, "c.txt") {
+		t.Fatalf("glob matched txt: %s", resp.Output)
+	}
+
+	resp = run(t, e, "Glob", `{"pattern":"**/*.go"}`)
+	if resp.ExitCode != 0 {
+		t.Fatalf("recursive glob failed: %s", resp.Output)
+	}
+	if !strings.Contains(resp.Output, "sub/d.go") {
+		t.Fatalf("recursive glob missed sub/d.go: %s", resp.Output)
+	}
+}
+
+func TestGrep(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "a.go"), []byte("package main\nfunc hello() {}\n"), 0644)
+	os.WriteFile(filepath.Join(dir, "b.go"), []byte("package main\nfunc world() {}\n"), 0644)
+	e := New(dir)
+
+	resp := run(t, e, "Grep", `{"pattern":"hello"}`)
+	if resp.ExitCode != 0 {
+		t.Fatalf("grep failed: %s", resp.Output)
+	}
+	if !strings.Contains(resp.Output, "hello") || !strings.Contains(resp.Output, "a.go") {
+		t.Fatalf("grep missed a.go/hello: %s", resp.Output)
+	}
+}
+
+func TestUnknownTool(t *testing.T) {
+	e := New(t.TempDir())
+	resp := run(t, e, "Banana", `{}`)
+	if resp.ExitCode == 0 {
+		t.Fatalf("expected error for unknown tool, got %s", resp.Output)
+	}
+	if !strings.Contains(resp.Output, "unknown tool") {
+		t.Fatalf("unexpected error: %s", resp.Output)
+	}
+}

--- a/internal/agent/executortools/tools_test.go
+++ b/internal/agent/executortools/tools_test.go
@@ -178,3 +178,11 @@ func TestUnknownTool(t *testing.T) {
 		t.Fatalf("unexpected error: %s", resp.Output)
 	}
 }
+
+func TestGrepMissingPath(t *testing.T) {
+	e := New(t.TempDir())
+	resp := run(t, e, "Grep", `{"pattern":"x","path":"does-not-exist"}`)
+	if resp.ExitCode == 0 {
+		t.Fatalf("expected error when grepping missing path, got success: %s", resp.Output)
+	}
+}

--- a/internal/agent/executortools/write.go
+++ b/internal/agent/executortools/write.go
@@ -1,0 +1,31 @@
+package executortools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+func (e *ToolExecutor) write(ctx context.Context, rawArgs json.RawMessage) ExecuteResponse {
+	var args struct {
+		FilePath string `json:"file_path"`
+		Content  string `json:"content"`
+	}
+	if err := json.Unmarshal(rawArgs, &args); err != nil {
+		return errResponse("invalid arguments: " + err.Error())
+	}
+	if args.FilePath == "" {
+		return errResponse("file_path is required")
+	}
+
+	p := resolvePath(e.WorkDir, args.FilePath)
+	if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
+		return errResponse("mkdir failed: " + err.Error())
+	}
+	if err := os.WriteFile(p, []byte(args.Content), 0644); err != nil {
+		return errResponse("write failed: " + err.Error())
+	}
+	return okResponse(fmt.Sprintf("wrote %d bytes to %s", len(args.Content), args.FilePath))
+}


### PR DESCRIPTION
## Summary

Phase 6 of the Stateless CC rollout: adds `agentserver-agent executor`, a new subcommand that registers the local machine with executor-registry and serves `remote_*` tool calls from cc-broker workers over a yamux tunnel.

End-to-end: WeChat → imbridge → agentserver → cc-broker worker → MCP `remote_bash` → executor-registry `/api/execute` → yamux stream → **this subcommand** → local `bash -lc`/`os` call → response back through the same path.

- **Subcommand skeleton** (`cmd/agentserver-agent/main.go`, `internal/agent/executor_cmd.go`): flags are `--registry`, `--workspace-id`, `--name`, `--work-dir`. Registration is unauthenticated, matching executor-registry's current posture.
- **Session persistence** (`internal/agent/executor_session.go`): stores credentials at `~/.agentserver/executors/{executor_id}.json`. On 401/404 from tunnel or heartbeat the file is wiped and the executor re-registers automatically.
- **Tunnel + heartbeat** (`internal/agent/executor_client.go`): reuses `tunnel.NewWSConn` + `tunnel.ClientMux`, dedicated 10s heartbeat client, reconnect backoff up to 60s, per-stream read/write deadlines (60s/30s), 16 MiB request-body cap, panic recovery per stream.
- **Tool executor** (`internal/agent/executortools/`): Bash, Read, Write, LS, Edit, Glob, Grep with unit tests. Grep prefers `rg` and falls back to a Go-native walker; missing search paths now return a clear error rather than silent "no matches".

Included review fixes (last commit) address stale-session loops, unbounded heartbeat/request timeouts, stream DoS vectors, and a few silent-failure paths. Remaining minor items (rg/goGrep regex-flavor disclosure, `bash -lc` Setpgid, Read offset/limit edge cases) are documented in the review and left for a follow-up.

## Test Plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `go test ./...` — all packages pass, including new `internal/agent/executortools` suite (Bash, Read+offset/limit, Write+LS, Edit+replace_all, Glob `**`, Grep+missing-path, unknown-tool dispatch)
- [ ] Manual: run `./agentserver-agent executor --registry http://localhost:8084 --workspace-id ws_test`, `curl POST /api/execute` with `{"tool":"Bash","arguments":{"command":"pwd"}}`, confirm output
- [ ] Manual: exercise stale-session path by deleting the registry row and confirming the agent re-registers

🤖 Generated with [Claude Code](https://claude.com/claude-code)