### PR TITLE
fix(helm): wire AGENTSERVER_URL into imbridge deployment

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.40.0
-appVersion: "0.40.0"
+version: 0.40.1
+appVersion: "0.40.1"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/deploy/helm/agentserver/templates/imbridge.yaml
+++ b/deploy/helm/agentserver/templates/imbridge.yaml
@@ -45,6 +45,8 @@ spec:
                 secretKeyRef:
                   name: {{ include "agentserver.databaseSecretName" . }}
                   key: database-url
+            - name: AGENTSERVER_URL
+              value: "http://{{ .Release.Name }}:{{ .Values.service.port }}"
             {{- if .Values.internal.apiSecret }}
             - name: INTERNAL_API_SECRET
               value: {{ .Values.internal.apiSecret | quote }}


### PR DESCRIPTION
## Summary

When a workspace IM channel's \`routing_mode\` is flipped to \`stateless_cc\`, imbridge's \`forwardToAgentserver\` posts to \`os.Getenv("AGENTSERVER_URL")\` — falling back to \`http://localhost:8080\` when unset (\`internal/imbridge/bridge.go:80\`). The helm template for imbridge was never wired with this env, so the fallback kicks in and every inbound message on a stateless_cc channel fails with:

\`\`\`
forward to agentserver: Post "http://localhost:8080/api/workspaces/.../im/inbound":
dial tcp [::1]:8080: connect: connection refused (will retry next poll)
\`\`\`

imbridge then loops the retry every ~2s indefinitely.

This PR sets \`AGENTSERVER_URL\` on the imbridge deployment, matching the pattern used by sibling services: \`CCBROKER_AGENTSERVER_URL\` (cc-broker.yaml:89), \`CREDPROXY_AGENTSERVER_URL\` (credentialproxy.yaml:47), \`LLMPROXY_AGENTSERVER_URL\` (llmproxy.yaml:54).

Discovered while smoke-testing the routing_mode toggle (PR #44) — the first stateless_cc channel ever flipped in production exposed this pre-existing helm gap. The code path was there in bridge.go from when stateless_cc forwarding was first introduced; it just never had real traffic until now.

## Test plan

- [ ] After merge + helm upgrade, \`kubectl -n agentserver get deploy agentserver-imbridge -o yaml | grep -A1 AGENTSERVER_URL\` shows \`http://agentserver:8080\`
- [ ] A weixin message into the flipped channel no longer produces \`connection refused\` in imbridge logs
- [ ] agentserver logs show a \`POST .../im/inbound\` hit
- [ ] cc-broker logs show a \`POST /api/turns\` hit
- [ ] CC worker spawns and the reply comes back to WeChat

🤖 Generated with [Claude Code](https://claude.com/claude-code)