### PR TITLE
fix(executor): move tunnel under /api/executors/{id}/tunnel (unblock executor mode)

### DIFF
--- a/internal/agent/executor_client.go
+++ b/internal/agent/executor_client.go
@@ -139,7 +139,7 @@ func (c *ExecutorClient) reRegister(ctx context.Context) error {
 }
 
 func (c *ExecutorClient) connectAndServe(ctx context.Context) error {
-	wsURL := httpToWS(c.session.ServerURL) + "/api/tunnel/" + c.session.ExecutorID + "?token=" + c.session.TunnelToken
+	wsURL := httpToWS(c.session.ServerURL) + "/api/executors/" + c.session.ExecutorID + "/tunnel?token=" + c.session.TunnelToken
 
 	log.Printf("connecting to %s", wsURL)
 

--- a/internal/executorregistry/server.go
+++ b/internal/executorregistry/server.go
@@ -42,6 +42,10 @@ func (s *Server) Routes() http.Handler {
 	r.Get("/api/executors", s.handleListExecutors)
 	r.Get("/api/executors/{id}", s.handleGetExecutor)
 	r.Put("/api/executors/{id}/capabilities", s.handleUpdateCapabilities)
+	// Tunnel: served under /api/executors/* so the gateway's
+	// /api/executors PathPrefix routes it here. The legacy /api/tunnel/{id}
+	// alias is retained so older agent binaries keep working until they upgrade.
+	r.Get("/api/executors/{executor_id}/tunnel", s.handleTunnel)
 	r.Get("/api/tunnel/{executor_id}", s.handleTunnel)
 	r.Post("/api/execute", s.handleExecute)
 


### PR DESCRIPTION
## Summary

Executor tunnel dial at \`wss://agent.cs.ac.cn/api/tunnel/exe_*\` returns 401 against the cluster.

**Root cause** (not from #72): the gateway HTTPRoute tries to discriminate executor vs sandbox tunnels with \`PathPrefix: /api/tunnel/exe_\`, but Gateway API requires \`PathPrefix\` to align on \`/\` segment boundaries — so the rule is silently ignored and all \`/api/tunnel/*\` falls through to \`sandboxproxy\`, which can't find \`exe_*\` IDs in the sandboxes table → 401.

**Fix**: move executor tunnel under \`/api/executors/{id}/tunnel\` — the gateway already routes \`/api/executors → executor-registry\` correctly, no HTTPRoute change needed.

- executor-registry: register the new route alongside the legacy \`/api/tunnel/{id}\` (legacy retained so deployed agent binaries keep working)
- agent client: dial the new path

## Test plan

- [x] \`go build ./...\` and \`go test ./internal/executorregistry ./internal/agent/...\` green
- [ ] Deploy → \`agentserver-agent\` executor mode reconnects without 401
- [ ] Backwards-compat: an old agent binary using \`/api/tunnel/{id}\` still connects (alias retained)

🤖 Generated with [Claude Code](https://claude.com/claude-code)