### PR TITLE
feat(tui): make --workspace-id optional, auto-resolve via saved session or API

### DIFF
--- a/cmd/agentserver-agent/main.go
+++ b/cmd/agentserver-agent/main.go
@@ -410,7 +410,7 @@ func init() {
 		defaultName = "TUI Agent (interactive)"
 	}
 	tuiCmd.Flags().StringVar(&tuiServer, "server", "", "agentserver URL (defaults to saved creds)")
-	tuiCmd.Flags().StringVar(&tuiWorkspaceID, "workspace-id", "", "workspace ID (required)")
+	tuiCmd.Flags().StringVar(&tuiWorkspaceID, "workspace-id", "", "workspace ID (optional; falls back to saved executor session, then most-recent workspace from server)")
 	tuiCmd.Flags().StringVar(&tuiName, "name", defaultName, "display name for this executor")
 	tuiCmd.Flags().StringVar(&tuiWorkDir, "work-dir", "", "executor working directory (default: cwd)")
 	tuiCmd.Flags().StringVarP(&tuiResumeID, "resume", "r", "", "attach to an existing session by ID")

--- a/cmd/agentserver-agent/tui_run.go
+++ b/cmd/agentserver-agent/tui_run.go
@@ -4,13 +4,19 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sort"
 	"sync"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/agentserver/agentserver/internal/agent"
 	"github.com/agentserver/agentserver/internal/agent/tui"
 )
+
+// defaultServerURL mirrors cmd/agentserver-agent/main.go: when the user
+// doesn't pass --server and has no saved credentials, fall back to this.
+const defaultServerURL = "https://agent.cs.ac.cn"
 
 func init() {
 	agent.RunTUIFunc = runTUI
@@ -27,15 +33,26 @@ func init() {
 //  2. ExecutorClient (yamux to executor-registry; spawned only if logged in).
 //  3. AuthController (callback from a polling goroutine).
 func runTUI(ctx context.Context, opts agent.TUIOpts) error {
-	// 1. Resolve server URL — flag wins, then saved creds.
+	// 1. Resolve server URL — flag wins, then saved creds, then the default.
 	server := opts.Server
 	creds, _ := agent.LoadCredentials(agent.DefaultCredentialsPath())
 	if server == "" && creds != nil {
 		server = creds.ServerURL
 	}
-	if opts.WorkspaceID == "" {
-		return fmt.Errorf("--workspace-id is required")
+	if server == "" {
+		server = defaultServerURL
 	}
+
+	// 2. Resolve workspace ID locally if possible (flag → saved executor
+	//    session for this server). If neither yields one, defer resolution
+	//    until after login (see resolveWorkspacePostLogin below).
+	workspaceID := opts.WorkspaceID
+	if workspaceID == "" {
+		if sess, err := agent.LoadAnyExecutorSessionForServer(server); err == nil && sess != nil {
+			workspaceID = sess.WorkspaceID
+		}
+	}
+
 	workDir := opts.WorkDir
 	if workDir == "" {
 		cwd, err := os.Getwd()
@@ -55,10 +72,12 @@ func runTUI(ctx context.Context, opts agent.TUIOpts) error {
 	var executorID string
 
 	// 3. Build Bus (executor ID may be empty if not yet logged in; SetExecutorID
-	//    is called by startExecutor after registration).
+	//    is called by startExecutor after registration. WorkspaceID may also
+	//    be empty if the user didn't pass --workspace-id and no saved session
+	//    matched; SetWorkspaceID is called by resolveWorkspacePostLogin.)
 	bus := tui.NewBus(tui.BusConfig{
 		ServerURL:   server,
-		WorkspaceID: opts.WorkspaceID,
+		WorkspaceID: workspaceID,
 		ExecutorID:  executorID,
 		Auth:        auth,
 	})
@@ -92,16 +111,47 @@ func runTUI(ctx context.Context, opts agent.TUIOpts) error {
 		}()
 	}
 
-	// startExecutor registers the executor with the server (once) and starts
-	// the yamux tunnel goroutine. Called on login or at startup if already
-	// logged in.
+	// resolveAndSetWorkspace fills in bus.WorkspaceID by querying the server
+	// when it isn't already known. Returns nil on success (workspace already
+	// set, or just resolved). Errors are non-terminal — the caller surfaces
+	// them via FatalErrorMsg and the user may retry by creating a workspace
+	// then restarting the TUI.
+	resolveAndSetWorkspace := func() error {
+		if bus.WorkspaceID() != "" {
+			return nil
+		}
+		listCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+		ws, err := bus.ListWorkspaces(listCtx)
+		if err != nil {
+			return fmt.Errorf("list workspaces: %w", err)
+		}
+		if len(ws) == 0 {
+			return fmt.Errorf("no workspaces found for this account; create one in the web UI first or pass --workspace-id")
+		}
+		sort.Slice(ws, func(i, j int) bool { return ws[i].CreatedAt > ws[j].CreatedAt })
+		bus.SetWorkspaceID(ws[0].ID)
+		return nil
+	}
+
+	// startExecutor resolves the workspace (if needed), then registers the
+	// executor with the server (once per process) and starts the yamux tunnel
+	// goroutine. Called on login or at startup if already logged in. Workspace
+	// resolution is OUTSIDE the once-guard so a transient failure (e.g.
+	// network) doesn't permanently lock out registration on subsequent /login
+	// attempts.
 	var executorOnce sync.Once
 	startExecutor := func() {
+		if err := resolveAndSetWorkspace(); err != nil {
+			p.Send(tui.FatalErrorMsg{Err: err})
+			return
+		}
+		wsID := bus.WorkspaceID()
 		executorOnce.Do(func() {
 			sess, err := agent.LoadOrRegisterExecutor(agent.ExecutorOpts{
 				ServerURL:   server,
 				Name:        opts.Name,
-				WorkspaceID: opts.WorkspaceID,
+				WorkspaceID: wsID,
 			})
 			if err != nil {
 				p.Send(tui.FatalErrorMsg{Err: fmt.Errorf("register executor after login: %w", err)})
@@ -116,7 +166,7 @@ func runTUI(ctx context.Context, opts agent.TUIOpts) error {
 	// 5. Build Model with lifecycle callbacks.
 	model := tui.NewModel(tui.ModelConfig{
 		ServerURL:      server,
-		WorkspaceID:    opts.WorkspaceID,
+		WorkspaceID:    workspaceID,
 		ExecutorID:     executorID,
 		Bus:            bus,
 		Auth:           auth,

--- a/internal/agent/executor_session.go
+++ b/internal/agent/executor_session.go
@@ -77,6 +77,51 @@ func loadLatestExecutorSession(serverURL, workspaceID string) (*ExecutorSession,
 	return sessions[0], nil
 }
 
+// LoadAnyExecutorSessionForServer scans the persisted executor sessions and
+// returns the most recently created one that matches serverURL, regardless of
+// workspace. Used by `agentserver tui` to auto-pick a workspace when
+// --workspace-id is not provided. Returns nil if no match is found; returns
+// an error only on filesystem failures other than "directory missing".
+func LoadAnyExecutorSessionForServer(serverURL string) (*ExecutorSession, error) {
+	dir, err := executorSessionsDir()
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var sessions []*ExecutorSession
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, entry.Name()))
+		if err != nil {
+			continue
+		}
+		var sess ExecutorSession
+		if err := json.Unmarshal(data, &sess); err != nil {
+			continue
+		}
+		if sess.ServerURL == serverURL {
+			sessions = append(sessions, &sess)
+		}
+	}
+
+	if len(sessions) == 0 {
+		return nil, nil
+	}
+	sort.Slice(sessions, func(i, j int) bool {
+		return sessions[i].CreatedAt.After(sessions[j].CreatedAt)
+	})
+	return sessions[0], nil
+}
+
 // removeExecutorSession deletes the persisted session file for the given
 // executor ID. Missing files are not considered an error.
 func removeExecutorSession(executorID string) error {

--- a/internal/agent/executor_session_test.go
+++ b/internal/agent/executor_session_test.go
@@ -1,0 +1,90 @@
+package agent
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// withTempHome points os.UserHomeDir at a fresh tempdir for the duration of the
+// test. executorSessionsDir derives from $HOME, so this isolates session files.
+func withTempHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	return home
+}
+
+func writeSession(t *testing.T, dir string, sess ExecutorSession) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := json.MarshalIndent(&sess, "", "  ")
+	path := filepath.Join(dir, sess.ExecutorID+".json")
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoadAnyExecutorSessionForServer_PicksMostRecent(t *testing.T) {
+	withTempHome(t)
+	dir, _ := executorSessionsDir()
+
+	older := time.Now().Add(-2 * time.Hour).UTC()
+	newer := time.Now().Add(-1 * time.Hour).UTC()
+	writeSession(t, dir, ExecutorSession{
+		ExecutorID: "exe_old", WorkspaceID: "ws_old",
+		ServerURL: "https://srv.example", CreatedAt: older,
+	})
+	writeSession(t, dir, ExecutorSession{
+		ExecutorID: "exe_new", WorkspaceID: "ws_new",
+		ServerURL: "https://srv.example", CreatedAt: newer,
+	})
+	// Different server should be ignored.
+	writeSession(t, dir, ExecutorSession{
+		ExecutorID: "exe_other", WorkspaceID: "ws_other",
+		ServerURL: "https://other.example", CreatedAt: time.Now().UTC(),
+	})
+
+	got, err := LoadAnyExecutorSessionForServer("https://srv.example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got == nil {
+		t.Fatal("expected a session, got nil")
+	}
+	if got.ExecutorID != "exe_new" || got.WorkspaceID != "ws_new" {
+		t.Errorf("expected exe_new/ws_new, got %+v", got)
+	}
+}
+
+func TestLoadAnyExecutorSessionForServer_NoMatchReturnsNil(t *testing.T) {
+	withTempHome(t)
+	dir, _ := executorSessionsDir()
+	writeSession(t, dir, ExecutorSession{
+		ExecutorID: "exe_a", WorkspaceID: "ws_a",
+		ServerURL: "https://other.example", CreatedAt: time.Now().UTC(),
+	})
+
+	got, err := LoadAnyExecutorSessionForServer("https://nomatch.example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+}
+
+func TestLoadAnyExecutorSessionForServer_NoSessionsDirReturnsNil(t *testing.T) {
+	withTempHome(t)
+	got, err := LoadAnyExecutorSessionForServer("https://srv.example")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != nil {
+		t.Errorf("expected nil, got %+v", got)
+	}
+}

--- a/internal/agent/tui/bus.go
+++ b/internal/agent/tui/bus.go
@@ -256,8 +256,38 @@ func (b *Bus) SetExecutorID(id string) {
 	b.cfg.ExecutorID = id
 }
 
+// SetWorkspaceID updates the workspace ID on the Bus. Same caveats as
+// SetExecutorID: only call during init, before any concurrent requests. Used
+// when --workspace-id wasn't provided and the ID is resolved post-login by
+// listing the user's workspaces.
+func (b *Bus) SetWorkspaceID(id string) {
+	b.cfg.WorkspaceID = id
+}
+
+func (b *Bus) WorkspaceID() string { return b.cfg.WorkspaceID }
+
 // AccessToken exposes Auth.EnsureValid for the SSE consumer, which builds
 // long-lived requests outside of `do`'s code path.
 func (b *Bus) AccessToken(ctx context.Context) (string, error) {
 	return b.cfg.Auth.EnsureValid(ctx)
+}
+
+// ---- GET /api/workspaces ----
+
+type WorkspaceListItem struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+// ListWorkspaces returns all workspaces the authenticated user is a member of.
+// Used at startup when --workspace-id is not provided and no saved executor
+// session matches the current server.
+func (b *Bus) ListWorkspaces(ctx context.Context) ([]WorkspaceListItem, error) {
+	var out []WorkspaceListItem
+	if err := b.do(ctx, http.MethodGet, "/api/workspaces", nil, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
 }

--- a/internal/agent/tui/bus_test.go
+++ b/internal/agent/tui/bus_test.go
@@ -178,6 +178,41 @@ func TestBus_AttachSession(t *testing.T) {
 	}
 }
 
+func TestBus_ListWorkspaces(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/workspaces" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		if r.Header.Get("Authorization") != "Bearer T" {
+			t.Errorf("missing auth header")
+		}
+		w.Write([]byte(`[
+			{"id":"ws_old","name":"Old","created_at":"2024-01-01T00:00:00Z","updated_at":"2024-01-01T00:00:00Z"},
+			{"id":"ws_new","name":"New","created_at":"2026-01-01T00:00:00Z","updated_at":"2026-01-01T00:00:00Z"}
+		]`))
+	}))
+	defer srv.Close()
+	bus := NewBus(BusConfig{ServerURL: srv.URL, Auth: &fakeAuth{tk: "T"}})
+	got, err := bus.ListWorkspaces(context.Background())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 2 || got[0].ID != "ws_old" || got[1].ID != "ws_new" {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestBus_SetWorkspaceID(t *testing.T) {
+	bus := NewBus(BusConfig{ServerURL: "x", WorkspaceID: "", Auth: &fakeAuth{tk: "t"}})
+	if bus.WorkspaceID() != "" {
+		t.Errorf("expected empty initial workspace, got %q", bus.WorkspaceID())
+	}
+	bus.SetWorkspaceID("ws_after")
+	if bus.WorkspaceID() != "ws_after" {
+		t.Errorf("SetWorkspaceID not applied, got %q", bus.WorkspaceID())
+	}
+}
+
 // Sanity check that Auth wiring is invoked
 func TestBus_PassesContextDeadline(t *testing.T) {
 	blocker := make(chan struct{})

--- a/internal/agent/tui/model.go
+++ b/internal/agent/tui/model.go
@@ -331,6 +331,16 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case RequeuePermissionMsg:
 		m.permQueue = append(m.permQueue, v.Panel)
 		return m, nil
+	case FatalErrorMsg:
+		if v.Err != nil {
+			m.timeline.Append(SSEEvent{
+				Type: "fatal_error",
+				Data: []byte(fmt.Sprintf(`{"error":%q}`, v.Err.Error())),
+			})
+			m.viewport.SetContent(m.timeline.Render(m.viewport.Width, m.cfg.ExecutorID))
+			m.viewport.GotoBottom()
+		}
+		return m, nil
 	}
 
 	// Plain key handling in ModeNormal.


### PR DESCRIPTION
## Why

\`agentserver tui\` errored out with \`Error: --workspace-id is required\` before the user could even reach \`/login\`. For a brand-new install the workspace ID isn't even discoverable without first hitting the web UI — fatal first-run UX.

## Resolution order

1. \`--workspace-id\` flag (explicit override).
2. \`~/.agentserver/executors/*.json\` — most recent saved session for the resolved server URL (covers \"I've used this machine before\").
3. After login, \`GET /api/workspaces\` → pick the most recently created (per Daisy's choice).

If the user truly has zero workspaces, the TUI surfaces a \`fatal_error\` event in the timeline with the message \"create one in the web UI first or pass --workspace-id\" — no crash.

## Implementation notes

- \`Bus.SetWorkspaceID\` mirrors the existing \`SetExecutorID\`; both are init-only updates (no concurrent-request safety needed).
- \`Bus.ListWorkspaces\` wraps \`GET /api/workspaces\` (existing endpoint, returns the user's memberships).
- \`agent.LoadAnyExecutorSessionForServer\` scans persisted executor sessions matching the server URL across any workspace.
- Workspace resolution sits **outside** \`executorOnce.Do\` so a transient failure doesn't permanently lock out a retry on the next \`/login\`.
- \`FatalErrorMsg\` was defined but had no Update case — added one so emitted errors actually render. Otherwise this PR's error path would be silent.
- Server URL also falls back to \`https://agent.cs.ac.cn\` (matches the root command's default) when no flag and no creds — previously you'd get an empty server in the Bus and confusing 404s.

## Test plan

- [x] \`go test -race -count=1 ./...\` clean
- [x] New unit tests: \`LoadAnyExecutorSessionForServer\` (most-recent picking, no-match, no-dir), \`Bus.ListWorkspaces\` (happy path), \`Bus.SetWorkspaceID\`
- [ ] Manual: fresh install, no \`--workspace-id\` → \`/login\` → land in a workspace
- [ ] Manual: existing user with one workspace, no flag → auto-pick
- [ ] Manual: user with multiple workspaces, no flag → most recent wins
- [ ] Manual: explicit \`--workspace-id ws_other\` overrides

🤖 Generated with [Claude Code](https://claude.com/claude-code)