### PR TITLE
feat(ccbroker): wire send_message / send_image MCP tools to imbridge

### DIFF
--- a/internal/ccbroker/config.go
+++ b/internal/ccbroker/config.go
@@ -16,6 +16,8 @@ type Config struct {
 	AgentserverURL      string
 	OpenVikingURL       string
 	OpenVikingAPIKey    string
+	IMBridgeURL         string
+	IMBridgeSecret      string
 }
 
 func LoadConfigFromEnv() (Config, error) {
@@ -36,6 +38,8 @@ func LoadConfigFromEnv() (Config, error) {
 	cfg.AgentserverURL = envOr("CCBROKER_AGENTSERVER_URL", "http://localhost:8080")
 	cfg.OpenVikingURL = envOr("CCBROKER_OPENVIKING_URL", "http://localhost:1933")
 	cfg.OpenVikingAPIKey = os.Getenv("CCBROKER_OPENVIKING_API_KEY")
+	cfg.IMBridgeURL = os.Getenv("CCBROKER_IMBRIDGE_URL")
+	cfg.IMBridgeSecret = os.Getenv("INTERNAL_API_SECRET")
 	if v := os.Getenv("CCBROKER_LOG_LEVEL"); v != "" {
 		switch strings.ToLower(v) {
 		case "debug":

--- a/internal/ccbroker/handler_turns.go
+++ b/internal/ccbroker/handler_turns.go
@@ -11,10 +11,16 @@ import (
 )
 
 // ProcessTurnRequest is the external API request body for POST /api/turns.
+//
+// IMChannelID and IMUserID are optional. When set (for turns originated by an
+// IM inbound) the cc-broker ToolRouter can route send_* MCP tool calls back
+// through imbridge to the originating IM channel / user.
 type ProcessTurnRequest struct {
 	SessionID   string `json:"session_id"`
 	WorkspaceID string `json:"workspace_id"`
 	UserMessage string `json:"user_message"`
+	IMChannelID string `json:"im_channel_id,omitempty"`
+	IMUserID    string `json:"im_user_id,omitempty"`
 }
 
 // handleProcessTurn handles POST /api/turns. It acquires the turn lock for
@@ -76,7 +82,7 @@ func (s *Server) handleProcessTurn(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Spawn CC worker.
-	worker, err := s.SpawnWorker(r.Context(), req.SessionID, req.WorkspaceID)
+	worker, err := s.SpawnWorker(r.Context(), req.SessionID, req.WorkspaceID, req.IMChannelID, req.IMUserID)
 	if err != nil {
 		s.logger.Error("spawn worker failed", "session_id", req.SessionID, "error", err)
 		writeError(w, http.StatusInternalServerError, "failed to spawn worker")

--- a/internal/ccbroker/mcp_router.go
+++ b/internal/ccbroker/mcp_router.go
@@ -312,7 +312,8 @@ func (r *ToolRouter) resolveMediaSource(ctx context.Context, source string) ([]b
 	return base64.StdEncoding.DecodeString(source)
 }
 
-// fetchURL GETs a URL and returns the body bytes. Caps the response at 20 MiB.
+// fetchURL GETs a URL and returns the body bytes. Rejects oversize responses
+// rather than silently truncating.
 func (r *ToolRouter) fetchURL(ctx context.Context, url string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -326,21 +327,40 @@ func (r *ToolRouter) fetchURL(ctx context.Context, url string) ([]byte, error) {
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("GET %s returned %d", url, resp.StatusCode)
 	}
-	return io.ReadAll(io.LimitReader(resp.Body, 20<<20))
+	const maxBytes = 20 << 20
+	// Read max+1 so a response that exactly fills max still reports truncation.
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(data) > maxBytes {
+		return nil, fmt.Errorf("source at %s exceeds %d byte limit", url, maxBytes)
+	}
+	return data, nil
 }
 
-// readFromExecutor executes a Read tool call on the executor and decodes the
-// base64-encoded bytes returned by the executor's Read handler.
+// readFromExecutor reads a file from the executor in a binary-safe way.
+//
+// The executor's Read tool returns `string(data)`, which is lossy for
+// non-UTF-8 bytes: the executor's JSON response goes through
+// encoding/json on the wire, which replaces invalid UTF-8 with U+FFFD.
+// Running `base64 | tr -d '\n'` on the executor and decoding client-side
+// preserves every byte of binary content.
 func (r *ToolRouter) readFromExecutor(ctx context.Context, executorID, filePath string) ([]byte, error) {
 	if r.executorRegistryURL == "" {
 		return nil, fmt.Errorf("executor-registry not configured")
 	}
+	// Shell-quote the path so crafted filenames (apostrophes, spaces, $()) can't
+	// alter the command.
+	quoted := "'" + strings.ReplaceAll(filePath, "'", "'\\''") + "'"
 	reqBody := map[string]interface{}{
 		"executor_id": executorID,
-		"tool":        "Read",
+		"tool":        "Bash",
 		"arguments": map[string]interface{}{
-			"file_path": filePath,
-			"binary":    true,
+			// `tr -d '\n'` strips the default 76-column wrapping that GNU
+			// base64 adds, so the result is a single clean base64 string
+			// portable across GNU and BSD base64 implementations.
+			"command": "base64 " + quoted + " | tr -d '\\n'",
 		},
 	}
 	buf, _ := json.Marshal(reqBody)
@@ -367,15 +387,13 @@ func (r *ToolRouter) readFromExecutor(ctx context.Context, executorID, filePath 
 		return nil, fmt.Errorf("decode executor response: %w", err)
 	}
 	if out.ExitCode != 0 {
-		return nil, fmt.Errorf("executor Read failed: %s", out.Output)
+		return nil, fmt.Errorf("base64 %s on executor failed: %s", filePath, strings.TrimSpace(out.Output))
 	}
-	// For binary reads the executor currently returns the raw file bytes as
-	// Output. Attempt a base64 decode first (forward-compat with a future
-	// binary-safe Read); if that fails, fall back to the raw string bytes.
-	if decoded, err := base64.StdEncoding.DecodeString(out.Output); err == nil && len(decoded) > 0 {
-		return decoded, nil
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(out.Output))
+	if err != nil {
+		return nil, fmt.Errorf("decode base64 from executor: %w", err)
 	}
-	return []byte(out.Output), nil
+	return decoded, nil
 }
 
 // routeToScheduler handles scheduling-related tools (*_scheduled_*).

--- a/internal/ccbroker/mcp_router.go
+++ b/internal/ccbroker/mcp_router.go
@@ -3,6 +3,7 @@ package ccbroker
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -19,9 +20,13 @@ import (
 type ToolRouter struct {
 	executorRegistryURL string
 	agentserverURL      string
+	imbridgeURL         string
+	imbridgeSecret      string
 	workspaceDir        string // set per-worker, local temp dir
 	sessionID           string
 	workspaceID         string
+	imChannelID         string
+	imUserID            string
 	httpClient          *http.Client
 	logger              *slog.Logger
 }
@@ -30,9 +35,13 @@ type ToolRouter struct {
 type ToolRouterConfig struct {
 	ExecutorRegistryURL string
 	AgentserverURL      string
+	IMBridgeURL         string
+	IMBridgeSecret      string
 	WorkspaceDir        string
 	SessionID           string
 	WorkspaceID         string
+	IMChannelID         string
+	IMUserID            string
 }
 
 // NewToolRouter creates a ToolRouter with the given configuration.
@@ -43,9 +52,13 @@ func NewToolRouter(cfg ToolRouterConfig, logger *slog.Logger) *ToolRouter {
 	return &ToolRouter{
 		executorRegistryURL: cfg.ExecutorRegistryURL,
 		agentserverURL:      cfg.AgentserverURL,
+		imbridgeURL:         cfg.IMBridgeURL,
+		imbridgeSecret:      cfg.IMBridgeSecret,
 		workspaceDir:        cfg.WorkspaceDir,
 		sessionID:           cfg.SessionID,
 		workspaceID:         cfg.WorkspaceID,
+		imChannelID:         cfg.IMChannelID,
+		imUserID:            cfg.IMUserID,
 		httpClient: &http.Client{
 			Timeout: 120 * time.Second,
 		},
@@ -204,10 +217,165 @@ func (r *ToolRouter) routeListExecutors(ctx context.Context, args map[string]int
 	return textResult(string(body)), nil
 }
 
-// routeToIM handles IM-related tools (send_message, send_image, send_file).
-// This is a placeholder until the IM integration is connected.
+// routeToIM handles send_message / send_image / send_file by forwarding to
+// imbridge's internal send endpoints. Requires per-turn IM context
+// (imChannelID + imUserID) populated by agentserver on the POST /api/turns
+// request when the turn was originated by an IM inbound.
 func (r *ToolRouter) routeToIM(ctx context.Context, toolName string, args map[string]interface{}) (*MCPToolResult, error) {
-	return textResult("IM tool " + toolName + " is not yet connected to agentserver"), nil
+	if r.imbridgeURL == "" {
+		return textError("IM tools are not configured (CCBROKER_IMBRIDGE_URL unset)"), nil
+	}
+	if r.imChannelID == "" || r.imUserID == "" {
+		return textError("IM tools require an IM-originated session"), nil
+	}
+
+	switch toolName {
+	case "send_message":
+		text, _ := args["text"].(string)
+		if text == "" {
+			return textError("text is required"), nil
+		}
+		return r.imbridgePost(ctx, "/api/internal/imbridge/send", map[string]string{
+			"channel_id": r.imChannelID,
+			"to_user_id": r.imUserID,
+			"text":       text,
+		})
+	case "send_image":
+		source, _ := args["source"].(string)
+		if source == "" {
+			return textError("source is required"), nil
+		}
+		data, err := r.resolveMediaSource(ctx, source)
+		if err != nil {
+			return textError("failed to resolve image source: " + err.Error()), nil
+		}
+		body := map[string]string{
+			"channel_id":   r.imChannelID,
+			"to_user_id":   r.imUserID,
+			"image_base64": base64.StdEncoding.EncodeToString(data),
+		}
+		if format, _ := args["format"].(string); format != "" {
+			body["format"] = format
+		}
+		if caption, _ := args["caption"].(string); caption != "" {
+			body["caption"] = caption
+		}
+		return r.imbridgePost(ctx, "/api/internal/imbridge/send-image", body)
+	case "send_file":
+		return textError("send_file is not yet supported by the IM provider"), nil
+	}
+	return textError("unknown IM tool: " + toolName), nil
+}
+
+// imbridgePost posts a JSON body to an imbridge internal endpoint.
+func (r *ToolRouter) imbridgePost(ctx context.Context, path string, body map[string]string) (*MCPToolResult, error) {
+	buf, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal imbridge request: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, r.imbridgeURL+path, bytes.NewReader(buf))
+	if err != nil {
+		return nil, fmt.Errorf("build imbridge request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if r.imbridgeSecret != "" {
+		req.Header.Set("X-Internal-Secret", r.imbridgeSecret)
+	}
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("imbridge request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return textError(fmt.Sprintf("imbridge %s returned %d: %s", path, resp.StatusCode, respBody)), nil
+	}
+	return textResult("sent"), nil
+}
+
+// resolveMediaSource decodes an image/file source into raw bytes. Supports:
+//   - `executor_id:/absolute/path` — Read the file via executor-registry
+//   - `http://…` or `https://…` — fetch over HTTP
+//   - anything else — treat as base64-encoded bytes
+func (r *ToolRouter) resolveMediaSource(ctx context.Context, source string) ([]byte, error) {
+	if strings.HasPrefix(source, "http://") || strings.HasPrefix(source, "https://") {
+		return r.fetchURL(ctx, source)
+	}
+	if idx := strings.Index(source, ":"); idx > 0 && idx < len(source)-1 {
+		candidate := source[:idx]
+		rest := source[idx+1:]
+		if strings.HasPrefix(candidate, "exe_") && strings.HasPrefix(rest, "/") {
+			return r.readFromExecutor(ctx, candidate, rest)
+		}
+	}
+	return base64.StdEncoding.DecodeString(source)
+}
+
+// fetchURL GETs a URL and returns the body bytes. Caps the response at 20 MiB.
+func (r *ToolRouter) fetchURL(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := r.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s returned %d", url, resp.StatusCode)
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, 20<<20))
+}
+
+// readFromExecutor executes a Read tool call on the executor and decodes the
+// base64-encoded bytes returned by the executor's Read handler.
+func (r *ToolRouter) readFromExecutor(ctx context.Context, executorID, filePath string) ([]byte, error) {
+	if r.executorRegistryURL == "" {
+		return nil, fmt.Errorf("executor-registry not configured")
+	}
+	reqBody := map[string]interface{}{
+		"executor_id": executorID,
+		"tool":        "Read",
+		"arguments": map[string]interface{}{
+			"file_path": filePath,
+			"binary":    true,
+		},
+	}
+	buf, _ := json.Marshal(reqBody)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		r.executorRegistryURL+"/api/execute", bytes.NewReader(buf))
+	if err != nil {
+		return nil, err
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	resp, err := r.httpClient.Do(httpReq)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("executor-registry returned %d: %s", resp.StatusCode, body)
+	}
+	var out struct {
+		Output   string `json:"output"`
+		ExitCode int    `json:"exit_code"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decode executor response: %w", err)
+	}
+	if out.ExitCode != 0 {
+		return nil, fmt.Errorf("executor Read failed: %s", out.Output)
+	}
+	// For binary reads the executor currently returns the raw file bytes as
+	// Output. Attempt a base64 decode first (forward-compat with a future
+	// binary-safe Read); if that fails, fall back to the raw string bytes.
+	if decoded, err := base64.StdEncoding.DecodeString(out.Output); err == nil && len(decoded) > 0 {
+		return decoded, nil
+	}
+	return []byte(out.Output), nil
 }
 
 // routeToScheduler handles scheduling-related tools (*_scheduled_*).

--- a/internal/ccbroker/mcp_router_im_test.go
+++ b/internal/ccbroker/mcp_router_im_test.go
@@ -129,8 +129,11 @@ func TestRouteToIM_SendImage_URL(t *testing.T) {
 }
 
 func TestRouteToIM_SendImage_ExecutorPath(t *testing.T) {
-	imageBytes := []byte("pixels")
-	// Mock executor-registry — returns Read result base64-encoded.
+	// Non-UTF-8 bytes so we catch any string-round-trip corruption.
+	imageBytes := []byte{0x89, 'P', 'N', 'G', 0x0d, 0x0a, 0x1a, 0x0a, 0xff, 0xfe}
+	// Mock executor-registry — expects `Bash: base64 <path> | tr -d '\n'` and
+	// returns the base64-encoded file bytes as Output, mimicking what the
+	// real executor's Bash tool would produce.
 	execSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var req struct {
 			ExecutorID string                 `json:"executor_id"`
@@ -138,8 +141,15 @@ func TestRouteToIM_SendImage_ExecutorPath(t *testing.T) {
 			Arguments  map[string]interface{} `json:"arguments"`
 		}
 		_ = json.NewDecoder(r.Body).Decode(&req)
-		if req.ExecutorID != "exe_dev" || req.Tool != "Read" {
+		if req.ExecutorID != "exe_dev" || req.Tool != "Bash" {
 			t.Errorf("wrong executor-registry call: %+v", req)
+		}
+		cmd, _ := req.Arguments["command"].(string)
+		if !strings.HasPrefix(cmd, "base64 ") || !strings.Contains(cmd, "tr -d") {
+			t.Errorf("expected `base64 ... | tr -d '\\n'` command, got %q", cmd)
+		}
+		if !strings.Contains(cmd, "'/tmp/cat.png'") {
+			t.Errorf("expected path to be shell-quoted, got %q", cmd)
 		}
 		resp := map[string]interface{}{
 			"output":    base64.StdEncoding.EncodeToString(imageBytes),
@@ -247,6 +257,48 @@ func TestResolveMediaSource_RejectsInvalidBase64(t *testing.T) {
 	_, err := router.resolveMediaSource(context.Background(), "!!!not-base64!!!")
 	if err == nil {
 		t.Fatalf("expected error for invalid base64")
+	}
+}
+
+func TestResolveMediaSource_ShellQuotesPathWithApostrophe(t *testing.T) {
+	// A filename with an apostrophe must not break the base64 command on
+	// the executor.
+	var gotCommand string
+	execSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			Arguments map[string]interface{} `json:"arguments"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		gotCommand, _ = req.Arguments["command"].(string)
+		resp := map[string]interface{}{"output": base64.StdEncoding.EncodeToString([]byte("x")), "exit_code": 0}
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer execSrv.Close()
+
+	router := newTestRouter("http://unused", execSrv.URL)
+	_, err := router.resolveMediaSource(context.Background(), "exe_dev:/tmp/don't.png")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(gotCommand, "'/tmp/don'\\''t.png'") {
+		t.Errorf("path not shell-safe: %q", gotCommand)
+	}
+}
+
+func TestFetchURL_RejectsOversize(t *testing.T) {
+	big := make([]byte, (20<<20)+1024)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(big)
+	}))
+	defer srv.Close()
+
+	router := newTestRouter("http://unused", "")
+	_, err := router.fetchURL(context.Background(), srv.URL)
+	if err == nil {
+		t.Fatalf("expected error for oversize URL response")
+	}
+	if !strings.Contains(err.Error(), "exceeds") {
+		t.Errorf("expected size-limit error, got: %v", err)
 	}
 }
 

--- a/internal/ccbroker/mcp_router_im_test.go
+++ b/internal/ccbroker/mcp_router_im_test.go
@@ -1,0 +1,259 @@
+package ccbroker
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func newTestRouter(imbridgeURL, executorURL string) *ToolRouter {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	return NewToolRouter(ToolRouterConfig{
+		ExecutorRegistryURL: executorURL,
+		AgentserverURL:      "http://localhost:0",
+		IMBridgeURL:         imbridgeURL,
+		IMBridgeSecret:      "test-secret",
+		WorkspaceDir:        "/tmp",
+		SessionID:           "sess_test",
+		WorkspaceID:         "ws_test",
+		IMChannelID:         "ch_test",
+		IMUserID:            "user_test",
+	}, logger)
+}
+
+func TestRouteToIM_SendMessage_PostsToImbridge(t *testing.T) {
+	var received struct {
+		path   string
+		body   map[string]string
+		secret string
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		received.path = r.URL.Path
+		received.secret = r.Header.Get("X-Internal-Secret")
+		_ = json.NewDecoder(r.Body).Decode(&received.body)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"sent"}`))
+	}))
+	defer srv.Close()
+
+	router := newTestRouter(srv.URL, "")
+	res, err := router.routeToIM(context.Background(), "send_message",
+		map[string]interface{}{"text": "hello"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("expected success, got error: %+v", res)
+	}
+	if received.path != "/api/internal/imbridge/send" {
+		t.Errorf("wrong path: %s", received.path)
+	}
+	if received.secret != "test-secret" {
+		t.Errorf("wrong secret header: %q", received.secret)
+	}
+	if received.body["channel_id"] != "ch_test" || received.body["to_user_id"] != "user_test" || received.body["text"] != "hello" {
+		t.Errorf("wrong body: %+v", received.body)
+	}
+}
+
+func TestRouteToIM_SendMessage_EmptyText(t *testing.T) {
+	router := newTestRouter("http://irrelevant", "")
+	res, _ := router.routeToIM(context.Background(), "send_message", map[string]interface{}{})
+	if !res.IsError {
+		t.Fatalf("expected error for missing text")
+	}
+}
+
+func TestRouteToIM_SendImage_Base64(t *testing.T) {
+	var receivedBody map[string]string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&receivedBody)
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"sent"}`))
+	}))
+	defer srv.Close()
+
+	b64 := base64.StdEncoding.EncodeToString([]byte("fake-png-bytes"))
+	router := newTestRouter(srv.URL, "")
+	res, _ := router.routeToIM(context.Background(), "send_image", map[string]interface{}{
+		"source":  b64,
+		"format":  "png",
+		"caption": "cat",
+	})
+	if res.IsError {
+		t.Fatalf("expected success, got: %+v", res)
+	}
+	if receivedBody["image_base64"] != b64 {
+		t.Errorf("image_base64 mismatch: %q vs %q", receivedBody["image_base64"], b64)
+	}
+	if receivedBody["format"] != "png" || receivedBody["caption"] != "cat" {
+		t.Errorf("optional fields not propagated: %+v", receivedBody)
+	}
+}
+
+func TestRouteToIM_SendImage_URL(t *testing.T) {
+	imageBytes := []byte("\x89PNG\r\n\x1a\nfake")
+	// URL server — returns image bytes.
+	urlSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(imageBytes)
+	}))
+	defer urlSrv.Close()
+
+	var receivedBody map[string]string
+	imbridgeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&receivedBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer imbridgeSrv.Close()
+
+	router := newTestRouter(imbridgeSrv.URL, "")
+	res, _ := router.routeToIM(context.Background(), "send_image", map[string]interface{}{
+		"source": urlSrv.URL + "/cat.png",
+	})
+	if res.IsError {
+		t.Fatalf("expected success, got: %+v", res)
+	}
+	decoded, err := base64.StdEncoding.DecodeString(receivedBody["image_base64"])
+	if err != nil {
+		t.Fatalf("image not base64-encoded: %v", err)
+	}
+	if string(decoded) != string(imageBytes) {
+		t.Errorf("image bytes differ: got %q, want %q", decoded, imageBytes)
+	}
+}
+
+func TestRouteToIM_SendImage_ExecutorPath(t *testing.T) {
+	imageBytes := []byte("pixels")
+	// Mock executor-registry — returns Read result base64-encoded.
+	execSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req struct {
+			ExecutorID string                 `json:"executor_id"`
+			Tool       string                 `json:"tool"`
+			Arguments  map[string]interface{} `json:"arguments"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&req)
+		if req.ExecutorID != "exe_dev" || req.Tool != "Read" {
+			t.Errorf("wrong executor-registry call: %+v", req)
+		}
+		resp := map[string]interface{}{
+			"output":    base64.StdEncoding.EncodeToString(imageBytes),
+			"exit_code": 0,
+		}
+		w.WriteHeader(http.StatusOK)
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer execSrv.Close()
+
+	var receivedBody map[string]string
+	imbridgeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewDecoder(r.Body).Decode(&receivedBody)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer imbridgeSrv.Close()
+
+	router := newTestRouter(imbridgeSrv.URL, execSrv.URL)
+	res, _ := router.routeToIM(context.Background(), "send_image", map[string]interface{}{
+		"source": "exe_dev:/tmp/cat.png",
+	})
+	if res.IsError {
+		t.Fatalf("expected success, got: %+v", res)
+	}
+	decoded, _ := base64.StdEncoding.DecodeString(receivedBody["image_base64"])
+	if string(decoded) != string(imageBytes) {
+		t.Errorf("bytes mismatch: %q vs %q", decoded, imageBytes)
+	}
+}
+
+func TestRouteToIM_SendFile_NotSupported(t *testing.T) {
+	router := newTestRouter("http://irrelevant", "")
+	res, _ := router.routeToIM(context.Background(), "send_file", map[string]interface{}{
+		"source":   "abc",
+		"filename": "doc.pdf",
+	})
+	if !res.IsError {
+		t.Fatalf("expected error for send_file, got: %+v", res)
+	}
+	if !strings.Contains(textOf(res), "not yet supported") {
+		t.Errorf("expected 'not yet supported' error, got: %s", textOf(res))
+	}
+}
+
+func TestRouteToIM_MissingIMContext(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	router := NewToolRouter(ToolRouterConfig{
+		IMBridgeURL: "http://anything",
+		// IMChannelID / IMUserID intentionally empty
+	}, logger)
+	res, _ := router.routeToIM(context.Background(), "send_message",
+		map[string]interface{}{"text": "hi"})
+	if !res.IsError {
+		t.Fatalf("expected error when IM context missing")
+	}
+	if !strings.Contains(textOf(res), "IM-originated") {
+		t.Errorf("expected IM-context error, got: %s", textOf(res))
+	}
+}
+
+func TestRouteToIM_MissingImbridgeURL(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	router := NewToolRouter(ToolRouterConfig{
+		IMChannelID: "ch",
+		IMUserID:    "u",
+	}, logger)
+	res, _ := router.routeToIM(context.Background(), "send_message",
+		map[string]interface{}{"text": "hi"})
+	if !res.IsError {
+		t.Fatalf("expected error when imbridgeURL unset")
+	}
+}
+
+func TestRouteToIM_ImbridgeErrorPropagates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "provider failure", http.StatusBadGateway)
+	}))
+	defer srv.Close()
+
+	router := newTestRouter(srv.URL, "")
+	res, _ := router.routeToIM(context.Background(), "send_message",
+		map[string]interface{}{"text": "hi"})
+	if !res.IsError {
+		t.Fatalf("expected error on imbridge 502")
+	}
+	if !strings.Contains(textOf(res), "502") {
+		t.Errorf("expected status code in error, got: %s", textOf(res))
+	}
+}
+
+func TestResolveMediaSource_Base64Fallback(t *testing.T) {
+	router := newTestRouter("http://unused", "")
+	bytes := []byte("abc123")
+	data, err := router.resolveMediaSource(context.Background(), base64.StdEncoding.EncodeToString(bytes))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(data) != string(bytes) {
+		t.Errorf("got %q, want %q", data, bytes)
+	}
+}
+
+func TestResolveMediaSource_RejectsInvalidBase64(t *testing.T) {
+	router := newTestRouter("http://unused", "")
+	_, err := router.resolveMediaSource(context.Background(), "!!!not-base64!!!")
+	if err == nil {
+		t.Fatalf("expected error for invalid base64")
+	}
+}
+
+// textOf returns the first text content from an MCPToolResult for assertions.
+func textOf(r *MCPToolResult) string {
+	if r == nil || len(r.Content) == 0 {
+		return ""
+	}
+	return r.Content[0].Text
+}

--- a/internal/ccbroker/server.go
+++ b/internal/ccbroker/server.go
@@ -68,13 +68,17 @@ func (s *Server) Routes() http.Handler {
 
 // CreateMCPServer creates a per-worker MCP server and returns (server, port, closer, error).
 // The caller should call closer() to stop the MCP server when done.
-func (s *Server) CreateMCPServer(sessionID, workspaceID, workspaceDir string) (*MCPServer, int, func(), error) {
+func (s *Server) CreateMCPServer(sessionID, workspaceID, workspaceDir, imChannelID, imUserID string) (*MCPServer, int, func(), error) {
 	router := NewToolRouter(ToolRouterConfig{
 		ExecutorRegistryURL: s.config.ExecutorRegistryURL,
 		AgentserverURL:      s.config.AgentserverURL,
+		IMBridgeURL:         s.config.IMBridgeURL,
+		IMBridgeSecret:      s.config.IMBridgeSecret,
 		WorkspaceDir:        workspaceDir,
 		SessionID:           sessionID,
 		WorkspaceID:         workspaceID,
+		IMChannelID:         imChannelID,
+		IMUserID:            imUserID,
 	}, s.logger)
 
 	mcpSrv := NewMCPServer(router, s.logger)

--- a/internal/ccbroker/worker.go
+++ b/internal/ccbroker/worker.go
@@ -78,8 +78,10 @@ func diffSnapshot(dir string, old map[string]fileInfo) []fileChange {
 }
 
 // SpawnWorker sets up a temporary workspace, downloads files from OpenViking,
-// starts an MCP server, and launches a Claude Code worker process.
-func (s *Server) SpawnWorker(ctx context.Context, sessionID, workspaceID string) (*CCWorker, error) {
+// starts an MCP server, and launches a Claude Code worker process. imChannelID
+// and imUserID are optional — populated when the turn was originated by an IM
+// inbound so the MCP server can route send_* tool calls back through imbridge.
+func (s *Server) SpawnWorker(ctx context.Context, sessionID, workspaceID, imChannelID, imUserID string) (*CCWorker, error) {
 	apiKey := os.Getenv("ANTHROPIC_API_KEY")
 	if apiKey == "" {
 		return nil, fmt.Errorf("ANTHROPIC_API_KEY environment variable is not set")
@@ -126,7 +128,7 @@ func (s *Server) SpawnWorker(ctx context.Context, sessionID, workspaceID string)
 	snapshot := takeFileSnapshot(claudeDir)
 
 	// 5. Start MCP server.
-	_, mcpPort, mcpCloser, err := s.CreateMCPServer(sessionID, workspaceID, claudeDir)
+	_, mcpPort, mcpCloser, err := s.CreateMCPServer(sessionID, workspaceID, claudeDir, imChannelID, imUserID)
 	if err != nil {
 		os.RemoveAll(tempDir)
 		return nil, fmt.Errorf("create MCP server: %w", err)

--- a/internal/imbridgesvc/handlers.go
+++ b/internal/imbridgesvc/handlers.go
@@ -213,6 +213,11 @@ func (s *Server) handleImbridgeDirectSend(w http.ResponseWriter, r *http.Request
 // AI-generated image while bounding memory use per request.
 const maxDirectSendImageBytes = 20 << 20
 
+// maxDirectSendImageRequestBytes bounds the raw request body before JSON
+// decode. A 20 MiB image base64-encodes to ~26.67 MiB; the extra headroom
+// covers JSON overhead and the other fields.
+const maxDirectSendImageRequestBytes = 32 << 20
+
 // handleImbridgeDirectSendImage sends an image to an IM user without a
 // sandbox binding. Parallel to handleImbridgeDirectSend but carries
 // base64-encoded image bytes. Auth via INTERNAL_API_SECRET.
@@ -224,6 +229,11 @@ func (s *Server) handleImbridgeDirectSendImage(w http.ResponseWriter, r *http.Re
 		}
 	}
 
+	// Cap the raw body before JSON decode so we never buffer an unbounded
+	// request. MaxBytesReader returns an error from subsequent Reads once
+	// the limit is exceeded, which Decode will surface.
+	r.Body = http.MaxBytesReader(w, r.Body, maxDirectSendImageRequestBytes)
+
 	var req struct {
 		ChannelID   string `json:"channel_id"`
 		ToUserID    string `json:"to_user_id"`
@@ -232,18 +242,11 @@ func (s *Server) handleImbridgeDirectSendImage(w http.ResponseWriter, r *http.Re
 		Caption     string `json:"caption,omitempty"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-		http.Error(w, "invalid request body", http.StatusBadRequest)
+		http.Error(w, "invalid or oversized request body", http.StatusBadRequest)
 		return
 	}
 	if req.ChannelID == "" || req.ToUserID == "" || req.ImageBase64 == "" {
 		http.Error(w, "channel_id, to_user_id, and image_base64 are required", http.StatusBadRequest)
-		return
-	}
-
-	// Reject oversize payloads before spending CPU on base64 decode.
-	// Base64 expands bytes by ~4/3, so cap the encoded length accordingly.
-	if len(req.ImageBase64) > ((maxDirectSendImageBytes/3)+1)*4+16 {
-		http.Error(w, "image exceeds 20 MiB limit", http.StatusRequestEntityTooLarge)
 		return
 	}
 

--- a/internal/imbridgesvc/handlers.go
+++ b/internal/imbridgesvc/handlers.go
@@ -2,6 +2,7 @@ package imbridgesvc
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -200,6 +201,94 @@ func (s *Server) handleImbridgeDirectSend(w http.ResponseWriter, r *http.Request
 		log.Printf("imbridge direct send: failed channel=%s provider=%s to=%s: %v",
 			channel.ID, provider.Name(), req.ToUserID, err)
 		http.Error(w, "failed to send message", http.StatusBadGateway)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "sent"})
+}
+
+// maxDirectSendImageBytes caps the decoded image payload size for the
+// direct send-image endpoint. 20 MiB covers any reasonable screenshot or
+// AI-generated image while bounding memory use per request.
+const maxDirectSendImageBytes = 20 << 20
+
+// handleImbridgeDirectSendImage sends an image to an IM user without a
+// sandbox binding. Parallel to handleImbridgeDirectSend but carries
+// base64-encoded image bytes. Auth via INTERNAL_API_SECRET.
+func (s *Server) handleImbridgeDirectSendImage(w http.ResponseWriter, r *http.Request) {
+	if secret := os.Getenv("INTERNAL_API_SECRET"); secret != "" {
+		if r.Header.Get("X-Internal-Secret") != secret {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+	}
+
+	var req struct {
+		ChannelID   string `json:"channel_id"`
+		ToUserID    string `json:"to_user_id"`
+		ImageBase64 string `json:"image_base64"`
+		Format      string `json:"format,omitempty"`
+		Caption     string `json:"caption,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+	if req.ChannelID == "" || req.ToUserID == "" || req.ImageBase64 == "" {
+		http.Error(w, "channel_id, to_user_id, and image_base64 are required", http.StatusBadRequest)
+		return
+	}
+
+	// Reject oversize payloads before spending CPU on base64 decode.
+	// Base64 expands bytes by ~4/3, so cap the encoded length accordingly.
+	if len(req.ImageBase64) > ((maxDirectSendImageBytes/3)+1)*4+16 {
+		http.Error(w, "image exceeds 20 MiB limit", http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	data, err := base64.StdEncoding.DecodeString(req.ImageBase64)
+	if err != nil {
+		http.Error(w, "invalid image_base64: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if len(data) > maxDirectSendImageBytes {
+		http.Error(w, "image exceeds 20 MiB limit", http.StatusRequestEntityTooLarge)
+		return
+	}
+
+	channel, err := s.db.GetIMChannel(req.ChannelID)
+	if err != nil {
+		http.Error(w, "channel not found", http.StatusNotFound)
+		return
+	}
+
+	provider := s.bridge.GetProvider(channel.Provider)
+	if provider == nil {
+		http.Error(w, "unknown IM provider: "+channel.Provider, http.StatusBadRequest)
+		return
+	}
+
+	isp, ok := provider.(imbridge.ImageSendProvider)
+	if !ok {
+		http.Error(w, "image sending not supported for provider: "+provider.Name(),
+			http.StatusNotImplemented)
+		return
+	}
+
+	s.bridge.StopTyping(channel.ID, req.ToUserID)
+
+	creds := &imbridge.Credentials{
+		ChannelID: channel.ID,
+		BotID:     channel.BotID,
+		BotToken:  channel.BotToken,
+		BaseURL:   channel.BaseURL,
+	}
+
+	if err := isp.SendImage(r.Context(), creds, req.ToUserID, data, req.Caption); err != nil {
+		log.Printf("imbridge direct send-image: failed channel=%s provider=%s to=%s: %v",
+			channel.ID, provider.Name(), req.ToUserID, err)
+		http.Error(w, "failed to send image", http.StatusBadGateway)
 		return
 	}
 

--- a/internal/imbridgesvc/server.go
+++ b/internal/imbridgesvc/server.go
@@ -52,6 +52,7 @@ func (s *Server) Routes() http.Handler {
 	// Internal API: agentserver sends IM replies for stateless CC sessions
 	// (auth via X-Internal-Secret shared secret).
 	r.Post("/api/internal/imbridge/send", s.handleImbridgeDirectSend)
+	r.Post("/api/internal/imbridge/send-image", s.handleImbridgeDirectSendImage)
 
 	// Authenticated API routes (cookie auth).
 	r.Group(func(r chi.Router) {

--- a/internal/server/im_inbound.go
+++ b/internal/server/im_inbound.go
@@ -88,10 +88,24 @@ func (s *Server) processWithCCBroker(ctx context.Context, session *db.AgentSessi
 	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
 
+	// Extract to_user_id from chat_jid (e.g., "user123@im.wechat" → "user123")
+	// and resolve the channel ID once, up-front, so the turn request and the
+	// final reply both carry the same IM context.
+	toUserID := msg.ChatJID
+	if idx := strings.Index(toUserID, "@"); idx > 0 {
+		toUserID = toUserID[:idx]
+	}
+	channelID := msg.ChannelID
+	if session != nil && session.IMChannelID != nil && *session.IMChannelID != "" {
+		channelID = *session.IMChannelID
+	}
+
 	body, _ := json.Marshal(map[string]interface{}{
-		"session_id":   session.ID,
-		"workspace_id": session.WorkspaceID,
-		"user_message": msg.Content,
+		"session_id":    session.ID,
+		"workspace_id":  session.WorkspaceID,
+		"user_message":  msg.Content,
+		"im_channel_id": channelID,
+		"im_user_id":    toUserID,
 	})
 
 	req, err := http.NewRequestWithContext(ctx, "POST", s.CCBrokerURL+"/api/turns", bytes.NewReader(body))
@@ -116,17 +130,6 @@ func (s *Server) processWithCCBroker(ctx context.Context, session *db.AgentSessi
 		return
 	}
 
-	// Extract to_user_id from chat_jid (e.g., "user123@im.wechat" → "user123").
-	toUserID := msg.ChatJID
-	if idx := strings.Index(toUserID, "@"); idx > 0 {
-		toUserID = toUserID[:idx]
-	}
-
-	// Use channel_id from session if available, falling back to the inbound message.
-	channelID := msg.ChannelID
-	if session != nil && session.IMChannelID != nil && *session.IMChannelID != "" {
-		channelID = *session.IMChannelID
-	}
 	if channelID == "" {
 		log.Printf("im_inbound: no IM channel for session %s, dropping reply", session.ID)
 		return


### PR DESCRIPTION
## Summary

Unblocks mid-turn proactive pushes from CC workers:

- \`send_message\` — text push to the originating IM user
- \`send_image\` — image push; source may be raw base64, an \`http(s)://\` URL, or \`executor_id:/path\`
- \`send_file\` — returns a clear \"not yet supported by IM provider\" (no \`FileSendProvider\` interface yet)

Routing: CC → MCP → \`cc-broker\` \`routeToIM\` → imbridge internal endpoints (\`X-Internal-Secret\` auth).

## Changes

- **cc-broker** — \`ProcessTurnRequest\` grows \`im_channel_id\`/\`im_user_id\`; threaded through \`SpawnWorker\` → \`CreateMCPServer\` → \`ToolRouter\`. \`routeToIM\` + \`resolveMediaSource\` (+ \`fetchURL\`, \`readFromExecutor\`) implemented. Config adds \`IMBridgeURL\`/\`IMBridgeSecret\`.
- **imbridge** — new \`POST /api/internal/imbridge/send-image\` handler: \`INTERNAL_API_SECRET\` auth, base64 decode, 20 MiB cap, \`ImageSendProvider\` check, \`SendImage\` dispatch.
- **agentserver** — \`im_inbound\` forwards \`im_channel_id\`+\`im_user_id\` (data already on hand — just not wired); channel/user extraction hoisted up so turn request and final reply share the same values.

## Test Plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./...\` — all pass
- [x] New \`internal/ccbroker/mcp_router_im_test.go\` — 9 cases covering the wire format for all three source types, error propagation, and guardrails (missing IM context, missing imbridge URL, invalid base64)
- [ ] Manual WeChat loop: send \"生成一张猫的图片并发给我\"; expect \`remote_bash\` to produce a PNG, then \`send_image(source=\"exe_...:/tmp/cat.png\")\` delivered through WeChat

## Out of scope (follow-up)

- \`FileSendProvider\` per-provider file sends (WeChat, Telegram, Matrix)
- Rate limiting on proactive pushes
- Retry policy on imbridge transient failures

## Environment additions

- \`CCBROKER_IMBRIDGE_URL\` — imbridge base URL
- \`INTERNAL_API_SECRET\` — shared secret (already used by agentserver → imbridge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)