### PR TITLE
fix(ccbroker): add type:http to MCP server config

### DIFF
--- a/internal/ccbroker/worker.go
+++ b/internal/ccbroker/worker.go
@@ -140,10 +140,14 @@ func (s *Server) SpawnWorker(ctx context.Context, sessionID, workspaceID, imChan
 	}
 
 	// 6. Write MCP config JSON to a temp file.
+	// Claude Code's MCP schema requires an explicit transport "type" — omitting
+	// it causes the CLI to reject the server entry with "Does not adhere to MCP
+	// server configuration schema" on startup.
 	mcpConfig := map[string]interface{}{
 		"mcpServers": map[string]interface{}{
 			"cc-broker": map[string]interface{}{
-				"url": fmt.Sprintf("http://127.0.0.1:%d", mcpPort),
+				"type": "http",
+				"url":  fmt.Sprintf("http://127.0.0.1:%d", mcpPort),
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

Claude Code's MCP configuration schema requires an explicit transport \`type\` field. Omitting it causes \`claude\` CLI to reject the server entry on startup with:

\`\`\`
Error: Invalid MCP configuration:
mcpServers.cc-broker: Does not adhere to MCP server configuration schema
\`\`\`

The stateless CC design spec (§2) explicitly shows the correct shape:
\`\`\`
--mcp-config '{"mcpServers":{"tool-router":{"type":"http","url":"..."}}}'
\`\`\`

but \`worker.go\` constructed the config without \`type\`. Every CC worker crashed at startup before reading a single bridge event.

Discovered as the fifth (and hopefully final!) blocker while smoke-testing the \`routing_mode\` toggle (PR #44 → #45 opencode bump → #46 Dockerfile python → #47 helm AGENTSERVER_URL → #48 AUTH_TOKEN → this).

## Test plan

- [ ] \`go test -race ./internal/ccbroker/...\` — still pass
- [ ] After CI rebuild + \`kubectl rollout restart deploy/agentserver-ccbroker\`, next weixin message no longer logs \`Invalid MCP configuration\`
- [ ] \`claude\` subprocess reaches the bridge SSE replay stage (cc-broker logs show worker SSE activity and \`agent_session_events\` grows beyond the initial user message)
- [ ] WeChat reply lands in the chat

## Known residuals (out of scope for this PR)

The OpenViking cleanup upload still fails with:
> ROOT requests to tenant-scoped APIs must include X-OpenViking-Account and X-OpenViking-User headers

This only affects CLAUDE.md / Memory / Skills persistence between turns; the event log (conversation state) lives in cc-broker's own DB and is unaffected. Tracked as a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)