### PR TITLE
fix(tui): address Phase 2 holistic review P0+P1 issues

### DIFF
--- a/cmd/agentserver-agent/tui_run.go
+++ b/cmd/agentserver-agent/tui_run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 
 	tea "github.com/charmbracelet/bubbletea"
 
@@ -53,24 +54,8 @@ func runTUI(ctx context.Context, opts agent.TUIOpts) error {
 
 	var executorID string
 
-	// 3. If logged in, register executor + start tunnel BEFORE the Bubble Tea
-	//    program starts. If not logged in, the executor goroutine is started
-	//    after /login completes.
-	if auth.State() == tui.AuthLoggedIn {
-		sess, err := agent.LoadOrRegisterExecutor(agent.ExecutorOpts{
-			ServerURL:   server,
-			Name:        opts.Name,
-			WorkspaceID: opts.WorkspaceID,
-		})
-		if err != nil {
-			return fmt.Errorf("register executor: %w", err)
-		}
-		executorID = sess.ExecutorID
-		ec := agent.NewExecutorClient(sess, workDir)
-		go func() { _ = ec.Run(ctx) }()
-	}
-
-	// 4. Build Bus.
+	// 3. Build Bus (executor ID may be empty if not yet logged in; SetExecutorID
+	//    is called by startExecutor after registration).
 	bus := tui.NewBus(tui.BusConfig{
 		ServerURL:   server,
 		WorkspaceID: opts.WorkspaceID,
@@ -78,40 +63,82 @@ func runTUI(ctx context.Context, opts agent.TUIOpts) error {
 		Auth:        auth,
 	})
 
-	// 5. Build Model.
-	model := tui.NewModel(tui.ModelConfig{
-		ServerURL:    server,
-		WorkspaceID:  opts.WorkspaceID,
-		ExecutorID:   executorID,
-		Bus:          bus,
-		Auth:         auth,
-		Yolo:         opts.Yolo,
-		InitialModel: opts.Model,
-		Resume:       opts.Resume,
-		Continue:     opts.Continue,
-	})
+	// 4. Build the Bubble Tea program placeholder so callbacks can call p.Send.
+	//    We assign model below, after defining the callbacks.
+	var p *tea.Program
 
-	// 6. Build the Bubble Tea program and wire AuthController.OnChange to
-	//    pump AuthStateChangedMsg into the program.
-	p := tea.NewProgram(model, tea.WithContext(ctx), tea.WithAltScreen())
-	auth.SetOnChange(func(s tui.AuthState) {
-		p.Send(tui.AuthStateChangedMsg{State: s})
-	})
-
-	// 7. If Resume is set, start SSE consumer and pump events into the program.
-	//    TODO(T17): also start SSE when sessionID is known dynamically (after
-	//    NewSessionReplyMsg, InboundAcceptedMsg, etc.).
-	if opts.Resume != "" && auth.State() == tui.AuthLoggedIn {
-		consumer := tui.NewSSEConsumer(bus, tui.SSEConfig{
-			SessionID: opts.Resume,
-		})
+	// restartSSE (re)starts the SSE consumer goroutine for the given session.
+	// Any previous consumer is cancelled first.
+	var sseCancel context.CancelFunc
+	var sseMu sync.Mutex
+	restartSSE := func(sid string) {
+		if sid == "" {
+			return
+		}
+		sseMu.Lock()
+		defer sseMu.Unlock()
+		if sseCancel != nil {
+			sseCancel() // cancel any previous consumer
+		}
+		sseCtx, cancel := context.WithCancel(ctx)
+		sseCancel = cancel
+		busCapture := bus // capture for goroutine
 		go func() {
-			evCh := consumer.Run(ctx)
+			consumer := tui.NewSSEConsumer(busCapture, tui.SSEConfig{SessionID: sid})
+			evCh := consumer.Run(sseCtx)
 			for ev := range evCh {
 				p.Send(tui.EventArrivedMsg{Event: ev})
 			}
 		}()
 	}
+
+	// startExecutor registers the executor with the server (once) and starts
+	// the yamux tunnel goroutine. Called on login or at startup if already
+	// logged in.
+	var executorOnce sync.Once
+	startExecutor := func() {
+		executorOnce.Do(func() {
+			sess, err := agent.LoadOrRegisterExecutor(agent.ExecutorOpts{
+				ServerURL:   server,
+				Name:        opts.Name,
+				WorkspaceID: opts.WorkspaceID,
+			})
+			if err != nil {
+				p.Send(tui.FatalErrorMsg{Err: fmt.Errorf("register executor after login: %w", err)})
+				return
+			}
+			bus.SetExecutorID(sess.ExecutorID)
+			ec := agent.NewExecutorClient(sess, workDir)
+			go func() { _ = ec.Run(ctx) }()
+		})
+	}
+
+	// 5. Build Model with lifecycle callbacks.
+	model := tui.NewModel(tui.ModelConfig{
+		ServerURL:      server,
+		WorkspaceID:    opts.WorkspaceID,
+		ExecutorID:     executorID,
+		Bus:            bus,
+		Auth:           auth,
+		Yolo:           opts.Yolo,
+		InitialModel:   opts.Model,
+		Resume:         opts.Resume,
+		Continue:       opts.Continue,
+		OnLoggedIn:     startExecutor,
+		OnSessionReady: restartSSE,
+	})
+
+	// 6. Build the Bubble Tea program and wire AuthController.OnChange to
+	//    pump AuthStateChangedMsg into the program.
+	p = tea.NewProgram(model, tea.WithContext(ctx), tea.WithAltScreen())
+	auth.SetOnChange(func(s tui.AuthState) {
+		p.Send(tui.AuthStateChangedMsg{State: s})
+	})
+
+	// 7. Wire the OnLoginFailed callback (surfaces OAuth errors to the TUI timeline).
+	auth.SetOnLoginFailed(func(err error) {
+		p.Send(tui.LoginPollDoneMsg{Err: err})
+	})
 
 	_, err := p.Run()
 	if err != nil {

--- a/internal/agent/tui/auth.go
+++ b/internal/agent/tui/auth.go
@@ -46,6 +46,11 @@ type AuthConfig struct {
 	SkipOpenBrowser bool
 	OnChange        func(AuthState)
 
+	// OnLoginFailed is called (from the poll goroutine) when the OAuth Device
+	// Flow fails for any reason other than user cancellation (context cancel).
+	// nil if caller doesn't need this signal.
+	OnLoginFailed func(error)
+
 	// Test seams (default to real implementations from internal/agent/login.go).
 	RequestDeviceCode func(serverURL string) (*agent.DeviceAuthResponse, error)
 	PollForToken      func(serverURL string, dr *agent.DeviceAuthResponse) (*agent.TokenResponse, error)
@@ -110,6 +115,12 @@ func (a *AuthController) setState(s AuthState) {
 // and the program exist.
 func (a *AuthController) SetOnChange(fn func(AuthState)) {
 	a.cfg.OnChange = fn
+}
+
+// SetOnLoginFailed installs or replaces the OnLoginFailed callback after
+// construction. Used by RunTUI to surface login errors to the TUI timeline.
+func (a *AuthController) SetOnLoginFailed(fn func(error)) {
+	a.cfg.OnLoginFailed = fn
 }
 
 // EnsureValid returns a non-empty access token or an error. If the token is
@@ -206,6 +217,9 @@ func (a *AuthController) runPoll(ctx context.Context, dr *agent.DeviceAuthRespon
 	}
 	if err != nil {
 		a.setState(AuthLoggedOut)
+		if a.cfg.OnLoginFailed != nil {
+			a.cfg.OnLoginFailed(err)
+		}
 		return
 	}
 	creds := &agent.Credentials{

--- a/internal/agent/tui/auth.go
+++ b/internal/agent/tui/auth.go
@@ -288,7 +288,10 @@ func refreshDirect(ctx context.Context, serverURL, refreshToken string) (*agent.
 	}
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
-	resp, err := http.DefaultClient.Do(req)
+	// Use a timeout client; http.DefaultClient has no timeout and a slow or
+	// hung token endpoint would block all Bus.do calls indefinitely.
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/agent/tui/auth_test.go
+++ b/internal/agent/tui/auth_test.go
@@ -105,6 +105,43 @@ func TestAuth_LoginFlowDenied(t *testing.T) {
 	}
 }
 
+func TestAuth_LoginFlowDenied_CallsOnLoginFailed(t *testing.T) {
+	var mu sync.Mutex
+	var capturedErr error
+	ac := NewAuthController(AuthConfig{
+		ServerURL:       "https://example",
+		CredentialsPath: t.TempDir() + "/creds.json",
+		RequestDeviceCode: func(_ string) (*agent.DeviceAuthResponse, error) {
+			return &agent.DeviceAuthResponse{DeviceCode: "dc", UserCode: "X", ExpiresIn: 60, Interval: 1}, nil
+		},
+		PollForToken: func(_ string, _ *agent.DeviceAuthResponse) (*agent.TokenResponse, error) {
+			return nil, errors.New("authorization denied by user")
+		},
+		OnLoginFailed: func(err error) {
+			mu.Lock()
+			capturedErr = err
+			mu.Unlock()
+		},
+	})
+	_, _ = ac.StartLogin(context.Background())
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		got := capturedErr
+		mu.Unlock()
+		if got != nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	mu.Lock()
+	got := capturedErr
+	mu.Unlock()
+	if got == nil {
+		t.Error("OnLoginFailed not invoked")
+	}
+}
+
 func TestAuth_Logout_ClearsCreds(t *testing.T) {
 	p := t.TempDir() + "/creds.json"
 	_ = agent.SaveCredentials(p, &agent.Credentials{

--- a/internal/agent/tui/bus.go
+++ b/internal/agent/tui/bus.go
@@ -248,6 +248,14 @@ func (b *Bus) FetchExecutorStatus(ctx context.Context) (*ExecutorStatusResp, err
 func (b *Bus) ServerURL() string  { return b.cfg.ServerURL }
 func (b *Bus) ExecutorID() string { return b.cfg.ExecutorID }
 
+// SetExecutorID updates the executor ID on the Bus. This should only be called
+// during initialization (before any session activity), not concurrently with
+// active requests. Used by tui_run.go when the executor is registered lazily
+// (post-login) and the ID wasn't known at Bus construction time.
+func (b *Bus) SetExecutorID(id string) {
+	b.cfg.ExecutorID = id
+}
+
 // AccessToken exposes Auth.EnsureValid for the SSE consumer, which builds
 // long-lived requests outside of `do`'s code path.
 func (b *Bus) AccessToken(ctx context.Context) (string, error) {

--- a/internal/agent/tui/model.go
+++ b/internal/agent/tui/model.go
@@ -4,6 +4,7 @@ package tui
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
@@ -36,6 +37,19 @@ type ModelConfig struct {
 	InitialModel string
 	Resume       string
 	Continue     bool
+
+	// OnLoggedIn fires when AuthState transitions to LoggedIn. Used to
+	// start ExecutorClient + register executor (lazily, post-login).
+	// nil if caller doesn't need this signal.
+	OnLoggedIn func()
+
+	// OnSessionReady fires whenever the model's sessionID becomes known
+	// or changes (Resume on Init, NewSessionReplyMsg, InboundAcceptedMsg
+	// for first-prompt-creates-session, ResumeRequestedMsg). Used to start
+	// / restart the SSE consumer goroutine. May be called multiple times;
+	// implementations should cancel any previous consumer before starting
+	// a new one.
+	OnSessionReady func(sessionID string)
 }
 
 type Model struct {
@@ -110,6 +124,12 @@ func (m *Model) Init() tea.Cmd {
 		m.SetAuthState(m.auth.State())
 	}
 	if m.authState == AuthLoggedIn {
+		// Already logged in at startup — fire OnLoggedIn so tui_run.go can
+		// start the executor. (AuthStateChangedMsg won't fire because state
+		// didn't "change"; it was already LoggedIn.)
+		if m.cfg.OnLoggedIn != nil {
+			m.cfg.OnLoggedIn()
+		}
 		cmds = append(cmds, m.startSessionCmds()...)
 	}
 	return tea.Batch(cmds...)
@@ -119,6 +139,9 @@ func (m *Model) startSessionCmds() []tea.Cmd {
 	var out []tea.Cmd
 	if m.cfg.Resume != "" {
 		m.sessionID = m.cfg.Resume
+		if m.cfg.OnSessionReady != nil {
+			m.cfg.OnSessionReady(m.sessionID)
+		}
 		out = append(out, m.attachAndSubscribe(m.sessionID))
 	} else if m.cfg.Continue {
 		out = append(out, m.continueLatestCmd())
@@ -177,10 +200,15 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 	if a, ok := msg.(AuthStateChangedMsg); ok {
 		m.SetAuthState(a.State)
-		if a.State == AuthLoggedIn && m.mode == ModeAwaitLogin {
-			m.mode = ModeNormal
-			m.activePanel = nil
-			return m, tea.Batch(m.startSessionCmds()...)
+		if a.State == AuthLoggedIn {
+			if m.cfg.OnLoggedIn != nil {
+				m.cfg.OnLoggedIn()
+			}
+			if m.mode == ModeAwaitLogin {
+				m.mode = ModeNormal
+				m.activePanel = nil
+				return m, tea.Batch(m.startSessionCmds()...)
+			}
 		}
 		return m, nil
 	}
@@ -242,21 +270,63 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, m.statusTickCmd()
 	case AttachReplyMsg:
 		if v.Err == nil && v.Resp != nil {
-			// SSE subscription would be started here in production.
-			// For T12 we just leave it; T14's RunTUI assembles the SSE goroutine.
+			// OnSessionReady was already called in startSessionCmds for the
+			// Resume path. For dynamic attach (take-control/observe), the
+			// sessionID is unchanged so no restart is needed.
 		}
 		return m, nil
 	case NewSessionReplyMsg:
 		if v.Err == nil && v.SessionID != "" {
 			m.sessionID = v.SessionID
+			if m.cfg.OnSessionReady != nil {
+				m.cfg.OnSessionReady(v.SessionID)
+			}
 		}
 		return m, nil
 	case InboundAcceptedMsg:
 		m.turnID = v.TurnID
 		m.statusTurn = "running"
+		if v.SessionID != "" && v.SessionID != m.sessionID {
+			// First prompt created a session implicitly.
+			m.sessionID = v.SessionID
+			if m.cfg.OnSessionReady != nil {
+				m.cfg.OnSessionReady(v.SessionID)
+			}
+		}
 		return m, nil
 	case InboundRejectedMsg:
 		// Render an error in timeline so user sees it.
+		return m, nil
+	case SendAnswerMsg:
+		// For now just log via timeline; agentserver doesn't yet have a
+		// /answers endpoint. v1.x adds the real wire path.
+		m.timeline.Append(SSEEvent{
+			Type: "ask_user_answered",
+			Data: []byte(fmt.Sprintf(`{"qid":%q,"selected":%s}`, v.QID, mustJSONList(v.Selected))),
+		})
+		m.viewport.SetContent(m.timeline.Render(m.viewport.Width, m.cfg.ExecutorID))
+		m.viewport.GotoBottom()
+		return m, nil
+	case LogoutDoneMsg:
+		if v.Err != nil {
+			m.timeline.Append(SSEEvent{
+				Type: "logout_error",
+				Data: []byte(fmt.Sprintf(`{"error":%q}`, v.Err.Error())),
+			})
+			m.viewport.SetContent(m.timeline.Render(m.viewport.Width, m.cfg.ExecutorID))
+			m.viewport.GotoBottom()
+		}
+		// SetAuthState was already called inside Logout → callback fired.
+		return m, nil
+	case LoginPollDoneMsg:
+		if v.Err != nil {
+			m.timeline.Append(SSEEvent{
+				Type: "login_failed",
+				Data: []byte(fmt.Sprintf(`{"error":%q}`, v.Err.Error())),
+			})
+			m.viewport.SetContent(m.timeline.Render(m.viewport.Width, m.cfg.ExecutorID))
+			m.viewport.GotoBottom()
+		}
 		return m, nil
 	}
 
@@ -493,4 +563,9 @@ func (m *Model) View() string {
 	return RenderView(m)
 }
 
-
+// mustJSONList marshals a []string to a JSON array string. Never fails for
+// plain string slices.
+func mustJSONList(ss []string) string {
+	b, _ := json.Marshal(ss)
+	return string(b)
+}

--- a/internal/agent/tui/model.go
+++ b/internal/agent/tui/model.go
@@ -328,6 +328,9 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.viewport.GotoBottom()
 		}
 		return m, nil
+	case RequeuePermissionMsg:
+		m.permQueue = append(m.permQueue, v.Panel)
+		return m, nil
 	}
 
 	// Plain key handling in ModeNormal.

--- a/internal/agent/tui/model.go
+++ b/internal/agent/tui/model.go
@@ -410,7 +410,17 @@ func (m *Model) runLocalCommand(name, args string) (tea.Model, tea.Cmd) {
 		return m, tea.Quit
 	case "yolo":
 		m.permMode = "bypass"
-		return m, nil
+		sid := m.sessionID
+		if sid == "" {
+			return m, nil // no session yet; permMode will apply on next session
+		}
+		bus := m.bus
+		return m, func() tea.Msg {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			body, err := bus.PostControl(ctx, sid, "permission", map[string]any{"mode": "bypass"})
+			return ControlReplyMsg{Command: "permission", Body: body, Err: err}
+		}
 	case "login":
 		if m.startLoginFn != nil {
 			return m, m.startLoginFn()

--- a/internal/agent/tui/model_test.go
+++ b/internal/agent/tui/model_test.go
@@ -3,6 +3,7 @@ package tui
 
 import (
 	"encoding/json"
+	"errors"
 	"strings"
 	"testing"
 
@@ -119,6 +120,58 @@ func TestModel_AuthStateChanged_LoggedIn_ClearsLoginPanel(t *testing.T) {
 	}
 	if m.activePanel != nil {
 		t.Errorf("activePanel should be cleared")
+	}
+}
+
+func TestModel_OnLoggedIn_FiresOnAuthTransition(t *testing.T) {
+	m := newTestModel(t)
+	m.SetAuthState(AuthLoggedOut)
+	var fired bool
+	m.cfg.OnLoggedIn = func() { fired = true }
+	m.Update(AuthStateChangedMsg{State: AuthLoggedIn})
+	if !fired {
+		t.Error("OnLoggedIn should fire on transition to LoggedIn")
+	}
+}
+
+func TestModel_OnSessionReady_FiresOnInboundAccepted(t *testing.T) {
+	m := newTestModel(t)
+	m.SetAuthState(AuthLoggedIn)
+	var got string
+	m.cfg.OnSessionReady = func(sid string) { got = sid }
+	m.Update(InboundAcceptedMsg{SessionID: "cse_new", TurnID: "trn_x"})
+	if got != "cse_new" {
+		t.Errorf("OnSessionReady got %q want cse_new", got)
+	}
+}
+
+func TestModel_SendAnswerMsg_AppendsToTimeline(t *testing.T) {
+	m := newTestModel(t)
+	m.SetAuthState(AuthLoggedIn)
+	before := m.timeline.Len()
+	m.Update(SendAnswerMsg{QID: "q1", Selected: []string{"foo"}})
+	if m.timeline.Len() != before+1 {
+		t.Errorf("timeline len did not grow: before=%d after=%d", before, m.timeline.Len())
+	}
+}
+
+func TestModel_LogoutDoneMsg_NoError_NoTimelineEntry(t *testing.T) {
+	m := newTestModel(t)
+	m.SetAuthState(AuthLoggedIn)
+	before := m.timeline.Len()
+	m.Update(LogoutDoneMsg{Err: nil})
+	if m.timeline.Len() != before {
+		t.Errorf("logout success should NOT add timeline entry; before=%d after=%d", before, m.timeline.Len())
+	}
+}
+
+func TestModel_LogoutDoneMsg_WithError_AppendsErrorEntry(t *testing.T) {
+	m := newTestModel(t)
+	m.SetAuthState(AuthLoggedIn)
+	before := m.timeline.Len()
+	m.Update(LogoutDoneMsg{Err: errors.New("boom")})
+	if m.timeline.Len() != before+1 {
+		t.Errorf("logout error should add timeline entry")
 	}
 }
 

--- a/internal/agent/tui/model_test.go
+++ b/internal/agent/tui/model_test.go
@@ -4,6 +4,9 @@ package tui
 import (
 	"encoding/json"
 	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -172,6 +175,39 @@ func TestModel_LogoutDoneMsg_WithError_AppendsErrorEntry(t *testing.T) {
 	m.Update(LogoutDoneMsg{Err: errors.New("boom")})
 	if m.timeline.Len() != before+1 {
 		t.Errorf("logout error should add timeline entry")
+	}
+}
+
+func TestModel_YoloCallsPostControl(t *testing.T) {
+	var hit bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hit = true
+		if !strings.HasSuffix(r.URL.Path, "/control") {
+			t.Errorf("path %q want /control", r.URL.Path)
+		}
+		body, _ := io.ReadAll(r.Body)
+		if !strings.Contains(string(body), `"mode":"bypass"`) {
+			t.Errorf("body %s missing mode=bypass", body)
+		}
+		w.Write([]byte(`{"applied":true,"mode":"bypass"}`))
+	}))
+	defer srv.Close()
+	m := NewModel(ModelConfig{
+		ServerURL: srv.URL, WorkspaceID: "ws", ExecutorID: "e",
+		Bus: NewBus(BusConfig{ServerURL: srv.URL, WorkspaceID: "ws", ExecutorID: "e", Auth: &fakeAuth{tk: "t"}}),
+	})
+	m.SetAuthState(AuthLoggedIn)
+	m.sessionID = "cse_test"
+	_, cmd := m.Update(CommandSelectedMsg{Command: "yolo"})
+	if cmd == nil {
+		t.Fatal("expected cmd")
+	}
+	_ = cmd()
+	if !hit {
+		t.Error("PostControl was not invoked")
+	}
+	if m.permMode != "bypass" {
+		t.Errorf("permMode=%q", m.permMode)
 	}
 }
 

--- a/internal/agent/tui/panels.go
+++ b/internal/agent/tui/panels.go
@@ -34,6 +34,11 @@ type SendDecisionMsg struct {
 	PID, Verdict, Scope string
 }
 
+// RequeuePermissionMsg is emitted by the permission panel when the user
+// presses Esc ("answer later"). The Model appends the panel to the back of
+// permQueue so the request isn't permanently dismissed.
+type RequeuePermissionMsg struct{ Panel Panel }
+
 type permissionPanel struct {
 	in            PermissionPanelInput
 	nestedDisable bool
@@ -102,7 +107,8 @@ func (p *permissionPanel) HandleKey(msg tea.KeyMsg) (Panel, tea.Cmd, bool) {
 	case keyIs(msg, "n"), msg.Type == tea.KeyEnter:
 		verdict, scope = "deny", "once"
 	case msg.Type == tea.KeyEsc:
-		return p, nil, true // dismissed without a decision; Model may re-queue
+		panel := Panel(p)
+		return p, func() tea.Msg { return RequeuePermissionMsg{Panel: panel} }, true // dismissed; Model re-queues
 	default:
 		return p, nil, false
 	}

--- a/internal/agent/tui/panels_test.go
+++ b/internal/agent/tui/panels_test.go
@@ -90,6 +90,28 @@ func TestPermissionPanel_DisablesAlwaysOnNestedShell(t *testing.T) {
 	}
 }
 
+func TestPermissionPanel_EscRequeues(t *testing.T) {
+	p := NewPermissionPanel(PermissionPanelInput{
+		PID: "p1", Tool: "remote_bash", ExecutorID: "e", SelfExecID: "e",
+		Args: json.RawMessage(`{}`),
+	})
+	_, cmd, dismissed := p.HandleKey(tea.KeyMsg{Type: tea.KeyEsc})
+	if !dismissed {
+		t.Fatal("Esc should dismiss the active panel")
+	}
+	if cmd == nil {
+		t.Fatal("Esc should produce a RequeuePermissionMsg cmd")
+	}
+	msg := cmd()
+	rq, ok := msg.(RequeuePermissionMsg)
+	if !ok {
+		t.Fatalf("got %T want RequeuePermissionMsg", msg)
+	}
+	if rq.Panel == nil || rq.Panel.ID() != "p1" {
+		t.Errorf("requeued panel = %+v", rq.Panel)
+	}
+}
+
 func TestAskUserPanel_SingleSelect(t *testing.T) {
 	p := NewAskUserPanel(AskUserPanelInput{
 		QID:      "q1",

--- a/internal/ccbroker/handler_tui_routes_test.go
+++ b/internal/ccbroker/handler_tui_routes_test.go
@@ -53,7 +53,7 @@ func TestDecidePermission_HappyPath(t *testing.T) {
 	case ev := <-sub.Ch:
 		var payload map[string]any
 		json.Unmarshal(ev.Payload, &payload)
-		capturedPID, _ = payload["PermissionID"].(string)
+		capturedPID, _ = payload["permission_id"].(string)
 	case <-time.After(time.Second):
 		t.Fatal("no permission_request event within 1s")
 	}

--- a/internal/ccbroker/permission_sse_test.go
+++ b/internal/ccbroker/permission_sse_test.go
@@ -90,9 +90,9 @@ func TestPermissionEventReachesSSE(t *testing.T) {
 	if err := json.Unmarshal(firstEv.Payload, &payload); err != nil {
 		t.Errorf("payload not valid JSON: %v", err)
 	}
-	// Event struct fields marshal with Go default (PascalCase) since no json tags.
-	if payload["PermissionID"] == "" || payload["PermissionID"] == nil {
-		t.Errorf("PermissionID missing from payload: %v", payload)
+	// Event struct fields now marshal with snake_case json tags.
+	if payload["permission_id"] == "" || payload["permission_id"] == nil {
+		t.Errorf("permission_id missing from payload: %v", payload)
 	}
 
 	// After timeout (200ms), a permission_resolved event should arrive.

--- a/internal/ccbroker/tools/permission.go
+++ b/internal/ccbroker/tools/permission.go
@@ -33,22 +33,22 @@ type CheckRequest struct {
 }
 
 type Decision struct {
-	Verdict string // "allow" | "deny"
-	Scope   string // "once" | "always"
-	By      string
+	Verdict string `json:"verdict"`           // "allow" | "deny"
+	Scope   string `json:"scope"`             // "once" | "always"
+	By      string `json:"by,omitempty"`
 }
 
 type Event struct {
-	Type         string          // "permission_request" | "permission_resolved"
-	SessionID    string
-	TurnID       string
-	PermissionID string
-	Tool         string
-	ExecutorID   string
-	Args         json.RawMessage
-	Decision     *Decision
-	Source       string // "live" | "sticky"
-	EmittedAt    time.Time
+	Type         string          `json:"event_type"`              // "permission_request" | "permission_resolved"
+	SessionID    string          `json:"session_id,omitempty"`
+	TurnID       string          `json:"turn_id,omitempty"`
+	PermissionID string          `json:"permission_id,omitempty"`
+	Tool         string          `json:"tool,omitempty"`
+	ExecutorID   string          `json:"executor_id,omitempty"`
+	Args         json.RawMessage `json:"args,omitempty"`
+	Decision     *Decision       `json:"decision,omitempty"`
+	Source       string          `json:"source,omitempty"`       // "live" | "sticky"
+	EmittedAt    time.Time       `json:"emitted_at,omitempty"`
 }
 
 type Notifier func(sessionID string, evt Event)

--- a/internal/ccbroker/tools/permission_test.go
+++ b/internal/ccbroker/tools/permission_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -237,6 +238,38 @@ func TestGate_CancelTurn_ResolvesAllPendingOfThatTurn(t *testing.T) {
 	for i, err := range errs {
 		if err != ErrPermissionDenied {
 			t.Errorf("call %d: err=%v want ErrPermissionDenied (cancelled)", i, err)
+		}
+	}
+}
+
+func TestEvent_JSONShape_UsesSnakeCase(t *testing.T) {
+	e := Event{
+		Type:         "permission_request",
+		PermissionID: "perm_xyz",
+		Tool:         "remote_bash",
+		ExecutorID:   "exe_a",
+		Decision:     &Decision{Verdict: "allow", Scope: "once"},
+	}
+	b, err := json.Marshal(e)
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := string(b)
+	for _, want := range []string{
+		`"event_type":"permission_request"`,
+		`"permission_id":"perm_xyz"`,
+		`"tool":"remote_bash"`,
+		`"executor_id":"exe_a"`,
+		`"decision":{"verdict":"allow","scope":"once"}`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Errorf("missing %q in marshalled event:\n%s", want, s)
+		}
+	}
+	// Make sure the old PascalCase keys are gone.
+	for _, bad := range []string{`"Type":`, `"PermissionID":`, `"Tool":`} {
+		if strings.Contains(s, bad) {
+			t.Errorf("unexpected PascalCase key %q in:\n%s", bad, s)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Holistic re-review of Phase 2 (PR #66) surfaced 3 Critical (P0) and 4 Important (P1) issues. This PR fixes all of them with minimal scope creep.

### P0 — Critical (production-broken without these)
- **JSON wire format mismatch** — `ccbroker/tools/permission.go` `Event`/`Decision` had no `json` tags, so the server emitted `Type`/`PermissionID`/...` while the TUI expects snake-case (`event_type`, `permission_id`, ...). The entire ask-permission flow was silently broken on the wire. Fixed by adding snake_case json tags to both structs; updated 2 SSE/route tests that had asserted the old PascalCase shape.
- **SSE/executor lifecycle not wired to auth & session transitions** — On post-login session creation, the SSE consumer and executor registration never started; only the very first session in a logged-in startup got them. Fixed by adding `OnLoggedIn` / `OnSessionReady` callbacks to `ModelConfig`, with `tui_run.go` providing closures that (a) register executor exactly once via `sync.Once` and (b) restart the SSE consumer on every new session ID under a mutex+cancel.
- **Missing `Update` cases** — `SendAnswerMsg` and `LogoutDoneMsg` were emitted but never matched, leaking goroutines and dangling state. Added the missing branches (and `LoginPollDoneMsg`, `RequeuePermissionMsg` while there).

### P1 — Important
- **Permission panel Esc dismissed the request entirely** instead of letting another panel handle it. Now emits `RequeuePermissionMsg{Panel: panel}` so the panel re-queues itself.
- **`refreshDirect` used `http.DefaultClient`** with no timeout — a stalled refresh could hang the auth controller forever. Switched to `&http.Client{Timeout: 30 * time.Second}`.
- **Login failures were silent** — added `OnLoginFailed func(error)` callback so device-flow errors surface to the user via the timeline.
- **`/yolo` only flipped local UI state** — now also POSTs `permission_mode=bypass` to the server so cc-broker actually stops gating tool calls.

## Test plan

- [x] `go test -race -count=1 ./...` clean across all 20 packages
- [x] Permission SSE test updated and passing with snake_case payload
- [x] TUI route test updated and passing
- [ ] Manual: run `agentserver-agent tui`, log in via /login, verify permission prompts arrive
- [ ] Manual: trigger /yolo and confirm subsequent tool calls bypass on the server side
- [ ] Manual: kill broker mid-session, confirm SSE reconnects with Last-Event-ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)