### PR TITLE
fix(agentserver/im_inbound): always reply on the inbound channel

### DIFF
--- a/internal/server/im_inbound.go
+++ b/internal/server/im_inbound.go
@@ -95,9 +95,19 @@ func (s *Server) processWithCCBroker(ctx context.Context, session *db.AgentSessi
 	if idx := strings.Index(toUserID, "@"); idx > 0 {
 		toUserID = toUserID[:idx]
 	}
+	// Always reply through the channel the message *came in on*, not whatever
+	// the session record happens to have stored. When a workspace re-binds an
+	// IM bot (e.g. the original bot's WeChat session expired and a fresh bot
+	// was registered for the same chat_jid), session resolution by external_id
+	// returns the existing session with its stale IMChannelID — replying there
+	// hits a deleted/stale channel and the user never sees the message.
+	// Persist the freshest channel so other consumers (downstream tasks,
+	// audits) also see the up-to-date binding.
 	channelID := msg.ChannelID
-	if session != nil && session.IMChannelID != nil && *session.IMChannelID != "" {
-		channelID = *session.IMChannelID
+	if session != nil && (session.IMChannelID == nil || *session.IMChannelID != channelID) {
+		if err := s.DB.SetSessionIMChannel(ctx, session.ID, channelID); err != nil {
+			log.Printf("im_inbound: failed to refresh im_channel_id for session %s: %v", session.ID, err)
+		}
 	}
 
 	body, _ := json.Marshal(map[string]interface{}{


### PR DESCRIPTION
Smoke test against PR #55 finally got the assistant reply all the way through cc-broker (\`200 in 4.75s\`), but agentserver's reply call got 404 from imbridge:

\`\`\`
im_inbound: reply failed session=cse_5e265cf6-... channel=a1e97fdf-... to=...: imbridge returned 404: channel not found
\`\`\`

The user had re-bound a fresh WeChat bot (\`99bf62cfd075-im-bot\`, channel \`446ded5b-...\`) for the same chat_jid because the old bot's WeChat session expired. The inbound message correctly hit the existing session via \`external_id\` resolution, but \`processWithCCBroker\` preferred \`session.IMChannelID\` (which still pointed at the deleted old channel \`a1e97fdf-...\`) over \`msg.ChannelID\` (the fresh \`446ded5b-...\`). imbridge couldn't find the deleted channel and returned 404; user saw nothing.

\`\`\`go
// before
channelID := msg.ChannelID
if session != nil && session.IMChannelID != nil && *session.IMChannelID != "" {
    channelID = *session.IMChannelID  // ← stale!
}
\`\`\`

\`session.IMChannelID\` exists for cases where there's no inbound to copy from (background tasks, audits). But during turn processing we always have a fresh inbound; that channel is the right answer. This PR uses \`msg.ChannelID\` unconditionally and refreshes \`session.IMChannelID\` in DB so other readers see the current binding.

## Test plan

- [ ] CI \`build-server\` green
- [ ] After rollout, send WeChat from the new bot — agentserver/imbridge both 200; **user receives the assistant reply in WeChat** ← end of the line, finally

🤖 Generated with [Claude Code](https://claude.com/claude-code)