### PR TITLE
fix(ccbroker/runner): strip cse_ prefix before --resume

### DIFF
--- a/internal/ccbroker/runner/options.go
+++ b/internal/ccbroker/runner/options.go
@@ -2,11 +2,24 @@ package runner
 
 import (
 	"strconv"
+	"strings"
 
 	agentsdk "github.com/agentserver/claude-agent-sdk-go"
 
 	"github.com/agentserver/agentserver/internal/ccbroker/workspace"
 )
+
+// cliResumeID strips the cc-broker session-ID prefix to give the Claude CLI
+// the bare UUID it expects from --resume. agentserver assigns session IDs
+// like "cse_<UUID>" (per its own protocol); the CLI rejects anything that
+// is not a valid UUID with:
+//
+//   Error: --resume requires a valid session ID or session title when used
+//   with --print. Provided value "cse_..." is not a UUID and does not match
+//   any session title.
+func cliResumeID(sessionID string) string {
+	return strings.TrimPrefix(sessionID, "cse_")
+}
 
 // Config holds the broker-level configuration relevant to spawning a CC worker.
 // All fields are populated from cc-broker's process env at startup.
@@ -60,7 +73,7 @@ func BuildSpec(ws *workspace.Workspace, sessionID string, cfg Config) Spec {
 		env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = strconv.Itoa(cfg.AutoCompactWindow)
 	}
 	return Spec{
-		Resume:       sessionID,
+		Resume:       cliResumeID(sessionID),
 		Cwd:          ws.ProjectDir,
 		Env:          env,
 		SystemPrompt: cfg.SystemPrompt,

--- a/internal/ccbroker/runner/options_test.go
+++ b/internal/ccbroker/runner/options_test.go
@@ -25,8 +25,8 @@ func TestBuildSpec(t *testing.T) {
 	}
 	spec := BuildSpec(ws, "cse_abc", cfg)
 
-	if spec.Resume != "cse_abc" {
-		t.Errorf("Resume=%q want cse_abc", spec.Resume)
+	if spec.Resume != "abc" {
+		t.Errorf("Resume=%q want abc (cse_ prefix stripped for CLI compatibility)", spec.Resume)
 	}
 	if spec.Cwd != ws.ProjectDir {
 		t.Errorf("Cwd=%q want %s", spec.Cwd, ws.ProjectDir)


### PR DESCRIPTION
Discovered during the PR #52 smoke test: after the cc-broker pod was switched to non-root and the CLI started without the bypassPermissions root check, the first turn produced a \`result\` event with \`subtype=error_during_execution\`:

\`\`\`
Error: --resume requires a valid session ID or session title when used with --print.
Usage: claude -p --resume <session-id|title>.
Provided value "cse_5e265cf6-9a9c-447e-b717-1f6dba7e3500" is not a UUID
and does not match any session title.
\`\`\`

The Claude CLI's \`--resume\` flag accepts either a valid UUID or a session title; agentserver-issued IDs come in the form \`cse_<UUID>\`, which the CLI rejects.

Fix: at the cc-broker → CLI boundary (\`runner.BuildSpec\`), strip the \`cse_\` prefix when populating \`Spec.Resume\`. The agentserver-facing protocol and our DB rows still use the prefixed form; only the CLI sees the bare UUID.

## Test plan
- [ ] CI \`build-cc-broker\` green
- [ ] After rollout, WeChat smoke produces \`agent_session_events\` with \`subtype=success\` (not \`error_during_execution\`)
- [ ] Multi-turn memory works: turn 1 "我叫 Alice"; turn 2 "我叫什么" → reply names "Alice"

🤖 Generated with [Claude Code](https://claude.com/claude-code)