### PR TITLE
chore(chart): bump version 0.40.1 → 0.41.0

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.40.1
-appVersion: "0.40.1"
+version: 0.41.0
+appVersion: "0.41.0"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
## Summary

Chart version bump to reflect breaking values changes from #57 (OpenViking → S3 migration).

Operators upgrading from 0.40.1 must:
- Drop `openviking:` and `ccbroker.openviking:` blocks from their values overrides
- Provide a k8s secret with `access_key_id` / `secret_access_key` keys
- Set `ccbroker.s3.existingSecret`, `ccbroker.s3.endpoint`, `ccbroker.s3.bucket` (required), and optionally `ccbroker.s3.{region,useSSL,pathStyle}`

`helm upgrade` will fail at template-render time with a clear error if `existingSecret` is missing while `ccbroker.enabled` is true.

## Test plan

- [x] Chart.yaml version field bumped
- [x] No other content changes (this PR is bump-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)