### PR TITLE
ccbroker: per-session state as full subtree tarball (not single jsonl)

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.44.0
-appVersion: "0.44.0"
+version: 0.45.0
+appVersion: "0.45.0"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/internal/ccbroker/workspace/s3store.go
+++ b/internal/ccbroker/workspace/s3store.go
@@ -264,65 +264,6 @@ func writeTarball(srcDir string, tw *tar.Writer, excludeRel func(rel string) boo
 	})
 }
 
-// DownloadFile fetches the object at key and writes it verbatim to destPath
-// (creating parent directories). Returns ErrObjectNotFound if the object
-// does not exist; the caller can ignore that to mean "no prior state".
-func (s *S3Store) DownloadFile(ctx context.Context, key, destPath string) error {
-	out, err := s.client.GetObject(ctx, &s3.GetObjectInput{
-		Bucket: &s.bucket,
-		Key:    &key,
-	})
-	if err != nil {
-		var nsk *s3types.NoSuchKey
-		if errors.As(err, &nsk) {
-			return ErrObjectNotFound
-		}
-		return fmt.Errorf("s3: get object %s: %w", key, err)
-	}
-	defer out.Body.Close()
-
-	if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
-		return fmt.Errorf("s3: mkdir parent of %s: %w", destPath, err)
-	}
-	f, err := os.OpenFile(destPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
-	if err != nil {
-		return fmt.Errorf("s3: create %s: %w", destPath, err)
-	}
-	if _, err := io.Copy(f, out.Body); err != nil {
-		_ = f.Close()
-		return fmt.Errorf("s3: copy %s: %w", destPath, err)
-	}
-	if err := f.Close(); err != nil {
-		return fmt.Errorf("s3: close %s: %w", destPath, err)
-	}
-	return nil
-}
-
-// UploadFile reads srcPath in full and PUTs it verbatim at key. ContentLength
-// is set so the SDK issues a single signed PUT.
-func (s *S3Store) UploadFile(ctx context.Context, srcPath, key string) error {
-	data, err := os.ReadFile(srcPath)
-	if err != nil {
-		return fmt.Errorf("s3: read %s: %w", srcPath, err)
-	}
-	body := bytes.NewReader(data)
-	_, err = s.client.PutObject(ctx, &s3.PutObjectInput{
-		Bucket:        &s.bucket,
-		Key:           &key,
-		Body:          body,
-		ContentLength: aws.Int64(int64(body.Len())),
-	})
-	if err != nil {
-		return fmt.Errorf("s3: put object %s: %w", key, err)
-	}
-	return nil
-}
-
-// ErrObjectNotFound is returned by DownloadFile when the requested key does
-// not exist. Sentinel so callers can distinguish missing-but-OK from a real
-// transport / auth failure.
-var ErrObjectNotFound = errors.New("s3: object not found")
-
 // ErrPreconditionFailed is returned by UploadTarGz when an If-Match or
 // If-None-Match precondition fails (HTTP 412). Optimistic-lock callers
 // distinguish this from a transport error and decide whether to drop

--- a/internal/ccbroker/workspace/workspace.go
+++ b/internal/ccbroker/workspace/workspace.go
@@ -46,12 +46,17 @@ func claudeHomeKey(workspaceID string) string {
 	return fmt.Sprintf("workspaces/%s/claude-home.tar.gz", workspaceID)
 }
 
-// sessionJsonlKey is the deterministic S3 object key for a single session's
-// conversation jsonl. One key per (workspace, session) pair so concurrent
-// sessions in the same workspace cannot overwrite each other's transcript
-// via the shared claude-home tarball.
-func sessionJsonlKey(workspaceID, sessionID string) string {
-	return fmt.Sprintf("workspaces/%s/sessions/%s.jsonl", workspaceID, sessionID)
+// sessionTarballKey is the deterministic S3 object key for a single session's
+// state — the entire projects/<projHash>/ subtree packaged as tar.gz. One key
+// per (workspace, session) pair so concurrent sessions in the same workspace
+// cannot overwrite each other via the shared claude-home tarball.
+//
+// The subtree currently contains only the conversation jsonl, but storing the
+// whole directory protects against future Claude CLI additions (metadata
+// files, checkpoints, etc.) silently disappearing because they fall in the
+// claude-home tarball's exclude window.
+func sessionTarballKey(workspaceID, sessionID string) string {
+	return fmt.Sprintf("workspaces/%s/sessions/%s.tar.gz", workspaceID, sessionID)
 }
 
 // projHashDir returns the directory name Claude CLI derives from cwd when
@@ -66,17 +71,16 @@ func projHashDir(cwd string) string {
 	return strings.NewReplacer("/", "-", "_", "-").Replace(cwd)
 }
 
-// sessionJsonlLocalPath is the on-disk location of the session jsonl that
-// Claude CLI's --resume flag will look for, given this workspace's CWD and
-// session ID.
-func sessionJsonlLocalPath(ws *Workspace) string {
-	uuid := strings.TrimPrefix(ws.SessionID, "cse_")
-	return filepath.Join(ws.ClaudeDir, "projects", projHashDir(ws.ProjectDir), uuid+".jsonl")
+// sessionSubtreeLocalDir is the on-disk directory Claude CLI uses for this
+// session's project state (jsonl + any future per-session files). It maps
+// 1:1 to sessionTarballKey on the S3 side.
+func sessionSubtreeLocalDir(ws *Workspace) string {
+	return filepath.Join(ws.ClaudeDir, "projects", projHashDir(ws.ProjectDir))
 }
 
 // sessionSubtreeRel is the rel-path (relative to ClaudeDir) of the
 // per-session subtree that should be omitted from the claude-home tarball
-// because it lives under sessionJsonlKey instead.
+// because it lives under sessionTarballKey instead.
 func sessionSubtreeRel(ws *Workspace) string {
 	return "projects/" + projHashDir(ws.ProjectDir)
 }
@@ -122,16 +126,24 @@ func Setup(ctx context.Context, workspaceID, sessionID string, store *S3Store) (
 	}
 	ws.claudeHomeETag = etag
 
-	// Per-session jsonl is downloaded AFTER claude-home so it overrides any
-	// stale copy that was still present in the tarball (a leftover from
-	// pre-split layout). 404 means a brand-new session — the CLI will create
-	// the file when --session-id runs.
-	if err := store.DownloadFile(ctx, sessionJsonlKey(workspaceID, sessionID), sessionJsonlLocalPath(ws)); err != nil && !errors.Is(err, ErrObjectNotFound) {
+	// Per-session subtree is downloaded AFTER claude-home so it overrides
+	// any stale copy that was still present in the tarball.
+	if _, err := store.DownloadTarGz(ctx, sessionTarballKey(workspaceID, sessionID), sessionSubtreeLocalDir(ws)); err != nil {
 		_ = os.RemoveAll(tempDir)
-		return nil, fmt.Errorf("download session jsonl for %s/%s: %w", workspaceID, sessionID, err)
+		return nil, fmt.Errorf("download session subtree for %s/%s: %w", workspaceID, sessionID, err)
 	}
 
 	return ws, nil
+}
+
+// subtreeHasFiles reports whether dir exists and contains at least one entry.
+// Used by Teardown to decide whether there's anything worth uploading.
+func subtreeHasFiles(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	return len(entries) > 0
 }
 
 // Teardown uploads the per-session jsonl, then packages ClaudeDir as a tar.gz
@@ -145,13 +157,11 @@ func Teardown(ctx context.Context, ws *Workspace, store *S3Store) error {
 	}
 	defer func() { _ = os.RemoveAll(ws.TempDir) }()
 
-	jsonlPath := sessionJsonlLocalPath(ws)
-	if _, err := os.Stat(jsonlPath); err == nil {
-		if err := store.UploadFile(ctx, jsonlPath, sessionJsonlKey(ws.WorkspaceID, ws.SessionID)); err != nil {
-			fmt.Fprintf(os.Stderr, "workspace.Teardown: upload session jsonl: %v\n", err)
+	subtreeDir := sessionSubtreeLocalDir(ws)
+	if subtreeHasFiles(subtreeDir) {
+		if err := store.UploadTarGz(ctx, subtreeDir, sessionTarballKey(ws.WorkspaceID, ws.SessionID), nil, UploadOpts{}); err != nil {
+			fmt.Fprintf(os.Stderr, "workspace.Teardown: upload session subtree: %v\n", err)
 		}
-	} else if !os.IsNotExist(err) {
-		fmt.Fprintf(os.Stderr, "workspace.Teardown: stat session jsonl: %v\n", err)
 	}
 
 	// Exclude THIS session's subtree from the claude-home tarball — it's

--- a/internal/ccbroker/workspace/workspace_test.go
+++ b/internal/ccbroker/workspace/workspace_test.go
@@ -124,7 +124,26 @@ func TestProjHashDir_MatchesObservedClaudeCLILayout(t *testing.T) {
 	}
 }
 
-func TestSetupAndTeardown_PerSessionJsonlRoundTrip(t *testing.T) {
+// writeSessionFile drops a file at <subtree>/<name> for a given workspace,
+// matching the layout Claude CLI uses during a turn.
+func writeSessionFile(t *testing.T, ws *Workspace, name, content string) {
+	t.Helper()
+	subtree := sessionSubtreeLocalDir(ws)
+	if err := os.MkdirAll(subtree, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subtree, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// jsonlName is the per-turn jsonl filename Claude CLI writes under the
+// per-session subtree directory.
+func jsonlName(ws *Workspace) string {
+	return strings.TrimPrefix(ws.SessionID, "cse_") + ".jsonl"
+}
+
+func TestSetupAndTeardown_PerSessionSubtreeRoundTrip(t *testing.T) {
 	old := TempDirBase
 	TempDirBase = t.TempDir()
 	defer func() { TempDirBase = old }()
@@ -139,58 +158,62 @@ func TestSetupAndTeardown_PerSessionJsonlRoundTrip(t *testing.T) {
 		t.Fatalf("Setup: %v", err)
 	}
 
-	// Simulate Claude CLI writing a session jsonl during the turn.
-	jsonlPath := sessionJsonlLocalPath(ws)
-	if err := os.MkdirAll(filepath.Dir(jsonlPath), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(jsonlPath, []byte("turn1-line\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	// Simulate Claude CLI writing the conversation jsonl + a hypothetical
+	// auxiliary file under the per-session subtree during the turn.
+	writeSessionFile(t, ws, jsonlName(ws), "turn1-line\n")
+	writeSessionFile(t, ws, "metadata.json", `{"v":1}`)
 
 	if err := Teardown(ctx, ws, store); err != nil {
 		t.Fatalf("Teardown: %v", err)
 	}
 
-	// Per-session jsonl must have been uploaded under its own key.
-	jsonlKey := sessionJsonlKey("ws1", "cse_abc")
-	uploadedJsonl, ok := fake.uploads[jsonlKey]
+	// Per-session subtree must have been uploaded as a tarball under its
+	// own key — including the auxiliary file, not just the jsonl.
+	tarballKey := sessionTarballKey("ws1", "cse_abc")
+	uploadedTarball, ok := fake.uploads[tarballKey]
 	if !ok {
-		t.Fatalf("expected jsonl upload at %s; uploads=%v", jsonlKey, keysOf(fake.uploads))
+		t.Fatalf("expected per-session tarball upload at %s; uploads=%v", tarballKey, keysOf(fake.uploads))
 	}
-	if string(uploadedJsonl) != "turn1-line\n" {
-		t.Fatalf("jsonl content mismatch: %q", uploadedJsonl)
+	if !hasTarFileContent(t, uploadedTarball, jsonlName(ws), "turn1-line\n") {
+		t.Fatalf("uploaded tarball missing jsonl content")
+	}
+	if !hasTarFileContent(t, uploadedTarball, "metadata.json", `{"v":1}`) {
+		t.Fatalf("uploaded tarball missing metadata.json — auxiliary file dropped (this is the regression we're guarding against)")
 	}
 
 	// claude-home tarball must NOT contain the per-session subtree.
-	tarBytes, ok := fake.uploads[claudeHomeKey("ws1")]
+	claudeHomeBytes, ok := fake.uploads[claudeHomeKey("ws1")]
 	if !ok {
 		t.Fatalf("expected claude-home upload; uploads=%v", keysOf(fake.uploads))
 	}
-	if hasTarEntry(t, tarBytes, sessionSubtreeRel(ws)+"/") {
+	if hasTarEntry(t, claudeHomeBytes, sessionSubtreeRel(ws)+"/") {
 		t.Fatalf("claude-home tarball must not include session subtree %s", sessionSubtreeRel(ws))
 	}
 
-	// Round-trip: stage uploads as objects, fresh Setup must reconstruct
-	// the jsonl from the per-session key.
-	fake.putObject(claudeHomeKey("ws1"), tarBytes, "etag-after-t1")
-	fake.objects[jsonlKey] = uploadedJsonl
+	// Round-trip: stage uploads as fetchable objects, fresh Setup must
+	// reconstruct both files from the per-session tarball.
+	fake.putObject(claudeHomeKey("ws1"), claudeHomeBytes, "etag-after-t1")
+	fake.objects[tarballKey] = uploadedTarball
 
 	ws2, err := Setup(ctx, "ws1", "cse_abc", store)
 	if err != nil {
 		t.Fatalf("Setup #2: %v", err)
 	}
 	defer Teardown(ctx, ws2, store)
-	got, err := os.ReadFile(sessionJsonlLocalPath(ws2))
-	if err != nil || string(got) != "turn1-line\n" {
-		t.Fatalf("post-roundtrip jsonl: got=%q err=%v", got, err)
+	gotJsonl, err := os.ReadFile(filepath.Join(sessionSubtreeLocalDir(ws2), jsonlName(ws2)))
+	if err != nil || string(gotJsonl) != "turn1-line\n" {
+		t.Fatalf("post-roundtrip jsonl: got=%q err=%v", gotJsonl, err)
+	}
+	gotMeta, err := os.ReadFile(filepath.Join(sessionSubtreeLocalDir(ws2), "metadata.json"))
+	if err != nil || string(gotMeta) != `{"v":1}` {
+		t.Fatalf("post-roundtrip metadata.json: got=%q err=%v", gotMeta, err)
 	}
 }
 
 func TestTeardown_TwoSessionsDoNotOverwriteEachOther(t *testing.T) {
 	// Workspace W has two concurrent sessions A and B. Each writes its own
 	// jsonl. Whichever Teardown runs second must not destroy the other's
-	// jsonl. With per-session keys, each lives in its own object.
+	// jsonl. With per-session tarball keys, each lives in its own object.
 	old := TempDirBase
 	TempDirBase = t.TempDir()
 	defer func() { TempDirBase = old }()
@@ -209,18 +232,8 @@ func TestTeardown_TwoSessionsDoNotOverwriteEachOther(t *testing.T) {
 		t.Fatalf("Setup B: %v", err)
 	}
 
-	if err := os.MkdirAll(filepath.Dir(sessionJsonlLocalPath(wsA)), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(sessionJsonlLocalPath(wsA), []byte("A-data\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.MkdirAll(filepath.Dir(sessionJsonlLocalPath(wsB)), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(sessionJsonlLocalPath(wsB), []byte("B-data\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
+	writeSessionFile(t, wsA, jsonlName(wsA), "A-data\n")
+	writeSessionFile(t, wsB, jsonlName(wsB), "B-data\n")
 
 	// A finishes first, then B.
 	if err := Teardown(ctx, wsA, store); err != nil {
@@ -230,12 +243,12 @@ func TestTeardown_TwoSessionsDoNotOverwriteEachOther(t *testing.T) {
 		t.Fatalf("Teardown B: %v", err)
 	}
 
-	// Both jsonls present at distinct keys.
-	if string(fake.uploads[sessionJsonlKey("wsX", "cse_A")]) != "A-data\n" {
-		t.Fatalf("A jsonl missing or wrong: uploads=%v", keysOf(fake.uploads))
+	// Both per-session tarballs present at distinct keys with distinct content.
+	if !hasTarFileContent(t, fake.uploads[sessionTarballKey("wsX", "cse_A")], jsonlName(wsA), "A-data\n") {
+		t.Fatalf("A's tarball missing or wrong content; uploads=%v", keysOf(fake.uploads))
 	}
-	if string(fake.uploads[sessionJsonlKey("wsX", "cse_B")]) != "B-data\n" {
-		t.Fatalf("B jsonl missing or wrong: uploads=%v", keysOf(fake.uploads))
+	if !hasTarFileContent(t, fake.uploads[sessionTarballKey("wsX", "cse_B")], jsonlName(wsB), "B-data\n") {
+		t.Fatalf("B's tarball missing or wrong content; uploads=%v", keysOf(fake.uploads))
 	}
 }
 


### PR DESCRIPTION
## Summary

Per-session S3 key was just the \`.jsonl\` file. The Teardown rule that excludes the per-session subtree from the claude-home tarball drops the WHOLE \`projects/<projHash>/\` directory, so any auxiliary file Claude CLI might add next to the jsonl (metadata, checkpoints, future per-session state) would silently disappear.

Switch per-session storage from raw file to whole-subtree tarball:

\`\`\`
workspaces/<wid>/sessions/<sid>.jsonl    →    workspaces/<wid>/sessions/<sid>.tar.gz
\`\`\`

Setup downloads the tarball into the subtree directory. Teardown packs the subtree back up. The claude-home exclude rule is unchanged.

## Removed

\`S3Store.DownloadFile\`, \`UploadFile\`, \`ErrObjectNotFound\` — dead code after the swap.

## Migration

**None.** Workspaces deployed under 0.43.x / 0.44.x with the legacy \`.jsonl\` key get a fresh session on the next turn after upgrade.

## Test plan

- [x] All workspace tests pass
- [x] \`go test ./...\` green
- [x] \`go vet ./...\` clean
- [x] \`go mod tidy\` clean
- [x] \`TestSetupAndTeardown_PerSessionSubtreeRoundTrip\` writes both a jsonl AND a \`metadata.json\` under the subtree, verifies both survive round-trip — directly guards against the regression that motivated this change

## Breaking

Chart bumped 0.44.0 → 0.45.0. Storage key changes from \`.jsonl\` to \`.tar.gz\`. Forward upgrade with no migration; rollback would orphan the new \`.tar.gz\` keys (harmless, just storage cost).

🤖 Generated with [Claude Code](https://claude.com/claude-code)