### PR TITLE
fix(docker): run cc-broker as non-root for Claude CLI

### DIFF
--- a/Dockerfile.cc-broker
+++ b/Dockerfile.cc-broker
@@ -6,9 +6,11 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -o cc-broker ./cmd/cc-broker
 
-# Runtime image. cc-broker execs the `claude` CLI per turn (SpawnWorker),
-# so the Claude Code native binary must be on PATH. Nothing else is needed
-# — workers route all file / bash ops through executor-registry tunnels.
+# Runtime image. cc-broker execs the `claude` CLI per turn via the
+# claude-agent-sdk-go subprocess transport. The Claude CLI refuses to
+# accept --permission-mode bypassPermissions or --dangerously-skip-permissions
+# when running as root/sudo (a hardcoded security check), so this image
+# runs as a non-root user (uid 1000).
 FROM debian:trixie-slim
 RUN apt-get update && \
     apt-get install -y --no-install-recommends ca-certificates curl && \
@@ -16,7 +18,11 @@ RUN apt-get update && \
     cp /root/.local/bin/claude /usr/local/bin/claude && \
     rm -rf /root/.local/bin/claude && \
     apt-get purge -y curl && apt-get autoremove -y && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd -g 1000 cc && \
+    useradd -u 1000 -g cc -m -d /home/cc -s /bin/bash cc
 COPY --from=builder /app/cc-broker /usr/local/bin/cc-broker
+USER 1000
+WORKDIR /home/cc
 EXPOSE 8085
 ENTRYPOINT ["cc-broker"]


### PR DESCRIPTION
Discovered during the PR #51 smoke test: the Claude CLI refuses to start when invoked under root with \`--permission-mode bypassPermissions\` (or \`--dangerously-skip-permissions\`):

\`\`\`
--dangerously-skip-permissions cannot be used with root/sudo privileges for security reasons
\`\`\`

This is a hardcoded check in the CLI binary; no env var or flag overrides it. The cc-broker pod was running as root → CLI exited immediately on startup → SDK channel closed without producing any \`assistant\`/\`tool_use\`/\`result\` events → \`handler_turns\` returned 200 with only the user message persisted.

Verified by manually invoking the CLI inside the running pod: with the flag, exit; without the flag, normal output ("OK") returns.

Fix: add a non-root user (uid 1000) to \`Dockerfile.cc-broker\` and switch via \`USER 1000\` before \`ENTRYPOINT\`. \`/tmp\` is world-writable for workspace tempdirs; \`/usr/local/bin/claude\` is mode 755 so uid 1000 can exec it; \`/home/cc\` is set as \`WORKDIR\` so the CLI has a writable \`HOME\` for its caches.

## Test plan

- [ ] CI \`build-cc-broker\` green
- [ ] After \`kubectl rollout restart deploy/agentserver-ccbroker\`, exec into the pod: \`whoami\` → \`cc\` (not root)
- [ ] WeChat smoke test on Mr.YAO's Workspace: \`agent_session_events\` row count grows by ≥3 per turn (user msg + assistant + result), not just 1
- [ ] cc-broker logs show no startup failures from the CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)