### PR TITLE
fix(docker): install python3 + build tools for opencode native addons

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,11 @@ RUN pnpm build
 # Stage 2: Build opencode frontend from submodule
 FROM oven/bun:1 AS opencode-frontend
 WORKDIR /app
+# python3 + g++ + make are needed by node-gyp to build native addons pulled
+# by opencode (e.g. tree-sitter-powershell) during `bun install`.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 make g++ \
+    && rm -rf /var/lib/apt/lists/*
 COPY opencode/ ./
 RUN bun install --frozen-lockfile
 RUN bun run --filter=@opencode-ai/app build

--- a/Dockerfile.sandboxproxy
+++ b/Dockerfile.sandboxproxy
@@ -1,6 +1,11 @@
 # Stage 1: Build opencode frontend from submodule (needed for embedded static files)
 FROM oven/bun:1 AS opencode-frontend
 WORKDIR /app
+# python3 + g++ + make are needed by node-gyp to build native addons pulled
+# by opencode (e.g. tree-sitter-powershell) during `bun install`.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 make g++ \
+    && rm -rf /var/lib/apt/lists/*
 COPY opencode/ ./
 RUN bun install --frozen-lockfile
 RUN bun run --filter=@opencode-ai/app build


### PR DESCRIPTION
## Summary

Third step in the chain to unblock main-branch CI. PR #45 bumped opencode to v1.14.31, which introduced a new native-addon dependency (`tree-sitter-powershell@0.25.10`). node-gyp needs python3 / make / g++ to compile it during \`bun install\`. The \`oven/bun:1\` image ships without any of those, so \`build-server\` and \`build-sandboxproxy\` now fail with:

\`\`\`
gyp ERR! configure error
gyp ERR! stack Error: Could not find any Python installation to use
error: install script from "tree-sitter-powershell" exited with 1
\`\`\`

This PR adds \`python3 make g++\` to the opencode-frontend stage in both Dockerfiles. After this lands, CI should build \`agentserver:main\` and \`sandboxproxy:main\` successfully, which unblocks the \`routing_mode\` UI shipping (PR #44) + finishes the rollout plan.

## Files

- \`Dockerfile\` — opencode-frontend stage
- \`Dockerfile.sandboxproxy\` — opencode-frontend stage

## Test plan

- [ ] CI build-server + build-sandboxproxy pass
- [ ] agentserver:main + sandboxproxy:main images get published
- [ ] kubectl rollout restart deploy/agentserver picks up the new image
- [ ] UI renders the routing_mode \`<select>\` in IM channel rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)