### PR TITLE
fix(tui): replay backlog on first SSE connect

### DIFF
--- a/internal/agent/tui/sse.go
+++ b/internal/agent/tui/sse.go
@@ -86,6 +86,13 @@ func (s *SSEConsumer) connectOnce(ctx context.Context, out chan<- SSEEvent) erro
 		return err
 	}
 	url := s.bus.ServerURL() + "/api/agents/sessions/" + s.cfg.SessionID + "/events"
+	// First connect: pull a backlog so events emitted between session
+	// creation and SSE subscribe (cc-broker is async — a fast turn can
+	// finish before the consumer is wired up) are not lost. Reconnects
+	// use Last-Event-ID instead.
+	if s.lastID == "" {
+		url += "?tail=500"
+	}
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

Fixes TUI hanging at \`turn/running\` after sending the first message — events were emitted by cc-broker before the SSE subscriber attached, so the live bus had nothing to fan out.

**Root cause** (verified against a stuck session in prod):

| Time | What happened |
|---|---|
| T+0ms | TUI POST inbound → 202 (with implicit session_id) |
| T+~5ms | cc-broker turn kicks off, events start flowing through the SSE bus AND get persisted to \`agent_session_events\` |
| T+~3s | Turn finishes (\`event_type=done\`) |
| T+? | TUI's SSE consumer goroutine actually dials \`/api/agents/sessions/{sid}/events\` — bus is empty, no replay requested → hangs forever |

The handler already supports \`?tail=N\` for replaying recent persisted events. We just weren't using it on first connect. Reconnects after the first event use \`Last-Event-ID\` and don't need this.

## Test plan

- [x] \`go build ./...\` and \`go test ./internal/agent/tui\` green
- [ ] Manual: send a message that finishes fast (e.g. "hi") — TUI should see the response and \`turn/running\` should clear
- [ ] Manual: reconnect after a network blip — Last-Event-ID path still works (no double-replay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)