### PR TITLE
fix(tui): unblock TUI on real server — typing while logged out, /api/agents/* Bearer auth, viewport polish

### DIFF
--- a/cmd/agentserver-agent/tui_run.go
+++ b/cmd/agentserver-agent/tui_run.go
@@ -136,31 +136,36 @@ func runTUI(ctx context.Context, opts agent.TUIOpts) error {
 
 	// startExecutor resolves the workspace (if needed), then registers the
 	// executor with the server (once per process) and starts the yamux tunnel
-	// goroutine. Called on login or at startup if already logged in. Workspace
-	// resolution is OUTSIDE the once-guard so a transient failure (e.g.
-	// network) doesn't permanently lock out registration on subsequent /login
-	// attempts.
+	// goroutine. Called on login or at startup if already logged in.
+	//
+	// CRITICAL: this MUST run async — Bubble Tea calls OnLoggedIn from Init()
+	// or Update(), and synchronous HTTP would block the event loop, leaving
+	// the screen frozen until both calls return (5–15s on a slow network).
+	// Workspace resolution sits OUTSIDE the once-guard so a transient failure
+	// doesn't permanently lock out a retry on the next /login.
 	var executorOnce sync.Once
 	startExecutor := func() {
-		if err := resolveAndSetWorkspace(); err != nil {
-			p.Send(tui.FatalErrorMsg{Err: err})
-			return
-		}
-		wsID := bus.WorkspaceID()
-		executorOnce.Do(func() {
-			sess, err := agent.LoadOrRegisterExecutor(agent.ExecutorOpts{
-				ServerURL:   server,
-				Name:        opts.Name,
-				WorkspaceID: wsID,
-			})
-			if err != nil {
-				p.Send(tui.FatalErrorMsg{Err: fmt.Errorf("register executor after login: %w", err)})
+		go func() {
+			if err := resolveAndSetWorkspace(); err != nil {
+				p.Send(tui.FatalErrorMsg{Err: err})
 				return
 			}
-			bus.SetExecutorID(sess.ExecutorID)
-			ec := agent.NewExecutorClient(sess, workDir)
-			go func() { _ = ec.Run(ctx) }()
-		})
+			wsID := bus.WorkspaceID()
+			executorOnce.Do(func() {
+				sess, err := agent.LoadOrRegisterExecutor(agent.ExecutorOpts{
+					ServerURL:   server,
+					Name:        opts.Name,
+					WorkspaceID: wsID,
+				})
+				if err != nil {
+					p.Send(tui.FatalErrorMsg{Err: fmt.Errorf("register executor after login: %w", err)})
+					return
+				}
+				bus.SetExecutorID(sess.ExecutorID)
+				ec := agent.NewExecutorClient(sess, workDir)
+				go func() { _ = ec.Run(ctx) }()
+			})
+		}()
 	}
 
 	// 5. Build Model with lifecycle callbacks.

--- a/internal/agent/login.go
+++ b/internal/agent/login.go
@@ -136,8 +136,12 @@ func RequestDeviceCode(serverURL string) (*DeviceAuthResponse, error) {
 func PollForToken(serverURL string, deviceResp *DeviceAuthResponse) (*TokenResponse, error) {
 	tokenURL := strings.TrimRight(serverURL, "/") + "/api/oauth2/token"
 	interval := time.Duration(deviceResp.Interval) * time.Second
-	if interval < 5*time.Second {
-		interval = 5 * time.Second
+	// The OAuth Device Flow spec lets the server suggest an interval; we
+	// floor at 1s so an interactive UX doesn't sit on its hands for 5+ seconds
+	// after the user clicks Approve. If the server rate-limits us, the
+	// slow_down branch below adds 5s back per occurrence.
+	if interval < 1*time.Second {
+		interval = 1 * time.Second
 	}
 	deadline := time.Now().Add(time.Duration(deviceResp.ExpiresIn) * time.Second)
 

--- a/internal/agent/tui/auth.go
+++ b/internal/agent/tui/auth.go
@@ -253,6 +253,18 @@ func (a *AuthController) CancelLogin() {
 	}
 }
 
+// Invalidate marks the current credentials as no longer trusted (e.g. server
+// returned 401). Clears in-memory creds, removes the credentials file, and
+// transitions to LoggedOut so the user can /login again. Safe to call from
+// any goroutine.
+func (a *AuthController) Invalidate() {
+	a.mu.Lock()
+	a.creds = nil
+	a.mu.Unlock()
+	_ = os.Remove(a.cfg.CredentialsPath)
+	a.setState(AuthLoggedOut)
+}
+
 // Logout clears in-memory credentials and invalidates the credentials file so
 // that subsequent LoadCredentials calls return an error (file contains no
 // parseable content).

--- a/internal/agent/tui/bus.go
+++ b/internal/agent/tui/bus.go
@@ -12,9 +12,11 @@ import (
 )
 
 // AuthSource is implemented by AuthController. Bus uses it to fetch a fresh
-// access token for every request (it's cheap when the token is already valid).
+// access token for every request (it's cheap when the token is already valid),
+// and to mark credentials as invalid when the server rejects them (401).
 type AuthSource interface {
 	EnsureValid(ctx context.Context) (string, error)
+	Invalidate()
 }
 
 type BusConfig struct {
@@ -89,6 +91,13 @@ func (b *Bus) do(ctx context.Context, method, path string, body any, out any) er
 		if wrap.Error.Code == "" {
 			wrap.Error.Code = fmt.Sprintf("http_%d", resp.StatusCode)
 			wrap.Error.Message = string(bb)
+		}
+		// 401 means the saved access token is no longer trusted by the server
+		// (revoked, account deleted, signing key rotated, etc). Tell auth to
+		// drop creds so the user can /login again — otherwise AuthController
+		// stays in LoggedIn and refuses StartLogin with "already logged in".
+		if resp.StatusCode == http.StatusUnauthorized {
+			b.cfg.Auth.Invalidate()
 		}
 		return &wrap.Error
 	}

--- a/internal/agent/tui/bus.go
+++ b/internal/agent/tui/bus.go
@@ -107,7 +107,7 @@ func (b *Bus) do(ctx context.Context, method, path string, body any, out any) er
 	return nil
 }
 
-// ---- POST /api/workspaces/{wid}/tui/inbound ----
+// ---- POST /api/agents/workspaces/{wid}/inbound ----
 
 type InboundRequest struct {
 	SessionID           string             `json:"session_id,omitempty"`
@@ -140,7 +140,7 @@ func (b *Bus) PostInbound(ctx context.Context, in InboundRequest) (*InboundRespo
 	}{InboundRequest: in, ExecutorID: b.cfg.ExecutorID}
 	var out InboundResponse
 	err := b.do(ctx, http.MethodPost,
-		fmt.Sprintf("/api/workspaces/%s/tui/inbound", b.cfg.WorkspaceID),
+		fmt.Sprintf("/api/agents/workspaces/%s/inbound", b.cfg.WorkspaceID),
 		body, &out)
 	if err != nil {
 		return nil, err
@@ -148,13 +148,13 @@ func (b *Bus) PostInbound(ctx context.Context, in InboundRequest) (*InboundRespo
 	return &out, nil
 }
 
-// ---- POST /api/agent-sessions ----
+// ---- POST /api/agents/sessions ----
 
 func (b *Bus) NewSession(ctx context.Context, permissionMode string, preferredExecutorID string) (string, error) {
 	var out struct {
 		SessionID string `json:"session_id"`
 	}
-	err := b.do(ctx, http.MethodPost, "/api/agent-sessions", map[string]any{
+	err := b.do(ctx, http.MethodPost, "/api/agents/sessions", map[string]any{
 		"workspace_id":          b.cfg.WorkspaceID,
 		"executor_id":           b.cfg.ExecutorID,
 		"permission_mode":       permissionMode,
@@ -163,7 +163,7 @@ func (b *Bus) NewSession(ctx context.Context, permissionMode string, preferredEx
 	return out.SessionID, err
 }
 
-// ---- POST /api/agent-sessions/{sid}/attach ----
+// ---- POST /api/agents/sessions/{sid}/attach ----
 
 type AttachResponse struct {
 	SessionID         string  `json:"session_id"`
@@ -175,7 +175,7 @@ type AttachResponse struct {
 func (b *Bus) AttachSession(ctx context.Context, sid, mode string) (*AttachResponse, error) {
 	var out AttachResponse
 	err := b.do(ctx, http.MethodPost,
-		fmt.Sprintf("/api/agent-sessions/%s/attach", sid),
+		fmt.Sprintf("/api/agents/sessions/%s/attach", sid),
 		map[string]any{
 			"executor_id":             b.cfg.ExecutorID,
 			"mode":                    mode,
@@ -185,7 +185,7 @@ func (b *Bus) AttachSession(ctx context.Context, sid, mode string) (*AttachRespo
 	return &out, err
 }
 
-// ---- GET /api/agent-sessions ----
+// ---- GET /api/agents/sessions ----
 
 type SessionListItem struct {
 	SessionID           string  `json:"session_id"`
@@ -204,33 +204,33 @@ func (b *Bus) ListSessions(ctx context.Context) ([]SessionListItem, error) {
 	var out struct {
 		Sessions []SessionListItem `json:"sessions"`
 	}
-	err := b.do(ctx, http.MethodGet, "/api/agent-sessions?"+q.Encode(), nil, &out)
+	err := b.do(ctx, http.MethodGet, "/api/agents/sessions?"+q.Encode(), nil, &out)
 	return out.Sessions, err
 }
 
-// ---- POST /api/agent-sessions/{sid}/control ----
+// ---- POST /api/agents/sessions/{sid}/control ----
 
 func (b *Bus) PostControl(ctx context.Context, sid, command string, args map[string]any) (json.RawMessage, error) {
 	var out json.RawMessage
 	err := b.do(ctx, http.MethodPost,
-		fmt.Sprintf("/api/agent-sessions/%s/control", sid),
+		fmt.Sprintf("/api/agents/sessions/%s/control", sid),
 		map[string]any{"command": command, "args": args}, &out)
 	return out, err
 }
 
-// ---- POST /api/agent-sessions/{sid}/turns/{tid}/cancel ----
+// ---- POST /api/agents/sessions/{sid}/turns/{tid}/cancel ----
 
 func (b *Bus) PostCancel(ctx context.Context, sid, tid string) error {
 	return b.do(ctx, http.MethodPost,
-		fmt.Sprintf("/api/agent-sessions/%s/turns/%s/cancel", sid, tid),
+		fmt.Sprintf("/api/agents/sessions/%s/turns/%s/cancel", sid, tid),
 		struct{}{}, nil)
 }
 
-// ---- POST /api/agent-sessions/{sid}/permissions/{pid} ----
+// ---- POST /api/agents/sessions/{sid}/permissions/{pid} ----
 
 func (b *Bus) PostDecision(ctx context.Context, sid, pid, decision, scope string) error {
 	return b.do(ctx, http.MethodPost,
-		fmt.Sprintf("/api/agent-sessions/%s/permissions/%s", sid, pid),
+		fmt.Sprintf("/api/agents/sessions/%s/permissions/%s", sid, pid),
 		map[string]any{
 			"decision":              decision,
 			"scope":                 scope,
@@ -238,7 +238,7 @@ func (b *Bus) PostDecision(ctx context.Context, sid, pid, decision, scope string
 		}, nil)
 }
 
-// ---- GET /api/executors/{id}/status ----
+// ---- GET /api/agents/executors/{id}/status ----
 
 type ExecutorStatusResp struct {
 	ExecutorID    string `json:"executor_id"`
@@ -248,7 +248,7 @@ type ExecutorStatusResp struct {
 
 func (b *Bus) FetchExecutorStatus(ctx context.Context) (*ExecutorStatusResp, error) {
 	var out ExecutorStatusResp
-	err := b.do(ctx, http.MethodGet, "/api/executors/"+b.cfg.ExecutorID+"/status", nil, &out)
+	err := b.do(ctx, http.MethodGet, "/api/agents/executors/"+b.cfg.ExecutorID+"/status", nil, &out)
 	return &out, err
 }
 
@@ -281,7 +281,7 @@ func (b *Bus) AccessToken(ctx context.Context) (string, error) {
 	return b.cfg.Auth.EnsureValid(ctx)
 }
 
-// ---- GET /api/workspaces ----
+// ---- GET /api/agents/workspaces ----
 
 type WorkspaceListItem struct {
 	ID        string `json:"id"`
@@ -295,7 +295,7 @@ type WorkspaceListItem struct {
 // session matches the current server.
 func (b *Bus) ListWorkspaces(ctx context.Context) ([]WorkspaceListItem, error) {
 	var out []WorkspaceListItem
-	if err := b.do(ctx, http.MethodGet, "/api/workspaces", nil, &out); err != nil {
+	if err := b.do(ctx, http.MethodGet, "/api/agents/workspaces", nil, &out); err != nil {
 		return nil, err
 	}
 	return out, nil

--- a/internal/agent/tui/bus_test.go
+++ b/internal/agent/tui/bus_test.go
@@ -12,11 +12,16 @@ import (
 	"time"
 )
 
-type fakeAuth struct{ tk string }
+type fakeAuth struct {
+	tk          string
+	invalidated int
+}
 
 func (f *fakeAuth) EnsureValid(_ context.Context) (string, error) {
 	return f.tk, nil
 }
+
+func (f *fakeAuth) Invalidate() { f.invalidated++ }
 
 func TestBus_PostInbound(t *testing.T) {
 	var receivedAuth, receivedBody string

--- a/internal/agent/tui/bus_test.go
+++ b/internal/agent/tui/bus_test.go
@@ -134,7 +134,7 @@ func TestBus_PostCancel_HitsCorrectURL(t *testing.T) {
 	if err := bus.PostCancel(context.Background(), "cse_1", "trn_2"); err != nil {
 		t.Fatal(err)
 	}
-	if !strings.HasSuffix(hitPath, "/agent-sessions/cse_1/turns/trn_2/cancel") {
+	if !strings.HasSuffix(hitPath, "/agents/sessions/cse_1/turns/trn_2/cancel") {
 		t.Errorf("path = %q", hitPath)
 	}
 }
@@ -185,7 +185,7 @@ func TestBus_AttachSession(t *testing.T) {
 
 func TestBus_ListWorkspaces(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/api/workspaces" {
+		if r.URL.Path != "/api/agents/workspaces" {
 			t.Errorf("unexpected path %q", r.URL.Path)
 		}
 		if r.Header.Get("Authorization") != "Bearer T" {

--- a/internal/agent/tui/e2e_test.go
+++ b/internal/agent/tui/e2e_test.go
@@ -38,11 +38,11 @@ func TestE2E_TUIHappyPath(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case strings.HasSuffix(r.URL.Path, "/tui/inbound"):
+		case strings.HasSuffix(r.URL.Path, "/inbound"):
 			w.WriteHeader(http.StatusAccepted)
 			_, _ = w.Write([]byte(`{"session_id":"cse_e","turn_id":"trn_e"}`))
 			sseTriggered.Store(true)
-		case strings.Contains(r.URL.Path, "/api/agent-sessions/cse_e/events"):
+		case strings.Contains(r.URL.Path, "/api/agents/sessions/cse_e/events"):
 			w.Header().Set("Content-Type", "text/event-stream")
 			sseW = w
 			sseFlush = w.(http.Flusher)
@@ -68,9 +68,9 @@ func TestE2E_TUIHappyPath(t *testing.T) {
 			_ = json.NewDecoder(r.Body).Decode(&b)
 			decideRcv <- b
 			w.WriteHeader(http.StatusOK)
-		case strings.HasSuffix(r.URL.Path, "/api/agent-sessions/cse_e/attach"):
+		case strings.HasSuffix(r.URL.Path, "/api/agents/sessions/cse_e/attach"):
 			_, _ = w.Write([]byte(`{"session_id":"cse_e","permission_responder":"exe_a"}`))
-		case strings.Contains(r.URL.Path, "/api/executors/exe_a/status"):
+		case strings.Contains(r.URL.Path, "/api/agents/executors/exe_a/status"):
 			_, _ = w.Write([]byte(`{"executor_id":"exe_a","status":"online"}`))
 		default:
 			w.WriteHeader(http.StatusNotFound)

--- a/internal/agent/tui/login_panel.go
+++ b/internal/agent/tui/login_panel.go
@@ -40,6 +40,8 @@ func (p *loginPanel) View(width int) string {
 	sb.WriteString(fmt.Sprintf("  Code:  %s\n\n", p.info.UserCode))
 	sb.WriteString(p.qr)
 	sb.WriteByte('\n')
+	sb.WriteString(StyleHint.Render("Waiting for browser approval (polls every ~1s)…"))
+	sb.WriteByte('\n')
 	sb.WriteString(StyleHint.Render("[ o ] open browser   [ esc ] cancel"))
 	return StyleBorder.Render(sb.String())
 }

--- a/internal/agent/tui/model.go
+++ b/internal/agent/tui/model.go
@@ -136,7 +136,25 @@ func (m *Model) resize(width, height int) {
 	m.viewport.Height = vh
 	// Input box has rounded border (1+1) + horizontal padding (1+1) on each side.
 	m.input.SetWidth(width - 4)
-	m.viewport.SetContent(m.timeline.Render(width, m.cfg.ExecutorID))
+	m.refreshViewport()
+}
+
+// refreshViewport re-renders the timeline into the viewport, bottom-aligned
+// so latest messages stick to the input box (claude-code style). When the
+// content is shorter than the viewport, leading blank lines pad the top.
+func (m *Model) refreshViewport() {
+	content := m.timeline.Render(m.viewport.Width, m.cfg.ExecutorID)
+	if m.viewport.Height > 0 {
+		lines := strings.Count(content, "\n") + 1
+		if content == "" {
+			lines = 0
+		}
+		if pad := m.viewport.Height - lines; pad > 0 {
+			content = strings.Repeat("\n", pad) + content
+		}
+	}
+	m.viewport.SetContent(content)
+	m.viewport.GotoBottom()
 }
 
 func (m *Model) InputEnabled() bool {
@@ -220,8 +238,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 	if ev, ok := msg.(EventArrivedMsg); ok {
 		m.timeline.Append(ev.Event)
-		m.viewport.SetContent(m.timeline.Render(m.viewport.Width, m.cfg.ExecutorID))
-		m.viewport.GotoBottom()
+		m.refreshViewport()
 		if cmd := m.maybeOpenPanelForEvent(ev.Event); cmd != nil {
 			return m, cmd
 		}
@@ -333,8 +350,7 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			Type: "ask_user_answered",
 			Data: []byte(fmt.Sprintf(`{"qid":%q,"selected":%s}`, v.QID, mustJSONList(v.Selected))),
 		})
-		m.viewport.SetContent(m.timeline.Render(m.viewport.Width, m.cfg.ExecutorID))
-		m.viewport.GotoBottom()
+		m.refreshViewport()
 		return m, nil
 	case LogoutDoneMsg:
 		if v.Err != nil {
@@ -413,8 +429,7 @@ func (m *Model) handleNormalKey(k tea.KeyMsg) (bool, tea.Cmd) {
 			Type: "hint",
 			Data: []byte(`{"text":"Not logged in. Type /login to authenticate first."}`),
 		})
-		m.viewport.SetContent(m.timeline.Render(m.viewport.Width, m.cfg.ExecutorID))
-		m.viewport.GotoBottom()
+		m.refreshViewport()
 		return true, nil
 	}
 	m.input.Reset()

--- a/internal/agent/tui/model.go
+++ b/internal/agent/tui/model.go
@@ -343,43 +343,52 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	// Plain key handling in ModeNormal.
+	// Plain key handling in ModeNormal. The textarea always receives keys
+	// regardless of auth state — otherwise a logged-out user couldn't even
+	// type "/login". Auth gating happens only in handleNormalKey on Enter.
 	var cmd tea.Cmd
 	if k, ok := msg.(tea.KeyMsg); ok && m.mode == ModeNormal {
 		if handled, c := m.handleNormalKey(k); handled {
 			return m, c
 		}
-		if m.InputEnabled() {
-			m.input, cmd = m.input.Update(msg)
-		}
+		m.input, cmd = m.input.Update(msg)
 		return m, cmd
 	}
-	if m.InputEnabled() {
-		m.input, cmd = m.input.Update(msg)
-	}
+	m.input, cmd = m.input.Update(msg)
 	return m, cmd
 }
 
 // handleNormalKey returns (true, cmd) if it consumed the keypress; otherwise
 // (false, nil) to let the textarea handle it. Cmd is the side-effect of the
 // keypress (e.g. POST inbound after Enter).
+//
+// Auth gating: slash commands work in any auth state (so a logged-out user
+// can run /login, /quit, /help). Plain text only sends when logged in;
+// otherwise we drop a hint into the timeline.
 func (m *Model) handleNormalKey(k tea.KeyMsg) (bool, tea.Cmd) {
 	if k.Type != tea.KeyEnter {
 		return false, nil
-	}
-	if !m.InputEnabled() {
-		return true, nil
 	}
 	text := strings.TrimSpace(m.input.Value())
 	if text == "" {
 		return true, nil
 	}
-	m.input.Reset()
 	if cmd, ok := ParseSlashCommand(text); ok {
+		m.input.Reset()
 		return true, func() tea.Msg {
 			return CommandSelectedMsg{Command: cmd.Name, Args: cmd.Args}
 		}
 	}
+	if !m.InputEnabled() {
+		m.timeline.Append(SSEEvent{
+			Type: "hint",
+			Data: []byte(`{"text":"Not logged in. Type /login to authenticate first."}`),
+		})
+		m.viewport.SetContent(m.timeline.Render(m.viewport.Width, m.cfg.ExecutorID))
+		m.viewport.GotoBottom()
+		return true, nil
+	}
+	m.input.Reset()
 	sid := m.sessionID
 	bus := m.bus
 	attachments := m.pendingAttachments

--- a/internal/agent/tui/model.go
+++ b/internal/agent/tui/model.go
@@ -119,6 +119,26 @@ func (m *Model) SetAuthState(s AuthState) {
 	}
 }
 
+// resize lays out viewport and input to the current terminal dimensions.
+// Reserved rows: input box (3 textarea + 2 border) + status bar (1) +
+// optional hint line (1, only when logged out). We always reserve 7 rows
+// for chrome to keep height stable across auth state.
+func (m *Model) resize(width, height int) {
+	if width <= 0 || height <= 0 {
+		return
+	}
+	const chromeRows = 7
+	vh := height - chromeRows
+	if vh < 3 {
+		vh = 3
+	}
+	m.viewport.Width = width
+	m.viewport.Height = vh
+	// Input box has rounded border (1+1) + horizontal padding (1+1) on each side.
+	m.input.SetWidth(width - 4)
+	m.viewport.SetContent(m.timeline.Render(width, m.cfg.ExecutorID))
+}
+
 func (m *Model) InputEnabled() bool {
 	return m.authState == AuthLoggedIn || m.authState == AuthRefreshing
 }
@@ -194,6 +214,10 @@ func (m *Model) attachAndSubscribe(sid string) tea.Cmd {
 //  3. Plain KeyMsg in ModeNormal goes to handleNormalKey, then falls
 //     through to the textarea if not handled.
 func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	if ws, ok := msg.(tea.WindowSizeMsg); ok {
+		m.resize(ws.Width, ws.Height)
+		return m, nil
+	}
 	if ev, ok := msg.(EventArrivedMsg); ok {
 		m.timeline.Append(ev.Event)
 		m.viewport.SetContent(m.timeline.Render(m.viewport.Width, m.cfg.ExecutorID))

--- a/internal/agent/tui/model.go
+++ b/internal/agent/tui/model.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/bubbles/textarea"
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 )
 
 // Mode tracks which input handler owns the keypress stream right now.
@@ -88,8 +89,12 @@ type Model struct {
 
 func NewModel(cfg ModelConfig) *Model {
 	ta := textarea.New()
-	ta.Placeholder = "Type a message…"
+	ta.Placeholder = "Type a message, or /login to sign in…"
+	ta.Prompt = "> "
+	ta.ShowLineNumbers = false
 	ta.SetHeight(3)
+	ta.FocusedStyle.CursorLine = lipgloss.NewStyle()
+	ta.BlurredStyle.CursorLine = lipgloss.NewStyle()
 	ta.Focus()
 	vp := viewport.New(80, 20)
 	return &Model{

--- a/internal/agent/tui/model_test.go
+++ b/internal/agent/tui/model_test.go
@@ -211,6 +211,62 @@ func TestModel_YoloCallsPostControl(t *testing.T) {
 	}
 }
 
+// TestModel_LoggedOut_AllowsTyping verifies that keypresses reach the
+// textarea even before the user is logged in — otherwise they couldn't
+// type "/login".
+func TestModel_LoggedOut_AllowsTyping(t *testing.T) {
+	m := newTestModel(t)
+	m.SetAuthState(AuthLoggedOut)
+	for _, r := range "/login" {
+		m.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{r}})
+	}
+	if got := m.input.Value(); got != "/login" {
+		t.Errorf("input value = %q, want %q", got, "/login")
+	}
+}
+
+// TestModel_LoggedOut_EnterDispatchesSlashCommand: pressing Enter on a
+// slash command should fire CommandSelectedMsg even when logged out.
+func TestModel_LoggedOut_EnterDispatchesSlashCommand(t *testing.T) {
+	m := newTestModel(t)
+	m.SetAuthState(AuthLoggedOut)
+	m.input.SetValue("/login")
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd == nil {
+		t.Fatal("expected cmd from Enter")
+	}
+	msg := cmd()
+	cs, ok := msg.(CommandSelectedMsg)
+	if !ok {
+		t.Fatalf("got %T want CommandSelectedMsg", msg)
+	}
+	if cs.Command != "login" {
+		t.Errorf("Command=%q want login", cs.Command)
+	}
+}
+
+// TestModel_LoggedOut_EnterPlainTextHints: pressing Enter on plain text
+// while logged out should drop a hint into the timeline (and not POST).
+func TestModel_LoggedOut_EnterPlainTextHints(t *testing.T) {
+	m := newTestModel(t)
+	m.SetAuthState(AuthLoggedOut)
+	m.input.SetValue("hello")
+	startLen := m.timeline.Len()
+	_, cmd := m.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	if cmd != nil {
+		// Cmd should be nil (no inbound posted) — but if non-nil, it must
+		// not be an inbound POST closure.
+		if msg := cmd(); msg != nil {
+			if _, ok := msg.(InboundAcceptedMsg); ok {
+				t.Errorf("logged-out plain text triggered inbound POST")
+			}
+		}
+	}
+	if m.timeline.Len() != startLen+1 {
+		t.Errorf("timeline len did not grow by 1 (got %d → %d)", startLen, m.timeline.Len())
+	}
+}
+
 // silence unused imports
 var _ = strings.Builder{}
 var _ = json.RawMessage{}

--- a/internal/agent/tui/sse.go
+++ b/internal/agent/tui/sse.go
@@ -85,7 +85,7 @@ func (s *SSEConsumer) connectOnce(ctx context.Context, out chan<- SSEEvent) erro
 	if err != nil {
 		return err
 	}
-	url := s.bus.ServerURL() + "/api/agent-sessions/" + s.cfg.SessionID + "/events"
+	url := s.bus.ServerURL() + "/api/agents/sessions/" + s.cfg.SessionID + "/events"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return err

--- a/internal/agent/tui/styles.go
+++ b/internal/agent/tui/styles.go
@@ -3,12 +3,43 @@ package tui
 
 import "github.com/charmbracelet/lipgloss"
 
+// Color palette. Kept narrow on purpose — terminal themes vary, so we lean on
+// adaptive contrast (Faint, lipgloss adaptive) where possible.
 var (
-	StyleBorder       = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(0, 1)
-	StylePanelTitle   = lipgloss.NewStyle().Bold(true)
-	StyleStatusBar    = lipgloss.NewStyle().Background(lipgloss.Color("#222")).Foreground(lipgloss.Color("#ccc"))
-	StyleStatusBarErr = StyleStatusBar.Foreground(lipgloss.Color("#FF7A7A"))
-	StyleHint         = lipgloss.NewStyle().Faint(true)
-	StyleAuthErr      = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF7A7A")).Bold(true)
-	StyleAuthOk       = lipgloss.NewStyle().Foreground(lipgloss.Color("#5FFF87"))
+	colorAccent = lipgloss.AdaptiveColor{Light: "#7C5CFF", Dark: "#A48BFF"} // brand violet
+	colorOk     = lipgloss.AdaptiveColor{Light: "#1F8A4C", Dark: "#5FFF87"} // tunnel online, success
+	colorWarn   = lipgloss.AdaptiveColor{Light: "#B97A00", Dark: "#FFD787"} // turn running, reconnecting
+	colorBad    = lipgloss.AdaptiveColor{Light: "#B53A3A", Dark: "#FF7A7A"} // logged out, error
+	colorMuted  = lipgloss.AdaptiveColor{Light: "#8C8C8C", Dark: "#666"}    // dim labels / separators
+)
+
+var (
+	StyleBorder     = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).Padding(0, 1)
+	StylePanelTitle = lipgloss.NewStyle().Bold(true)
+	StyleHint       = lipgloss.NewStyle().Faint(true)
+	StyleAuthErr    = lipgloss.NewStyle().Foreground(colorBad).Bold(true)
+	StyleAuthOk     = lipgloss.NewStyle().Foreground(colorOk)
+
+	// Status bar pieces.
+	StyleStatusLabel = lipgloss.NewStyle().Foreground(colorMuted)
+	StyleStatusValue = lipgloss.NewStyle()
+	StyleStatusOk    = lipgloss.NewStyle().Foreground(colorOk)
+	StyleStatusWarn  = lipgloss.NewStyle().Foreground(colorWarn)
+	StyleStatusBad   = lipgloss.NewStyle().Foreground(colorBad)
+	StyleStatusSep   = lipgloss.NewStyle().Foreground(colorMuted).SetString(" · ")
+
+	// Input box.
+	StyleInputBox = lipgloss.NewStyle().
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(colorMuted).
+			Padding(0, 1)
+	StyleInputBoxFocus = lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(colorAccent).
+				Padding(0, 1)
+	StyleInputHint = lipgloss.NewStyle().Foreground(colorMuted).Faint(true)
+
+	// Welcome banner.
+	StyleWelcomeTitle = lipgloss.NewStyle().Foreground(colorAccent).Bold(true)
+	StyleWelcomeBody  = lipgloss.NewStyle().Faint(true)
 )

--- a/internal/agent/tui/timeline.go
+++ b/internal/agent/tui/timeline.go
@@ -192,6 +192,14 @@ func renderItem(it TimelineItem, selfExecID string) string {
 		return styleSystem.Render("▸ ask_user — answer in panel")
 	case "permission_responder_lost", "permission_responder_changed":
 		return styleSystem.Render("⚠ control transferred")
+	case "hint":
+		var p struct{ Text string `json:"text"` }
+		_ = json.Unmarshal(it.Payload, &p)
+		return styleSystem.Render("ℹ " + p.Text)
+	case "fatal_error", "login_failed", "logout_error":
+		var p struct{ Error string `json:"error"` }
+		_ = json.Unmarshal(it.Payload, &p)
+		return styleErr.Render("✗ "+it.EventType+": ") + p.Error
 	default:
 		return styleSystem.Render("▸ " + it.EventType)
 	}

--- a/internal/agent/tui/view.go
+++ b/internal/agent/tui/view.go
@@ -6,47 +6,157 @@ import (
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/agentserver/agentserver/internal/agent"
 )
 
 // RenderView produces the full screen text for the Model. Layout:
 //
-//	[statusBar 2 lines]
-//	[viewport (scrolling timeline)]
+//	[viewport (scrolling timeline; replaced by welcome banner if empty + LoggedOut)]
 //	[activePanel (optional)]
-//	[input area + LoggedOut hint]
+//	[input box]
+//	[status bar 1 line]
+//	[hint line (LoggedOut only)]
 func RenderView(m *Model) string {
 	var sb strings.Builder
-	sb.WriteString(renderStatusBar(m))
+
+	if m.timeline.Len() == 0 && m.authState == AuthLoggedOut {
+		sb.WriteString(renderWelcome(m))
+	} else {
+		sb.WriteString(m.viewport.View())
+	}
 	sb.WriteByte('\n')
-	sb.WriteString(m.viewport.View())
-	sb.WriteByte('\n')
+
 	if m.activePanel != nil {
 		sb.WriteString(m.activePanel.View(m.viewport.Width))
 		sb.WriteByte('\n')
 	}
+
 	sb.WriteString(renderInput(m))
+	sb.WriteByte('\n')
+	sb.WriteString(renderStatusBar(m))
+
+	if m.authState == AuthLoggedOut {
+		sb.WriteByte('\n')
+		sb.WriteString(StyleInputHint.Render("  Type /login to authenticate  ·  /quit to exit"))
+	}
 	return sb.String()
 }
 
+// renderStatusBar produces a single line of color-coded status pills:
+//
+//	✻ agentserver  ws/abcd  cwd/.../foo  cse/wxyz  ⏵ idle  ▼ online  𝓂 sonnet
 func renderStatusBar(m *Model) string {
-	line1 := fmt.Sprintf(" session: %s · cwd: %s · server: %s ",
-		emptyDash(m.sessionID), emptyDash(m.cwd), emptyDash(m.cfg.ServerURL))
-	line2 := fmt.Sprintf(" auth: %s · tunnel: %s · events: %s · turn: %s · model: %s ",
-		m.authState, m.statusTunnel, m.statusEvents, m.statusTurn, emptyDash(m.model))
-	style := StyleStatusBar
-	if m.authState == AuthLoggedOut {
-		style = StyleStatusBarErr
+	var parts []string
+	parts = append(parts, StyleWelcomeTitle.Render(" ✻ agentserver"))
+	if v := emptyDash(short(m.cfg.WorkspaceID, 8)); v != "—" {
+		parts = append(parts, kv("ws", v, StyleStatusValue))
 	}
-	return style.Render(line1) + "\n" + style.Render(line2)
+	if v := emptyDash(shortPath(m.cwd)); v != "—" {
+		parts = append(parts, kv("cwd", v, StyleStatusValue))
+	}
+	if v := emptyDash(short(m.sessionID, 8)); v != "—" {
+		parts = append(parts, kv("cse", v, StyleStatusValue))
+	}
+	parts = append(parts, kv("turn", m.statusTurn, turnStyle(m.statusTurn)))
+	parts = append(parts, kv("tunnel", m.statusTunnel, tunnelStyle(m.statusTunnel)))
+	if m.model != "" {
+		parts = append(parts, kv("model", m.model, StyleStatusValue))
+	}
+	if m.authState != AuthLoggedIn {
+		parts = append(parts, kv("auth", m.authState.String(), authStyle(m.authState)))
+	}
+	return strings.Join(parts, StyleStatusSep.String())
 }
 
 func renderInput(m *Model) string {
-	if m.authState == AuthLoggedOut {
-		hint := lipgloss.NewStyle().Foreground(lipgloss.Color("#FF7A7A")).Render(
-			"Use /login to authenticate")
-		return lipgloss.JoinVertical(lipgloss.Left, hint, m.input.View())
+	style := StyleInputBox
+	if m.authState == AuthLoggedIn {
+		style = StyleInputBoxFocus
 	}
-	return m.input.View()
+	return style.Render(strings.TrimRight(m.input.View(), "\n"))
+}
+
+func renderWelcome(m *Model) string {
+	title := fmt.Sprintf("✻ Welcome to agentserver tui  v%s", agent.Version)
+	body := []string{
+		"",
+		"This is the local TUI for cc-broker — your harness lives remotely;",
+		"this terminal is just I/O and a permission gate.",
+		"",
+		"  /login      sign in via OAuth Device Flow",
+		"  /quit       exit",
+		"",
+		"After login, type a message to start a turn.",
+	}
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(colorAccent).
+		Padding(1, 2).
+		Width(min(72, m.viewport.Width-2))
+	content := StyleWelcomeTitle.Render(title) + "\n" +
+		StyleWelcomeBody.Render(strings.Join(body, "\n"))
+	return box.Render(content)
+}
+
+// kv renders "label/value" with the value styled and the label muted.
+func kv(label, value string, valStyle lipgloss.Style) string {
+	return StyleStatusLabel.Render(label+"/") + valStyle.Render(value)
+}
+
+func tunnelStyle(s string) lipgloss.Style {
+	switch s {
+	case "online", "connected":
+		return StyleStatusOk
+	case "reconnecting":
+		return StyleStatusWarn
+	case "offline", "disconnected":
+		return StyleStatusBad
+	default:
+		return StyleStatusLabel
+	}
+}
+
+func turnStyle(s string) lipgloss.Style {
+	switch s {
+	case "running":
+		return StyleStatusWarn
+	case "cancelling":
+		return StyleStatusBad
+	default:
+		return StyleStatusValue
+	}
+}
+
+func authStyle(a AuthState) lipgloss.Style {
+	switch a {
+	case AuthLoggedIn:
+		return StyleStatusOk
+	case AuthLoggingIn, AuthRefreshing:
+		return StyleStatusWarn
+	default:
+		return StyleStatusBad
+	}
+}
+
+// short returns id truncated to n runes (no ellipsis to keep the bar tight).
+func short(id string, n int) string {
+	if len(id) <= n {
+		return id
+	}
+	return id[:n]
+}
+
+// shortPath collapses a long path: …/parent/child for depths > 2.
+func shortPath(p string) string {
+	if p == "" {
+		return ""
+	}
+	parts := strings.Split(strings.Trim(p, "/"), "/")
+	if len(parts) <= 2 {
+		return p
+	}
+	return ".../" + strings.Join(parts[len(parts)-2:], "/")
 }
 
 func emptyDash(s string) string {
@@ -54,4 +164,11 @@ func emptyDash(s string) string {
 		return "—"
 	}
 	return s
+}
+
+func min(a, b int) int {
+	if b < a {
+		return b
+	}
+	return a
 }

--- a/internal/agent/tui/view_test.go
+++ b/internal/agent/tui/view_test.go
@@ -12,7 +12,7 @@ func TestRenderView_LoggedOut_HasLoginHint(t *testing.T) {
 	m.viewport.Width = 80
 	m.viewport.Height = 10
 	out := RenderView(m)
-	if !strings.Contains(out, "Use /login") {
+	if !strings.Contains(out, "/login") {
 		t.Errorf("missing /login hint: %s", out)
 	}
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/agentserver/agentserver/internal/db"
@@ -80,7 +81,8 @@ func (a *Auth) ValidateToken(token string) (string, bool) {
 	return userID, true
 }
 
-// Middleware enforces authentication and injects user ID into context.
+// Middleware authenticates web requests via session cookie. The TUI / agent
+// CLI does NOT use this — it goes through BearerMiddleware on /api/agents/*.
 func (a *Auth) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		cookie, err := r.Cookie(cookieName)
@@ -96,6 +98,31 @@ func (a *Auth) Middleware(next http.Handler) http.Handler {
 		ctx := context.WithValue(r.Context(), userIDKey, userID)
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+// BearerMiddleware authenticates TUI / agent CLI requests via OAuth Bearer
+// token, using Hydra introspection. The web app does NOT use this — it goes
+// through Middleware (cookie auth). Token must be Active and have a non-empty
+// Subject (= user ID), which is then injected into request context under the
+// same key Middleware uses.
+func BearerMiddleware(h *HydraClient) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			authz := r.Header.Get("Authorization")
+			if !strings.HasPrefix(authz, "Bearer ") {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			token := strings.TrimPrefix(authz, "Bearer ")
+			intro, err := h.IntrospectToken(token)
+			if err != nil || !intro.Active || intro.Subject == "" {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			ctx := context.WithValue(r.Context(), userIDKey, intro.Subject)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
 }
 
 // ValidateRequest checks whether a request has a valid auth cookie and returns the user ID.

--- a/internal/server/e2e_tui_test.go
+++ b/internal/server/e2e_tui_test.go
@@ -79,10 +79,10 @@ func TestE2E_TUITurnFlow(t *testing.T) {
 		rr := httptest.NewRecorder()
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
-		req := mustAuthRequest(t, "GET", "/api/agent-sessions/"+sid+"/events", "")
+		req := mustAuthRequest(t, "GET", "/api/agents/sessions/"+sid+"/events", "")
 		req = req.WithContext(ctx)
 		router := chi.NewRouter()
-		router.Get("/api/agent-sessions/{sid}/events", s.handleTUIEventStream)
+		router.Get("/api/agents/sessions/{sid}/events", s.handleTUIEventStream)
 		router.ServeHTTP(rr, req)
 		for _, line := range strings.Split(rr.Body.String(), "\n") {
 			if strings.HasPrefix(line, "event: ") {
@@ -96,9 +96,9 @@ func TestE2E_TUITurnFlow(t *testing.T) {
 	// POST inbound (use existing session).
 	body := `{"executor_id":"exe_a","text":"hi","session_id":"` + sid + `"}`
 	rr := httptest.NewRecorder()
-	req := mustAuthRequest(t, "POST", "/api/workspaces/ws_test/tui/inbound", body)
+	req := mustAuthRequest(t, "POST", "/api/agents/workspaces/ws_test/inbound", body)
 	inbR := chi.NewRouter()
-	inbR.Post("/api/workspaces/{wid}/tui/inbound", s.handleTUIInbound)
+	inbR.Post("/api/agents/workspaces/{wid}/inbound", s.handleTUIInbound)
 	inbR.ServeHTTP(rr, req)
 	if rr.Code != http.StatusAccepted {
 		t.Fatalf("inbound status %d body=%s", rr.Code, rr.Body)
@@ -122,9 +122,9 @@ func TestE2E_TUITurnFlow(t *testing.T) {
 	decBody := `{"decision":"allow","scope":"once","responder_executor_id":"exe_a"}`
 	decRR := httptest.NewRecorder()
 	decReq := mustAuthRequest(t, "POST",
-		"/api/agent-sessions/"+sid+"/permissions/perm_e", decBody)
+		"/api/agents/sessions/"+sid+"/permissions/perm_e", decBody)
 	decR := chi.NewRouter()
-	decR.Post("/api/agent-sessions/{sid}/permissions/{pid}", s.handlePermissionDecision)
+	decR.Post("/api/agents/sessions/{sid}/permissions/{pid}", s.handlePermissionDecision)
 	decR.ServeHTTP(decRR, decReq)
 	if decRR.Code != http.StatusOK {
 		t.Errorf("decide %d body=%s", decRR.Code, decRR.Body)

--- a/internal/server/handler_tui_control_test.go
+++ b/internal/server/handler_tui_control_test.go
@@ -16,7 +16,7 @@ import (
 // controlRouter wires only the control route for unit/integration tests.
 func controlRouter(s *Server) *chi.Mux {
 	r := chi.NewRouter()
-	r.Post("/api/agent-sessions/{sid}/control", s.handleAgentSessionControl)
+	r.Post("/api/agents/sessions/{sid}/control", s.handleAgentSessionControl)
 	return r
 }
 
@@ -26,7 +26,7 @@ func TestControl_NoAuth_Returns401(t *testing.T) {
 	s := &Server{}
 	r := controlRouter(s)
 
-	req := httptest.NewRequest("POST", "/api/agent-sessions/cse_x/control",
+	req := httptest.NewRequest("POST", "/api/agents/sessions/cse_x/control",
 		strings.NewReader(`{"command":"model","args":{"model":"claude-3-5-sonnet"}}`))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
@@ -54,7 +54,7 @@ func TestControl_UnknownCommand(t *testing.T) {
 	}
 	t.Cleanup(func() { s.DB.Exec(`DELETE FROM agent_sessions WHERE id=$1`, sid) })
 
-	req := mustAuthRequest(t, "POST", "/api/agent-sessions/"+sid+"/control",
+	req := mustAuthRequest(t, "POST", "/api/agents/sessions/"+sid+"/control",
 		`{"command":"does_not_exist"}`)
 	rr := httptest.NewRecorder()
 	controlRouter(s).ServeHTTP(rr, req)
@@ -87,7 +87,7 @@ func TestControl_ModelWritesPreference(t *testing.T) {
 	t.Cleanup(func() { s.DB.Exec(`DELETE FROM agent_sessions WHERE id=$1`, sid) })
 
 	body := `{"command":"model","args":{"model":"claude-opus-4-5"}}`
-	req := mustAuthRequest(t, "POST", "/api/agent-sessions/"+sid+"/control", body)
+	req := mustAuthRequest(t, "POST", "/api/agents/sessions/"+sid+"/control", body)
 	rr := httptest.NewRecorder()
 	controlRouter(s).ServeHTTP(rr, req)
 
@@ -133,7 +133,7 @@ func TestControl_ModelMissingArg(t *testing.T) {
 	}
 	t.Cleanup(func() { s.DB.Exec(`DELETE FROM agent_sessions WHERE id=$1`, sid) })
 
-	req := mustAuthRequest(t, "POST", "/api/agent-sessions/"+sid+"/control",
+	req := mustAuthRequest(t, "POST", "/api/agents/sessions/"+sid+"/control",
 		`{"command":"model","args":{}}`)
 	rr := httptest.NewRecorder()
 	controlRouter(s).ServeHTTP(rr, req)
@@ -161,7 +161,7 @@ func TestControl_PermissionWritesMode(t *testing.T) {
 	t.Cleanup(func() { s.DB.Exec(`DELETE FROM agent_sessions WHERE id=$1`, sid) })
 
 	body := `{"command":"permission","args":{"mode":"bypass"}}`
-	req := mustAuthRequest(t, "POST", "/api/agent-sessions/"+sid+"/control", body)
+	req := mustAuthRequest(t, "POST", "/api/agents/sessions/"+sid+"/control", body)
 	rr := httptest.NewRecorder()
 	controlRouter(s).ServeHTTP(rr, req)
 
@@ -208,7 +208,7 @@ func TestControl_PermissionRejectsBadMode(t *testing.T) {
 	t.Cleanup(func() { s.DB.Exec(`DELETE FROM agent_sessions WHERE id=$1`, sid) })
 
 	body := `{"command":"permission","args":{"mode":"superuser"}}`
-	req := mustAuthRequest(t, "POST", "/api/agent-sessions/"+sid+"/control", body)
+	req := mustAuthRequest(t, "POST", "/api/agents/sessions/"+sid+"/control", body)
 	rr := httptest.NewRecorder()
 	controlRouter(s).ServeHTTP(rr, req)
 
@@ -242,7 +242,7 @@ func TestControl_CompactProxiesToCCBroker(t *testing.T) {
 	}
 	t.Cleanup(func() { s.DB.Exec(`DELETE FROM agent_sessions WHERE id=$1`, sid) })
 
-	req := mustAuthRequest(t, "POST", "/api/agent-sessions/"+sid+"/control",
+	req := mustAuthRequest(t, "POST", "/api/agents/sessions/"+sid+"/control",
 		`{"command":"compact"}`)
 	rr := httptest.NewRecorder()
 	controlRouter(s).ServeHTTP(rr, req)
@@ -284,7 +284,7 @@ func TestControl_CompactNoCCBroker_Returns503(t *testing.T) {
 	}
 	t.Cleanup(func() { s.DB.Exec(`DELETE FROM agent_sessions WHERE id=$1`, sid) })
 
-	req := mustAuthRequest(t, "POST", "/api/agent-sessions/"+sid+"/control", `{"command":"compact"}`)
+	req := mustAuthRequest(t, "POST", "/api/agents/sessions/"+sid+"/control", `{"command":"compact"}`)
 	rr := httptest.NewRecorder()
 	controlRouter(s).ServeHTTP(rr, req)
 
@@ -310,7 +310,7 @@ func TestControl_CostReturnsZeroForEmptySession(t *testing.T) {
 	}
 	t.Cleanup(func() { s.DB.Exec(`DELETE FROM agent_sessions WHERE id=$1`, sid) })
 
-	req := mustAuthRequest(t, "POST", "/api/agent-sessions/"+sid+"/control", `{"command":"cost"}`)
+	req := mustAuthRequest(t, "POST", "/api/agents/sessions/"+sid+"/control", `{"command":"cost"}`)
 	rr := httptest.NewRecorder()
 	controlRouter(s).ServeHTTP(rr, req)
 
@@ -360,7 +360,7 @@ func TestControl_AgentsProxiesToRegistry(t *testing.T) {
 	}
 	t.Cleanup(func() { s.DB.Exec(`DELETE FROM agent_sessions WHERE id=$1`, sid) })
 
-	req := mustAuthRequest(t, "POST", "/api/agent-sessions/"+sid+"/control", `{"command":"agents"}`)
+	req := mustAuthRequest(t, "POST", "/api/agents/sessions/"+sid+"/control", `{"command":"agents"}`)
 	rr := httptest.NewRecorder()
 	controlRouter(s).ServeHTTP(rr, req)
 
@@ -396,7 +396,7 @@ func TestControl_AgentsNoRegistry_Returns503(t *testing.T) {
 	}
 	t.Cleanup(func() { s.DB.Exec(`DELETE FROM agent_sessions WHERE id=$1`, sid) })
 
-	req := mustAuthRequest(t, "POST", "/api/agent-sessions/"+sid+"/control", `{"command":"agents"}`)
+	req := mustAuthRequest(t, "POST", "/api/agents/sessions/"+sid+"/control", `{"command":"agents"}`)
 	rr := httptest.NewRecorder()
 	controlRouter(s).ServeHTTP(rr, req)
 

--- a/internal/server/handler_tui_events_test.go
+++ b/internal/server/handler_tui_events_test.go
@@ -44,9 +44,9 @@ func newTestServerForEvents(t *testing.T, ccBrokerURL string) (*Server, func()) 
 func TestTUIEvents_NoAuth_Returns401(t *testing.T) {
 	s := &Server{}
 	r := chi.NewRouter()
-	r.Get("/api/agent-sessions/{sid}/events", s.handleTUIEventStream)
+	r.Get("/api/agents/sessions/{sid}/events", s.handleTUIEventStream)
 	rr := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/api/agent-sessions/cse_x/events", nil)
+	req := httptest.NewRequest("GET", "/api/agents/sessions/cse_x/events", nil)
 	r.ServeHTTP(rr, req)
 	if rr.Code != http.StatusUnauthorized {
 		t.Errorf("status %d want 401", rr.Code)
@@ -58,10 +58,10 @@ func TestTUIEvents_UnknownSession_Returns404(t *testing.T) {
 	defer cleanup()
 
 	router := chi.NewRouter()
-	router.Get("/api/agent-sessions/{sid}/events", s.handleTUIEventStream)
+	router.Get("/api/agents/sessions/{sid}/events", s.handleTUIEventStream)
 
 	rr := httptest.NewRecorder()
-	req := mustAuthRequest(t, "GET", "/api/agent-sessions/cse_does_not_exist_xyz/events", "")
+	req := mustAuthRequest(t, "GET", "/api/agents/sessions/cse_does_not_exist_xyz/events", "")
 	router.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusNotFound {
@@ -109,10 +109,10 @@ func TestTUIEvents_BridgesCCBrokerSSE(t *testing.T) {
 		defer subWG.Done()
 		ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
 		defer cancel()
-		req := mustAuthRequest(t, "GET", "/api/agent-sessions/"+sid+"/events", "")
+		req := mustAuthRequest(t, "GET", "/api/agents/sessions/"+sid+"/events", "")
 		req = req.WithContext(ctx)
 		router := chi.NewRouter()
-		router.Get("/api/agent-sessions/{sid}/events", s.handleTUIEventStream)
+		router.Get("/api/agents/sessions/{sid}/events", s.handleTUIEventStream)
 		rr := httptest.NewRecorder()
 		router.ServeHTTP(rr, req)
 		for _, line := range strings.Split(rr.Body.String(), "\n") {
@@ -129,9 +129,9 @@ func TestTUIEvents_BridgesCCBrokerSSE(t *testing.T) {
 	// Trigger inbound which calls cc-broker → bridges events.
 	body := `{"executor_id":"exe_a","text":"hi","session_id":"` + sid + `","permission_responder":true}`
 	inboundRR := httptest.NewRecorder()
-	inboundReq := mustAuthRequest(t, "POST", "/api/workspaces/ws_test/tui/inbound", body)
+	inboundReq := mustAuthRequest(t, "POST", "/api/agents/workspaces/ws_test/inbound", body)
 	inboundRouter := chi.NewRouter()
-	inboundRouter.Post("/api/workspaces/{wid}/tui/inbound", s.handleTUIInbound)
+	inboundRouter.Post("/api/agents/workspaces/{wid}/inbound", s.handleTUIInbound)
 	inboundRouter.ServeHTTP(inboundRR, inboundReq)
 	if inboundRR.Code != http.StatusAccepted {
 		t.Fatalf("inbound %d body=%s", inboundRR.Code, inboundRR.Body)

--- a/internal/server/handler_tui_inbound_test.go
+++ b/internal/server/handler_tui_inbound_test.go
@@ -54,7 +54,7 @@ func mustTUIRequest(t *testing.T, method, target, body string) *http.Request {
 // tuiRouter wires a chi router with only the TUI inbound route (no auth middleware).
 func tuiRouter(s *Server) *chi.Mux {
 	router := chi.NewRouter()
-	router.Post("/api/workspaces/{wid}/tui/inbound", s.handleTUIInbound)
+	router.Post("/api/agents/workspaces/{wid}/inbound", s.handleTUIInbound)
 	return router
 }
 
@@ -65,7 +65,7 @@ func TestTUIInbound_MissingExecutorID(t *testing.T) {
 	router := tuiRouter(s)
 
 	body := `{"text":"hello"}`
-	req := mustTUIRequest(t, "POST", "/api/workspaces/ws_test/tui/inbound", body)
+	req := mustTUIRequest(t, "POST", "/api/agents/workspaces/ws_test/inbound", body)
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
@@ -79,7 +79,7 @@ func TestTUIInbound_MissingText(t *testing.T) {
 	router := tuiRouter(s)
 
 	body := `{"executor_id":"exe_a"}`
-	req := mustTUIRequest(t, "POST", "/api/workspaces/ws_test/tui/inbound", body)
+	req := mustTUIRequest(t, "POST", "/api/agents/workspaces/ws_test/inbound", body)
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
@@ -94,7 +94,7 @@ func TestTUIInbound_NoUserID_Returns401(t *testing.T) {
 
 	body := `{"executor_id":"exe_a","text":"hi"}`
 	// Request without injected user — auth.UserIDFromContext returns "".
-	req := httptest.NewRequest("POST", "/api/workspaces/ws_test/tui/inbound", strings.NewReader(body))
+	req := httptest.NewRequest("POST", "/api/agents/workspaces/ws_test/inbound", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
@@ -118,7 +118,7 @@ func TestTUIInbound_NewSession_CreatesAndReturns202(t *testing.T) {
 
 	body := `{"executor_id":"exe_a","text":"hello","permission_responder":true,"metadata":{"channel_type":"tui"}}`
 	rr := httptest.NewRecorder()
-	req := mustTUIRequest(t, "POST", "/api/workspaces/ws_test/tui/inbound", body)
+	req := mustTUIRequest(t, "POST", "/api/agents/workspaces/ws_test/inbound", body)
 	tuiRouter(s).ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusAccepted {
@@ -193,7 +193,7 @@ func TestTUIInbound_TurnInProgress_Returns409(t *testing.T) {
 
 	body := `{"session_id":"` + sid + `","executor_id":"exe_a","text":"hi"}`
 	rr := httptest.NewRecorder()
-	req := mustTUIRequest(t, "POST", "/api/workspaces/ws_test/tui/inbound", body)
+	req := mustTUIRequest(t, "POST", "/api/agents/workspaces/ws_test/inbound", body)
 	tuiRouter(s).ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusConflict {

--- a/internal/server/handler_tui_proxy_test.go
+++ b/internal/server/handler_tui_proxy_test.go
@@ -16,9 +16,9 @@ import (
 // proxyRouter wires the 3 proxy routes for unit/integration tests.
 func proxyRouter(s *Server) *chi.Mux {
 	r := chi.NewRouter()
-	r.Post("/api/agent-sessions/{sid}/turns/{tid}/cancel", s.handleCancelTurn)
-	r.Post("/api/agent-sessions/{sid}/permissions/{pid}", s.handlePermissionDecision)
-	r.Get("/api/executors/{id}/status", s.handleExecutorStatus)
+	r.Post("/api/agents/sessions/{sid}/turns/{tid}/cancel", s.handleCancelTurn)
+	r.Post("/api/agents/sessions/{sid}/permissions/{pid}", s.handlePermissionDecision)
+	r.Get("/api/agents/executors/{id}/status", s.handleExecutorStatus)
 	return r
 }
 
@@ -27,7 +27,7 @@ func proxyRouter(s *Server) *chi.Mux {
 func TestCancelTurn_NoAuth_Returns401(t *testing.T) {
 	s := &Server{}
 	r := proxyRouter(s)
-	req := httptest.NewRequest("POST", "/api/agent-sessions/cse_x/turns/trn_y/cancel", nil)
+	req := httptest.NewRequest("POST", "/api/agents/sessions/cse_x/turns/trn_y/cancel", nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 	if rr.Code != http.StatusUnauthorized {
@@ -38,7 +38,7 @@ func TestCancelTurn_NoAuth_Returns401(t *testing.T) {
 func TestCancelTurn_NoCCBroker_Returns503(t *testing.T) {
 	s := &Server{} // CCBrokerURL == ""
 	r := proxyRouter(s)
-	req := mustAuthRequest(t, "POST", "/api/agent-sessions/cse_x/turns/trn_y/cancel", "")
+	req := mustAuthRequest(t, "POST", "/api/agents/sessions/cse_x/turns/trn_y/cancel", "")
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 	if rr.Code != http.StatusServiceUnavailable {
@@ -59,7 +59,7 @@ func TestCancelTurn_ProxiesToCCBroker(t *testing.T) {
 
 	s := &Server{CCBrokerURL: cc.URL}
 	r := proxyRouter(s)
-	req := mustAuthRequest(t, "POST", "/api/agent-sessions/cse_x/turns/trn_y/cancel", "")
+	req := mustAuthRequest(t, "POST", "/api/agents/sessions/cse_x/turns/trn_y/cancel", "")
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -81,7 +81,7 @@ func TestCancelTurn_ProxiesToCCBroker(t *testing.T) {
 func TestExecutorStatus_NoAuth_Returns401(t *testing.T) {
 	s := &Server{}
 	r := proxyRouter(s)
-	req := httptest.NewRequest("GET", "/api/executors/exe_a/status", nil)
+	req := httptest.NewRequest("GET", "/api/agents/executors/exe_a/status", nil)
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 	if rr.Code != http.StatusUnauthorized {
@@ -92,7 +92,7 @@ func TestExecutorStatus_NoAuth_Returns401(t *testing.T) {
 func TestExecutorStatus_NoRegistry_Returns503(t *testing.T) {
 	s := &Server{} // ExecutorRegistryURL == ""
 	r := proxyRouter(s)
-	req := mustAuthRequest(t, "GET", "/api/executors/exe_a/status", "")
+	req := mustAuthRequest(t, "GET", "/api/agents/executors/exe_a/status", "")
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 	if rr.Code != http.StatusServiceUnavailable {
@@ -110,7 +110,7 @@ func TestExecutorStatus_StreamsUpstreamResponse(t *testing.T) {
 
 	s := &Server{ExecutorRegistryURL: registry.URL}
 	r := proxyRouter(s)
-	req := mustAuthRequest(t, "GET", "/api/executors/exe_a/status", "")
+	req := mustAuthRequest(t, "GET", "/api/agents/executors/exe_a/status", "")
 	rr := httptest.NewRecorder()
 	r.ServeHTTP(rr, req)
 
@@ -151,7 +151,7 @@ func TestPermissionDecision_WrongResponder_Returns403(t *testing.T) {
 
 	// Try to decide with exe_b (wrong responder).
 	body := `{"decision":"allow","scope":"once","responder_executor_id":"exe_b"}`
-	req := mustAuthRequest(t, "POST", "/api/agent-sessions/"+sid+"/permissions/perm_1", body)
+	req := mustAuthRequest(t, "POST", "/api/agents/sessions/"+sid+"/permissions/perm_1", body)
 	rr := httptest.NewRecorder()
 	proxyRouter(s).ServeHTTP(rr, req)
 
@@ -198,7 +198,7 @@ func TestPermissionDecision_CorrectResponder_ProxiesToCCBroker(t *testing.T) {
 	}
 
 	body := `{"decision":"allow","scope":"once","responder_executor_id":"exe_a"}`
-	req := mustAuthRequest(t, "POST", "/api/agent-sessions/"+sid+"/permissions/perm_1", body)
+	req := mustAuthRequest(t, "POST", "/api/agents/sessions/"+sid+"/permissions/perm_1", body)
 	rr := httptest.NewRecorder()
 	proxyRouter(s).ServeHTTP(rr, req)
 
@@ -243,7 +243,7 @@ func TestPermissionDecision_CCBrokerConflict_Returns409(t *testing.T) {
 	}
 
 	body := `{"decision":"allow","scope":"once","responder_executor_id":"exe_a"}`
-	req := mustAuthRequest(t, "POST", "/api/agent-sessions/"+sid+"/permissions/perm_1", body)
+	req := mustAuthRequest(t, "POST", "/api/agents/sessions/"+sid+"/permissions/perm_1", body)
 	rr := httptest.NewRecorder()
 	proxyRouter(s).ServeHTTP(rr, req)
 

--- a/internal/server/handler_tui_session_test.go
+++ b/internal/server/handler_tui_session_test.go
@@ -17,9 +17,9 @@ import (
 // sessionRouter wires a chi router with the 3 agent-session routes (no auth middleware).
 func sessionRouter(s *Server) *chi.Mux {
 	router := chi.NewRouter()
-	router.Post("/api/agent-sessions", s.handleCreateAgentSession)
-	router.Post("/api/agent-sessions/{sid}/attach", s.handleAttachAgentSession)
-	router.Get("/api/agent-sessions", s.handleListAgentSessions)
+	router.Post("/api/agents/sessions", s.handleCreateAgentSession)
+	router.Post("/api/agents/sessions/{sid}/attach", s.handleAttachAgentSession)
+	router.Get("/api/agents/sessions", s.handleListAgentSessions)
 	return router
 }
 
@@ -45,7 +45,7 @@ func TestCreateAgentSession_RequiresWorkspaceID(t *testing.T) {
 	router := sessionRouter(s)
 
 	body := `{"executor_id":"exe_a"}`
-	req := mustAuthRequest(t, "POST", "/api/agent-sessions", body)
+	req := mustAuthRequest(t, "POST", "/api/agents/sessions", body)
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
@@ -62,7 +62,7 @@ func TestCreateAgentSession_NoUserID_Returns401(t *testing.T) {
 	router := sessionRouter(s)
 
 	body := `{"workspace_id":"ws_test","executor_id":"exe_a"}`
-	req := httptest.NewRequest("POST", "/api/agent-sessions", strings.NewReader(body))
+	req := httptest.NewRequest("POST", "/api/agents/sessions", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
@@ -77,7 +77,7 @@ func TestAttachAgentSession_NoUserID_Returns401(t *testing.T) {
 	router := sessionRouter(s)
 
 	body := `{"executor_id":"exe_a"}`
-	req := httptest.NewRequest("POST", "/api/agent-sessions/cse_test/attach", strings.NewReader(body))
+	req := httptest.NewRequest("POST", "/api/agents/sessions/cse_test/attach", strings.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
@@ -91,7 +91,7 @@ func TestListAgentSessions_RequiresWorkspaceID(t *testing.T) {
 	s := &Server{}
 	router := sessionRouter(s)
 
-	req := mustAuthRequest(t, "GET", "/api/agent-sessions?channel_type=tui", "")
+	req := mustAuthRequest(t, "GET", "/api/agents/sessions?channel_type=tui", "")
 	rr := httptest.NewRecorder()
 	router.ServeHTTP(rr, req)
 
@@ -107,7 +107,7 @@ func TestCreateAgentSession_TUI(t *testing.T) {
 	defer cleanup()
 
 	body := `{"workspace_id":"ws_test","executor_id":"exe_a","permission_mode":"ask"}`
-	req := mustAuthRequest(t, "POST", "/api/agent-sessions", body)
+	req := mustAuthRequest(t, "POST", "/api/agents/sessions", body)
 	rr := httptest.NewRecorder()
 	sessionRouter(s).ServeHTTP(rr, req)
 
@@ -169,7 +169,7 @@ func TestAttachAgentSession_OperatorMode(t *testing.T) {
 
 	// Attach as operator with also_become_preferred.
 	body := `{"executor_id":"exe_b","mode":"operator","also_become_preferred":true}`
-	req := mustAuthRequest(t, "POST", "/api/agent-sessions/"+sid+"/attach", body)
+	req := mustAuthRequest(t, "POST", "/api/agents/sessions/"+sid+"/attach", body)
 	rr := httptest.NewRecorder()
 	sessionRouter(s).ServeHTTP(rr, req)
 
@@ -223,7 +223,7 @@ func TestAttachAgentSession_ObserverMode_LeavesResponder(t *testing.T) {
 
 	// Attach as observer — should not change the responder.
 	body := `{"executor_id":"exe_c","mode":"observer"}`
-	req := mustAuthRequest(t, "POST", "/api/agent-sessions/"+sid+"/attach", body)
+	req := mustAuthRequest(t, "POST", "/api/agents/sessions/"+sid+"/attach", body)
 	rr := httptest.NewRecorder()
 	sessionRouter(s).ServeHTTP(rr, req)
 
@@ -277,7 +277,7 @@ func TestListAgentSessions_FiltersByExecutor(t *testing.T) {
 	})
 
 	// List filtering by exe_alpha — should return only sid1.
-	req := mustAuthRequest(t, "GET", "/api/agent-sessions?workspace_id=ws_list_test&channel_type=tui&executor_id=exe_alpha", "")
+	req := mustAuthRequest(t, "GET", "/api/agents/sessions?workspace_id=ws_list_test&channel_type=tui&executor_id=exe_alpha", "")
 	rr := httptest.NewRecorder()
 	sessionRouter(s).ServeHTTP(rr, req)
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -384,25 +384,6 @@ func (s *Server) Router() http.Handler {
 		// Agent interaction audit trail
 		r.Get("/api/workspaces/{wid}/agent-interactions", s.handleListInteractions)
 
-		// TUI inbound (user-authenticated prompt submission for TUI sessions)
-		r.Post("/api/workspaces/{wid}/tui/inbound", s.handleTUIInbound)
-
-		// Agent-session management (TUI: create, attach, list)
-		r.Post("/api/agent-sessions", s.handleCreateAgentSession)
-		r.Post("/api/agent-sessions/{sid}/attach", s.handleAttachAgentSession)
-		r.Get("/api/agent-sessions", s.handleListAgentSessions)
-
-		// TUI SSE event stream (live events + replay)
-		r.Get("/api/agent-sessions/{sid}/events", s.handleTUIEventStream)
-
-		// TUI control commands (model, permission, compact, cost, agents)
-		r.Post("/api/agent-sessions/{sid}/control", s.handleAgentSessionControl)
-
-		// TUI proxy handlers (T18)
-		r.Post("/api/agent-sessions/{sid}/turns/{tid}/cancel", s.handleCancelTurn)
-		r.Post("/api/agent-sessions/{sid}/permissions/{pid}", s.handlePermissionDecision)
-		r.Get("/api/executors/{id}/status", s.handleExecutorStatus)
-
 		// Admin routes
 		r.Route("/api/admin", func(r chi.Router) {
 			r.Use(s.requireAdmin)
@@ -429,6 +410,38 @@ func (s *Server) Router() http.Handler {
 			r.Delete("/workspaces/{id}/llm-quota", s.handleAdminDeleteWorkspaceLLMQuota)
 		})
 	})
+
+	// TUI / agent CLI API: Bearer token auth (Hydra introspection) only.
+	// All endpoints reachable only when HydraClient is configured.
+	if s.HydraClient != nil {
+		r.Group(func(r chi.Router) {
+			r.Use(auth.BearerMiddleware(s.HydraClient))
+
+			// Workspace listing for the TUI to auto-resolve --workspace-id.
+			r.Get("/api/agents/workspaces", s.handleListWorkspaces)
+
+			// User-authenticated prompt submission for TUI sessions.
+			r.Post("/api/agents/workspaces/{wid}/inbound", s.handleTUIInbound)
+
+			// Agent-session management (create, attach, list).
+			r.Post("/api/agents/sessions", s.handleCreateAgentSession)
+			r.Post("/api/agents/sessions/{sid}/attach", s.handleAttachAgentSession)
+			r.Get("/api/agents/sessions", s.handleListAgentSessions)
+
+			// SSE event stream (live events + replay).
+			r.Get("/api/agents/sessions/{sid}/events", s.handleTUIEventStream)
+
+			// Control commands (model, permission, compact, cost, agents).
+			r.Post("/api/agents/sessions/{sid}/control", s.handleAgentSessionControl)
+
+			// Turn cancel + permission decision.
+			r.Post("/api/agents/sessions/{sid}/turns/{tid}/cancel", s.handleCancelTurn)
+			r.Post("/api/agents/sessions/{sid}/permissions/{pid}", s.handlePermissionDecision)
+
+			// Executor status.
+			r.Get("/api/agents/executors/{id}/status", s.handleExecutorStatus)
+		})
+	}
 
 	// Bridge API (CCR V2 compatible)
 	if s.BridgeHandler != nil {


### PR DESCRIPTION
## Summary

End-to-end fixes that make the new TUI usable against a deployed agentserver. Several are independent UX/visual polish; the last commit is the load-bearing one — without it every TUI request gets a 401.

- **Allow typing while logged out** so `/login` can be entered (c50d094)
- **Visual refresh**: rounded input, condensed status bar, welcome banner (0454cef)
- **Respect terminal size** + faster device-flow polling (faedc0b)
- **Invalidate auth on 401** + bottom-align viewport (cbdb2b1)
- **Split TUI / web auth** (d8d0e99): web app keeps cookie auth; TUI / agent CLI uses OAuth Bearer (Hydra introspection). All TUI endpoints moved to `/api/agents/*` under a Bearer-only chi.Group:
  - `GET  /api/agents/workspaces`
  - `POST /api/agents/workspaces/{wid}/inbound`
  - `POST /api/agents/sessions` / `/attach` / `GET /api/agents/sessions`
  - `GET  /api/agents/sessions/{sid}/events`
  - `POST /api/agents/sessions/{sid}/control`
  - `POST /api/agents/sessions/{sid}/turns/{tid}/cancel`
  - `POST /api/agents/sessions/{sid}/permissions/{pid}`
  - `GET  /api/agents/executors/{id}/status`

## Test plan

- [x] `go build ./...` green
- [x] `go test ./...` green (auth, server, agent/tui all pass)
- [ ] Manual: `agentserver-agent tui --server <deployed>` → `/login` → workspace auto-resolves → send a turn
- [ ] Manual: web app login + workspace list still works (no regression on cookie-only paths)
- [ ] Manual: TUI 401 path triggers re-login flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)