### PR TITLE
fix(ccbroker): accept ANTHROPIC_AUTH_TOKEN as alternative to API_KEY

### DIFF
--- a/internal/ccbroker/worker.go
+++ b/internal/ccbroker/worker.go
@@ -82,9 +82,14 @@ func diffSnapshot(dir string, old map[string]fileInfo) []fileChange {
 // and imUserID are optional — populated when the turn was originated by an IM
 // inbound so the MCP server can route send_* tool calls back through imbridge.
 func (s *Server) SpawnWorker(ctx context.Context, sessionID, workspaceID, imChannelID, imUserID string) (*CCWorker, error) {
+	// Claude Code supports two auth paths: ANTHROPIC_API_KEY for direct
+	// Anthropic access, or ANTHROPIC_AUTH_TOKEN (optionally with
+	// ANTHROPIC_BASE_URL) for third-party API gateways. Accept either.
 	apiKey := os.Getenv("ANTHROPIC_API_KEY")
-	if apiKey == "" {
-		return nil, fmt.Errorf("ANTHROPIC_API_KEY environment variable is not set")
+	authToken := os.Getenv("ANTHROPIC_AUTH_TOKEN")
+	baseURL := os.Getenv("ANTHROPIC_BASE_URL")
+	if apiKey == "" && authToken == "" {
+		return nil, fmt.Errorf("neither ANTHROPIC_API_KEY nor ANTHROPIC_AUTH_TOKEN is set")
 	}
 
 	// 1. Create temp dir structure.
@@ -174,12 +179,21 @@ func (s *Server) SpawnWorker(ctx context.Context, sessionID, workspaceID, imChan
 	cmd.Env = []string{
 		"CLAUDE_CONFIG_DIR=" + claudeDir,
 		"CLAUDE_COWORK_MEMORY_PATH_OVERRIDE=" + memoryDir,
-		"ANTHROPIC_API_KEY=" + apiKey,
 		"CLAUDE_CODE_DISABLE_FILE_CHECKPOINTING=1",
 		"CLAUDE_CODE_AUTO_COMPACT_WINDOW=165000",
 		"HOME=" + tempDir,
 		"PATH=" + os.Getenv("PATH"),
 		"TERM=xterm-256color",
+	}
+	// Forward whichever Anthropic credentials the broker was started with.
+	if apiKey != "" {
+		cmd.Env = append(cmd.Env, "ANTHROPIC_API_KEY="+apiKey)
+	}
+	if authToken != "" {
+		cmd.Env = append(cmd.Env, "ANTHROPIC_AUTH_TOKEN="+authToken)
+	}
+	if baseURL != "" {
+		cmd.Env = append(cmd.Env, "ANTHROPIC_BASE_URL="+baseURL)
 	}
 
 	// 9. Start the process.


### PR DESCRIPTION
## Summary

\`SpawnWorker\` previously required \`ANTHROPIC_API_KEY\` to be non-empty and only forwarded that single variable to the spawned Claude Code worker. Claude Code supports two auth paths:

- \`ANTHROPIC_API_KEY\` for direct Anthropic access
- \`ANTHROPIC_AUTH_TOKEN\` (optionally with \`ANTHROPIC_BASE_URL\`) for third-party API gateways

The current production deployment uses the second (\`agentserver-secret\` carries \`anthropic-auth-token\` + \`anthropic-base-url\` that route through \`cloudapi.ai.cs.ac.cn\`). cc-broker's check \`os.Getenv("ANTHROPIC_API_KEY")\` returned empty and every \`stateless_cc\` turn failed at the SpawnWorker entry point:

\`\`\`
spawn worker failed ... ANTHROPIC_API_KEY environment variable is not set
\`\`\`

This PR:
1. Accepts either \`ANTHROPIC_API_KEY\` or \`ANTHROPIC_AUTH_TOKEN\` (or both); only errors when both are empty.
2. Forwards all three Anthropic env vars (API_KEY, AUTH_TOKEN, BASE_URL) that are present to the CC worker process so the \`claude\` CLI picks the right auth path itself.

Discovered while smoke-testing the routing_mode toggle (PRs #44 / #47). Fourth in the chain — each unlocked the next layer of the flow.

## Test plan

- [ ] \`go build ./...\` clean; existing cc-broker tests still pass (\`go test -race ./internal/ccbroker/...\`)
- [ ] After CI rebuilds \`cc-broker:main\` and \`kubectl rollout restart deploy/agentserver-ccbroker\`, the next weixin message on the flipped channel no longer produces \`ANTHROPIC_API_KEY environment variable is not set\` in cc-broker logs
- [ ] A CC worker actually spawns (\`claude\` subprocess visible via \`ps\` inside the pod); \`agent_session_events\` gets new rows from the worker's bridge writeback
- [ ] User gets a reply in WeChat

🤖 Generated with [Claude Code](https://claude.com/claude-code)