### PR TITLE
chore(chart): inject CC_BROKER_URL + INTERNAL_API_SECRET into agentserver + imbridge

### DIFF
--- a/deploy/helm/agentserver/templates/deployment.yaml
+++ b/deploy/helm/agentserver/templates/deployment.yaml
@@ -181,6 +181,14 @@ spec:
             {{- end }}
             - name: IMBRIDGE_URL
               value: {{ printf "http://%s-imbridge.%s.svc:%v" .Release.Name .Release.Namespace (int .Values.imbridge.port) | quote }}
+            {{- if .Values.ccbroker.enabled }}
+            - name: CC_BROKER_URL
+              value: {{ printf "http://%s-ccbroker.%s.svc:%v" .Release.Name .Release.Namespace (int .Values.ccbroker.port) | quote }}
+            {{- end }}
+            {{- if .Values.internal.apiSecret }}
+            - name: INTERNAL_API_SECRET
+              value: {{ .Values.internal.apiSecret | quote }}
+            {{- end }}
             - name: OPENCODE_SUBDOMAIN_PREFIX
               value: {{ .Values.sandbox.opencode.subdomainPrefix | default "code" | quote }}
             - name: OPENCLAW_SUBDOMAIN_PREFIX

--- a/deploy/helm/agentserver/templates/imbridge.yaml
+++ b/deploy/helm/agentserver/templates/imbridge.yaml
@@ -45,6 +45,10 @@ spec:
                 secretKeyRef:
                   name: {{ include "agentserver.databaseSecretName" . }}
                   key: database-url
+            {{- if .Values.internal.apiSecret }}
+            - name: INTERNAL_API_SECRET
+              value: {{ .Values.internal.apiSecret | quote }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
## Summary

PR B of the stateless-CC deployment rollout — **depends on #39**. Adds the three missing env-var injections so existing services actually talk to cc-broker once it's running.

Targets #39's branch so the \`.Values.internal.apiSecret\` / \`.Values.ccbroker.*\` keys referenced here exist in CI; merge #39 first, then this rebases automatically onto main.

## Changes

\`templates/deployment.yaml\` (agentserver):
- \`CC_BROKER_URL\` — emitted when \`ccbroker.enabled=true\`; points at the in-cluster \`{release}-ccbroker\` service. Read by \`cmd/serve.go:228\` via \`os.Getenv(\"CC_BROKER_URL\")\`.
- \`INTERNAL_API_SECRET\` — emitted when \`internal.apiSecret\` is non-empty. Used by both directions of the agentserver ↔ imbridge calls.

\`templates/imbridge.yaml\`:
- \`INTERNAL_API_SECRET\` — same secret; imbridge checks the \`X-Internal-Secret\` header on \`/api/internal/imbridge/send{,-image}\`.

Both injections are conditional — with chart defaults (ccbroker.enabled=false, internal.apiSecret=\"\") no new env vars are emitted. Verified.

## Verification

- [x] \`helm lint --strict\` clean both with and without the new flags
- [x] \`helm template\` with \`ccbroker.enabled=true,internal.apiSecret=shh\` renders \`CC_BROKER_URL\` + \`INTERNAL_API_SECRET\` on agentserver and \`INTERNAL_API_SECRET\` on imbridge
- [x] \`helm template\` with defaults emits neither var anywhere

## After this lands

Stateless-CC deployment has everything it needs on the agentserver-repo side. Remaining work is in the Pulumi stack at \`/root/k8s/stacks/agentserver.ts\`: bump the chart to \`0.39.0\`, generate a shared \`internal.apiSecret\` (like the existing \`credproxyKey\`/\`hydraSecret\`), set \`ccbroker.enabled\` / \`executorRegistry.enabled\`, then \`pulumi up\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)