### PR TITLE
chore(chart): vendor OpenViking as subchart + harden DB helpers

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.39.0
-appVersion: "0.39.0"
+version: 0.40.0
+appVersion: "0.40.0"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver
@@ -17,3 +17,12 @@ keywords:
   - terminal
   - code-server
 icon: https://raw.githubusercontent.com/agentserver/agentserver/main/docs/icon.png
+# Vendored subcharts. OpenViking provides per-workspace context persistence
+# (CLAUDE.md / Memory / Skills / settings) for cc-broker's stateless CC workers.
+# See `charts/openviking/` — the chart is a verbatim copy of the upstream
+# OpenViking Helm chart; upgrade by replacing the directory.
+dependencies:
+  - name: openviking
+    version: 0.1.0
+    repository: ""
+    condition: openviking.enabled

--- a/deploy/helm/agentserver/charts/openviking/.helmignore
+++ b/deploy/helm/agentserver/charts/openviking/.helmignore
@@ -1,0 +1,18 @@
+# Patterns to ignore when building packages.
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/helm/agentserver/charts/openviking/Chart.yaml
+++ b/deploy/helm/agentserver/charts/openviking/Chart.yaml
@@ -1,0 +1,18 @@
+apiVersion: v2
+name: openviking
+description: OpenViking - The Context Database for AI Agents
+type: application
+version: 0.1.0
+appVersion: "0.1.18"
+keywords:
+  - openviking
+  - ai
+  - agents
+  - context-database
+  - rag
+home: https://github.com/volcengine/OpenViking
+sources:
+  - https://github.com/volcengine/OpenViking
+maintainers:
+  - name: OpenViking Contributors
+    url: https://github.com/volcengine/OpenViking

--- a/deploy/helm/agentserver/charts/openviking/templates/NOTES.txt
+++ b/deploy/helm/agentserver/charts/openviking/templates/NOTES.txt
@@ -1,0 +1,41 @@
+Thank you for installing OpenViking!
+
+Your release is named: {{ .Release.Name }}
+
+To check the status of your deployment:
+
+  kubectl get pods -l "app.kubernetes.io/name={{ include "openviking.name" . }},app.kubernetes.io/instance={{ .Release.Name }}"
+
+To access the OpenViking API:
+
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "openviking.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo "http://$NODE_IP:$NODE_PORT"
+{{- else if contains "LoadBalancer" .Values.service.type }}
+  NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+  kubectl get --namespace {{ .Release.Namespace }} svc {{ include "openviking.fullname" . }} -w
+{{- else }}
+  kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ include "openviking.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+  echo "Visit http://127.0.0.1:{{ .Values.service.port }}/health to verify the server is running."
+{{- end }}
+
+IMPORTANT: Make sure to configure your embedding and VLM API keys in values.yaml
+or via extraEnv before using OpenViking. The server will not function correctly
+without valid model provider credentials.
+
+{{- if not .Values.config.server.root_api_key }}
+
+WARNING: config.server.root_api_key is not set. When the server binds to 0.0.0.0
+(the default), a root_api_key is REQUIRED for security. The server will refuse to
+start without it.
+
+Set it via:
+
+  helm upgrade {{ .Release.Name }} <chart> --set config.server.root_api_key="YOUR_SECRET_KEY"
+
+{{- end }}

--- a/deploy/helm/agentserver/charts/openviking/templates/_helpers.tpl
+++ b/deploy/helm/agentserver/charts/openviking/templates/_helpers.tpl
@@ -1,0 +1,71 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "openviking.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this
+(by the DNS naming spec). If release name contains chart name it will be used
+as a full name.
+*/}}
+{{- define "openviking.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "openviking.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels.
+*/}}
+{{- define "openviking.labels" -}}
+helm.sh/chart: {{ include "openviking.chart" . }}
+{{ include "openviking.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "openviking.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "openviking.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "openviking.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "openviking.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Return the image name including tag.
+*/}}
+{{- define "openviking.image" -}}
+{{- $tag := default .Chart.AppVersion .Values.image.tag -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end }}

--- a/deploy/helm/agentserver/charts/openviking/templates/configmap.yaml
+++ b/deploy/helm/agentserver/charts/openviking/templates/configmap.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "openviking.fullname" . }}-config
+  labels:
+    {{- include "openviking.labels" . | nindent 4 }}
+data:
+  ov.conf: |
+    {{- .Values.config | toPrettyJson | nindent 4 }}

--- a/deploy/helm/agentserver/charts/openviking/templates/deployment.yaml
+++ b/deploy/helm/agentserver/charts/openviking/templates/deployment.yaml
@@ -1,0 +1,101 @@
+{{- if gt (int .Values.replicaCount) 1 }}
+{{- fail "replicaCount must be 1. OpenViking uses RocksDB which does not support concurrent access from multiple pods sharing the same PVC." }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "openviking.fullname" . }}
+  labels:
+    {{- include "openviking.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "openviking.selectorLabels" . | nindent 6 }}
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- include "openviking.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "openviking.serviceAccountName" . }}
+      {{- end }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          image: {{ include "openviking.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["openviking-server"]
+          env:
+            - name: OPENVIKING_CONFIG_FILE
+              value: /app/ov.conf
+            {{- with .Values.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.config.server.port | default 1933 }}
+              protocol: TCP
+          {{- with .Values.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
+          readinessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: config
+              mountPath: /app/ov.conf
+              subPath: ov.conf
+              readOnly: true
+            - name: data
+              mountPath: {{ .Values.persistence.mountPath }}
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "openviking.fullname" . }}-config
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Values.persistence.existingClaim | default (printf "%s-data" (include "openviking.fullname" .)) }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/agentserver/charts/openviking/templates/ingress.yaml
+++ b/deploy/helm/agentserver/charts/openviking/templates/ingress.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "openviking.fullname" . }}
+  labels:
+    {{- include "openviking.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "openviking.fullname" $ }}
+                port:
+                  name: http
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/agentserver/charts/openviking/templates/pvc.yaml
+++ b/deploy/helm/agentserver/charts/openviking/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "openviking.fullname" . }}-data
+  labels:
+    {{- include "openviking.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/deploy/helm/agentserver/charts/openviking/templates/service.yaml
+++ b/deploy/helm/agentserver/charts/openviking/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "openviking.fullname" . }}
+  labels:
+    {{- include "openviking.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "openviking.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/agentserver/charts/openviking/values.yaml
+++ b/deploy/helm/agentserver/charts/openviking/values.yaml
@@ -1,0 +1,146 @@
+# Default values for openviking.
+
+replicaCount: 1
+
+image:
+  repository: ghcr.io/volcengine/openviking
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created.
+  create: false
+  # Annotations to add to the service account.
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template.
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 1000
+
+securityContext: {}
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 1933
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # cert-manager.io/cluster-issuer: letsencrypt-prod
+  hosts:
+    - host: openviking.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+  #  - secretName: openviking-tls
+  #    hosts:
+  #      - openviking.local
+
+resources:
+  limits:
+    cpu: "2"
+    memory: 4Gi
+  requests:
+    cpu: 500m
+    memory: 1Gi
+
+persistence:
+  enabled: true
+  # Storage class for the PVC. Leave empty for the default storage class.
+  storageClass: ""
+  accessMode: ReadWriteOnce
+  size: 20Gi
+  # Existing PVC name. If set, no new PVC is created.
+  existingClaim: ""
+  # Mount path inside the container for data directory.
+  mountPath: /app/data
+
+# OpenViking server configuration (ov.conf).
+# This is rendered into a ConfigMap and mounted at /app/ov.conf.
+config:
+  storage:
+    workspace: /app/data/openviking_workspace
+    vectordb:
+      name: context
+      backend: local
+      project: default
+    agfs:
+      backend: local
+      timeout: 10
+  log:
+    level: INFO
+    output: stdout
+  server:
+    host: "0.0.0.0"
+    port: 1933
+    workers: 1
+    root_api_key: ""
+    cors_origins:
+      - "*"
+  embedding:
+    dense:
+      api_base: "https://ark.cn-beijing.volces.com/api/v3"
+      api_key: ""
+      provider: "volcengine"
+      dimension: 1024
+      model: "doubao-embedding-vision-251215"
+      input: "multimodal"
+    max_concurrent: 10
+  vlm:
+    api_base: "https://ark.cn-beijing.volces.com/api/v3"
+    api_key: ""
+    provider: "volcengine"
+    model: "doubao-seed-2-0-pro-260215"
+    temperature: 0.0
+    max_retries: 2
+    thinking: false
+    max_concurrent: 100
+
+# Extra environment variables to set on the container.
+# Use this for secrets or overrides that should not be in the ConfigMap.
+extraEnv: []
+  # - name: OPENVIKING_CONFIG_FILE
+  #   value: /app/ov.conf
+  # - name: SOME_SECRET
+  #   valueFrom:
+  #     secretKeyRef:
+  #       name: my-secret
+  #       key: api-key
+
+# Liveness and readiness probes.
+livenessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 30
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+readinessProbe:
+  httpGet:
+    path: /health
+    port: http
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+nodeSelector: {}
+tolerations: []
+affinity: {}

--- a/deploy/helm/agentserver/templates/_helpers.tpl
+++ b/deploy/helm/agentserver/templates/_helpers.tpl
@@ -44,12 +44,18 @@ postgres://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.pas
 Construct the cc-broker DATABASE_URL.
 - Shared PG: same instance, separate database (default: ccbroker)
 - External: ccbroker.database.externalUrl
+
+`dig` is used for nil-safe nested access — helm v4 does not deep-merge a
+`--set ccbroker.enabled=true` onto the values.yaml defaults, so the nested
+`database` map can be absent at render time.
 */}}
 {{- define "agentserver.ccbrokerDatabaseUrl" -}}
-{{- if .Values.ccbroker.database.externalUrl -}}
-{{ .Values.ccbroker.database.externalUrl }}
+{{- $extUrl := (dig "database" "externalUrl" "" .Values.ccbroker) -}}
+{{- $dbName := (dig "database" "name" "ccbroker" .Values.ccbroker) -}}
+{{- if $extUrl -}}
+{{ $extUrl }}
 {{- else -}}
-postgres://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.ccbroker.database.name }}?sslmode=disable
+postgres://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Release.Name }}-postgresql:5432/{{ $dbName }}?sslmode=disable
 {{- end -}}
 {{- end -}}
 
@@ -59,9 +65,11 @@ Construct the executor-registry DATABASE_URL.
 - External: executorRegistry.database.externalUrl
 */}}
 {{- define "agentserver.executorRegistryDatabaseUrl" -}}
-{{- if .Values.executorRegistry.database.externalUrl -}}
-{{ .Values.executorRegistry.database.externalUrl }}
+{{- $extUrl := (dig "database" "externalUrl" "" .Values.executorRegistry) -}}
+{{- $dbName := (dig "database" "name" "executorregistry" .Values.executorRegistry) -}}
+{{- if $extUrl -}}
+{{ $extUrl }}
 {{- else -}}
-postgres://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Release.Name }}-postgresql:5432/{{ .Values.executorRegistry.database.name }}?sslmode=disable
+postgres://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Release.Name }}-postgresql:5432/{{ $dbName }}?sslmode=disable
 {{- end -}}
 {{- end -}}

--- a/deploy/helm/agentserver/templates/cc-broker.yaml
+++ b/deploy/helm/agentserver/templates/cc-broker.yaml
@@ -92,18 +92,23 @@ spec:
               value: "http://{{ .Release.Name }}-imbridge:{{ .Values.imbridge.port }}"
             {{/* Prefer the explicit ccbroker.openviking.url; otherwise, if
                  the OpenViking subchart is enabled in this release, point at
-                 its in-cluster service DNS. */}}
-            {{- $ovURL := .Values.ccbroker.openviking.url }}
-            {{- if and (not $ovURL) .Values.openviking.enabled }}
-            {{- $ovURL = printf "http://%s-openviking:%v" .Release.Name (int .Values.openviking.service.port) }}
+                 its in-cluster service DNS. `dig` keeps this nil-safe when
+                 an operator omits the nested `ccbroker.openviking` or
+                 top-level `openviking` blocks from their values override. */}}
+            {{- $ovURL := (dig "openviking" "url" "" .Values.ccbroker) }}
+            {{- $ovEnabled := (dig "enabled" false .Values.openviking) }}
+            {{- $ovPort := (dig "service" "port" 1933 .Values.openviking) }}
+            {{- if and (not $ovURL) $ovEnabled }}
+            {{- $ovURL = printf "http://%s-openviking:%v" .Release.Name (int $ovPort) }}
             {{- end }}
             {{- if $ovURL }}
             - name: CCBROKER_OPENVIKING_URL
               value: {{ $ovURL | quote }}
             {{- end }}
-            {{- if .Values.ccbroker.openviking.apiKey }}
+            {{- $ovAPIKey := (dig "openviking" "apiKey" "" .Values.ccbroker) }}
+            {{- if $ovAPIKey }}
             - name: CCBROKER_OPENVIKING_API_KEY
-              value: {{ .Values.ccbroker.openviking.apiKey | quote }}
+              value: {{ $ovAPIKey | quote }}
             {{- end }}
             {{- if .Values.ccbroker.logLevel }}
             - name: CCBROKER_LOG_LEVEL

--- a/deploy/helm/agentserver/templates/cc-broker.yaml
+++ b/deploy/helm/agentserver/templates/cc-broker.yaml
@@ -54,8 +54,9 @@ spec:
             - sh
             - -c
             - |
-              PGPASSWORD="$PG_PASSWORD" psql -h {{ .Release.Name }}-postgresql -U {{ .Values.postgresql.auth.username }} -d {{ .Values.postgresql.auth.database }} -tc "SELECT 1 FROM pg_database WHERE datname='{{ .Values.ccbroker.database.name }}'" | grep -q 1 || \
-              PGPASSWORD="$PG_PASSWORD" createdb -h {{ .Release.Name }}-postgresql -U {{ .Values.postgresql.auth.username }} {{ .Values.ccbroker.database.name }}
+              {{- $dbName := (dig "database" "name" "ccbroker" .Values.ccbroker) }}
+              PGPASSWORD="$PG_PASSWORD" psql -h {{ .Release.Name }}-postgresql -U {{ .Values.postgresql.auth.username }} -d {{ .Values.postgresql.auth.database }} -tc "SELECT 1 FROM pg_database WHERE datname='{{ $dbName }}'" | grep -q 1 || \
+              PGPASSWORD="$PG_PASSWORD" createdb -h {{ .Release.Name }}-postgresql -U {{ .Values.postgresql.auth.username }} {{ $dbName }}
           env:
             - name: PG_PASSWORD
               valueFrom:
@@ -89,9 +90,16 @@ spec:
               value: "http://{{ .Release.Name }}:{{ .Values.service.port }}"
             - name: CCBROKER_IMBRIDGE_URL
               value: "http://{{ .Release.Name }}-imbridge:{{ .Values.imbridge.port }}"
-            {{- if .Values.ccbroker.openviking.url }}
+            {{/* Prefer the explicit ccbroker.openviking.url; otherwise, if
+                 the OpenViking subchart is enabled in this release, point at
+                 its in-cluster service DNS. */}}
+            {{- $ovURL := .Values.ccbroker.openviking.url }}
+            {{- if and (not $ovURL) .Values.openviking.enabled }}
+            {{- $ovURL = printf "http://%s-openviking:%v" .Release.Name (int .Values.openviking.service.port) }}
+            {{- end }}
+            {{- if $ovURL }}
             - name: CCBROKER_OPENVIKING_URL
-              value: {{ .Values.ccbroker.openviking.url | quote }}
+              value: {{ $ovURL | quote }}
             {{- end }}
             {{- if .Values.ccbroker.openviking.apiKey }}
             - name: CCBROKER_OPENVIKING_API_KEY

--- a/deploy/helm/agentserver/templates/executor-registry.yaml
+++ b/deploy/helm/agentserver/templates/executor-registry.yaml
@@ -46,8 +46,9 @@ spec:
             - sh
             - -c
             - |
-              PGPASSWORD="$PG_PASSWORD" psql -h {{ .Release.Name }}-postgresql -U {{ .Values.postgresql.auth.username }} -d {{ .Values.postgresql.auth.database }} -tc "SELECT 1 FROM pg_database WHERE datname='{{ .Values.executorRegistry.database.name }}'" | grep -q 1 || \
-              PGPASSWORD="$PG_PASSWORD" createdb -h {{ .Release.Name }}-postgresql -U {{ .Values.postgresql.auth.username }} {{ .Values.executorRegistry.database.name }}
+              {{- $dbName := (dig "database" "name" "executorregistry" .Values.executorRegistry) }}
+              PGPASSWORD="$PG_PASSWORD" psql -h {{ .Release.Name }}-postgresql -U {{ .Values.postgresql.auth.username }} -d {{ .Values.postgresql.auth.database }} -tc "SELECT 1 FROM pg_database WHERE datname='{{ $dbName }}'" | grep -q 1 || \
+              PGPASSWORD="$PG_PASSWORD" createdb -h {{ .Release.Name }}-postgresql -U {{ .Values.postgresql.auth.username }} {{ $dbName }}
           env:
             - name: PG_PASSWORD
               valueFrom:

--- a/deploy/helm/agentserver/values.yaml
+++ b/deploy/helm/agentserver/values.yaml
@@ -257,6 +257,41 @@ executorRegistry:
     pullPolicy: Always
   replicaCount: 1
   port: 8084
+
+# OpenViking (vendored subchart — charts/openviking/) provides per-workspace
+# context persistence for cc-broker workers: CLAUDE.md, auto-memory, skills,
+# settings.json. Enable alongside ccbroker.enabled to get a full-context flow.
+#
+# When enabled and ccbroker.openviking.url is left empty, cc-broker's URL is
+# auto-wired to the in-cluster service by the chart template.
+#
+# Set `openviking.config.server.root_api_key` AND
+# `ccbroker.openviking.apiKey` to the same value so cc-broker can authenticate.
+openviking:
+  enabled: false
+  # Upstream default image is ghcr.io/volcengine/openviking. Override here if
+  # you're pulling through a mirror registry.
+  image:
+    repository: ghcr.io/volcengine/openviking
+    pullPolicy: IfNotPresent
+    tag: ""
+  persistence:
+    enabled: true
+    # Leave empty to use the cluster default storage class, or set to match
+    # your environment (e.g. csi-rbd-sc).
+    storageClass: ""
+    size: 20Gi
+  service:
+    type: ClusterIP
+    port: 1933
+  # OpenViking server config (subset — see charts/openviking/values.yaml for
+  # the full list including embedding/VLM settings that cc-broker does not
+  # exercise and can safely be left blank).
+  config:
+    server:
+      # Required for auth. Generate one and set both this AND
+      # ccbroker.openviking.apiKey to the same value.
+      root_api_key: ""
   logLevel: info
   database:
     name: executorregistry


### PR DESCRIPTION
## Summary

PR C of the stateless-CC deployment rollout — **depends on #39 and #40**. Bundles OpenViking with the agentserver chart so cc-broker workers get proper CLAUDE.md / Memory / Skills / settings persistence out of the box.

Also hardens the chart against a helm v4 value-merge quirk that surfaced when `--set ccbroker.enabled=true` is used without also setting the nested \`database.*\` defaults.

## Changes

- \`charts/openviking/\` — verbatim copy of upstream OpenViking Helm chart v0.1.0 (appVersion 0.1.18). No local edits; upgrade by replacing the directory.
- \`Chart.yaml\` — new \`dependencies:\` entry (\`repository: \"\"\` resolves to the bundled directory), gated on \`openviking.enabled\`. Version \`0.39.0\` → \`0.40.0\`.
- \`values.yaml\` — new top-level \`openviking:\` section with \`enabled: false\` default. Embedding / VLM API keys left blank by design — cc-broker only hits \`/api/v1/{fs,content,resources}\` endpoints.
- \`templates/cc-broker.yaml\` — when \`openviking.enabled\` is true and \`ccbroker.openviking.url\` is empty, auto-wire \`CCBROKER_OPENVIKING_URL\` to \`http://{release}-openviking:1933\`. An explicit \`ccbroker.openviking.url\` still wins, for externally-managed OV.
- \`templates/_helpers.tpl\` + \`cc-broker.yaml\` + \`executor-registry.yaml\` — read \`database.*\` via \`dig\` so helm v4 doesn't throw \"nil pointer evaluating interface {}.externalUrl\" when a caller overrides \`.enabled\` without respecifying the nested map.

## Test Plan

- [x] \`helm lint --strict\` clean with defaults
- [x] \`helm lint --strict\` clean with \`--set ccbroker.enabled=true,executorRegistry.enabled=true,internal.apiSecret=shh\`
- [x] \`helm lint --strict\` clean with all three + \`openviking.enabled=true,openviking.config.server.root_api_key=ovkey,ccbroker.openviking.apiKey=ovkey\`
- [x] \`helm template\` verifies \`CCBROKER_OPENVIKING_URL\` auto-wires to \`http://{release}-openviking:1933\`
- [x] Subchart renders expected ConfigMap / Deployment / Service / PVC

## Why vendor instead of a remote repo

OpenViking doesn't publish an OCI Helm chart — the README only shows local installs. Vendoring keeps the agentserver chart self-contained and CI-buildable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)