### PR TITLE
feat: IM channel routing_mode toggle (nanoclaw / stateless_cc)

### DIFF
--- a/docs/superpowers/plans/2026-05-02-im-channel-routing-mode-toggle.md
+++ b/docs/superpowers/plans/2026-05-02-im-channel-routing-mode-toggle.md
@@ -1,0 +1,813 @@
+# IM Channel Routing Mode Toggle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让 workspace 管理员能在 web UI 上把某个 IM channel 的 `routing_mode` 在 `nanoclaw` 与 `stateless_cc` 之间切换，立即生效（下一条 IM 消息就按新路由走），无需重启服务或执行 SQL。
+
+**Architecture:** 复用现有 `PATCH /api/workspaces/{wid}/im/channels/{id}` 路径；镜像 `require_mention` 的 in-memory 模式 —— DB 写 `workspace_im_channels.routing_mode` 列，同时在 Bridge 里更新 `channelRouting` 内存 map，让 `forwardMessage` 先查 map 再回落到初始 `binding.RoutingMode`。
+
+**Tech Stack:** Go 1.22+ (chi router), React 19 + TypeScript, PostgreSQL (migration 018 已建列，无 schema 变更)。
+
+**Testing strategy note:** `internal/imbridgesvc/` 与 `internal/db/` 目前没有任何测试基础设施（grep `_test.go` 为空）。本 plan 只在 `internal/imbridge/` 补一份单测（与现有 `matrix_api_test.go` 风格对齐），DB 函数与 handler 的行为通过手动 smoke test 覆盖。这和 repo 现有风格一致，避免本次 PR 引入整套 mock infra。
+
+**Spec:** `docs/superpowers/specs/2026-05-02-im-channel-routing-mode-toggle-design.md`
+
+---
+
+## File Structure
+
+| 操作 | 路径 | 职责 |
+|------|------|------|
+| Create | `internal/imbridge/bridge_routing_test.go` | Bridge in-memory routing map 的单测（并发 Set/Get + forwardMessage 走向） |
+| Modify | `internal/db/im_channels.go` | 新增 `UpdateIMChannelRoutingMode` 函数 |
+| Modify | `internal/imbridge/bridge.go` | Bridge struct 加 `channelRouting` map；`NewBridge` 初始化；`SetChannelRoutingMode`/`getChannelRoutingMode` 方法；`StartPoller` seed map；`forwardMessage` 先查 map |
+| Modify | `internal/imbridgesvc/handlers.go` | `handleUpdateWorkspaceIMChannel` 的 req struct 增加 `RoutingMode *string` 字段 + 校验 + 双写 |
+| Modify | `web/src/lib/api.ts` | `IMChannel` interface 加 `routing_mode`；`updateWorkspaceIMChannel` 的 settings 参数加 `routing_mode` |
+| Modify | `web/src/components/WorkspaceDetail.tsx` | channel 行内 `require_mention` 旁加 `<select>` 控件 |
+
+---
+
+## Phase 1 — DB Layer
+
+### Task 1.1: 新增 `UpdateIMChannelRoutingMode` 函数
+
+**Files:**
+- Modify: `internal/db/im_channels.go` (追加到文件末尾；紧邻现有 `UpdateIMChannelSettings` 后更易维护)
+
+- [ ] **Step 1: 打开 `internal/db/im_channels.go`，在 `UpdateIMChannelSettings` 函数 (~line 175) 正下方追加**
+
+```go
+// UpdateIMChannelRoutingMode updates the routing_mode column for a channel.
+// Caller is expected to validate `mode` before calling (valid values:
+// "nanoclaw", "stateless_cc"). Unknown values are accepted by the DB but
+// will cause forwardMessage to fall through to the default nanoclaw branch.
+func (db *DB) UpdateIMChannelRoutingMode(channelID, mode string) error {
+	_, err := db.Exec(
+		`UPDATE workspace_im_channels SET routing_mode = $1 WHERE id = $2`,
+		mode, channelID,
+	)
+	return err
+}
+```
+
+- [ ] **Step 2: 编译验证**
+
+Run: `cd /root/agentserver && go build ./internal/db/...`
+Expected: 0 errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/db/im_channels.go
+git commit -m "feat(db): add UpdateIMChannelRoutingMode
+
+For the upcoming routing_mode toggle UI. Kept as a standalone setter
+(separate from UpdateIMChannelSettings) so each mutable column has a
+clear-purpose function."
+```
+
+---
+
+## Phase 2 — Bridge In-Memory State + forwardMessage
+
+This phase is TDD: we write the `forwardMessage` behaviour test first (red), then change the Bridge code to make it pass (green).
+
+### Task 2.1: 写 failing 单测
+
+**Files:**
+- Create: `internal/imbridge/bridge_routing_test.go`
+
+- [ ] **Step 1: 新建文件并写入下面内容**
+
+Path: `internal/imbridge/bridge_routing_test.go`
+
+```go
+package imbridge
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+// TestForwardMessageChannelRoutingOverridesBinding verifies that
+// SetChannelRoutingMode's in-memory value wins over the initial
+// binding.RoutingMode captured at StartPoller time. This is the
+// core property that makes the toggle take effect without restarting
+// the poller.
+func TestForwardMessageChannelRoutingOverridesBinding(t *testing.T) {
+	b := &Bridge{
+		providers:        map[string]Provider{},
+		pollers:          map[string]context.CancelFunc{},
+		registeredGroups: map[string]string{},
+		channelMention:   map[string]bool{},
+		channelRouting:   map[string]string{},
+		typingSessions:   map[string]func(){},
+	}
+
+	// Override with stateless_cc in the in-memory map.
+	b.SetChannelRoutingMode("ch-abc", "stateless_cc")
+
+	// Simulate forwardMessage's routing decision directly. We cannot
+	// invoke forwardMessage end-to-end here without a real provider /
+	// HTTP target, so we assert on the effective mode computation.
+	got := b.getChannelRoutingMode("ch-abc")
+	if got != "stateless_cc" {
+		t.Fatalf("expected in-memory routing=stateless_cc, got %q", got)
+	}
+
+	// Missing channel → empty string so forwardMessage falls back to
+	// binding.RoutingMode.
+	if b.getChannelRoutingMode("unknown") != "" {
+		t.Fatalf("expected empty routing for unknown channel")
+	}
+}
+
+// TestSetChannelRoutingModeConcurrent ensures the setter/getter
+// are safe under concurrent access (mirrors SetChannelRequireMention
+// concurrency assumptions).
+func TestSetChannelRoutingModeConcurrent(t *testing.T) {
+	b := &Bridge{
+		providers:        map[string]Provider{},
+		pollers:          map[string]context.CancelFunc{},
+		registeredGroups: map[string]string{},
+		channelMention:   map[string]bool{},
+		channelRouting:   map[string]string{},
+		typingSessions:   map[string]func(){},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			b.SetChannelRoutingMode("ch1", "stateless_cc")
+		}()
+		go func() {
+			defer wg.Done()
+			_ = b.getChannelRoutingMode("ch1")
+		}()
+	}
+	wg.Wait()
+
+	if b.getChannelRoutingMode("ch1") != "stateless_cc" {
+		t.Fatalf("expected stateless_cc after concurrent writes")
+	}
+}
+```
+
+- [ ] **Step 2: 运行测试验证 FAIL**
+
+Run: `cd /root/agentserver && go test -run TestForwardMessageChannelRoutingOverridesBinding -v ./internal/imbridge/`
+Expected: 编译失败，错误大意是 `undefined: channelRouting` / `undefined: SetChannelRoutingMode` / `undefined: getChannelRoutingMode`（也可能是 `Bridge struct has no field channelRouting`）。这是预期的 — 说明测试和目标代码对齐。
+
+---
+
+### Task 2.2: 给 `Bridge` 加 `channelRouting` 字段 + `NewBridge` 初始化
+
+**Files:**
+- Modify: `internal/imbridge/bridge.go` (Bridge struct at ~line 56, NewBridge at ~line 71)
+
+- [ ] **Step 1: 在 `Bridge` struct 里 `channelMention` 行下方新增字段**
+
+把 `internal/imbridge/bridge.go` 里（约 line 64）：
+
+```go
+	channelMention   map[string]bool               // key: channelID → require_mention setting
+	typingSessions   map[string]func()             // key: "channelID:userID" → cancel func
+```
+
+改为：
+
+```go
+	channelMention   map[string]bool               // key: channelID → require_mention setting
+	channelRouting   map[string]string             // key: channelID → routing_mode (runtime override of binding)
+	typingSessions   map[string]func()             // key: "channelID:userID" → cancel func
+```
+
+- [ ] **Step 2: 在 `NewBridge` 的 return literal 里加 map 初始化**
+
+约 line 85。把：
+
+```go
+		channelMention:   make(map[string]bool),
+		typingSessions:   make(map[string]func()),
+```
+
+改为：
+
+```go
+		channelMention:   make(map[string]bool),
+		channelRouting:   make(map[string]string),
+		typingSessions:   make(map[string]func()),
+```
+
+- [ ] **Step 3: 编译验证**
+
+Run: `cd /root/agentserver && go build ./internal/imbridge/...`
+Expected: 0 errors (tests 仍然会失败，因为 Set/Get 方法还没加)。
+
+---
+
+### Task 2.3: 加 `SetChannelRoutingMode` / `getChannelRoutingMode` 方法
+
+**Files:**
+- Modify: `internal/imbridge/bridge.go` (紧随 `getChannelRequireMention` 之后插入，约 line 210)
+
+- [ ] **Step 1: 在 `getChannelRequireMention` 结束位置下方追加**
+
+约 line 209（`return v` 后的大括号后）。插入：
+
+```go
+// SetChannelRoutingMode updates the in-memory routing_mode for a channel.
+// The value takes precedence over the routing_mode captured in
+// BridgeBinding at StartPoller time, so a configuration change applied
+// via this setter is visible on the next inbound message.
+func (b *Bridge) SetChannelRoutingMode(channelID, mode string) {
+	b.mu.Lock()
+	b.channelRouting[channelID] = mode
+	b.mu.Unlock()
+}
+
+// getChannelRoutingMode reads the in-memory routing_mode. Returns ""
+// if the channel has no override — callers fall back to
+// BridgeBinding.RoutingMode in that case.
+func (b *Bridge) getChannelRoutingMode(channelID string) string {
+	b.mu.Lock()
+	v := b.channelRouting[channelID]
+	b.mu.Unlock()
+	return v
+}
+```
+
+- [ ] **Step 2: 跑测试验证先前失败的单测现在通过**
+
+Run: `cd /root/agentserver && go test -run 'TestForwardMessageChannelRoutingOverridesBinding|TestSetChannelRoutingModeConcurrent' -race -v ./internal/imbridge/`
+Expected: 两个测试都 PASS；`-race` 无 data race 报告。
+
+---
+
+### Task 2.4: 让 `forwardMessage` 先查内存 map 再回落 binding
+
+**Files:**
+- Modify: `internal/imbridge/bridge.go` (~line 319)
+
+- [ ] **Step 1: 打开 bridge.go，把 `forwardMessage` 函数整体改成**
+
+原函数（约 line 316-325）：
+
+```go
+func (b *Bridge) forwardMessage(ctx context.Context, binding BridgeBinding, msg InboundMessage) (bool, error) {
+	switch binding.RoutingMode {
+	case "stateless_cc":
+		return b.forwardToAgentserver(ctx, binding, msg)
+	default: // "nanoclaw" or empty (backward compatible)
+		return b.forwardToNanoClaw(ctx, binding, msg)
+	}
+}
+```
+
+改为：
+
+```go
+func (b *Bridge) forwardMessage(ctx context.Context, binding BridgeBinding, msg InboundMessage) (bool, error) {
+	// In-memory routing mode (set via SetChannelRoutingMode) wins over
+	// the routing_mode captured at StartPoller time. Empty map value
+	// means no override — fall through to binding.RoutingMode.
+	mode := b.getChannelRoutingMode(binding.ChannelID)
+	if mode == "" {
+		mode = binding.RoutingMode
+	}
+	switch mode {
+	case "stateless_cc":
+		return b.forwardToAgentserver(ctx, binding, msg)
+	default: // "nanoclaw" or empty (backward compatible)
+		return b.forwardToNanoClaw(ctx, binding, msg)
+	}
+}
+```
+
+- [ ] **Step 2: 编译验证 + 跑全量 imbridge 包测试**
+
+Run: `cd /root/agentserver && go test -race ./internal/imbridge/...`
+Expected: all PASS。
+
+---
+
+### Task 2.5: `StartPoller` 内 seed map
+
+**Files:**
+- Modify: `internal/imbridge/bridge.go` (~line 108)
+
+目的：一个刚启动的 poller 会把 `binding.RoutingMode` 写进 map，这样后续 PATCH 调 `SetChannelRoutingMode` 覆盖值也是从一个已知的基线出发（便于排查：`channelRouting[channelID]` 始终等于"当前生效的值"）。
+
+- [ ] **Step 1: 打开 bridge.go，在 `StartPoller` 里 `go b.pollLoop(ctx, binding)` 之前加 seed 语句**
+
+原函数（约 line 108-122）：
+
+```go
+func (b *Bridge) StartPoller(binding BridgeBinding) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	key := binding.ChannelID
+	if cancel, ok := b.pollers[key]; ok {
+		cancel()
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	b.pollers[key] = cancel
+
+	go b.pollLoop(ctx, binding)
+}
+```
+
+改为：
+
+```go
+func (b *Bridge) StartPoller(binding BridgeBinding) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	key := binding.ChannelID
+	if cancel, ok := b.pollers[key]; ok {
+		cancel()
+	}
+
+	// Seed the in-memory routing map so getChannelRoutingMode returns
+	// the value that forwardMessage would use by default. Later calls
+	// to SetChannelRoutingMode override this seeded value.
+	b.channelRouting[key] = binding.RoutingMode
+
+	ctx, cancel := context.WithCancel(context.Background())
+	b.pollers[key] = cancel
+
+	go b.pollLoop(ctx, binding)
+}
+```
+
+- [ ] **Step 2: 跑测试**
+
+Run: `cd /root/agentserver && go test -race ./internal/imbridge/...`
+Expected: all PASS。
+
+---
+
+### Task 2.6: Commit Phase 2
+
+- [ ] **Step 1: commit**
+
+```bash
+git add internal/imbridge/bridge.go internal/imbridge/bridge_routing_test.go
+git commit -m "feat(imbridge): runtime routing_mode override via channelRouting map
+
+Mirror the require_mention pattern: Bridge now keeps an in-memory
+channelRouting map, updated via SetChannelRoutingMode. forwardMessage
+consults the map first and falls back to BridgeBinding.RoutingMode
+when the map has no entry. StartPoller seeds the map so the override
+always reflects the currently effective value.
+
+Enables the upcoming routing_mode toggle API to take effect without
+restarting the long-poller."
+```
+
+---
+
+## Phase 3 — imbridgesvc Handler
+
+### Task 3.1: 扩展 `handleUpdateWorkspaceIMChannel`
+
+**Files:**
+- Modify: `internal/imbridgesvc/handlers.go` (~line 898 `handleUpdateWorkspaceIMChannel`)
+
+- [ ] **Step 1: 打开 handlers.go，把 `handleUpdateWorkspaceIMChannel` 函数整体改成**
+
+原函数（约 line 898-932）：
+
+```go
+func (s *Server) handleUpdateWorkspaceIMChannel(w http.ResponseWriter, r *http.Request) {
+	wsID := chi.URLParam(r, "id")
+	channelID := chi.URLParam(r, "channelId")
+	if _, ok := s.requireWorkspaceMember(w, r, wsID); !ok {
+		return
+	}
+
+	ch, err := s.db.GetIMChannel(channelID)
+	if err != nil || ch.WorkspaceID != wsID {
+		http.Error(w, "channel not found", http.StatusNotFound)
+		return
+	}
+
+	var req struct {
+		RequireMention *bool `json:"require_mention"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if req.RequireMention != nil {
+		if err := s.db.UpdateIMChannelSettings(channelID, *req.RequireMention); err != nil {
+			http.Error(w, "failed to update channel", http.StatusInternalServerError)
+			return
+		}
+		s.bridge.SetChannelRequireMention(channelID, *req.RequireMention)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "updated"})
+}
+```
+
+改为：
+
+```go
+func (s *Server) handleUpdateWorkspaceIMChannel(w http.ResponseWriter, r *http.Request) {
+	wsID := chi.URLParam(r, "id")
+	channelID := chi.URLParam(r, "channelId")
+	if _, ok := s.requireWorkspaceMember(w, r, wsID); !ok {
+		return
+	}
+
+	ch, err := s.db.GetIMChannel(channelID)
+	if err != nil || ch.WorkspaceID != wsID {
+		http.Error(w, "channel not found", http.StatusNotFound)
+		return
+	}
+
+	var req struct {
+		RequireMention *bool   `json:"require_mention"`
+		RoutingMode    *string `json:"routing_mode"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if req.RequireMention != nil {
+		if err := s.db.UpdateIMChannelSettings(channelID, *req.RequireMention); err != nil {
+			http.Error(w, "failed to update channel", http.StatusInternalServerError)
+			return
+		}
+		s.bridge.SetChannelRequireMention(channelID, *req.RequireMention)
+	}
+
+	if req.RoutingMode != nil {
+		mode := *req.RoutingMode
+		if mode != "nanoclaw" && mode != "stateless_cc" {
+			http.Error(w, "invalid routing_mode", http.StatusBadRequest)
+			return
+		}
+		if err := s.db.UpdateIMChannelRoutingMode(channelID, mode); err != nil {
+			http.Error(w, "failed to update channel", http.StatusInternalServerError)
+			return
+		}
+		s.bridge.SetChannelRoutingMode(channelID, mode)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{"status": "updated"})
+}
+```
+
+- [ ] **Step 2: 编译验证**
+
+Run: `cd /root/agentserver && go build ./internal/imbridgesvc/...`
+Expected: 0 errors。
+
+- [ ] **Step 3: 跑全量 Go 测试确保无回归**
+
+Run: `cd /root/agentserver && go test -race ./...`
+Expected: all PASS (关注 `imbridge` 和 `imbridgesvc` 包；其他包不受影响)。
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/imbridgesvc/handlers.go
+git commit -m "feat(imbridgesvc): accept routing_mode in PATCH IM channel
+
+handleUpdateWorkspaceIMChannel now accepts {require_mention?,
+routing_mode?}. routing_mode is validated against {nanoclaw,
+stateless_cc}; invalid values return 400. On success we write both
+the DB column and the Bridge in-memory map so the change takes effect
+on the next inbound message."
+```
+
+---
+
+## Phase 4 — Frontend
+
+### Task 4.1: 扩展 `IMChannel` 接口 + `updateWorkspaceIMChannel` 参数
+
+**Files:**
+- Modify: `web/src/lib/api.ts` (~line 444, 460)
+
+- [ ] **Step 1: 扩展 `IMChannel` interface**
+
+约 line 444。把：
+
+```ts
+export interface IMChannel {
+  id: string
+  workspace_id: string
+  provider: string
+  bot_id: string
+  user_id: string
+  require_mention: boolean
+  bound_at: string
+}
+```
+
+改为：
+
+```ts
+export interface IMChannel {
+  id: string
+  workspace_id: string
+  provider: string
+  bot_id: string
+  user_id: string
+  require_mention: boolean
+  routing_mode: string
+  bound_at: string
+}
+```
+
+- [ ] **Step 2: 扩展 `updateWorkspaceIMChannel` 的 settings 参数**
+
+约 line 460。把：
+
+```ts
+export async function updateWorkspaceIMChannel(workspaceId: string, channelId: string, settings: { require_mention?: boolean }): Promise<void> {
+```
+
+改为：
+
+```ts
+export async function updateWorkspaceIMChannel(
+  workspaceId: string,
+  channelId: string,
+  settings: { require_mention?: boolean; routing_mode?: 'nanoclaw' | 'stateless_cc' },
+): Promise<void> {
+```
+
+（函数体不变。）
+
+- [ ] **Step 3: TypeScript 编译验证**
+
+Run: `cd /root/agentserver/web && pnpm tsc --noEmit`
+Expected: 0 errors.
+
+---
+
+### Task 4.2: 在 `WorkspaceDetail.tsx` 的 channel 行加 `<select>`
+
+**Files:**
+- Modify: `web/src/components/WorkspaceDetail.tsx` (~line 744，在 require_mention `<label>` 之前)
+
+注意：此处没有已成型的 `<Select>` 组件库（repo 未引入 shadcn Select；现有 UI 控件基于原生 `<input>`/`<button>` + Tailwind），沿用原生 `<select>` 保持风格一致。
+
+- [ ] **Step 1: 打开 WorkspaceDetail.tsx，定位到现有 require_mention `<label>` (~line 741)**
+
+该段当前形如：
+
+```tsx
+                  <div className="flex items-center gap-2">
+                    <label className="flex items-center gap-1.5 text-[11px] text-[var(--muted-foreground)] cursor-pointer" title="Only reply when @mentioned in group chats">
+                      <input
+                        type="checkbox"
+                        checked={ch.require_mention}
+                        onChange={async (e) => {
+                          try {
+                            await updateWorkspaceIMChannel(workspaceId, ch.id, { require_mention: e.target.checked })
+                            loadChannels()
+                          } catch {}
+                        }}
+                        className="rounded"
+                      />
+                      @mention
+                    </label>
+                    <button
+                      onClick={() => setConfirmDeleteChannel(ch)}
+```
+
+在 `<label>` **之前**插入一个 `<select>`：
+
+```tsx
+                  <div className="flex items-center gap-2">
+                    <select
+                      value={ch.routing_mode || 'nanoclaw'}
+                      onChange={async (e) => {
+                        try {
+                          await updateWorkspaceIMChannel(workspaceId, ch.id, {
+                            routing_mode: e.target.value as 'nanoclaw' | 'stateless_cc',
+                          })
+                          loadChannels()
+                        } catch {}
+                      }}
+                      className="rounded border border-[var(--border)] bg-[var(--background)] px-1.5 py-0.5 text-[11px] text-[var(--foreground)]"
+                      title="Routing mode: nanoclaw = legacy NanoClaw sandbox; stateless_cc = new stateless Claude Code broker (Beta)"
+                    >
+                      <option value="nanoclaw">nanoclaw</option>
+                      <option value="stateless_cc">stateless_cc (Beta)</option>
+                    </select>
+                    <label className="flex items-center gap-1.5 text-[11px] text-[var(--muted-foreground)] cursor-pointer" title="Only reply when @mentioned in group chats">
+```
+
+（`||  'nanoclaw'` 兼容旧后端返回 `undefined` 的情况；其余代码不变。）
+
+- [ ] **Step 2: 前端类型检查 + 打包**
+
+Run: `cd /root/agentserver/web && pnpm tsc --noEmit && pnpm build`
+Expected: TypeScript 0 errors；`pnpm build` 成功产生 dist。
+
+- [ ] **Step 3: Commit Phase 4**
+
+```bash
+git add web/src/lib/api.ts web/src/components/WorkspaceDetail.tsx
+git commit -m "feat(web): IM channel routing_mode toggle
+
+Add routing_mode to IMChannel and updateWorkspaceIMChannel settings.
+Render a native <select> in the workspace IM channel row with
+nanoclaw / stateless_cc (Beta) options. onChange PATCHes the backend
+and refetches the channel list."
+```
+
+---
+
+## Phase 5 — Deploy & Smoke Test
+
+### Task 5.1: 推分支 + CI 构建
+
+- [ ] **Step 1: 推分支，触发 CI**
+
+```bash
+git push -u origin HEAD
+```
+
+- [ ] **Step 2: 等 `agentserver` / `imbridge` 镜像 CI 跑完**
+
+检查 `.gitlab-ci.yml` 相关 job 成功；新的 `:main` 或 PR tag 镜像已推到 `registry.nj.cs.ac.cn/ghcr/agentserver/`.
+
+---
+
+### Task 5.2: 部署到 k8s
+
+- [ ] **Step 1: 触发两个 Deployment 的 rollout**
+
+```bash
+kubectl -n agentserver rollout restart deploy/agentserver
+kubectl -n agentserver rollout restart deploy/agentserver-imbridge
+```
+
+- [ ] **Step 2: 等 Pod 就绪**
+
+```bash
+kubectl -n agentserver rollout status deploy/agentserver --timeout=2m
+kubectl -n agentserver rollout status deploy/agentserver-imbridge --timeout=2m
+```
+
+Expected: 两个 rollout 都 `successfully rolled out`。
+
+---
+
+### Task 5.3: API smoke test — 合法切换
+
+- [ ] **Step 1: 选一个测试 channel 并记下 ID**
+
+```bash
+PG=$(kubectl -n agentserver get secret agentserver-secret -o jsonpath='{.data.database-url}' | base64 -d)
+kubectl -n agentserver exec agentserver-postgresql-0 -- \
+  psql "$PG" -c "SELECT id, workspace_id, provider, bot_id, routing_mode FROM workspace_im_channels LIMIT 5;"
+```
+
+Expected: 能看到多行，挑一个 provider/bot_id 便于后面对照。记下 `WID` 和 `CID`。
+
+- [ ] **Step 2: PATCH routing_mode 到 stateless_cc**
+
+需要携带用户 session cookie（通过浏览器登录后 F12 → Application → Cookies 拷贝 `session=...`），或在 kubectl 端内部 pod 里直接调。最简单是从浏览器的 devtools Network 面板 copy curl。
+
+内部 pod 内部调（无需 auth，直接通过 imbridge svc）示例：
+
+```bash
+kubectl -n agentserver run -i --rm curl-patch --image=curlimages/curl:latest --restart=Never --quiet -- \
+  curl -s -X PATCH \
+    "http://agentserver-imbridge.agentserver.svc:8083/api/workspaces/<WID>/im/channels/<CID>" \
+    -H 'Content-Type: application/json' \
+    -H 'X-Internal-Secret: <INTERNAL_API_SECRET from env>' \
+    -d '{"routing_mode":"stateless_cc"}'
+```
+
+> Note: 直接打 imbridge svc 绕过了 agentserver 的 session auth，仅供内网 smoke test。真实 UI 场景通过 agentserver 代理已带好 cookie。
+
+Expected: `{"status":"updated"}`。
+
+- [ ] **Step 3: 验证 DB 生效**
+
+```bash
+kubectl -n agentserver exec agentserver-postgresql-0 -- \
+  psql "$PG" -c "SELECT id, routing_mode FROM workspace_im_channels WHERE id = '<CID>';"
+```
+
+Expected: `routing_mode = stateless_cc`。
+
+- [ ] **Step 4: 验证 imbridge 日志里下一条消息走 stateless**
+
+```bash
+kubectl -n agentserver logs deploy/agentserver-imbridge --tail=200 -f
+```
+
+然后从对应 IM 向 bot 发一条消息。
+Expected: 日志里出现 `forward to agentserver` 相关条目（或 `forwardToAgentserver`），且 agentserver 也会 log 对应的 `/im/inbound` 请求。
+
+同时可以查 cc-broker 的 session 表确认事件入库：
+
+```bash
+kubectl -n agentserver exec agentserver-postgresql-0 -- \
+  psql "${PG%/*}/ccbroker" -c "SELECT id, workspace_id, source FROM agent_sessions ORDER BY created_at DESC LIMIT 3;"
+```
+
+Expected: 看到一条新 session（`source='weixin'` 或类似）。
+
+---
+
+### Task 5.4: API smoke test — 非法值返回 400
+
+- [ ] **Step 1: 发非法 routing_mode**
+
+```bash
+kubectl -n agentserver run -i --rm curl-bad --image=curlimages/curl:latest --restart=Never --quiet -- \
+  curl -s -o /dev/null -w '%{http_code}\n' -X PATCH \
+    "http://agentserver-imbridge.agentserver.svc:8083/api/workspaces/<WID>/im/channels/<CID>" \
+    -H 'Content-Type: application/json' \
+    -d '{"routing_mode":"bogus"}'
+```
+
+Expected: `400`.
+
+- [ ] **Step 2: 确认 DB 值未变**
+
+```bash
+kubectl -n agentserver exec agentserver-postgresql-0 -- \
+  psql "$PG" -c "SELECT routing_mode FROM workspace_im_channels WHERE id = '<CID>';"
+```
+
+Expected: 仍是上一步设的 `stateless_cc`，未被非法请求改动。
+
+---
+
+### Task 5.5: API smoke test — 回切到 nanoclaw
+
+- [ ] **Step 1: PATCH 切回**
+
+```bash
+kubectl -n agentserver run -i --rm curl-back --image=curlimages/curl:latest --restart=Never --quiet -- \
+  curl -s -X PATCH \
+    "http://agentserver-imbridge.agentserver.svc:8083/api/workspaces/<WID>/im/channels/<CID>" \
+    -H 'Content-Type: application/json' \
+    -d '{"routing_mode":"nanoclaw"}'
+```
+
+Expected: `{"status":"updated"}`.
+
+- [ ] **Step 2: 再发一条 IM 消息，确认落到 NanoClaw 路径**
+
+观察 imbridge 日志没有 `forwardToAgentserver`，改为原本的 NanoClaw pod 转发路径。
+
+---
+
+### Task 5.6: UI smoke test（可选但推荐）
+
+- [ ] **Step 1: 打开前端 Workspace 详情页**
+
+浏览器访问 `https://agent.cs.ac.cn/workspaces/<WID>`，定位到 IM channels 区块。
+
+- [ ] **Step 2: 看到 routing_mode 下拉**
+
+Expected: 每个 channel 旁有一个 `<select>`，显示当前值。
+
+- [ ] **Step 3: 切换并验证**
+
+选 `stateless_cc (Beta)` → 刷新后值保持为 stateless_cc。切回 nanoclaw → 值保持 nanoclaw。
+
+---
+
+## Rollback
+
+如果上线后发现问题：
+
+1. **快速回滚 routing_mode 数据**：
+   ```sql
+   UPDATE workspace_im_channels SET routing_mode = 'nanoclaw' WHERE routing_mode = 'stateless_cc';
+   ```
+   并 `kubectl -n agentserver rollout restart deploy/agentserver-imbridge` 让重启时的 `restoreAllPollers` 走 DB 最新值（虽然 in-memory seed 会覆盖）。
+
+2. **回滚代码**：`git revert` 相关 commit，`git push`，等 CI 构建，`kubectl rollout restart` 两个 deployment。由于无 schema 变更，无需回滚 migration。
+
+---
+
+## Open Risks (from spec §7)
+
+1. **Race on rapid toggle** — 可接受：DB + map 都是 last-write-wins，收敛一致。
+2. **Poller 重建时的 seed** — `StartPoller` 现在会 seed `channelRouting`，重启 imbridge 后从 DB 读的 `binding.RoutingMode` 会被 seed 回内存，和 DB 一致。
+3. **stateless_cc 下游未就绪** — 本 plan 不加 readiness check；用户切错会导致下一条 IM 无响应。由运维/smoke-test 阶段检测。

--- a/docs/superpowers/plans/2026-05-02-im-channel-routing-mode-toggle.md
+++ b/docs/superpowers/plans/2026-05-02-im-channel-routing-mode-toggle.md
@@ -495,6 +495,52 @@ on the next inbound message."
 
 ---
 
+### Task 3.2: 扩展 list handler 的 `channelResp` JSON 结构
+
+**Files:**
+- Modify: `internal/imbridgesvc/handlers.go` (~line 848 `handleListWorkspaceIMChannels`)
+
+Without this change, `GET /api/workspaces/{wid}/im/channels` omits `routing_mode` from the response and the frontend `<select>` falls back to `nanoclaw` on every refetch, making the Phase 4 toggle appear broken.
+
+- [ ] **Step 1: Extend `channelResp` struct to include `RoutingMode`**
+
+把：
+
+```go
+	type channelResp struct {
+		ID             string `json:"id"`
+		Provider       string `json:"provider"`
+		BotID          string `json:"bot_id"`
+		UserID         string `json:"user_id,omitempty"`
+		RequireMention bool   `json:"require_mention"`
+		BoundAt        string `json:"bound_at"`
+	}
+```
+
+改为：
+
+```go
+	type channelResp struct {
+		ID             string `json:"id"`
+		Provider       string `json:"provider"`
+		BotID          string `json:"bot_id"`
+		UserID         string `json:"user_id,omitempty"`
+		RequireMention bool   `json:"require_mention"`
+		RoutingMode    string `json:"routing_mode"`
+		BoundAt        string `json:"bound_at"`
+	}
+```
+
+并在其下方 for-loop 的 `resp = append(resp, channelResp{...})` 里添加 `RoutingMode: ch.RoutingMode,`。
+
+- [ ] **Step 2: 编译验证**
+
+`cd /root/agentserver && go build ./internal/imbridgesvc/...` — 0 errors.
+
+- [ ] **Step 3: Commit**（可和 Task 3.1 合并为同一个 commit，或独立 commit 均可）
+
+---
+
 ## Phase 4 — Frontend
 
 ### Task 4.1: 扩展 `IMChannel` 接口 + `updateWorkspaceIMChannel` 参数

--- a/docs/superpowers/specs/2026-05-02-im-channel-routing-mode-toggle-design.md
+++ b/docs/superpowers/specs/2026-05-02-im-channel-routing-mode-toggle-design.md
@@ -1,0 +1,230 @@
+# IM Channel Routing Mode Toggle
+
+**Date:** 2026-05-02
+**Status:** Draft
+**Author:** mryao + Claude
+
+## 1. Overview
+
+### 1.1 Problem Statement
+
+The stateless CC stack is deployed on k8s but has never served real traffic because every IM channel still has `routing_mode='nanoclaw'` (the default after migration 018). Switching `routing_mode` today requires a raw SQL UPDATE — there is no HTTP API and no UI control. This blocks smoke-testing the stateless CC flow end-to-end.
+
+### 1.2 Goal
+
+Expose a per-channel `routing_mode` toggle in the workspace IM channel management UI, so a workspace member can switch a channel between `nanoclaw` and `stateless_cc` from the web UI and have the change take effect on the next inbound IM message — no service restart, no SQL.
+
+### 1.3 Non-Goals
+
+- Any pre-flight readiness check (OpenViking tree validation, executor availability). If the user switches to `stateless_cc` without those conditions met, the turn will fail downstream — that is acceptable for smoke-test sophistication. Readiness checks can be added later as a separate concern.
+- Routing modes other than `nanoclaw` and `stateless_cc`.
+- Changing defaults for existing channels (they stay `nanoclaw`).
+
+## 2. Architecture
+
+Extends the existing `PATCH /api/workspaces/{wid}/im/channels/{id}` path. No new routes, no new services. Follows the exact pattern already used for `require_mention`: write both the database and an in-memory map on the Bridge so the change is visible to the next inbound message without restarting the long-poller.
+
+```
+Web UI (WorkspaceDetail.tsx)
+   │  select value change
+   ▼
+PATCH /api/workspaces/{wid}/im/channels/{cid}   Body: {"routing_mode":"stateless_cc"}
+   │
+   ▼
+agentserver  (server.go:333 → imbridgeProxy, existing)
+   │
+   ▼
+imbridgesvc.handleUpdateWorkspaceIMChannel  (handlers.go:898)
+   ├─ requireWorkspaceMember                              (existing auth)
+   ├─ GetIMChannel + workspace ownership check           (existing)
+   ├─ validate routing_mode ∈ {nanoclaw, stateless_cc}   (new)
+   ├─ db.UpdateIMChannelRoutingMode(channelID, mode)     (new DB fn)
+   └─ bridge.SetChannelRoutingMode(channelID, mode)      (new in-memory setter)
+   │
+   ▼
+200 {"status":"updated"}
+
+Next inbound message from this channel:
+  forwardMessage → getChannelRoutingMode(channelID) hit
+                → "stateless_cc" → forwardToAgentserver
+```
+
+## 3. Components
+
+### 3.1 Bridge Runtime State (`internal/imbridge/bridge.go`)
+
+Add an in-memory map mirroring `channelMention`:
+
+```go
+type Bridge struct {
+    // ... existing fields ...
+    channelMention map[string]bool
+    channelRouting map[string]string  // NEW — channelID → "nanoclaw" | "stateless_cc"
+    mu             sync.Mutex
+}
+
+// SetChannelRoutingMode updates the in-memory routing_mode for a channel.
+func (b *Bridge) SetChannelRoutingMode(channelID, mode string) {
+    b.mu.Lock()
+    b.channelRouting[channelID] = mode
+    b.mu.Unlock()
+}
+
+// getChannelRoutingMode returns the in-memory routing_mode, or "" if not set.
+func (b *Bridge) getChannelRoutingMode(channelID string) string {
+    b.mu.Lock()
+    v := b.channelRouting[channelID]
+    b.mu.Unlock()
+    return v
+}
+```
+
+`StartPoller` seeds the map with `binding.RoutingMode` so the map is authoritative once a poller has started.
+
+`forwardMessage` is changed to consult the map first, falling back to `binding.RoutingMode` only if the map has no entry (defensive; should not happen once StartPoller seeds it):
+
+```go
+func (b *Bridge) forwardMessage(ctx context.Context, binding BridgeBinding, msg InboundMessage) (bool, error) {
+    mode := b.getChannelRoutingMode(binding.ChannelID)
+    if mode == "" {
+        mode = binding.RoutingMode
+    }
+    switch mode {
+    case "stateless_cc":
+        return b.forwardToAgentserver(ctx, binding, msg)
+    default:
+        return b.forwardToNanoClaw(ctx, binding, msg)
+    }
+}
+```
+
+### 3.2 DB Layer (`internal/db/im_channels.go`)
+
+New standalone function (kept separate from `UpdateIMChannelSettings` so each settable column has a clear-purpose setter):
+
+```go
+// UpdateIMChannelRoutingMode updates the routing_mode column for a channel.
+// Caller must validate `mode` before calling.
+func (db *DB) UpdateIMChannelRoutingMode(channelID, mode string) error {
+    _, err := db.Exec(
+        `UPDATE workspace_im_channels SET routing_mode = $1 WHERE id = $2`,
+        mode, channelID,
+    )
+    return err
+}
+```
+
+### 3.3 imbridgesvc Handler (`internal/imbridgesvc/handlers.go:898`)
+
+Extend the existing request struct to accept the new optional field:
+
+```go
+var req struct {
+    RequireMention *bool   `json:"require_mention"`
+    RoutingMode    *string `json:"routing_mode"`  // NEW
+}
+```
+
+After the existing `require_mention` branch, add:
+
+```go
+if req.RoutingMode != nil {
+    mode := *req.RoutingMode
+    if mode != "nanoclaw" && mode != "stateless_cc" {
+        http.Error(w, "invalid routing_mode", http.StatusBadRequest)
+        return
+    }
+    if err := s.db.UpdateIMChannelRoutingMode(channelID, mode); err != nil {
+        http.Error(w, "failed to update channel", http.StatusInternalServerError)
+        return
+    }
+    s.bridge.SetChannelRoutingMode(channelID, mode)
+}
+```
+
+Existing checks (`requireWorkspaceMember`, workspace ownership) cover this new branch without changes.
+
+### 3.4 Frontend (`web/src/`)
+
+**`lib/api.ts`**
+
+- Extend `IMChannel`:
+  ```ts
+  export interface IMChannel {
+      id: string
+      provider: string
+      bot_id: string
+      require_mention: boolean
+      routing_mode: string          // NEW
+  }
+  ```
+- Extend `updateWorkspaceIMChannel` settings:
+  ```ts
+  settings: {
+      require_mention?: boolean
+      routing_mode?: 'nanoclaw' | 'stateless_cc'   // NEW
+  }
+  ```
+
+**`components/WorkspaceDetail.tsx` (near line 744, inside the IM channel row)**
+
+Add a Select control below the existing `require_mention` checkbox, bound to `ch.routing_mode`. Options:
+- `nanoclaw`
+- `stateless_cc (Beta)` — label contains the suffix; value is `stateless_cc`
+
+onChange handler:
+```tsx
+onChange={async (e) => {
+    await updateWorkspaceIMChannel(workspaceId, ch.id, { routing_mode: e.target.value })
+    // refetch
+    listWorkspaceIMChannels(workspaceId).then(r => setImChannels(r.channels || []))
+}}
+```
+
+Use the same Select primitive the codebase already uses (match the existing `WorkspaceDetail` patterns; no new component library).
+
+## 4. Error Handling
+
+| Failure | Response | State consistency |
+|---------|----------|-------------------|
+| Body malformed | 400 `invalid request body` (existing) | No mutation |
+| `routing_mode` not in `{nanoclaw, stateless_cc}` | 400 `invalid routing_mode` | No mutation |
+| Caller not a workspace member | 403 (existing) | No mutation |
+| Channel not found or not in workspace | 404 (existing) | No mutation |
+| `db.UpdateIMChannelRoutingMode` fails | 500 `failed to update channel`, `SetChannelRoutingMode` NOT called | DB and in-memory both unchanged — consistent |
+| `SetChannelRoutingMode` — no IO, cannot fail | n/a | n/a |
+
+If DB succeeds but the process crashes before `SetChannelRoutingMode` returns, the next imbridge startup reads `routing_mode` from DB via `restoreAllPollers` and seeds the map from `binding.RoutingMode`. Convergence is preserved across restarts.
+
+## 5. Testing
+
+### 5.1 Unit
+
+- `db.UpdateIMChannelRoutingMode`: write then read back via `GetIMChannel`, both values observed.
+- `Bridge.SetChannelRoutingMode` / `getChannelRoutingMode`: basic set/get; concurrent writers/readers do not race (leveraging existing `b.mu`).
+- `Bridge.forwardMessage`: with map populated with `stateless_cc`, assert it calls `forwardToAgentserver` even when `binding.RoutingMode` is `nanoclaw` (proves in-memory map wins over the frozen binding).
+
+### 5.2 Handler
+
+- PATCH with `{routing_mode:"stateless_cc"}` → 200, DB updated, `SetChannelRoutingMode` called with `"stateless_cc"`.
+- PATCH with `{routing_mode:"bogus"}` → 400, DB unchanged, Bridge unchanged.
+- PATCH with both fields → both applied.
+- PATCH with neither field → 200, noop (matches current behavior).
+
+### 5.3 Manual Smoke Test (post-deploy)
+
+1. Pick an `agent-ws-*` test workspace that has a bound WeChat channel.
+2. Open the UI, flip routing_mode to `stateless_cc (Beta)`.
+3. Verify `SELECT routing_mode FROM workspace_im_channels WHERE id = …;` shows `stateless_cc`.
+4. Send a WeChat message; observe imbridge logs show `forwardToAgentserver`; observe `agent_session_events` in the `ccbroker` DB gets rows.
+5. Flip back to `nanoclaw`; next message goes to the NanoClaw pod.
+
+## 6. Rollout
+
+Single PR. Requires deploying `agentserver`, `imbridge` containers (new handler + Bridge state) and the web frontend (bundled with agentserver). No schema migration (migration 018 already added the column). No data backfill. No feature flag — the new field is optional in both API and request body, so old clients keep working.
+
+## 7. Risks
+
+1. **Race on rapid toggle.** If a user flips the Select twice within a few hundred ms, two PATCHes race. DB `UPDATE` is single-row and last-write-wins; the in-memory Set is under `b.mu`, also last-write-wins. Final state matches whichever PATCH arrived last at the DB. Acceptable.
+2. **Bridge instance that never started a poller for this channel.** `StartPoller` is what seeds `channelRouting`. If a channel has no active poller (e.g., credentials missing, sandbox paused) and someone PATCHes routing_mode, `SetChannelRoutingMode` still writes the map entry — it just sits there until a poller appears. Next `StartPoller` call seeds the map again with `binding.RoutingMode` from DB, which is the value we just wrote. Convergent.
+3. **Downstream readiness failures.** Switching to `stateless_cc` for a workspace without OpenViking tree or online executors means the next turn will log an error and the user will get no reply. This is intentional scope — out of this spec, tracked as a separate smoke-test precondition.

--- a/docs/superpowers/specs/2026-05-02-im-channel-routing-mode-toggle-design.md
+++ b/docs/superpowers/specs/2026-05-02-im-channel-routing-mode-toggle-design.md
@@ -144,6 +144,10 @@ if req.RoutingMode != nil {
 
 Existing checks (`requireWorkspaceMember`, workspace ownership) cover this new branch without changes.
 
+### 3.3b imbridgesvc List Handler
+
+`handleListWorkspaceIMChannels` (in the same file) renders each channel through an inline `channelResp` struct that is also used as the JSON shape for `GET /api/workspaces/{wid}/im/channels`. Extend it with `RoutingMode string `json:"routing_mode"`` and populate it from `ch.RoutingMode` during the append. Without this, the frontend `<select>` value cannot be hydrated after a refetch and the toggle appears to revert on every page load.
+
 ### 3.4 Frontend (`web/src/`)
 
 **`lib/api.ts`**

--- a/internal/db/im_channels.go
+++ b/internal/db/im_channels.go
@@ -180,6 +180,18 @@ func (db *DB) UpdateIMChannelSettings(channelID string, requireMention bool) err
 	return err
 }
 
+// UpdateIMChannelRoutingMode updates the routing_mode column for a channel.
+// Caller is expected to validate `mode` before calling (valid values:
+// "nanoclaw", "stateless_cc"). Unknown values are accepted by the DB but
+// will cause forwardMessage to fall through to the default nanoclaw branch.
+func (db *DB) UpdateIMChannelRoutingMode(channelID, mode string) error {
+	_, err := db.Exec(
+		`UPDATE workspace_im_channels SET routing_mode = $1 WHERE id = $2`,
+		mode, channelID,
+	)
+	return err
+}
+
 // UpsertChannelMeta inserts or updates a channel-specific metadata entry.
 func (db *DB) UpsertChannelMeta(channelID, userID, key, value string) error {
 	_, err := db.Exec(

--- a/internal/imbridge/bridge.go
+++ b/internal/imbridge/bridge.go
@@ -62,6 +62,7 @@ type Bridge struct {
 	pollers          map[string]context.CancelFunc // key: channelID
 	registeredGroups map[string]string             // key: "sandboxID:chatJID" → cached settings hash
 	channelMention   map[string]bool               // key: channelID → require_mention setting
+	channelRouting   map[string]string             // key: channelID → routing_mode (runtime override of binding)
 	typingSessions   map[string]func()             // key: "channelID:userID" → cancel func
 	mu               sync.Mutex
 }
@@ -85,6 +86,7 @@ func NewBridge(db BridgeDB, resolver SandboxResolver, exec ExecCommander, provid
 		pollers:          make(map[string]context.CancelFunc),
 		registeredGroups: make(map[string]string),
 		channelMention:   make(map[string]bool),
+		channelRouting:   make(map[string]string),
 		typingSessions:   make(map[string]func()),
 	}
 }
@@ -113,6 +115,11 @@ func (b *Bridge) StartPoller(binding BridgeBinding) {
 	if cancel, ok := b.pollers[key]; ok {
 		cancel()
 	}
+
+	// Seed the in-memory routing map so getChannelRoutingMode returns
+	// the value that forwardMessage would use by default. Later calls
+	// to SetChannelRoutingMode override this seeded value.
+	b.channelRouting[key] = binding.RoutingMode
 
 	ctx, cancel := context.WithCancel(context.Background())
 	b.pollers[key] = cancel
@@ -204,6 +211,26 @@ func (b *Bridge) SetChannelRequireMention(channelID string, requireMention bool)
 func (b *Bridge) getChannelRequireMention(channelID string) bool {
 	b.mu.Lock()
 	v := b.channelMention[channelID]
+	b.mu.Unlock()
+	return v
+}
+
+// SetChannelRoutingMode updates the in-memory routing_mode for a channel.
+// The value takes precedence over the routing_mode captured in
+// BridgeBinding at StartPoller time, so a configuration change applied
+// via this setter is visible on the next inbound message.
+func (b *Bridge) SetChannelRoutingMode(channelID, mode string) {
+	b.mu.Lock()
+	b.channelRouting[channelID] = mode
+	b.mu.Unlock()
+}
+
+// getChannelRoutingMode reads the in-memory routing_mode. Returns ""
+// if the channel has no override — callers fall back to
+// BridgeBinding.RoutingMode in that case.
+func (b *Bridge) getChannelRoutingMode(channelID string) string {
+	b.mu.Lock()
+	v := b.channelRouting[channelID]
 	b.mu.Unlock()
 	return v
 }
@@ -317,7 +344,14 @@ func (b *Bridge) pollLoop(ctx context.Context, binding BridgeBinding) {
 // "stateless_cc" forwards to the agentserver HTTP API; all other values
 // (including empty, for backward compatibility) forward to NanoClaw.
 func (b *Bridge) forwardMessage(ctx context.Context, binding BridgeBinding, msg InboundMessage) (bool, error) {
-	switch binding.RoutingMode {
+	// In-memory routing mode (set via SetChannelRoutingMode) wins over
+	// the routing_mode captured at StartPoller time. Empty map value
+	// means no override — fall through to binding.RoutingMode.
+	mode := b.getChannelRoutingMode(binding.ChannelID)
+	if mode == "" {
+		mode = binding.RoutingMode
+	}
+	switch mode {
 	case "stateless_cc":
 		return b.forwardToAgentserver(ctx, binding, msg)
 	default: // "nanoclaw" or empty (backward compatible)

--- a/internal/imbridge/bridge_routing_test.go
+++ b/internal/imbridge/bridge_routing_test.go
@@ -1,0 +1,72 @@
+package imbridge
+
+import (
+	"context"
+	"sync"
+	"testing"
+)
+
+// TestForwardMessageChannelRoutingOverridesBinding verifies that
+// SetChannelRoutingMode's in-memory value wins over the initial
+// binding.RoutingMode captured at StartPoller time. This is the
+// core property that makes the toggle take effect without restarting
+// the poller.
+func TestForwardMessageChannelRoutingOverridesBinding(t *testing.T) {
+	b := &Bridge{
+		providers:        map[string]Provider{},
+		pollers:          map[string]context.CancelFunc{},
+		registeredGroups: map[string]string{},
+		channelMention:   map[string]bool{},
+		channelRouting:   map[string]string{},
+		typingSessions:   map[string]func(){},
+	}
+
+	// Override with stateless_cc in the in-memory map.
+	b.SetChannelRoutingMode("ch-abc", "stateless_cc")
+
+	// Simulate forwardMessage's routing decision directly. We cannot
+	// invoke forwardMessage end-to-end here without a real provider /
+	// HTTP target, so we assert on the effective mode computation.
+	got := b.getChannelRoutingMode("ch-abc")
+	if got != "stateless_cc" {
+		t.Fatalf("expected in-memory routing=stateless_cc, got %q", got)
+	}
+
+	// Missing channel → empty string so forwardMessage falls back to
+	// binding.RoutingMode.
+	if b.getChannelRoutingMode("unknown") != "" {
+		t.Fatalf("expected empty routing for unknown channel")
+	}
+}
+
+// TestSetChannelRoutingModeConcurrent ensures the setter/getter
+// are safe under concurrent access (mirrors SetChannelRequireMention
+// concurrency assumptions).
+func TestSetChannelRoutingModeConcurrent(t *testing.T) {
+	b := &Bridge{
+		providers:        map[string]Provider{},
+		pollers:          map[string]context.CancelFunc{},
+		registeredGroups: map[string]string{},
+		channelMention:   map[string]bool{},
+		channelRouting:   map[string]string{},
+		typingSessions:   map[string]func(){},
+	}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			b.SetChannelRoutingMode("ch1", "stateless_cc")
+		}()
+		go func() {
+			defer wg.Done()
+			_ = b.getChannelRoutingMode("ch1")
+		}()
+	}
+	wg.Wait()
+
+	if b.getChannelRoutingMode("ch1") != "stateless_cc" {
+		t.Fatalf("expected stateless_cc after concurrent writes")
+	}
+}

--- a/internal/imbridgesvc/handlers.go
+++ b/internal/imbridgesvc/handlers.go
@@ -909,7 +909,8 @@ func (s *Server) handleUpdateWorkspaceIMChannel(w http.ResponseWriter, r *http.R
 	}
 
 	var req struct {
-		RequireMention *bool `json:"require_mention"`
+		RequireMention *bool   `json:"require_mention"`
+		RoutingMode    *string `json:"routing_mode"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
@@ -922,6 +923,19 @@ func (s *Server) handleUpdateWorkspaceIMChannel(w http.ResponseWriter, r *http.R
 			return
 		}
 		s.bridge.SetChannelRequireMention(channelID, *req.RequireMention)
+	}
+
+	if req.RoutingMode != nil {
+		mode := *req.RoutingMode
+		if mode != "nanoclaw" && mode != "stateless_cc" {
+			http.Error(w, "invalid routing_mode", http.StatusBadRequest)
+			return
+		}
+		if err := s.db.UpdateIMChannelRoutingMode(channelID, mode); err != nil {
+			http.Error(w, "failed to update channel", http.StatusInternalServerError)
+			return
+		}
+		s.bridge.SetChannelRoutingMode(channelID, mode)
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/imbridgesvc/handlers.go
+++ b/internal/imbridgesvc/handlers.go
@@ -851,6 +851,7 @@ func (s *Server) handleListWorkspaceIMChannels(w http.ResponseWriter, r *http.Re
 		BotID          string `json:"bot_id"`
 		UserID         string `json:"user_id,omitempty"`
 		RequireMention bool   `json:"require_mention"`
+		RoutingMode    string `json:"routing_mode"`
 		BoundAt        string `json:"bound_at"`
 	}
 	resp := make([]channelResp, 0, len(channels))
@@ -861,6 +862,7 @@ func (s *Server) handleListWorkspaceIMChannels(w http.ResponseWriter, r *http.Re
 			BotID:          ch.BotID,
 			UserID:         ch.UserID,
 			RequireMention: ch.RequireMention,
+			RoutingMode:    ch.RoutingMode,
 			BoundAt:        ch.BoundAt.Format(time.RFC3339),
 		})
 	}

--- a/web/src/components/WorkspaceDetail.tsx
+++ b/web/src/components/WorkspaceDetail.tsx
@@ -738,6 +738,22 @@ function SettingsTab({ workspaceId }: { workspaceId: string }) {
                     </span>
                   </div>
                   <div className="flex items-center gap-2">
+                    <select
+                      value={ch.routing_mode || 'nanoclaw'}
+                      onChange={async (e) => {
+                        try {
+                          await updateWorkspaceIMChannel(workspaceId, ch.id, {
+                            routing_mode: e.target.value as 'nanoclaw' | 'stateless_cc',
+                          })
+                          loadChannels()
+                        } catch {}
+                      }}
+                      className="rounded border border-[var(--border)] bg-[var(--background)] px-1.5 py-0.5 text-[11px] text-[var(--foreground)]"
+                      title="Routing mode: nanoclaw = legacy NanoClaw sandbox; stateless_cc = new stateless Claude Code broker (Beta)"
+                    >
+                      <option value="nanoclaw">nanoclaw</option>
+                      <option value="stateless_cc">stateless_cc (Beta)</option>
+                    </select>
                     <label className="flex items-center gap-1.5 text-[11px] text-[var(--muted-foreground)] cursor-pointer" title="Only reply when @mentioned in group chats">
                       <input
                         type="checkbox"

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -448,6 +448,7 @@ export interface IMChannel {
   bot_id: string
   user_id: string
   require_mention: boolean
+  routing_mode: string
   bound_at: string
 }
 
@@ -457,7 +458,11 @@ export async function listWorkspaceIMChannels(workspaceId: string): Promise<{ ch
   return res.json()
 }
 
-export async function updateWorkspaceIMChannel(workspaceId: string, channelId: string, settings: { require_mention?: boolean }): Promise<void> {
+export async function updateWorkspaceIMChannel(
+  workspaceId: string,
+  channelId: string,
+  settings: { require_mention?: boolean; routing_mode?: 'nanoclaw' | 'stateless_cc' },
+): Promise<void> {
   const res = await fetch(`/api/workspaces/${workspaceId}/im/channels/${channelId}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary

- Per-channel `routing_mode` toggle (`nanoclaw` / `stateless_cc`) wired end-to-end: DB → Bridge → PATCH handler → list handler → frontend API → UI Select
- Mirrors the existing `require_mention` pattern (DB write + Bridge in-memory map; no poller restart)
- Unblocks end-to-end smoke-testing of the stateless CC flow from IM — currently all 17 channels are stuck on `nanoclaw` and there's no way to flip them other than raw SQL

Spec: `docs/superpowers/specs/2026-05-02-im-channel-routing-mode-toggle-design.md`
Plan: `docs/superpowers/plans/2026-05-02-im-channel-routing-mode-toggle.md`

## Changes

- `internal/db/im_channels.go` — new `UpdateIMChannelRoutingMode` setter
- `internal/imbridge/bridge.go` — new `channelRouting` in-memory map + `SetChannelRoutingMode`/`getChannelRoutingMode`; `StartPoller` seeds the map; `forwardMessage` consults the map first and falls back to `BridgeBinding.RoutingMode`
- `internal/imbridge/bridge_routing_test.go` — new unit tests (Set/Get round-trip + concurrent-safety under `-race`)
- `internal/imbridgesvc/handlers.go` — `PATCH /api/workspaces/{wid}/im/channels/{cid}` now accepts `{routing_mode?: "nanoclaw"|"stateless_cc"}` (400 on bad enum; DB first, then Bridge setter). `GET ... /channels` list response now includes `routing_mode` in `channelResp`.
- `web/src/lib/api.ts` — `IMChannel.routing_mode` + `updateWorkspaceIMChannel` settings
- `web/src/components/WorkspaceDetail.tsx` — native `<select>` in each channel row (Beta tag on `stateless_cc` option)

## Testing

- `go test -race ./internal/imbridge/...` — both new tests pass under race detector
- `go build ./...` — clean
- `pnpm tsc --noEmit && pnpm build` — 0 errors; dist produced
- DB + handler unit tests skipped: neither `internal/db/` nor `internal/imbridgesvc/` has any test infrastructure in this repo. Covered instead by the manual smoke test plan below.

## Test plan

Post-merge, with the new `:main` images deployed:

- [ ] Deploy order: `kubectl -n agentserver rollout restart deploy/agentserver-imbridge` (Recreate strategy, brief downtime) first; then `deploy/agentserver` (RollingUpdate). Each followed by `rollout status`.
- [ ] `GET /api/workspaces/{wid}/im/channels` response JSON includes `routing_mode` for every row (DevTools or `curl`).
- [ ] UI: open a workspace page; Select in each IM channel row shows the current DB value (not always `nanoclaw`).
- [ ] PATCH smoke: flip Select → 200; `SELECT routing_mode FROM workspace_im_channels WHERE id = …` reflects the new value.
- [ ] Next inbound message on the flipped channel reaches `forwardToAgentserver` (visible in `imbridge` logs); ccbroker `agent_sessions` gets a new row.
- [ ] Flip back to `nanoclaw` → next message routes to NanoClaw as before.
- [ ] Invalid enum (`curl -d '{"routing_mode":"bogus"}' ...`) → 400; DB unchanged.
- [ ] Rapid toggle (3 clicks in ~1s) → final DB value matches last click; next message honors it.
- [ ] Downstream precondition check before flipping a real user's channel: OpenViking workspace tree exists; at least one online executor.

Known scope limits (documented in spec Non-Goals):
- No pre-flight readiness check (switching to `stateless_cc` with no downstream executor will silently drop replies — accepted risk during Beta)
- No audit log of who flipped what
- Rollback: either UPDATE SQL back to `nanoclaw` + imbridge rollout restart, or `git revert` the commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)