### PR TITLE
feat(ccbroker): v2 fire-and-forget endpoint + caller migration

### DIFF
--- a/internal/ccbroker/enqueue.go
+++ b/internal/ccbroker/enqueue.go
@@ -1,0 +1,115 @@
+package ccbroker
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/uuid"
+)
+
+// errEnqueueValidation and errEnqueueDepth are sentinel errors so handlers
+// can map them to HTTP status codes.
+var (
+	errEnqueueValidation = errors.New("session_id, workspace_id, and user_message are required")
+	errEnqueueDepth      = errors.New("too many pending turns for this session")
+)
+
+// enqueueResult carries the IDs the handler needs to subscribe / respond.
+type enqueueResult struct {
+	TurnID      string
+	UserEventID string
+	Epoch       int
+}
+
+// enqueueTurn is the shared work between v1 (handleProcessTurn) and v2
+// (handleProcessTurnV2): validate, ensure session, depth-check, persist user
+// message + agent_turns row, Notify the worker. Streaming/response is the
+// caller's responsibility.
+func (s *Server) enqueueTurn(ctx context.Context, req ProcessTurnRequest) (*enqueueResult, error) {
+	if req.SessionID == "" || req.WorkspaceID == "" || req.UserMessage == "" {
+		return nil, errEnqueueValidation
+	}
+
+	sess, err := s.store.GetSession(ctx, req.SessionID)
+	if err != nil {
+		return nil, fmt.Errorf("get session: %w", err)
+	}
+	if sess == nil {
+		if err := s.store.CreateSession(ctx, req.SessionID, req.WorkspaceID, "", "api", nil); err != nil {
+			return nil, fmt.Errorf("create session: %w", err)
+		}
+	}
+
+	pending, err := s.store.CountPending(ctx, req.SessionID)
+	if err != nil {
+		return nil, fmt.Errorf("count pending: %w", err)
+	}
+	if pending >= maxPendingPerSession {
+		return nil, errEnqueueDepth
+	}
+
+	turnID := req.TurnID
+	if turnID == "" {
+		turnID = "trn_" + uuid.NewString()
+	}
+
+	epoch, err := s.store.GetSessionEpoch(ctx, req.SessionID)
+	if err != nil {
+		return nil, fmt.Errorf("get epoch: %w", err)
+	}
+
+	userEventID := uuid.NewString()
+	userPayload, _ := json.Marshal(map[string]interface{}{
+		"type": "user",
+		"message": map[string]interface{}{
+			"role":    "user",
+			"content": req.UserMessage,
+		},
+		"parent_tool_use_id": nil,
+		"session_id":         req.SessionID,
+	})
+	if _, err := s.store.InsertEventsWithTurn(ctx, req.SessionID, epoch, turnID, []EventInput{
+		{EventID: userEventID, Payload: userPayload, Ephemeral: false},
+	}); err != nil {
+		return nil, fmt.Errorf("insert user message: %w", err)
+	}
+
+	metaBytes, _ := json.Marshal(req.Metadata)
+	turn := AgentTurn{
+		ID:          turnID,
+		SessionID:   req.SessionID,
+		WorkspaceID: req.WorkspaceID,
+		UserEventID: userEventID,
+		UserMessage: req.UserMessage,
+		Metadata:    metaBytes,
+	}
+	if req.IMChannelID != "" {
+		turn.IMChannelID.String, turn.IMChannelID.Valid = req.IMChannelID, true
+	}
+	if req.IMUserID != "" {
+		turn.IMUserID.String, turn.IMUserID.Valid = req.IMUserID, true
+	}
+	if err := s.store.EnqueueTurn(ctx, turn); err != nil {
+		return nil, fmt.Errorf("enqueue: %w", err)
+	}
+
+	s.workerRegistry.Notify(req.SessionID)
+
+	return &enqueueResult{TurnID: turnID, UserEventID: userEventID, Epoch: epoch}, nil
+}
+
+// enqueueErrorToHTTP maps sentinel errors to (status, message) pairs.
+// Used by both v1 and v2 handlers to return consistent error responses.
+func enqueueErrorToHTTP(err error) (int, string) {
+	switch {
+	case errors.Is(err, errEnqueueValidation):
+		return http.StatusBadRequest, err.Error()
+	case errors.Is(err, errEnqueueDepth):
+		return http.StatusTooManyRequests, err.Error()
+	default:
+		return http.StatusInternalServerError, "internal error"
+	}
+}

--- a/internal/ccbroker/handler_turns.go
+++ b/internal/ccbroker/handler_turns.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"time"
-
-	"github.com/google/uuid"
 )
 
 // TurnMetadata carries optional per-turn metadata sent by TUI / API callers.
@@ -26,6 +24,7 @@ type ProcessTurnRequest struct {
 	IMChannelID string       `json:"im_channel_id,omitempty"`
 	IMUserID    string       `json:"im_user_id,omitempty"`
 	Metadata    TurnMetadata `json:"metadata,omitempty"`
+	TurnID      string       `json:"turn_id,omitempty"` // optional caller-supplied id
 }
 
 func defaultStr(v, def string) string {
@@ -38,8 +37,8 @@ func defaultStr(v, def string) string {
 const maxPendingPerSession = 16
 
 // handleProcessTurn is the synchronous wrapper around the async queue. It:
-//  1. Validates and persists the user message + agent_turns row
-//  2. Notifies the per-session worker
+//  1. Validates and persists the user message + agent_turns row (via enqueueTurn)
+//  2. Notifies the per-session worker (via enqueueTurn)
 //  3. Subscribes to SSEBroker, filters by this turn_id, streams to client
 //  4. Returns when a terminal event for this turn arrives, or on disconnect
 //
@@ -50,85 +49,18 @@ func (s *Server) handleProcessTurn(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "invalid request body")
 		return
 	}
-	if req.SessionID == "" || req.WorkspaceID == "" || req.UserMessage == "" {
-		writeError(w, http.StatusBadRequest, "session_id, workspace_id, and user_message are required")
-		return
-	}
 
-	// Ensure session exists.
-	sess, err := s.store.GetSession(r.Context(), req.SessionID)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to check session")
-		return
-	}
-	if sess == nil {
-		if err := s.store.CreateSession(r.Context(), req.SessionID, req.WorkspaceID, "", "api", nil); err != nil {
-			writeError(w, http.StatusInternalServerError, "failed to create session")
-			return
-		}
-	}
-
-	// Per-session backpressure.
-	pending, err := s.store.CountPending(r.Context(), req.SessionID)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to check pending depth")
-		return
-	}
-	if pending >= maxPendingPerSession {
-		writeError(w, http.StatusTooManyRequests, "too many pending turns for this session")
-		return
-	}
-
-	turnID := "trn_" + uuid.NewString()
-
-	epoch, err := s.store.GetSessionEpoch(r.Context(), req.SessionID)
-	if err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to get session epoch")
-		return
-	}
-
-	userEventID := uuid.NewString()
-	userPayload, _ := json.Marshal(map[string]interface{}{
-		"type": "user",
-		"message": map[string]interface{}{
-			"role":    "user",
-			"content": req.UserMessage,
-		},
-		"parent_tool_use_id": nil,
-		"session_id":         req.SessionID,
-	})
-	if _, err := s.store.InsertEventsWithTurn(r.Context(), req.SessionID, epoch, turnID, []EventInput{
-		{EventID: userEventID, Payload: userPayload, Ephemeral: false},
-	}); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to insert user message")
-		return
-	}
-
-	metaBytes, _ := json.Marshal(req.Metadata)
-	turn := AgentTurn{
-		ID:          turnID,
-		SessionID:   req.SessionID,
-		WorkspaceID: req.WorkspaceID,
-		UserEventID: userEventID,
-		UserMessage: req.UserMessage,
-		Metadata:    metaBytes,
-	}
-	if req.IMChannelID != "" {
-		turn.IMChannelID.String, turn.IMChannelID.Valid = req.IMChannelID, true
-	}
-	if req.IMUserID != "" {
-		turn.IMUserID.String, turn.IMUserID.Valid = req.IMUserID, true
-	}
-	if err := s.store.EnqueueTurn(r.Context(), turn); err != nil {
-		writeError(w, http.StatusInternalServerError, "failed to enqueue turn")
-		return
-	}
-
-	// Subscribe BEFORE notifying so we can't miss the worker's first event.
+	// Subscribe BEFORE enqueueing so we can't miss the worker's first event.
+	// On enqueue error we unsubscribe and return.
 	sub := s.sse.Subscribe(req.SessionID)
+	res, err := s.enqueueTurn(r.Context(), req)
+	if err != nil {
+		s.sse.Unsubscribe(req.SessionID, sub)
+		statusCode, msg := enqueueErrorToHTTP(err)
+		writeError(w, statusCode, msg)
+		return
+	}
 	defer s.sse.Unsubscribe(req.SessionID, sub)
-
-	s.workerRegistry.Notify(req.SessionID)
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {
@@ -143,7 +75,7 @@ func (s *Server) handleProcessTurn(w http.ResponseWriter, r *http.Request) {
 
 	// Send turn_id in the prelude so clients know which turn this stream
 	// represents.
-	fmt.Fprintf(w, "data: {\"event_type\":\"turn_started\",\"turn_id\":%q}\n\n", turnID)
+	fmt.Fprintf(w, "data: {\"event_type\":\"turn_started\",\"turn_id\":%q}\n\n", res.TurnID)
 	flusher.Flush()
 
 	keepalive := time.NewTicker(15 * time.Second)
@@ -156,14 +88,14 @@ func (s *Server) handleProcessTurn(w http.ResponseWriter, r *http.Request) {
 			// separate explicit endpoint.
 			return
 		case evt := <-sub.Ch:
-			if evt.TurnID != "" && evt.TurnID != turnID {
+			if evt.TurnID != "" && evt.TurnID != res.TurnID {
 				continue // belongs to another turn on this session
 			}
 			data, _ := json.Marshal(evt)
 			fmt.Fprintf(w, "data: %s\n\n", data)
 			flusher.Flush()
-			if isTerminalEventType(evt.EventType) && evt.TurnID == turnID {
-				fmt.Fprintf(w, "data: {\"event_type\":\"done\",\"turn_id\":%q}\n\n", turnID)
+			if isTerminalEventType(evt.EventType) && evt.TurnID == res.TurnID {
+				fmt.Fprintf(w, "data: {\"event_type\":\"done\",\"turn_id\":%q}\n\n", res.TurnID)
 				flusher.Flush()
 				return
 			}

--- a/internal/ccbroker/handler_turns_test.go
+++ b/internal/ccbroker/handler_turns_test.go
@@ -363,3 +363,51 @@ func TestHandleProcessTurn_DepthLimit(t *testing.T) {
 		t.Fatalf("expected 429, got %d (body=%s)", rec.Code, rec.Body.String())
 	}
 }
+
+// TestHandleProcessTurn_RespectsCallerTurnID asserts that when the request
+// body includes a non-empty turn_id, cc-broker uses it as agent_turns.id
+// instead of generating a new one. Used by the TUI inbound caller which
+// pre-CASes its active_turn_id agentserver-side.
+func TestHandleProcessTurn_RespectsCallerTurnID(t *testing.T) {
+	store := newFakeStore()
+	sse := NewSSEBroker()
+	registry := newWorkerRegistry(workerDeps{
+		store: store, sse: sse,
+		activeTurns: newActiveTurnRegistry(), compactQueue: newCompactQueue(),
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	registry.executeOverride = func(_ context.Context, turn *AgentTurn) {
+		_ = store.MarkTurnDone(context.Background(), turn.ID)
+		sse.Publish(turn.SessionID, &StreamClientEvent{
+			EventID:   "evt_t",
+			EventType: "turn_done",
+			TurnID:    turn.ID,
+			Payload:   json.RawMessage(`{}`),
+			CreatedAt: time.Now().Format(time.RFC3339Nano),
+		})
+	}
+	defer registry.Shutdown(context.Background())
+
+	srv := &Server{
+		store: store, sse: sse,
+		activeTurns:    newActiveTurnRegistry(),
+		compactQueue:   newCompactQueue(),
+		workerRegistry: registry,
+		logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	body := bytes.NewBufferString(`{"session_id":"sess_c","workspace_id":"ws","user_message":"hi","turn_id":"trn_caller_supplied"}`)
+	req := httptest.NewRequest("POST", "/api/turns", body)
+	rec := httptest.NewRecorder()
+	srv.handleProcessTurn(rec, req)
+	if rec.Code != 200 {
+		t.Fatalf("status %d body=%s", rec.Code, rec.Body.String())
+	}
+	turns, _ := store.ListSessionTurns(context.Background(), "sess_c", 10)
+	if len(turns) != 1 || turns[0].ID != "trn_caller_supplied" {
+		t.Fatalf("expected caller-supplied id, got %+v", turns)
+	}
+	if !strings.Contains(rec.Body.String(), `"turn_id":"trn_caller_supplied"`) {
+		t.Fatalf("expected turn_started prelude to echo caller turn_id, got %s", rec.Body.String())
+	}
+}

--- a/internal/ccbroker/handler_v2_turns.go
+++ b/internal/ccbroker/handler_v2_turns.go
@@ -1,0 +1,34 @@
+package ccbroker
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// handleProcessTurnV2 is the fire-and-forget enqueue endpoint. It validates,
+// persists the user message, inserts the agent_turns row, signals the worker,
+// then returns 202 with {turn_id, events_url}. Callers fetch events separately
+// via GET /api/turns/{turn_id}/events.
+//
+// Compared to v1 (handleProcessTurn), this never holds a long-lived HTTP
+// connection — the SSE stream is consumed on a separate request — so caller
+// timeouts on the POST become irrelevant.
+func (s *Server) handleProcessTurnV2(w http.ResponseWriter, r *http.Request) {
+	var req ProcessTurnRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid request body")
+		return
+	}
+	res, err := s.enqueueTurn(r.Context(), req)
+	if err != nil {
+		statusCode, msg := enqueueErrorToHTTP(err)
+		writeError(w, statusCode, msg)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusAccepted)
+	json.NewEncoder(w).Encode(map[string]string{
+		"turn_id":    res.TurnID,
+		"events_url": "/api/turns/" + res.TurnID + "/events",
+	})
+}

--- a/internal/ccbroker/handler_v2_turns_test.go
+++ b/internal/ccbroker/handler_v2_turns_test.go
@@ -1,0 +1,134 @@
+package ccbroker
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandleProcessTurnV2_Returns202WithTurnID(t *testing.T) {
+	store := newFakeStore()
+	sse := NewSSEBroker()
+	registry := newWorkerRegistry(workerDeps{
+		store: store, sse: sse,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	registry.executeOverride = func(context.Context, *AgentTurn) {} // no-op
+	defer registry.Shutdown(context.Background())
+
+	srv := &Server{
+		store: store, sse: sse,
+		activeTurns:    newActiveTurnRegistry(),
+		compactQueue:   newCompactQueue(),
+		workerRegistry: registry,
+		logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	body := bytes.NewBufferString(`{"session_id":"sess_v","workspace_id":"ws","user_message":"hi"}`)
+	req := httptest.NewRequest("POST", "/api/v2/turns", body)
+	rec := httptest.NewRecorder()
+	srv.handleProcessTurnV2(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("expected 202, got %d body=%s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		TurnID    string `json:"turn_id"`
+		EventsURL string `json:"events_url"`
+	}
+	if err := json.NewDecoder(rec.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.TurnID == "" {
+		t.Fatalf("turn_id missing")
+	}
+	if resp.EventsURL != "/api/turns/"+resp.TurnID+"/events" {
+		t.Fatalf("events_url=%q", resp.EventsURL)
+	}
+	turns, _ := store.ListSessionTurns(context.Background(), "sess_v", 10)
+	if len(turns) != 1 || turns[0].ID != resp.TurnID {
+		t.Fatalf("turn not enqueued under returned id: %+v", turns)
+	}
+}
+
+func TestHandleProcessTurnV2_DepthLimit(t *testing.T) {
+	store := newFakeStore()
+	sse := NewSSEBroker()
+	registry := newWorkerRegistry(workerDeps{
+		store: store, sse: sse,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	registry.executeOverride = func(context.Context, *AgentTurn) {}
+	defer registry.Shutdown(context.Background())
+
+	srv := &Server{
+		store: store, sse: sse,
+		activeTurns: newActiveTurnRegistry(), compactQueue: newCompactQueue(),
+		workerRegistry: registry,
+		logger:         slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	store.sessions["sess_full"] = &Session{ID: "sess_full", WorkspaceID: "ws"}
+	for i := 0; i < maxPendingPerSession; i++ {
+		_ = store.EnqueueTurn(context.Background(), AgentTurn{
+			ID: "preexist_" + string(rune('a'+i)), SessionID: "sess_full", WorkspaceID: "ws",
+			UserEventID: "u", UserMessage: "x",
+		})
+	}
+
+	body := bytes.NewBufferString(`{"session_id":"sess_full","workspace_id":"ws","user_message":"overflow"}`)
+	req := httptest.NewRequest("POST", "/api/v2/turns", body)
+	rec := httptest.NewRecorder()
+	srv.handleProcessTurnV2(rec, req)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("expected 429, got %d", rec.Code)
+	}
+}
+
+func TestHandleProcessTurnV2_RespectsCallerTurnID(t *testing.T) {
+	store := newFakeStore()
+	sse := NewSSEBroker()
+	registry := newWorkerRegistry(workerDeps{
+		store: store, sse: sse,
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	registry.executeOverride = func(context.Context, *AgentTurn) {}
+	defer registry.Shutdown(context.Background())
+	srv := &Server{store: store, sse: sse,
+		activeTurns: newActiveTurnRegistry(), compactQueue: newCompactQueue(),
+		workerRegistry: registry,
+		logger:         slog.New(slog.NewTextHandler(io.Discard, nil))}
+	body := bytes.NewBufferString(`{"session_id":"sess_x","workspace_id":"ws","user_message":"hi","turn_id":"trn_supplied"}`)
+	req := httptest.NewRequest("POST", "/api/v2/turns", body)
+	rec := httptest.NewRecorder()
+	srv.handleProcessTurnV2(rec, req)
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status: %d body: %s", rec.Code, rec.Body.String())
+	}
+	var resp struct {
+		TurnID string `json:"turn_id"`
+	}
+	_ = json.NewDecoder(rec.Body).Decode(&resp)
+	if resp.TurnID != "trn_supplied" {
+		t.Fatalf("turn_id=%q", resp.TurnID)
+	}
+}
+
+func TestHandleProcessTurnV2_ValidationFailure(t *testing.T) {
+	srv := &Server{
+		store: newFakeStore(), sse: NewSSEBroker(),
+		activeTurns: newActiveTurnRegistry(), compactQueue: newCompactQueue(),
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	body := bytes.NewBufferString(`{"workspace_id":"ws"}`) // missing session_id + user_message
+	req := httptest.NewRequest("POST", "/api/v2/turns", body)
+	rec := httptest.NewRecorder()
+	srv.handleProcessTurnV2(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rec.Code)
+	}
+}

--- a/internal/ccbroker/server.go
+++ b/internal/ccbroker/server.go
@@ -150,6 +150,7 @@ func (s *Server) Routes() http.Handler {
 	})
 
 	r.Post("/api/turns", s.handleProcessTurn)
+	r.Post("/api/v2/turns", s.handleProcessTurnV2)
 	r.Post("/v1/sessions", s.handleCreateSession)
 
 	// Task 12: TUI control endpoints

--- a/internal/server/ccbroker_v2_client.go
+++ b/internal/server/ccbroker_v2_client.go
@@ -1,0 +1,71 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+// ccbrokerV2Submit POSTs to cc-broker's /api/v2/turns and returns the
+// canonical turn_id assigned by cc-broker (or echoes back the caller-supplied
+// one if the body included a "turn_id" field). Body is the same shape as v1:
+// {session_id, workspace_id, user_message, im_channel_id?, im_user_id?,
+// metadata?, turn_id?}.
+//
+// Returns an error on any non-202 response. Caller-supplied IDs preserved
+// agentserver-side allow the TUI inbound's CAS-on-active_turn flow to refer
+// to the same ID cc-broker uses.
+func ccbrokerV2Submit(ctx context.Context, brokerURL string, body []byte) (string, error) {
+	req, err := http.NewRequestWithContext(ctx, "POST", brokerURL+"/api/v2/turns", bytes.NewReader(body))
+	if err != nil {
+		return "", fmt.Errorf("build v2 request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("v2 submit: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		respBody, _ := io.ReadAll(resp.Body)
+		return "", fmt.Errorf("v2 submit returned %d: %s", resp.StatusCode, respBody)
+	}
+	var out struct {
+		TurnID string `json:"turn_id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return "", fmt.Errorf("decode v2 response: %w", err)
+	}
+	if out.TurnID == "" {
+		return "", fmt.Errorf("v2 response missing turn_id")
+	}
+	return out.TurnID, nil
+}
+
+// ccbrokerOpenEventStream opens GET /api/turns/{tid}/events and returns the
+// raw response body for SSE parsing. Caller is responsible for closing the
+// returned body.
+//
+// The stream wire format is identical to v1's POST /api/turns response, so
+// existing parsers (extractFinalText, the bufio.Scanner loop in
+// handler_tui_inbound) work unchanged.
+func ccbrokerOpenEventStream(ctx context.Context, brokerURL, turnID string) (io.ReadCloser, error) {
+	req, err := http.NewRequestWithContext(ctx, "GET", brokerURL+"/api/turns/"+turnID+"/events", nil)
+	if err != nil {
+		return nil, fmt.Errorf("build events request: %w", err)
+	}
+	req.Header.Set("Accept", "text/event-stream")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("open events stream: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		respBody, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		return nil, fmt.Errorf("events stream returned %d: %s", resp.StatusCode, respBody)
+	}
+	return resp.Body, nil
+}

--- a/internal/server/ccbroker_v2_client_test.go
+++ b/internal/server/ccbroker_v2_client_test.go
@@ -1,0 +1,99 @@
+package server
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestCcbrokerV2Submit_Success(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v2/turns" {
+			t.Errorf("path=%q", r.URL.Path)
+		}
+		if r.Method != "POST" {
+			t.Errorf("method=%q", r.Method)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Errorf("content-type=%q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusAccepted)
+		w.Write([]byte(`{"turn_id":"trn_xyz","events_url":"/api/turns/trn_xyz/events"}`))
+	}))
+	defer srv.Close()
+
+	tid, err := ccbrokerV2Submit(context.Background(), srv.URL, []byte(`{"session_id":"s","workspace_id":"w","user_message":"hi"}`))
+	if err != nil {
+		t.Fatalf("submit: %v", err)
+	}
+	if tid != "trn_xyz" {
+		t.Fatalf("turn_id=%q", tid)
+	}
+}
+
+func TestCcbrokerV2Submit_Returns429(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte(`{"error":"too many"}`))
+	}))
+	defer srv.Close()
+	_, err := ccbrokerV2Submit(context.Background(), srv.URL, []byte(`{}`))
+	if err == nil {
+		t.Fatal("expected error on 429")
+	}
+	if !strings.Contains(err.Error(), "429") {
+		t.Errorf("error should mention 429: %v", err)
+	}
+}
+
+func TestCcbrokerV2Submit_MalformedResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+		w.Write([]byte(`{"turn_id":""}`)) // empty turn_id
+	}))
+	defer srv.Close()
+	_, err := ccbrokerV2Submit(context.Background(), srv.URL, []byte(`{}`))
+	if err == nil {
+		t.Fatal("expected error on empty turn_id")
+	}
+}
+
+func TestCcbrokerOpenEventStream_StreamsBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasPrefix(r.URL.Path, "/api/turns/") || !strings.HasSuffix(r.URL.Path, "/events") {
+			t.Errorf("path=%q", r.URL.Path)
+		}
+		if got := r.Header.Get("Accept"); got != "text/event-stream" {
+			t.Errorf("accept=%q", got)
+		}
+		w.Header().Set("Content-Type", "text/event-stream")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("data: {}\n\n"))
+	}))
+	defer srv.Close()
+	rc, err := ccbrokerOpenEventStream(context.Background(), srv.URL, "trn_x")
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer rc.Close()
+	data, _ := io.ReadAll(rc)
+	if !strings.Contains(string(data), "data: {}") {
+		t.Fatalf("body=%q", data)
+	}
+}
+
+func TestCcbrokerOpenEventStream_404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"code":"not_found"}`))
+	}))
+	defer srv.Close()
+	_, err := ccbrokerOpenEventStream(context.Background(), srv.URL, "trn_unknown")
+	if err == nil {
+		t.Fatal("expected error on 404")
+	}
+}

--- a/internal/server/e2e_tui_test.go
+++ b/internal/server/e2e_tui_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -29,7 +30,18 @@ func TestE2E_TUITurnFlow(t *testing.T) {
 
 	cc := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch {
-		case strings.HasSuffix(r.URL.Path, "/api/turns"):
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/api/v2/turns"):
+			body, _ := io.ReadAll(r.Body)
+			var req map[string]any
+			_ = json.Unmarshal(body, &req)
+			tid, _ := req["turn_id"].(string)
+			if tid == "" {
+				tid = "trn_stub_e2e"
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+			fmt.Fprintf(w, `{"turn_id":%q,"events_url":"/api/turns/%s/events"}`, tid, tid)
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/api/turns/") && strings.HasSuffix(r.URL.Path, "/events"):
 			w.Header().Set("Content-Type", "text/event-stream")
 			f := w.(http.Flusher)
 			fmt.Fprint(w, "event: tool_use\ndata: {\"tool\":\"remote_bash\",\"executor_id\":\"exe_a\"}\n\n")

--- a/internal/server/handler_tui_events_test.go
+++ b/internal/server/handler_tui_events_test.go
@@ -2,7 +2,9 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -72,14 +74,27 @@ func TestTUIEvents_UnknownSession_Returns404(t *testing.T) {
 func TestTUIEvents_BridgesCCBrokerSSE(t *testing.T) {
 	// Start a fake cc-broker that streams 3 events.
 	ccBroker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if !strings.HasSuffix(r.URL.Path, "/api/turns") {
-			return
-		}
-		w.Header().Set("Content-Type", "text/event-stream")
-		f := w.(http.Flusher)
-		for i, ev := range []string{"tool_use", "tool_result", "turn_done"} {
-			fmt.Fprintf(w, "event: %s\ndata: {\"seq\":%d}\n\n", ev, i+1)
-			f.Flush()
+		switch {
+		case r.Method == "POST" && strings.HasSuffix(r.URL.Path, "/api/v2/turns"):
+			// Echo the caller-supplied turn_id so the GET-events path uses the
+			// expected URL.
+			body, _ := io.ReadAll(r.Body)
+			var req map[string]any
+			_ = json.Unmarshal(body, &req)
+			tid, _ := req["turn_id"].(string)
+			if tid == "" {
+				tid = "trn_stub"
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+			fmt.Fprintf(w, `{"turn_id":%q,"events_url":"/api/turns/%s/events"}`, tid, tid)
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/api/turns/") && strings.HasSuffix(r.URL.Path, "/events"):
+			w.Header().Set("Content-Type", "text/event-stream")
+			f := w.(http.Flusher)
+			for i, ev := range []string{"tool_use", "tool_result", "turn_done"} {
+				fmt.Fprintf(w, "event: %s\ndata: {\"seq\":%d}\n\n", ev, i+1)
+				f.Flush()
+			}
 		}
 	}))
 	defer ccBroker.Close()

--- a/internal/server/handler_tui_inbound.go
+++ b/internal/server/handler_tui_inbound.go
@@ -160,6 +160,7 @@ func (s *Server) callCCBrokerForTUI(ctx context.Context, sid, turnID, wid, userI
 		"session_id":   sid,
 		"workspace_id": wid,
 		"user_message": req.Text,
+		"turn_id":      turnID, // unify with agentserver's CAS-claimed id
 		"metadata": map[string]any{
 			"channel_type":          "tui",
 			"creator_user_id":       userID,
@@ -169,28 +170,29 @@ func (s *Server) callCCBrokerForTUI(ctx context.Context, sid, turnID, wid, userI
 			"turn_kind":             turnKind,
 		},
 	})
-	httpReq, err := http.NewRequestWithContext(ctx, "POST", s.CCBrokerURL+"/api/turns", bytes.NewReader(body))
-	if err != nil {
-		log.Printf("tui_inbound: build cc-broker request: %v", err)
-		_ = s.DB.ClearActiveTurn(ctx, sid, turnID)
-		return
-	}
-	httpReq.Header.Set("Content-Type", "application/json")
-	httpReq.Header.Set("Accept", "text/event-stream")
-	resp, err := http.DefaultClient.Do(httpReq)
+	returnedTurnID, err := ccbrokerV2Submit(ctx, s.CCBrokerURL, body)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			log.Printf("tui_inbound: cc-broker turn timed out after 30m sid=%s", sid)
+			log.Printf("tui_inbound: cc-broker v2 submit timed out sid=%s tid=%s", sid, turnID)
 		} else {
-			log.Printf("tui_inbound: cc-broker call failed: %v", err)
+			log.Printf("tui_inbound: cc-broker v2 submit failed sid=%s tid=%s: %v", sid, turnID, err)
 		}
 		_ = s.DB.ClearActiveTurn(ctx, sid, turnID)
 		return
 	}
-	defer resp.Body.Close()
+	if returnedTurnID != turnID {
+		log.Printf("tui_inbound: cc-broker returned turn_id=%s, expected %s — proceeding with returned id", returnedTurnID, turnID)
+	}
+	stream, err := ccbrokerOpenEventStream(ctx, s.CCBrokerURL, returnedTurnID)
+	if err != nil {
+		log.Printf("tui_inbound: open events stream failed sid=%s tid=%s: %v", sid, returnedTurnID, err)
+		_ = s.DB.ClearActiveTurn(ctx, sid, turnID)
+		return
+	}
+	defer stream.Close()
 
 	// Stream and bridge SSE events from cc-broker → agent_session_events + SSE broker.
-	sc := bufio.NewScanner(resp.Body)
+	sc := bufio.NewScanner(stream)
 	sc.Buffer(make([]byte, 0, 64<<10), 4<<20)
 	var (
 		eventType string

--- a/internal/server/im_inbound.go
+++ b/internal/server/im_inbound.go
@@ -116,22 +116,21 @@ func (s *Server) processWithCCBroker(ctx context.Context, session *db.AgentSessi
 		"im_user_id":    toUserID,
 	})
 
-	req, err := http.NewRequestWithContext(ctx, "POST", s.CCBrokerURL+"/api/turns", bytes.NewReader(body))
+	tid, err := ccbrokerV2Submit(ctx, s.CCBrokerURL, body)
 	if err != nil {
+		log.Printf("im_inbound: cc-broker v2 submit failed sid=%s: %v", session.ID, err)
 		return
 	}
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := http.DefaultClient.Do(req)
+	stream, err := ccbrokerOpenEventStream(ctx, s.CCBrokerURL, tid)
 	if err != nil {
-		// Log error but don't crash — user already got 202
+		log.Printf("im_inbound: open events stream failed sid=%s tid=%s: %v", session.ID, tid, err)
 		return
 	}
-	defer resp.Body.Close()
+	defer stream.Close()
 
-	// Read SSE stream from cc-broker — events are persisted by cc-broker itself.
-	// We just need to wait for completion and extract the final text response.
-	finalResponse := extractFinalText(resp.Body)
+	// Read SSE stream from cc-broker — events are persisted by cc-broker
+	// itself; we just need the final assistant text to relay back to IM.
+	finalResponse := extractFinalText(stream)
 
 	// Reply to IM via imbridge.
 	if finalResponse == "" {

--- a/internal/server/im_inbound_v2_test.go
+++ b/internal/server/im_inbound_v2_test.go
@@ -1,0 +1,104 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/agentserver/agentserver/internal/db"
+)
+
+// TestProcessWithCCBroker_UsesV2Flow asserts that processWithCCBroker:
+//  1. POSTs to /api/v2/turns (not /api/turns)
+//  2. Opens GET /api/turns/{tid}/events
+//  3. Extracts the final assistant text from the events stream
+//  4. Calls IM bridge with that text
+func TestProcessWithCCBroker_UsesV2Flow(t *testing.T) {
+	var (
+		v2Hits     atomic.Int32
+		eventsHits atomic.Int32
+		mu         sync.Mutex
+		seenURLs   []string
+	)
+	ccbroker := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		seenURLs = append(seenURLs, r.URL.Path)
+		mu.Unlock()
+		switch {
+		case r.Method == "POST" && r.URL.Path == "/api/v2/turns":
+			v2Hits.Add(1)
+			body, _ := io.ReadAll(r.Body)
+			var req map[string]any
+			_ = json.Unmarshal(body, &req)
+			if req["session_id"] != "sess_im" || req["user_message"] != "ping" {
+				t.Errorf("unexpected v2 body: %s", body)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusAccepted)
+			fmt.Fprintln(w, `{"turn_id":"trn_im_test","events_url":"/api/turns/trn_im_test/events"}`)
+		case r.Method == "GET" && strings.HasPrefix(r.URL.Path, "/api/turns/") && strings.HasSuffix(r.URL.Path, "/events"):
+			eventsHits.Add(1)
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			// Emit a minimal SSE stream: one assistant message + a result.
+			fmt.Fprintf(w, "data: %s\n\n", `{"event_type":"client_event","payload":{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"hello back"}]}}}`)
+			fmt.Fprintf(w, "data: %s\n\n", `{"event_type":"client_event","payload":{"type":"result","subtype":"success","is_error":false,"result":"hello back"}}`)
+			fmt.Fprintf(w, "data: %s\n\n", `{"event_type":"turn_done","turn_id":"trn_im_test"}`)
+			fmt.Fprintf(w, "data: %s\n\n", `{"event_type":"done","turn_id":"trn_im_test"}`)
+		default:
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}))
+	defer ccbroker.Close()
+
+	// Stub IM bridge to record the reply call.
+	var imReplyBody []byte
+	imbridge := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		imReplyBody = body
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer imbridge.Close()
+
+	srv := &Server{
+		CCBrokerURL: ccbroker.URL,
+		IMBridgeURL: imbridge.URL,
+	}
+	chanID := "chan_42"
+	session := &db.AgentSession{
+		ID:          "sess_im",
+		WorkspaceID: "ws_im",
+		IMChannelID: &chanID, // matches msg.ChannelID so SetSessionIMChannel branch is skipped
+	}
+	msg := IMInboundMessage{
+		ChatJID:    "user_42",
+		SenderName: "Alice",
+		Content:    "ping",
+		Provider:   "wechat",
+		ChannelID:  "chan_42",
+	}
+	srv.processWithCCBroker(context.Background(), session, msg)
+
+	if v2Hits.Load() != 1 {
+		t.Errorf("expected 1 v2 POST, got %d (urls=%v)", v2Hits.Load(), seenURLs)
+	}
+	if eventsHits.Load() != 1 {
+		t.Errorf("expected 1 events GET, got %d (urls=%v)", eventsHits.Load(), seenURLs)
+	}
+	if imReplyBody == nil {
+		t.Fatal("imbridge was never called")
+	}
+	var reply map[string]string
+	_ = json.Unmarshal(imReplyBody, &reply)
+	if reply["text"] != "hello back" {
+		t.Errorf("expected reply text 'hello back', got %q", reply["text"])
+	}
+}


### PR DESCRIPTION
## Summary

Adds `POST /api/v2/turns` (fire-and-forget enqueue) and migrates both agentserver callers (`im_inbound`, `handler_tui_inbound`) to the two-step v2 + GET-events flow.

**Why:** Today the v1 `POST /api/turns` keeps the cc-broker HTTP handler tied up streaming SSE for the entire turn duration (potentially minutes). After this PR, cc-broker's POST handler returns immediately, and a separate GET-events request streams the SSE — so cc-broker's connection pool is no longer pinned by long turns.

Builds on PR #73 (async turn queue). v1 endpoint is preserved as-is for backward compatibility / ad-hoc testing.

Metrics (the third piece of the original PR 2 spec) deferred to a follow-up; behavior here is just the endpoint + migration.

## What changed

- **`enqueueTurn` helper** extracted from `handleProcessTurn` so both v1 and v2 share the validate → ensure session → backpressure → persist user message → enqueue → Notify pipeline.
- **Optional caller-supplied `turn_id`** on the request body. The TUI flow generates `turn_id` agentserver-side (CASes `active_turn_id` first), so cc-broker needs to honor that ID rather than mint its own.
- **`POST /api/v2/turns`** returns `202 Accepted` + `{turn_id, events_url}`.
- **`internal/server/ccbroker_v2_client.go`**: thin agentserver-side helpers (`ccbrokerV2Submit`, `ccbrokerOpenEventStream`).
- **im_inbound** migrated: POST v2 → open events stream → `extractFinalText` → IM reply.
- **handler_tui_inbound** migrated: passes generated `turn_id` in v2 body, opens events stream, same SSE-parse loop fans out to bridge.SSE + DB.

## Test plan

- [x] cc-broker: `TestHandleProcessTurnV2_*` (4 cases) + existing `TestHandleProcessTurn_*` regression suite + `TestHandleProcessTurn_RespectsCallerTurnID`.
- [x] agentserver helper: `TestCcbrokerV2Submit_*` + `TestCcbrokerOpenEventStream_*` (5 cases against httptest stubs).
- [x] agentserver integration: `TestProcessWithCCBroker_UsesV2Flow` proves IM inbound POSTs v2 + opens events stream + relays final text.
- [x] Updated `TestTUIEvents_BridgesCCBrokerSSE` and `TestE2E_TUITurnFlow` stubs to v2 wire shape; both compile cleanly (DB-dependent so skipped in this env).
- [x] Full `internal/server/` + `internal/ccbroker/` suite passes with `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)