### PR TITLE
chore(chart): add cc-broker + executor-registry templates and CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,6 +187,76 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  build-cc-broker:
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v6
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/agentserver/cc-broker
+          tags: |
+            type=sha,prefix=
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile.cc-broker
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-executor-registry:
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v6
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/agentserver/executor-registry
+          tags: |
+            type=sha,prefix=
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile.executor-registry
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   build-credentialproxy:
     runs-on: ubuntu-latest
     needs: [test]
@@ -331,7 +401,7 @@ jobs:
 
   publish-helm:
     runs-on: ubuntu-latest
-    needs: [build-server, build-opencode, build-llmproxy, build-imbridge, build-credentialproxy, build-sandboxproxy, build-nanoclaw, build-claudecode]
+    needs: [build-server, build-opencode, build-llmproxy, build-imbridge, build-cc-broker, build-executor-registry, build-credentialproxy, build-sandboxproxy, build-nanoclaw, build-claudecode]
     steps:
       - uses: actions/checkout@v6
 
@@ -349,7 +419,7 @@ jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    needs: [build-server, build-opencode, build-llmproxy, build-imbridge, build-credentialproxy, build-sandboxproxy, build-nanoclaw, build-claudecode]
+    needs: [build-server, build-opencode, build-llmproxy, build-imbridge, build-cc-broker, build-executor-registry, build-credentialproxy, build-sandboxproxy, build-nanoclaw, build-claudecode]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/Dockerfile.cc-broker
+++ b/Dockerfile.cc-broker
@@ -6,10 +6,17 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -o cc-broker ./cmd/cc-broker
 
-# Runtime image (minimal — no Docker CLI, no frontend)
+# Runtime image. cc-broker execs the `claude` CLI per turn (SpawnWorker),
+# so the Claude Code native binary must be on PATH. Nothing else is needed
+# — workers route all file / bash ops through executor-registry tunnels.
 FROM debian:trixie-slim
-RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates curl && \
+    curl -fsSL https://claude.ai/install.sh | bash && \
+    cp /root/.local/bin/claude /usr/local/bin/claude && \
+    rm -rf /root/.local/bin/claude && \
+    apt-get purge -y curl && apt-get autoremove -y && \
+    rm -rf /var/lib/apt/lists/*
 COPY --from=builder /app/cc-broker /usr/local/bin/cc-broker
 EXPOSE 8085
 ENTRYPOINT ["cc-broker"]

--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.38.1
-appVersion: "0.38.1"
+version: 0.39.0
+appVersion: "0.39.0"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/deploy/helm/agentserver/templates/_helpers.tpl
+++ b/deploy/helm/agentserver/templates/_helpers.tpl
@@ -39,3 +39,29 @@ postgres://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.pas
 {{ .Release.Name }}-secret
 {{- end -}}
 {{- end -}}
+
+{{/*
+Construct the cc-broker DATABASE_URL.
+- Shared PG: same instance, separate database (default: ccbroker)
+- External: ccbroker.database.externalUrl
+*/}}
+{{- define "agentserver.ccbrokerDatabaseUrl" -}}
+{{- if .Values.ccbroker.database.externalUrl -}}
+{{ .Values.ccbroker.database.externalUrl }}
+{{- else -}}
+postgres://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.ccbroker.database.name }}?sslmode=disable
+{{- end -}}
+{{- end -}}
+
+{{/*
+Construct the executor-registry DATABASE_URL.
+- Shared PG: same instance, separate database (default: executorregistry)
+- External: executorRegistry.database.externalUrl
+*/}}
+{{- define "agentserver.executorRegistryDatabaseUrl" -}}
+{{- if .Values.executorRegistry.database.externalUrl -}}
+{{ .Values.executorRegistry.database.externalUrl }}
+{{- else -}}
+postgres://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.executorRegistry.database.name }}?sslmode=disable
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/agentserver/templates/cc-broker.yaml
+++ b/deploy/helm/agentserver/templates/cc-broker.yaml
@@ -1,0 +1,156 @@
+{{- if .Values.ccbroker.enabled }}
+{{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (printf "%s-ccbroker-secret" .Release.Name)) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-ccbroker-secret
+  labels:
+    app: {{ .Release.Name }}-ccbroker
+type: Opaque
+stringData:
+  database-url: {{ include "agentserver.ccbrokerDatabaseUrl" . | quote }}
+  {{- if .Values.ccbroker.jwtSecret }}
+  jwt-secret: {{ .Values.ccbroker.jwtSecret | quote }}
+  {{- else if $existingSecret }}
+  jwt-secret: {{ index $existingSecret.data "jwt-secret" | b64dec | quote }}
+  {{- else }}
+  jwt-secret: {{ randAlphaNum 48 | quote }}
+  {{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-ccbroker
+  labels:
+    app: {{ .Release.Name }}-ccbroker
+spec:
+  replicas: {{ .Values.ccbroker.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-ccbroker
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-ccbroker
+    spec:
+      serviceAccountName: {{ .Release.Name }}
+      initContainers:
+        {{- if .Values.postgresql.enabled }}
+        - name: wait-for-postgresql
+          image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          command:
+            - sh
+            - -c
+            - |
+              until pg_isready -h {{ .Release.Name }}-postgresql -p 5432 -U {{ .Values.postgresql.auth.username }}; do
+                echo "Waiting for PostgreSQL to be ready..."
+                sleep 2
+              done
+        - name: create-ccbroker-database
+          image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          command:
+            - sh
+            - -c
+            - |
+              PGPASSWORD="$PG_PASSWORD" psql -h {{ .Release.Name }}-postgresql -U {{ .Values.postgresql.auth.username }} -d {{ .Values.postgresql.auth.database }} -tc "SELECT 1 FROM pg_database WHERE datname='{{ .Values.ccbroker.database.name }}'" | grep -q 1 || \
+              PGPASSWORD="$PG_PASSWORD" createdb -h {{ .Release.Name }}-postgresql -U {{ .Values.postgresql.auth.username }} {{ .Values.ccbroker.database.name }}
+          env:
+            - name: PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-postgresql
+                  key: POSTGRES_PASSWORD
+        {{- end }}
+      containers:
+        - name: cc-broker
+          image: "{{ .Values.ccbroker.image.repository }}:{{ .Values.ccbroker.image.tag }}"
+          imagePullPolicy: {{ .Values.ccbroker.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.ccbroker.port }}
+              protocol: TCP
+          env:
+            - name: CCBROKER_PORT
+              value: {{ .Values.ccbroker.port | quote }}
+            - name: CCBROKER_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-ccbroker-secret
+                  key: database-url
+            - name: CCBROKER_JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-ccbroker-secret
+                  key: jwt-secret
+            - name: CCBROKER_EXECUTOR_REGISTRY_URL
+              value: "http://{{ .Release.Name }}-executor-registry:{{ .Values.executorRegistry.port }}"
+            - name: CCBROKER_AGENTSERVER_URL
+              value: "http://{{ .Release.Name }}:{{ .Values.service.port }}"
+            - name: CCBROKER_IMBRIDGE_URL
+              value: "http://{{ .Release.Name }}-imbridge:{{ .Values.imbridge.port }}"
+            {{- if .Values.ccbroker.openviking.url }}
+            - name: CCBROKER_OPENVIKING_URL
+              value: {{ .Values.ccbroker.openviking.url | quote }}
+            {{- end }}
+            {{- if .Values.ccbroker.openviking.apiKey }}
+            - name: CCBROKER_OPENVIKING_API_KEY
+              value: {{ .Values.ccbroker.openviking.apiKey | quote }}
+            {{- end }}
+            {{- if .Values.ccbroker.logLevel }}
+            - name: CCBROKER_LOG_LEVEL
+              value: {{ .Values.ccbroker.logLevel | quote }}
+            {{- end }}
+            {{- if .Values.internal.apiSecret }}
+            - name: INTERNAL_API_SECRET
+              value: {{ .Values.internal.apiSecret | quote }}
+            {{- end }}
+            # Anthropic credentials come from the shared agentserver secret so
+            # there is a single source of truth (`models.anthropicApiKey`).
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secret
+                  key: anthropic-api-key
+                  optional: true
+            - name: ANTHROPIC_BASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secret
+                  key: anthropic-base-url
+                  optional: true
+            - name: ANTHROPIC_AUTH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secret
+                  key: anthropic-auth-token
+                  optional: true
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.ccbroker.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.ccbroker.port }}
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          {{- with .Values.ccbroker.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-ccbroker
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.ccbroker.port }}
+      targetPort: {{ .Values.ccbroker.port }}
+      protocol: TCP
+  selector:
+    app: {{ .Release.Name }}-ccbroker
+{{- end }}

--- a/deploy/helm/agentserver/templates/executor-registry.yaml
+++ b/deploy/helm/agentserver/templates/executor-registry.yaml
@@ -1,0 +1,107 @@
+{{- if .Values.executorRegistry.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-executor-registry-secret
+  labels:
+    app: {{ .Release.Name }}-executor-registry
+type: Opaque
+stringData:
+  database-url: {{ include "agentserver.executorRegistryDatabaseUrl" . | quote }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-executor-registry
+  labels:
+    app: {{ .Release.Name }}-executor-registry
+spec:
+  replicas: {{ .Values.executorRegistry.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-executor-registry
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-executor-registry
+    spec:
+      serviceAccountName: {{ .Release.Name }}
+      initContainers:
+        {{- if .Values.postgresql.enabled }}
+        - name: wait-for-postgresql
+          image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          command:
+            - sh
+            - -c
+            - |
+              until pg_isready -h {{ .Release.Name }}-postgresql -p 5432 -U {{ .Values.postgresql.auth.username }}; do
+                echo "Waiting for PostgreSQL to be ready..."
+                sleep 2
+              done
+        - name: create-executor-registry-database
+          image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          command:
+            - sh
+            - -c
+            - |
+              PGPASSWORD="$PG_PASSWORD" psql -h {{ .Release.Name }}-postgresql -U {{ .Values.postgresql.auth.username }} -d {{ .Values.postgresql.auth.database }} -tc "SELECT 1 FROM pg_database WHERE datname='{{ .Values.executorRegistry.database.name }}'" | grep -q 1 || \
+              PGPASSWORD="$PG_PASSWORD" createdb -h {{ .Release.Name }}-postgresql -U {{ .Values.postgresql.auth.username }} {{ .Values.executorRegistry.database.name }}
+          env:
+            - name: PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-postgresql
+                  key: POSTGRES_PASSWORD
+        {{- end }}
+      containers:
+        - name: executor-registry
+          image: "{{ .Values.executorRegistry.image.repository }}:{{ .Values.executorRegistry.image.tag }}"
+          imagePullPolicy: {{ .Values.executorRegistry.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.executorRegistry.port }}
+              name: http
+              protocol: TCP
+          env:
+            - name: EXECREG_PORT
+              value: {{ .Values.executorRegistry.port | quote }}
+            - name: EXECREG_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-executor-registry-secret
+                  key: database-url
+            {{- if .Values.executorRegistry.logLevel }}
+            - name: EXECREG_LOG_LEVEL
+              value: {{ .Values.executorRegistry.logLevel | quote }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.executorRegistry.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.executorRegistry.port }}
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          {{- with .Values.executorRegistry.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-executor-registry
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.executorRegistry.port }}
+      targetPort: {{ .Values.executorRegistry.port }}
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ .Release.Name }}-executor-registry
+{{- end }}

--- a/deploy/helm/agentserver/values.yaml
+++ b/deploy/helm/agentserver/values.yaml
@@ -209,6 +209,60 @@ credentialproxy:
   # Override database URL (defaults to shared agentserver database).
   externalDatabaseUrl: ""
 
+# Shared secret used on all internal service-to-service calls:
+#   agentserver → imbridge, imbridge → agentserver, cc-broker → imbridge.
+# When empty, internal endpoints fall open (no auth); set this in production.
+internal:
+  apiSecret: ""
+
+# cc-broker: runs Claude Code workers on demand and exposes the bridge +
+# MCP server used by stateless-CC sessions.
+ccbroker:
+  enabled: false
+  image:
+    repository: ghcr.io/agentserver/cc-broker
+    tag: latest
+    pullPolicy: Always
+  replicaCount: 1
+  port: 8085
+  logLevel: info
+  # Secret used to sign per-turn worker JWTs. Generated at install time if
+  # left empty; supply your own for stable values across re-installs.
+  jwtSecret: ""
+  database:
+    # Database name inside the shared PostgreSQL instance (ignored when
+    # externalUrl is set).
+    name: ccbroker
+    # Full DSN; overrides the shared PostgreSQL helper when set.
+    externalUrl: ""
+  # OpenViking provides per-workspace context persistence (CLAUDE.md, Memory,
+  # Skills, settings). When both fields are empty, cc-broker will start but
+  # workers will run without workspace context — fine for basic text chat,
+  # but skills/memory/CLAUDE.md won't persist.
+  openviking:
+    url: ""
+    apiKey: ""
+  # Spawned CC workers need Anthropic credentials. They're read from the
+  # shared agentserver secret (see `models.anthropicApiKey` /
+  # `models.anthropicBaseUrl` / `models.anthropicAuthToken` above).
+  resources: {}
+
+# executor-registry: tracks local tool-executor agents and routes remote_*
+# tool calls to them over WebSocket + yamux tunnels.
+executorRegistry:
+  enabled: false
+  image:
+    repository: ghcr.io/agentserver/executor-registry
+    tag: latest
+    pullPolicy: Always
+  replicaCount: 1
+  port: 8084
+  logLevel: info
+  database:
+    name: executorregistry
+    externalUrl: ""
+  resources: {}
+
 service:
   type: ClusterIP
   port: 8080


### PR DESCRIPTION
## Summary

PR A of the stateless-CC deployment rollout. Adds Helm templates and CI image builds for \`cc-broker\` and \`executor-registry\`. No existing release changes behavior — both services default to \`enabled: false\`.

## Changes

- **CI** (\`.github/workflows/build.yml\`): two new Docker build jobs (mirroring \`build-imbridge\`) for \`cc-broker\` and \`executor-registry\`, added to \`publish-helm\` + \`release\` \`needs\` lists.
- **Dockerfile.cc-broker**: installs the \`claude\` CLI via the native installer. \`SpawnWorker\` execs \`claude\` per turn — without this the image builds but every worker fails with \"claude: command not found\".
- **templates/cc-broker.yaml** (new): Secret + Deployment + Service. Init containers wait for PostgreSQL and create the \`ccbroker\` DB on the shared instance (same pattern as \`hydra\`). JWT secret generated once, kept stable across upgrades via \`lookup\`. Anthropic creds are pulled from the existing \`{{ .Release.Name }}-secret\` so there is a single source of truth.
- **templates/executor-registry.yaml** (new): Secret + Deployment + Service. Same DB-init pattern; no Anthropic keys required.
- **templates/_helpers.tpl**: \`ccbrokerDatabaseUrl\` and \`executorRegistryDatabaseUrl\` helpers.
- **values.yaml**: \`internal.apiSecret\` (shared across agentserver / imbridge / cc-broker; wired by PR B), \`ccbroker\` and \`executorRegistry\` sections with \`enabled: false\` defaults.
- **Chart.yaml**: \`0.38.1\` → \`0.39.0\` (new services, backward compatible).

## Verification

- [x] \`helm lint --strict deploy/helm/agentserver\` (default values) — clean
- [x] \`helm lint --strict deploy/helm/agentserver --set ccbroker.enabled=true,executorRegistry.enabled=true\` — clean
- [x] \`helm template\` with both services enabled — rendered Secrets / Deployments / Services look correct; init-container wait-for-pg + createdb wire up; env vars resolve to the right service DNS and secretKeyRefs (PG_PASSWORD from \`-postgresql\` secret, ANTHROPIC_* from \`-secret\`)
- [x] Default render (no flags) — new services omitted entirely
- [ ] Manual: once merged, verify CI produces images \`ghcr.io/agentserver/{cc-broker,executor-registry}:main\`

## Follow-ups (separate PRs)

- **PR B**: inject \`INTERNAL_API_SECRET\` + \`CCBROKER_URL\` into agentserver + imbridge deployments so the running services actually talk to cc-broker.
- **Pulumi stack**: bump chart to \`0.39.0\`, add values for the two new services, \`pulumi up\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)