### PR TITLE
fix(ccbroker): use Claude Code SDK shape for user-message events

### DIFF
--- a/internal/ccbroker/handler_turns.go
+++ b/internal/ccbroker/handler_turns.go
@@ -56,12 +56,20 @@ func (s *Server) handleProcessTurn(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Insert user message as an event.
+	// Insert user message as an event. The payload follows the Claude Code
+	// SDK's SDKUserMessage shape (type:"user", message:{role,content},
+	// parent_tool_use_id, session_id) — CC parses events from the bridge
+	// event-stream against this structure. A simpler `{type, content}`
+	// payload is silently ignored by CC and the turn runs with no user input.
 	eventUUID := uuid.NewString()
-	payload, _ := json.Marshal(map[string]string{
-		"uuid":    eventUUID,
-		"type":    "user",
-		"content": req.UserMessage,
+	payload, _ := json.Marshal(map[string]interface{}{
+		"type": "user",
+		"message": map[string]interface{}{
+			"role":    "user",
+			"content": req.UserMessage,
+		},
+		"parent_tool_use_id": nil,
+		"session_id":         req.SessionID,
 	})
 	_, err = s.store.InsertEvents(r.Context(), req.SessionID, epoch, []EventInput{
 		{

--- a/internal/ccbroker/integration_test.go
+++ b/internal/ccbroker/integration_test.go
@@ -144,12 +144,24 @@ func TestEventBatchAndReplay(t *testing.T) {
 	sessionID := createSession(t, srv, "ws_test", "Event Test")
 	bridge := attachBridge(t, srv, sessionID)
 
-	// 2. POST events with JWT auth
+	// 2. POST events with JWT auth. Payload uses CC's SDKUserMessage shape
+	// plus a `uuid` field — cc-broker's handleWorkerEvents extracts the
+	// dedup key from payload.uuid. (Real CC events don't carry uuid; that's
+	// a known limitation of the current bridge dedup model.)
 	eventsReq := map[string]any{
 		"worker_epoch": 1,
 		"events": []map[string]any{
 			{
-				"payload":   map[string]any{"uuid": "evt1", "type": "user", "content": "hello"},
+				"payload": map[string]any{
+					"uuid": "evt1",
+					"type": "user",
+					"message": map[string]any{
+						"role":    "user",
+						"content": "hello",
+					},
+					"parent_tool_use_id": nil,
+					"session_id":         sessionID,
+				},
 				"ephemeral": false,
 			},
 		},
@@ -189,7 +201,16 @@ func TestEpochMismatch(t *testing.T) {
 		"worker_epoch": 99,
 		"events": []map[string]any{
 			{
-				"payload":   map[string]any{"uuid": "evt_wrong", "type": "user", "content": "oops"},
+				"payload": map[string]any{
+					"uuid": "evt_wrong",
+					"type": "user",
+					"message": map[string]any{
+						"role":    "user",
+						"content": "oops",
+					},
+					"parent_tool_use_id": nil,
+					"session_id":         sessionID,
+				},
 				"ephemeral": false,
 			},
 		},


### PR DESCRIPTION
## Problem

Tracing the WeChat multi-turn conversation flow end-to-end surfaced a blocker in cc-broker: when CC's bridge mode replays events from \`/v1/sessions/{id}/worker/events/stream\`, it expects the SDK \`SDKUserMessage\` shape:

\`\`\`json
{
  \"type\": \"user\",
  \"message\": { \"role\": \"user\", \"content\": \"...\" },
  \"parent_tool_use_id\": null,
  \"session_id\": \"...\"
}
\`\`\`

but \`handler_turns.go:60-65\` was writing \`{uuid, type, content}\` — CC parses \`entry.message.content\`, finds nothing, and the turn runs with an empty user message. Both single-turn and multi-turn chat fail silently.

Verified shape against three independent sources:
- nanoclaw agent-runner: \`container/agent-runner/src/index.ts:56-61\`
- agentserver's own parser: \`internal/server/task_output.go:16-21\`
- spec §16.1 (AskUserQuestion snippet)

## Changes

- \`internal/ccbroker/handler_turns.go\` — emit the SDKUserMessage shape; \`eventUUID\` still flows into \`EventInput.EventID\` directly (no payload dependency).
- \`internal/ccbroker/integration_test.go\` — update \`TestEventBatchAndReplay\` and \`TestEpochMismatch\` fixtures so test payloads model real CC shape. Retained \`uuid\` in payload because \`handleWorkerEvents:126-131\` currently reads the dedup key from \`payload.uuid\` — promoting that to a top-level \`event_id\` is a separate refactor.

## Test Plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/ccbroker/...\` — existing tests pass with new fixtures
- [ ] Manual WeChat round-trip once #37 is merged and services are deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)