### PR TITLE
fix(ccbroker/runner): use --session-id for first turn, --resume after

### DIFF
--- a/internal/ccbroker/runner/options.go
+++ b/internal/ccbroker/runner/options.go
@@ -37,8 +37,15 @@ type Config struct {
 // the Claude SDK for one turn." It exists so tests can assert exactly what we
 // would have asked the SDK to do, without depending on the SDK's unexported
 // queryConfig. ToOptions() translates a Spec into an agentsdk option slice.
+//
+// Session lifecycle: the Claude CLI requires distinct flags for "create a
+// new session with this UUID" (--session-id) versus "continue an existing
+// session" (--resume). They are mutually exclusive: --session-id rejects
+// IDs that already have a jsonl on disk, --resume rejects IDs that don't.
+// runner.Run inspects ws.ClaudeDir before BuildSpec to decide.
 type Spec struct {
-	Resume                          string
+	SessionUUID                     string // bare UUID (cse_ prefix already stripped)
+	SessionExists                   bool   // true → --resume, false → --session-id
 	Cwd                             string
 	Env                             map[string]string
 	SystemPrompt                    string
@@ -51,8 +58,10 @@ type Spec struct {
 }
 
 // BuildSpec composes a Spec from workspace + sessionID + config. Pure.
-// Mirrors §2 of the design spec.
-func BuildSpec(ws *workspace.Workspace, sessionID string, cfg Config) Spec {
+// Mirrors §2 of the design spec. sessionExists must be true iff a session
+// jsonl for this UUID is already present in ws.ClaudeDir (caller checks via
+// filepath.Glob before invoking).
+func BuildSpec(ws *workspace.Workspace, sessionID string, cfg Config, sessionExists bool) Spec {
 	env := map[string]string{
 		"CLAUDE_CONFIG_DIR":                  ws.ClaudeDir,
 		"CLAUDE_COWORK_MEMORY_PATH_OVERRIDE": ws.MemoryDir,
@@ -73,8 +82,9 @@ func BuildSpec(ws *workspace.Workspace, sessionID string, cfg Config) Spec {
 		env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] = strconv.Itoa(cfg.AutoCompactWindow)
 	}
 	return Spec{
-		Resume:       cliResumeID(sessionID),
-		Cwd:          ws.ProjectDir,
+		SessionUUID:   cliResumeID(sessionID),
+		SessionExists: sessionExists,
+		Cwd:           ws.ProjectDir,
 		Env:          env,
 		SystemPrompt: cfg.SystemPrompt,
 		AllowedTools: []string{"WebSearch", "WebFetch", "mcp__cc-broker__*"},
@@ -93,11 +103,20 @@ func BuildSpec(ws *workspace.Workspace, sessionID string, cfg Config) Spec {
 // callers usually build the MCP tools after BuildSpec.
 func (s Spec) ToOptions() []agentsdk.QueryOption {
 	opts := []agentsdk.QueryOption{
-		agentsdk.WithResume(s.Resume),
 		agentsdk.WithCwd(s.Cwd),
 		agentsdk.WithEnv(s.Env),
 		agentsdk.WithSystemPrompt(s.SystemPrompt),
 		agentsdk.WithAllowedTools(s.AllowedTools...),
+	}
+	if s.SessionUUID != "" {
+		// --session-id rejects already-existing IDs; --resume rejects missing
+		// ones. They are exclusive: pick exactly one based on whether the
+		// session jsonl was present after Setup downloaded from OpenViking.
+		if s.SessionExists {
+			opts = append(opts, agentsdk.WithResume(s.SessionUUID))
+		} else {
+			opts = append(opts, agentsdk.WithSessionID(s.SessionUUID))
+		}
 	}
 	if len(s.DisallowedTools) > 0 {
 		opts = append(opts, agentsdk.WithDisallowedTools(s.DisallowedTools...))

--- a/internal/ccbroker/runner/options_test.go
+++ b/internal/ccbroker/runner/options_test.go
@@ -23,10 +23,13 @@ func TestBuildSpec(t *testing.T) {
 		DisableFileCheckpointing: true,
 		AutoCompactWindow:        165000,
 	}
-	spec := BuildSpec(ws, "cse_abc", cfg)
+	spec := BuildSpec(ws, "cse_abc", cfg, false)
 
-	if spec.Resume != "abc" {
-		t.Errorf("Resume=%q want abc (cse_ prefix stripped for CLI compatibility)", spec.Resume)
+	if spec.SessionUUID != "abc" {
+		t.Errorf("SessionUUID=%q want abc (cse_ prefix stripped for CLI compatibility)", spec.SessionUUID)
+	}
+	if spec.SessionExists {
+		t.Errorf("SessionExists must be false when caller indicated no jsonl present")
 	}
 	if spec.Cwd != ws.ProjectDir {
 		t.Errorf("Cwd=%q want %s", spec.Cwd, ws.ProjectDir)
@@ -86,7 +89,7 @@ func TestBuildSpec_PrefersAPIKeyWhenBothSet(t *testing.T) {
 		AnthropicAPIKey:    "key-1",
 		AnthropicAuthToken: "tok-2",
 	}
-	spec := BuildSpec(ws, "sid", cfg)
+	spec := BuildSpec(ws, "sid", cfg, false)
 
 	if spec.Env["ANTHROPIC_API_KEY"] != "key-1" {
 		t.Errorf("API_KEY not forwarded")

--- a/internal/ccbroker/runner/runner.go
+++ b/internal/ccbroker/runner/runner.go
@@ -3,6 +3,8 @@ package runner
 import (
 	"context"
 	"fmt"
+	"path/filepath"
+	"strings"
 
 	agentsdk "github.com/agentserver/claude-agent-sdk-go"
 
@@ -31,7 +33,7 @@ func Run(
 	cfg Config,
 	mcp *agentsdk.McpSdkServer,
 ) (<-chan agentsdk.SDKMessage, error) {
-	spec := BuildSpec(ws, sessionID, cfg)
+	spec := BuildSpec(ws, sessionID, cfg, sessionJSONLExists(ws, sessionID))
 	spec.McpServer = mcp
 
 	sess, err := newV1Session(ctx, spec.ToOptions())
@@ -56,6 +58,25 @@ func Run(
 		}
 	}()
 	return out, nil
+}
+
+// sessionJSONLExists checks whether a Claude CLI session jsonl for the
+// given sessionID is already on disk under ws.ClaudeDir. The CLI stores
+// session files at <CLAUDE_CONFIG_DIR>/projects/<encoded-cwd>/<UUID>.jsonl,
+// where <encoded-cwd> is derived from the worker's Cwd via a CLI-internal
+// transformation we do not replicate here. A glob over all encoded-cwd
+// subdirectories matches whichever one the CLI would compute, since each
+// turn's Cwd is deterministic for a given sessionID.
+//
+// Returns true → caller must use --resume; false → caller must use
+// --session-id (the two flags are mutually exclusive in the CLI).
+func sessionJSONLExists(ws *workspace.Workspace, sessionID string) bool {
+	bare := strings.TrimPrefix(sessionID, "cse_")
+	if bare == "" {
+		return false
+	}
+	matches, _ := filepath.Glob(filepath.Join(ws.ClaudeDir, "projects", "*", bare+".jsonl"))
+	return len(matches) > 0
 }
 
 // v1Session is the agentsdk.Client-based adapter for the stable V1 SDK API.


### PR DESCRIPTION
Discovered during the PR #53 smoke test: with the bare UUID now accepted by the CLI, the first turn errored with:

\`\`\`
No conversation found with session ID: 5e265cf6-9a9c-447e-b717-1f6dba7e3500
\`\`\`

\`--resume\` requires the session jsonl to already exist; on the very first turn for a new session, it doesn't. Verified inside the running pod:

| flag | first turn (no jsonl) | second turn (jsonl exists) |
|------|----------------------|---------------------------|
| \`--session-id <UUID>\` | ✅ creates session, replies | ❌ "Session ID is already in use" |
| \`--resume <UUID>\` | ❌ "No conversation found" | ✅ continues, replies "Alice" |

The two flags are mutually exclusive — must pick exactly one based on whether the jsonl exists.

\`runner.Run\` now globs \`<ws.ClaudeDir>/projects/*/<bareUUID>.jsonl\`. Match → \`WithResume\`; no match → \`WithSessionID\`. After Setup downloads the workspace tree from OpenViking on the next turn, the jsonl is back on disk and the resume branch fires automatically.

Spec field renamed \`Resume\` → \`SessionUUID\` + new \`SessionExists\` boolean to encode the dual-flag semantics; \`ToOptions\` emits exactly one of \`WithResume\`/\`WithSessionID\` based on \`SessionExists\`.

## Test plan
- [ ] CI \`build-cc-broker\` green
- [ ] After rollout, first WeChat message produces \`agent_session_events\` with \`subtype="success"\` (not \`error_during_execution\`)
- [ ] User receives an actual reply in WeChat
- [ ] Multi-turn memory: deferred until OpenViking tenant-auth fix lands (pre-existing, spec §1.3 / §7) — without that, jsonl can't persist between turns even with this fix in place

🤖 Generated with [Claude Code](https://claude.com/claude-code)