### PR TITLE
fix(ccbroker/runner): close SDK session after terminal result message

### DIFF
--- a/internal/ccbroker/runner/runner.go
+++ b/internal/ccbroker/runner/runner.go
@@ -55,6 +55,18 @@ func Run(
 				return
 			case out <- msg:
 			}
+			// The Claude CLI in --print mode keeps stdin open after emitting
+			// the terminal "result" message, waiting for another user turn
+			// that never comes (the SDK's Client doesn't auto-close stdin
+			// like Query does). Without an explicit close here the SDK
+			// channel never drains, the pump in handler_turns blocks
+			// forever, and the SSE response to agentserver stays open until
+			// the HTTP read deadline. Returning here triggers
+			// `defer sess.Close()` which closes the transport and kills
+			// the subprocess.
+			if msg.Type == "result" {
+				return
+			}
 		}
 	}()
 	return out, nil


### PR DESCRIPTION
Smoke test against PR #54 produced an assistant reply and a result/success event in the DB:

\`\`\`
13 | result    | success | 02:05:14
12 | assistant |         | 02:05:14   "你好！有什么我可以帮助你的吗？"
11 | system    | init    | 02:05:09
10 | user      |         | 02:05:08
\`\`\`

But the user never received a message in WeChat. Tracing showed the cc-broker workspace tempdir \`/tmp/cc-broker/sess_cse_5e265cf6-...\` still on disk 5+ minutes after the result event landed, meaning \`workspace.Teardown\` never ran. The pump goroutine was blocked on \`for msg := range sess.Messages()\`.

**Root cause**: the Claude CLI in \`--print\` mode keeps stdin open after emitting the terminal \`result\` message, waiting for another user turn. The agentsdk \`Client\` (unlike \`Query\`) does not auto-close stdin on result. So:

- SDK transport never sees stdin EOF → never sees CLI exit
- SDK \`msgCh\` never closes
- \`runner.Run\`'s pump goroutine \`for msg := range sess.Messages()\` blocks forever
- \`handler_turns\` pump waits for runner's channel → blocks
- SSE response to agentserver stays open
- agentserver's \`extractFinalText\` (which terminates on the \`done\` sentinel) sits on the read deadline
- IM reply never sent

**Fix**: in the SDK pump goroutine, return immediately after forwarding a \`result\`-typed message. The deferred \`sess.Close()\` closes the transport and kills the subprocess; the entire chain unblocks naturally.

## Test plan

- [ ] CI \`build-cc-broker\` green
- [ ] After rollout, send a WeChat message — agentserver/cc-broker logs show the request **completing** (POST /api/turns access log fires within seconds, not stuck open)
- [ ] \`/tmp/cc-broker/sess_*\` is gone after Teardown
- [ ] **The user receives the assistant reply in WeChat** ← end of the line

🤖 Generated with [Claude Code](https://claude.com/claude-code)