### PR TITLE
chore(chart): inject CC_BROKER_URL + INTERNAL_API_SECRET into agentserver + imbridge

### DIFF
--- a/deploy/helm/agentserver/templates/deployment.yaml
+++ b/deploy/helm/agentserver/templates/deployment.yaml
@@ -181,6 +181,14 @@ spec:
             {{- end }}
             - name: IMBRIDGE_URL
               value: {{ printf "http://%s-imbridge.%s.svc:%v" .Release.Name .Release.Namespace (int .Values.imbridge.port) | quote }}
+            {{- if .Values.ccbroker.enabled }}
+            - name: CC_BROKER_URL
+              value: {{ printf "http://%s-ccbroker.%s.svc:%v" .Release.Name .Release.Namespace (int .Values.ccbroker.port) | quote }}
+            {{- end }}
+            {{- if .Values.internal.apiSecret }}
+            - name: INTERNAL_API_SECRET
+              value: {{ .Values.internal.apiSecret | quote }}
+            {{- end }}
             - name: OPENCODE_SUBDOMAIN_PREFIX
               value: {{ .Values.sandbox.opencode.subdomainPrefix | default "code" | quote }}
             - name: OPENCLAW_SUBDOMAIN_PREFIX

--- a/deploy/helm/agentserver/templates/imbridge.yaml
+++ b/deploy/helm/agentserver/templates/imbridge.yaml
@@ -45,6 +45,10 @@ spec:
                 secretKeyRef:
                   name: {{ include "agentserver.databaseSecretName" . }}
                   key: database-url
+            {{- if .Values.internal.apiSecret }}
+            - name: INTERNAL_API_SECRET
+              value: {{ .Values.internal.apiSecret | quote }}
+            {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz


### PR DESCRIPTION
(Re-filing — original #40 was auto-closed when its base branch \`feature/chart-cc-broker-executor-registry\` was removed after #39 merged.)

## Summary

PR B of the stateless-CC deployment rollout. Wires the three missing env vars so agentserver + imbridge can talk to cc-broker once it's running.

## Changes

\`templates/deployment.yaml\` (agentserver):
- \`CC_BROKER_URL\` — emitted when \`ccbroker.enabled=true\`; points at the in-cluster \`{release}-ccbroker\` service. Read by \`cmd/serve.go:228\` via \`os.Getenv(\"CC_BROKER_URL\")\`.
- \`INTERNAL_API_SECRET\` — emitted when \`internal.apiSecret\` is non-empty. Used by both directions of the agentserver ↔ imbridge calls.

\`templates/imbridge.yaml\`:
- \`INTERNAL_API_SECRET\` — same secret; imbridge checks the \`X-Internal-Secret\` header on \`/api/internal/imbridge/send{,-image}\`.

Both conditional; default render unchanged.

## Test Plan

- [x] \`helm lint --strict\` clean (defaults + flags)
- [x] \`helm template\` shows env vars render correctly when flags set

🤖 Generated with [Claude Code](https://claude.com/claude-code)