### PR TITLE
fix(im): extract assistant text from CC SDK message shape

### DIFF
--- a/internal/server/im_inbound.go
+++ b/internal/server/im_inbound.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -110,39 +109,7 @@ func (s *Server) processWithCCBroker(ctx context.Context, session *db.AgentSessi
 
 	// Read SSE stream from cc-broker — events are persisted by cc-broker itself.
 	// We just need to wait for completion and extract the final text response.
-	var finalResponse string
-	scanner := bufio.NewScanner(resp.Body)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if !strings.HasPrefix(line, "data: ") {
-			continue
-		}
-		data := strings.TrimPrefix(line, "data: ")
-
-		var event map[string]interface{}
-		if err := json.Unmarshal([]byte(data), &event); err != nil {
-			continue
-		}
-
-		// Check for done event
-		if eventType, _ := event["event_type"].(string); eventType == "done" {
-			break
-		}
-
-		// Extract text from assistant messages for IM reply.
-		// CC events have nested payload; look for text content.
-		if payload, ok := event["payload"]; ok {
-			payloadMap, _ := payload.(map[string]interface{})
-			if payloadMap != nil {
-				// Look for assistant message with text content
-				if msgType, _ := payloadMap["type"].(string); msgType == "assistant" {
-					if content, ok := payloadMap["content"].(string); ok {
-						finalResponse = content
-					}
-				}
-			}
-		}
-	}
+	finalResponse := extractFinalText(resp.Body)
 
 	// Reply to IM via imbridge.
 	if finalResponse == "" {

--- a/internal/server/im_inbound_parse.go
+++ b/internal/server/im_inbound_parse.go
@@ -1,0 +1,144 @@
+package server
+
+import (
+	"bufio"
+	"encoding/json"
+	"io"
+	"strings"
+)
+
+// extractFinalText consumes the cc-broker SSE stream (one event per
+// `data: ...\n\n`) and returns the final assistant text for the turn.
+//
+// The cc-broker streams bridge events verbatim. Each event has the shape:
+//
+//	{
+//	  "event_type": "assistant" | "user" | "result" | "system" | "done",
+//	  "payload": { "type": "assistant", "message": { "content": [...] }, ... },
+//	  ...
+//	}
+//
+// For assistant messages the content is an array of blocks of the form
+// `{"type": "text", "text": "..."}` or `{"type": "tool_use", ...}`; we only
+// keep the text blocks. For the terminal `result` event the final answer is
+// under the top-level `result` key (CC's synthesized reply string) and is
+// preferred when present.
+//
+// Returns an empty string if the stream contains no assistant/result text.
+func extractFinalText(body io.Reader) string {
+	// bufio.Scanner's default 64 KiB line limit is too small — a single
+	// assistant message with tool output can easily exceed it.
+	reader := bufio.NewReaderSize(body, 1<<20)
+
+	var lastAssistantText string
+	var resultText string
+
+	for {
+		line, err := reader.ReadString('\n')
+		if len(line) > 0 {
+			line = strings.TrimRight(line, "\r\n")
+			if data, ok := strings.CutPrefix(line, "data: "); ok {
+				if t, stop := parseSSEEvent(data); stop {
+					break
+				} else if t.resultText != "" {
+					resultText = t.resultText
+				} else if t.assistantText != "" {
+					lastAssistantText = t.assistantText
+				}
+			}
+		}
+		if err != nil {
+			break
+		}
+	}
+
+	if resultText != "" {
+		return resultText
+	}
+	return lastAssistantText
+}
+
+type sseEventText struct {
+	assistantText string
+	resultText    string
+}
+
+// parseSSEEvent extracts text from a single SSE `data:` payload.
+// Returns stop=true when the terminating `done` event is seen.
+func parseSSEEvent(data string) (text sseEventText, stop bool) {
+	var env struct {
+		EventType string          `json:"event_type"`
+		Payload   json.RawMessage `json:"payload"`
+	}
+	if err := json.Unmarshal([]byte(data), &env); err != nil {
+		return sseEventText{}, false
+	}
+	if env.EventType == "done" {
+		return sseEventText{}, true
+	}
+	if len(env.Payload) == 0 {
+		return sseEventText{}, false
+	}
+
+	// CC SDK payload envelope: `{"type": "assistant"|"user"|"result"|..., ...}`
+	var payloadHead struct {
+		Type    string          `json:"type"`
+		Message json.RawMessage `json:"message"`
+		Result  string          `json:"result"`
+	}
+	if err := json.Unmarshal(env.Payload, &payloadHead); err != nil {
+		return sseEventText{}, false
+	}
+
+	switch payloadHead.Type {
+	case "assistant":
+		return sseEventText{assistantText: extractAssistantText(payloadHead.Message)}, false
+	case "result":
+		// CC's synthesized final result — preferred when non-empty.
+		return sseEventText{resultText: payloadHead.Result}, false
+	}
+	return sseEventText{}, false
+}
+
+// extractAssistantText pulls the concatenated text from the content blocks
+// of a CC SDK assistant `message`. Tool-use and other non-text blocks are
+// ignored.
+func extractAssistantText(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var msg struct {
+		Content json.RawMessage `json:"content"`
+	}
+	if err := json.Unmarshal(raw, &msg); err != nil {
+		return ""
+	}
+	if len(msg.Content) == 0 {
+		return ""
+	}
+
+	// content may be either a string (rare) or an array of blocks.
+	if len(msg.Content) > 0 && msg.Content[0] == '"' {
+		var s string
+		if err := json.Unmarshal(msg.Content, &s); err == nil {
+			return s
+		}
+		return ""
+	}
+
+	var blocks []struct {
+		Type string `json:"type"`
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(msg.Content, &blocks); err != nil {
+		return ""
+	}
+
+	var sb strings.Builder
+	for _, b := range blocks {
+		if b.Type == "text" {
+			sb.WriteString(b.Text)
+		}
+	}
+	return sb.String()
+}

--- a/internal/server/im_inbound_parse_test.go
+++ b/internal/server/im_inbound_parse_test.go
@@ -1,0 +1,96 @@
+package server
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtractFinalText_AssistantBlocks(t *testing.T) {
+	stream := strings.Join([]string{
+		`data: {"event_type":"system","payload":{"type":"system","subtype":"init"}}`,
+		`data: {"event_type":"assistant","payload":{"type":"assistant","message":{"content":[{"type":"text","text":"hello "}]}}}`,
+		`data: {"event_type":"assistant","payload":{"type":"assistant","message":{"content":[{"type":"tool_use","name":"remote_bash"},{"type":"text","text":"world"}]}}}`,
+		`data: {"event_type":"done"}`,
+		``,
+	}, "\n\n")
+
+	got := extractFinalText(strings.NewReader(stream))
+	if got != "world" {
+		t.Fatalf("expected 'world', got %q", got)
+	}
+}
+
+func TestExtractFinalText_ResultPreferredOverAssistant(t *testing.T) {
+	stream := strings.Join([]string{
+		`data: {"event_type":"assistant","payload":{"type":"assistant","message":{"content":[{"type":"text","text":"intermediate"}]}}}`,
+		`data: {"event_type":"result","payload":{"type":"result","subtype":"success","result":"final synthesized answer"}}`,
+		`data: {"event_type":"done"}`,
+		``,
+	}, "\n\n")
+
+	got := extractFinalText(strings.NewReader(stream))
+	if got != "final synthesized answer" {
+		t.Fatalf("expected result to win, got %q", got)
+	}
+}
+
+func TestExtractFinalText_MultipleTextBlocks(t *testing.T) {
+	stream := `data: {"event_type":"assistant","payload":{"type":"assistant","message":{"content":[{"type":"text","text":"a"},{"type":"text","text":"b"},{"type":"text","text":"c"}]}}}` + "\n\n" +
+		`data: {"event_type":"done"}` + "\n\n"
+
+	got := extractFinalText(strings.NewReader(stream))
+	if got != "abc" {
+		t.Fatalf("expected concat 'abc', got %q", got)
+	}
+}
+
+func TestExtractFinalText_EmptyStream(t *testing.T) {
+	got := extractFinalText(strings.NewReader(""))
+	if got != "" {
+		t.Fatalf("expected empty, got %q", got)
+	}
+}
+
+func TestExtractFinalText_NoAssistantMessage(t *testing.T) {
+	stream := `data: {"event_type":"system","payload":{"type":"system"}}` + "\n\n" +
+		`data: {"event_type":"done"}` + "\n\n"
+	got := extractFinalText(strings.NewReader(stream))
+	if got != "" {
+		t.Fatalf("expected empty for no assistant, got %q", got)
+	}
+}
+
+func TestExtractFinalText_IgnoresMalformedLines(t *testing.T) {
+	stream := strings.Join([]string{
+		`: keepalive`,
+		`data: {not json}`,
+		`data: {"event_type":"assistant","payload":{"type":"assistant","message":{"content":[{"type":"text","text":"ok"}]}}}`,
+		`data: {"event_type":"done"}`,
+		``,
+	}, "\n\n")
+	got := extractFinalText(strings.NewReader(stream))
+	if got != "ok" {
+		t.Fatalf("expected 'ok', got %q", got)
+	}
+}
+
+func TestExtractFinalText_LargeSingleEvent(t *testing.T) {
+	// bufio.Scanner's default 64 KiB cap would truncate this; we use ReadString.
+	big := strings.Repeat("x", 256*1024)
+	stream := `data: {"event_type":"assistant","payload":{"type":"assistant","message":{"content":[{"type":"text","text":"` + big + `"}]}}}` + "\n\n" +
+		`data: {"event_type":"done"}` + "\n\n"
+	got := extractFinalText(strings.NewReader(stream))
+	if got != big {
+		t.Fatalf("expected %d-byte payload, got %d bytes", len(big), len(got))
+	}
+}
+
+func TestExtractFinalText_StringContent(t *testing.T) {
+	// Some SDK variants emit content as a plain string. Handle it gracefully.
+	stream := `data: {"event_type":"assistant","payload":{"type":"assistant","message":{"content":"plain"}}}` + "\n\n" +
+		`data: {"event_type":"done"}` + "\n\n"
+	got := extractFinalText(strings.NewReader(stream))
+	if got != "plain" {
+		t.Fatalf("expected 'plain', got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

The Phase 5 IM reply path never delivered replies because the extractor in \`processWithCCBroker\` looked for \`payload.content\` as a plain string, but CC's assistant events put text blocks at \`payload.message.content[].text\`. As a result \`finalResponse\` stayed empty and the \`sendIMReply\` call was skipped — every WeChat multi-turn reply was silently dropped.

This fix rewrites the extraction to match CC's actual SDK message shape and adds unit tests so the format can't drift unnoticed.

## Changes

- \`internal/server/im_inbound_parse.go\`: new \`extractFinalText\` reader-based parser (replaces \`bufio.Scanner\` which caps lines at 64 KiB and would silently truncate large assistant messages). Handles text-block arrays, string-form content, and prefers the terminal \`result\` event's synthesized answer when present.
- \`internal/server/im_inbound.go\`: swap inline extraction for the helper; drop now-unused \`bufio\` import.
- \`internal/server/im_inbound_parse_test.go\`: 8 cases covering blocks, tool_use interleaving, result preference, string content, malformed lines, 256 KiB single events, empty stream, no-assistant stream.

## Test Plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/server/...\` — all pass
- [ ] Manual: send a WeChat message to a \`routing_mode=stateless_cc\` channel and confirm the assistant reply arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)