### PR TITLE
feat(codex-app-gateway): subprocess runtime — thin proxy around codex app-server

### DIFF
--- a/cmd/codex-app-gateway/main.go
+++ b/cmd/codex-app-gateway/main.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/agentserver/agentserver/internal/codexappgateway"
 	"github.com/agentserver/agentserver/internal/codexappgateway/envmcp"
 )
 
@@ -44,8 +45,7 @@ func main() {
 	case "env-mcp":
 		runEnvMcp(os.Args[2:])
 	case "serve":
-		fmt.Fprintln(os.Stderr, "codex-app-gateway: serve subcommand not implemented in this plan")
-		os.Exit(2)
+		runServe(os.Args[2:])
 	case "-h", "--help", "help":
 		fmt.Fprint(os.Stderr, usage)
 		os.Exit(0)
@@ -73,6 +73,47 @@ func runEnvMcp(rawArgs []string) {
 		os.Exit(1)
 	}
 }
+
+func runServe(rawArgs []string) {
+	args, err := parseServeArgs(rawArgs)
+	if errors.Is(err, flag.ErrHelp) {
+		fmt.Fprint(os.Stderr, serveHelp)
+		os.Exit(0)
+	}
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "codex-app-gateway serve:", err)
+		os.Exit(2)
+	}
+	cfg, err := codexappgateway.LoadServeConfigFromEnv()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "codex-app-gateway serve: config:", err)
+		os.Exit(2)
+	}
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: cfg.LogLevel}))
+	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer cancel()
+	srv, err := codexappgateway.NewServer(cfg, args.CodexBin, logger)
+	if err != nil {
+		logger.Error("NewServer failed", "err", err)
+		os.Exit(1)
+	}
+	if err := srv.Run(ctx, args.ListenAddr); err != nil {
+		logger.Error("server exited with error", "err", err)
+		os.Exit(1)
+	}
+	logger.Info("server clean exit")
+}
+
+const serveHelp = `Usage: codex-app-gateway serve [flags]
+
+Run the codex-app-gateway HTTP/WS server: per-thread codex app-server
+subprocess manager + transparent ws frame proxy. See env vars (CXG_*)
+in the spec.
+
+Flags:
+  --listen-addr <addr>   HTTP listen address (default :8086, env CXG_LISTEN_ADDR)
+  --codex-bin   <path>   path to the codex binary (default ` + "`" + `codex` + "`" + `, env CXG_CODEX_BIN)
+`
 
 func parseEnvMcpArgs(rawArgs []string) (envmcp.RunArgs, error) {
 	fs := flag.NewFlagSet("env-mcp", flag.ContinueOnError)

--- a/cmd/codex-app-gateway/serve_args.go
+++ b/cmd/codex-app-gateway/serve_args.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"flag"
+	"io"
+	"os"
+)
+
+type serveArgs struct {
+	ListenAddr string
+	CodexBin   string
+}
+
+func parseServeArgs(rawArgs []string) (serveArgs, error) {
+	fs := flag.NewFlagSet("serve", flag.ContinueOnError)
+	fs.SetOutput(io.Discard)
+	listen := fs.String("listen-addr", ":8086", "HTTP listen address (env CXG_LISTEN_ADDR)")
+	codexBin := fs.String("codex-bin", "codex", "path to codex binary used for `codex app-server` (env CXG_CODEX_BIN)")
+	if err := fs.Parse(rawArgs); err != nil {
+		return serveArgs{}, err
+	}
+	if envListen := os.Getenv("CXG_LISTEN_ADDR"); envListen != "" && *listen == ":8086" {
+		*listen = envListen
+	}
+	if envBin := os.Getenv("CXG_CODEX_BIN"); envBin != "" && *codexBin == "codex" {
+		*codexBin = envBin
+	}
+	return serveArgs{ListenAddr: *listen, CodexBin: *codexBin}, nil
+}

--- a/cmd/codex-app-gateway/serve_args_test.go
+++ b/cmd/codex-app-gateway/serve_args_test.go
@@ -1,0 +1,29 @@
+package main
+
+import "testing"
+
+func TestParseServeArgs_Defaults(t *testing.T) {
+	args, err := parseServeArgs([]string{})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if args.ListenAddr != ":8086" {
+		t.Errorf("ListenAddr = %q", args.ListenAddr)
+	}
+	if args.CodexBin != "codex" {
+		t.Errorf("CodexBin = %q", args.CodexBin)
+	}
+}
+
+func TestParseServeArgs_Overrides(t *testing.T) {
+	args, err := parseServeArgs([]string{
+		"--listen-addr", ":9090",
+		"--codex-bin", "/usr/local/bin/codex",
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if args.ListenAddr != ":9090" || args.CodexBin != "/usr/local/bin/codex" {
+		t.Errorf("got %+v", args)
+	}
+}

--- a/internal/codexappgateway/auth/auth.go
+++ b/internal/codexappgateway/auth/auth.go
@@ -50,16 +50,33 @@ func (a *HMAC) Mint(workspaceID, threadID string) string {
 }
 
 // Verify parses and HMAC-verifies a token.
+//
+// Token format: <workspace_id>.<thread_id>.<hex-hmac>
+//
+// The sig is always the last dot-separated field. The workspace_id is
+// always the first dot-separated field in the prefix (everything before
+// the sig); the thread_id is everything between the first and last dots.
+// This means thread_id may contain dots but workspace_id may not.
+//
+// Last dot separates the sig from the (workspace_id, thread_id, ...) prefix.
+// We split into "head" and "sig" instead of 3 fixed parts so thread
+// ids that themselves contain dots verify correctly.
 func (a *HMAC) Verify(token string) (Identity, error) {
-	parts := strings.Split(token, ".")
-	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+	lastDot := strings.LastIndex(token, ".")
+	if lastDot < 0 || lastDot == 0 || lastDot == len(token)-1 {
 		return Identity{}, errors.New("auth: malformed token")
 	}
-	expected := a.Mint(parts[0], parts[1])
-	if !hmac.Equal([]byte(expected), []byte(token)) {
+	head, sig := token[:lastDot], token[lastDot+1:]
+	sep := strings.IndexByte(head, '.')
+	if sep < 0 || sep == 0 || sep == len(head)-1 {
+		return Identity{}, errors.New("auth: malformed token")
+	}
+	workspaceID, threadID := head[:sep], head[sep+1:]
+	expected := a.Mint(workspaceID, threadID)
+	if !hmac.Equal([]byte(expected), []byte(workspaceID+"."+threadID+"."+sig)) {
 		return Identity{}, errors.New("auth: signature mismatch")
 	}
-	return Identity{WorkspaceID: parts[0], ThreadID: parts[1]}, nil
+	return Identity{WorkspaceID: workspaceID, ThreadID: threadID}, nil
 }
 
 // ExtractBearer pulls the token out of `Authorization: Bearer <tok>`.

--- a/internal/codexappgateway/auth/auth.go
+++ b/internal/codexappgateway/auth/auth.go
@@ -1,0 +1,73 @@
+// Package auth handles inbound caller authentication for codex-app-gateway.
+//
+// Phase 1 uses an HMAC-signed token of the form
+//
+//	<workspace_id>.<thread_id>.<hex-hmac-sha256>
+//
+// where the HMAC covers `<workspace_id>\0<thread_id>` keyed by a
+// deployment-shared secret. This matches the wstoken / internal-API
+// pattern used elsewhere in agentserver and avoids pulling a JWT lib
+// just for phase 1. Phase 2 can swap in a JWT impl behind the same
+// `Authenticator` interface.
+package auth
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"net/http"
+	"strings"
+)
+
+// Identity is what a verified token decodes to.
+type Identity struct {
+	WorkspaceID string
+	ThreadID    string
+}
+
+// Authenticator is the seam for inbound auth. Phase-1 impl is HMAC.
+type Authenticator interface {
+	Verify(token string) (Identity, error)
+}
+
+// HMAC is the phase-1 Authenticator.
+type HMAC struct{ secret []byte }
+
+// NewHMAC returns a phase-1 Authenticator. The secret must be non-empty
+// for tokens to verify; an empty secret will still mint and verify
+// against itself but represents a deployment misconfiguration.
+func NewHMAC(secret []byte) *HMAC { return &HMAC{secret: secret} }
+
+// Mint produces a token for `(workspaceID, threadID)`. Useful for tests
+// and CLI tools; production callers receive tokens from agentserver.
+func (a *HMAC) Mint(workspaceID, threadID string) string {
+	mac := hmac.New(sha256.New, a.secret)
+	mac.Write([]byte(workspaceID))
+	mac.Write([]byte{0})
+	mac.Write([]byte(threadID))
+	return workspaceID + "." + threadID + "." + hex.EncodeToString(mac.Sum(nil))
+}
+
+// Verify parses and HMAC-verifies a token.
+func (a *HMAC) Verify(token string) (Identity, error) {
+	parts := strings.Split(token, ".")
+	if len(parts) != 3 || parts[0] == "" || parts[1] == "" || parts[2] == "" {
+		return Identity{}, errors.New("auth: malformed token")
+	}
+	expected := a.Mint(parts[0], parts[1])
+	if !hmac.Equal([]byte(expected), []byte(token)) {
+		return Identity{}, errors.New("auth: signature mismatch")
+	}
+	return Identity{WorkspaceID: parts[0], ThreadID: parts[1]}, nil
+}
+
+// ExtractBearer pulls the token out of `Authorization: Bearer <tok>`.
+func ExtractBearer(r *http.Request) (string, bool) {
+	h := r.Header.Get("Authorization")
+	const prefix = "Bearer "
+	if !strings.HasPrefix(h, prefix) {
+		return "", false
+	}
+	return strings.TrimPrefix(h, prefix), true
+}

--- a/internal/codexappgateway/auth/auth_test.go
+++ b/internal/codexappgateway/auth/auth_test.go
@@ -40,6 +40,23 @@ func TestHMACAuthenticator_RejectsBadShape(t *testing.T) {
 	}
 }
 
+func TestHMACAuthenticator_RoundTrip_DottedIDs(t *testing.T) {
+	// workspaceID has no dots (first field); threadID may contain dots
+	// (everything between first and last dot in the token prefix).
+	a := NewHMAC([]byte("secret"))
+	tok := a.Mint("ws_alpha", "thr.42.extra")
+	got, err := a.Verify(tok)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if got.WorkspaceID != "ws_alpha" {
+		t.Errorf("WorkspaceID = %q", got.WorkspaceID)
+	}
+	if got.ThreadID != "thr.42.extra" {
+		t.Errorf("ThreadID = %q", got.ThreadID)
+	}
+}
+
 func TestExtractBearer(t *testing.T) {
 	r := httptest.NewRequest("GET", "/", nil)
 	r.Header.Set("Authorization", "Bearer foo.bar.baz")

--- a/internal/codexappgateway/auth/auth_test.go
+++ b/internal/codexappgateway/auth/auth_test.go
@@ -1,0 +1,58 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestHMACAuthenticator_RoundTrip(t *testing.T) {
+	a := NewHMAC([]byte("secret"))
+	tok := a.Mint("ws_alpha", "thr_42")
+	if !strings.HasPrefix(tok, "ws_alpha.thr_42.") {
+		t.Fatalf("token shape unexpected: %s", tok)
+	}
+	got, err := a.Verify(tok)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if got.WorkspaceID != "ws_alpha" || got.ThreadID != "thr_42" {
+		t.Errorf("decoded = %+v", got)
+	}
+}
+
+func TestHMACAuthenticator_RejectsBadSig(t *testing.T) {
+	a := NewHMAC([]byte("secret"))
+	tok := a.Mint("ws_a", "thr_1")
+	tampered := tok[:len(tok)-1] + "0"
+	if _, err := a.Verify(tampered); err == nil {
+		t.Fatal("want signature mismatch error")
+	}
+}
+
+func TestHMACAuthenticator_RejectsBadShape(t *testing.T) {
+	a := NewHMAC([]byte("secret"))
+	for _, bad := range []string{"", "no-dots", "one.two", "..."} {
+		if _, err := a.Verify(bad); err == nil {
+			t.Errorf("want error for %q", bad)
+		}
+	}
+}
+
+func TestExtractBearer(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.Header.Set("Authorization", "Bearer foo.bar.baz")
+	if got, ok := ExtractBearer(r); !ok || got != "foo.bar.baz" {
+		t.Errorf("got %q ok=%v", got, ok)
+	}
+	r2, _ := http.NewRequest("GET", "/", nil)
+	if _, ok := ExtractBearer(r2); ok {
+		t.Error("missing header should return false")
+	}
+	r3 := httptest.NewRequest("GET", "/", nil)
+	r3.Header.Set("Authorization", "Basic foo")
+	if _, ok := ExtractBearer(r3); ok {
+		t.Error("non-Bearer should return false")
+	}
+}

--- a/internal/codexappgateway/codexhome/codexhome.go
+++ b/internal/codexappgateway/codexhome/codexhome.go
@@ -59,7 +59,8 @@ func (m *Manager) NewTmpDir(workspaceID, threadID string) (string, error) {
 // RemoveTmpDir removes a previously-created tmpdir tree, but refuses
 // to remove anything outside the manager's root.
 func (m *Manager) RemoveTmpDir(path string) error {
-	if !strings.HasPrefix(path, m.root) {
+	rel, err := filepath.Rel(m.root, path)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return fmt.Errorf("codexhome: refusing to remove %s outside root %s", path, m.root)
 	}
 	return os.RemoveAll(path)
@@ -82,6 +83,11 @@ func RenderConfigTOML(cfg ConfigInput) (string, error) {
 	}
 	if cfg.Model == "" {
 		return "", fmt.Errorf("codexhome: Model required")
+	}
+	if len(cfg.ModelProviders) > 0 {
+		if _, ok := cfg.ModelProviders[cfg.ModelProvider]; !ok {
+			return "", fmt.Errorf("codexhome: ModelProvider %q not in ModelProviders", cfg.ModelProvider)
+		}
 	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "model_provider = %q\n", cfg.ModelProvider)

--- a/internal/codexappgateway/codexhome/codexhome.go
+++ b/internal/codexappgateway/codexhome/codexhome.go
@@ -1,0 +1,144 @@
+// Package codexhome owns per-thread CODEX_HOME tmpdirs: creation,
+// destruction, and the rendering of the config.toml fragment we plant
+// inside each one before spawning `codex app-server`.
+package codexhome
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type ModelProvider struct {
+	Name    string
+	BaseURL string
+	EnvKey  string
+	WireAPI string
+}
+
+type ExecutorEntry struct {
+	ID        string
+	BridgeURL string
+	TokenEnv  string
+	TokenVal  string // injected via env, not written to TOML
+	Desc      string
+	CodexBin  string // path to codex-app-gateway binary (for `env-mcp` subcommand)
+	TurnID    string
+}
+
+type ConfigInput struct {
+	ModelProvider       string
+	Model               string
+	ModelProviders      map[string]ModelProvider
+	Executors           []ExecutorEntry
+	ProjectTrustedPaths []string
+}
+
+// Manager creates per-thread CODEX_HOME tmpdirs under root.
+type Manager struct{ root string }
+
+func NewManager(root string) *Manager { return &Manager{root: root} }
+
+// NewTmpDir creates `<root>/<workspaceID>/<threadID>/` with mode 0700.
+// Idempotent: returns the existing path if already present.
+func (m *Manager) NewTmpDir(workspaceID, threadID string) (string, error) {
+	if workspaceID == "" || threadID == "" {
+		return "", fmt.Errorf("codexhome: empty workspace or thread id")
+	}
+	d := filepath.Join(m.root, workspaceID, threadID)
+	if err := os.MkdirAll(d, 0o700); err != nil {
+		return "", fmt.Errorf("mkdir %s: %w", d, err)
+	}
+	if err := os.Chmod(d, 0o700); err != nil {
+		return "", fmt.Errorf("chmod %s: %w", d, err)
+	}
+	return d, nil
+}
+
+// RemoveTmpDir removes a previously-created tmpdir tree, but refuses
+// to remove anything outside the manager's root.
+func (m *Manager) RemoveTmpDir(path string) error {
+	if !strings.HasPrefix(path, m.root) {
+		return fmt.Errorf("codexhome: refusing to remove %s outside root %s", path, m.root)
+	}
+	return os.RemoveAll(path)
+}
+
+// WriteConfig renders `config.toml` into the given CODEX_HOME dir.
+func (m *Manager) WriteConfig(codexHome string, cfg ConfigInput) error {
+	out, err := RenderConfigTOML(cfg)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(filepath.Join(codexHome, "config.toml"), []byte(out), 0o600)
+}
+
+// RenderConfigTOML produces the TOML body. Pure function so tests can
+// assert exact substrings without filesystem.
+func RenderConfigTOML(cfg ConfigInput) (string, error) {
+	if cfg.ModelProvider == "" {
+		return "", fmt.Errorf("codexhome: ModelProvider required")
+	}
+	if cfg.Model == "" {
+		return "", fmt.Errorf("codexhome: Model required")
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "model_provider = %q\n", cfg.ModelProvider)
+	fmt.Fprintf(&b, "model = %q\n\n", cfg.Model)
+
+	for name, p := range cfg.ModelProviders {
+		fmt.Fprintf(&b, "[model_providers.%s]\n", tomlKey(name))
+		fmt.Fprintf(&b, "name = %q\n", p.Name)
+		fmt.Fprintf(&b, "base_url = %q\n", p.BaseURL)
+		fmt.Fprintf(&b, "env_key = %q\n", p.EnvKey)
+		fmt.Fprintf(&b, "wire_api = %q\n\n", p.WireAPI)
+	}
+
+	for _, p := range cfg.ProjectTrustedPaths {
+		fmt.Fprintf(&b, "[projects.%q]\n", p)
+		b.WriteString("trust_level = \"trusted\"\n\n")
+	}
+
+	// Disable codex's builtin local-execution paths so the only way the
+	// LLM can reach a shell is through the env-mcp children below.
+	b.WriteString("[features]\n")
+	b.WriteString("shell_tool = false\n")
+	b.WriteString("unified_exec = false\n")
+	b.WriteString("apply_patch_freeform = false\n\n")
+
+	for _, e := range cfg.Executors {
+		fmt.Fprintf(&b, "[mcp_servers.%s]\n", tomlKey(e.ID))
+		fmt.Fprintf(&b, "command = %q\n", e.CodexBin)
+		args := []string{
+			"env-mcp",
+			"--exe-id", e.ID,
+			"--bridge-url", e.BridgeURL,
+			"--token-env", e.TokenEnv,
+			"--exe-desc", e.Desc,
+		}
+		if e.TurnID != "" {
+			args = append(args, "--turn-id", e.TurnID)
+		}
+		b.WriteString("args = [")
+		for i, a := range args {
+			if i > 0 {
+				b.WriteString(", ")
+			}
+			fmt.Fprintf(&b, "%q", a)
+		}
+		b.WriteString("]\n")
+		fmt.Fprintf(&b, "env = { %s = %q }\n\n", e.TokenEnv, e.TokenVal)
+	}
+	return b.String(), nil
+}
+
+// tomlKey leaves bare keys for safe identifiers, otherwise quotes.
+func tomlKey(s string) string {
+	for _, r := range s {
+		if !(r == '_' || (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9')) {
+			return fmt.Sprintf("%q", s)
+		}
+	}
+	return s
+}

--- a/internal/codexappgateway/codexhome/codexhome_test.go
+++ b/internal/codexappgateway/codexhome/codexhome_test.go
@@ -44,6 +44,26 @@ func TestManager_RemoveTmpDir(t *testing.T) {
 	}
 }
 
+func TestManager_RemoveTmpDir_RejectsOutsideRoot(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "root")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	m := NewManager(root)
+	// Sibling directory whose name starts with the same prefix as root
+	sibling := root + "-evil"
+	if err := os.MkdirAll(sibling, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := m.RemoveTmpDir(filepath.Join(sibling, "x")); err == nil {
+		t.Fatal("RemoveTmpDir should reject sibling-prefix path")
+	}
+	// Confirm the sibling still exists.
+	if _, err := os.Stat(sibling); err != nil {
+		t.Errorf("sibling unexpectedly removed: %v", err)
+	}
+}
+
 func TestRenderConfigTOML_DisablesBuiltinShellAndRegistersMCPServers(t *testing.T) {
 	cfg := ConfigInput{
 		ModelProvider: "modelserver",
@@ -98,6 +118,20 @@ func TestRenderConfigTOML_DisablesBuiltinShellAndRegistersMCPServers(t *testing.
 		if !strings.Contains(out, want) {
 			t.Errorf("missing %q in:\n%s", want, out)
 		}
+	}
+}
+
+func TestRenderConfigTOML_RejectsActiveProviderNotInMap(t *testing.T) {
+	cfg := ConfigInput{
+		ModelProvider: "missing",
+		Model:         "m",
+		ModelProviders: map[string]ModelProvider{
+			"other": {Name: "other", BaseURL: "http://x", EnvKey: "K", WireAPI: "responses"},
+		},
+	}
+	_, err := RenderConfigTOML(cfg)
+	if err == nil || !strings.Contains(err.Error(), "missing") {
+		t.Fatalf("want error naming missing provider, got %v", err)
 	}
 }
 

--- a/internal/codexappgateway/codexhome/codexhome_test.go
+++ b/internal/codexappgateway/codexhome/codexhome_test.go
@@ -1,0 +1,125 @@
+package codexhome
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestManager_NewTmpDir_LayoutAndPermissions(t *testing.T) {
+	root := t.TempDir()
+	m := NewManager(root)
+	d, err := m.NewTmpDir("ws_a", "thr_1")
+	if err != nil {
+		t.Fatalf("NewTmpDir: %v", err)
+	}
+	if !strings.HasPrefix(d, filepath.Join(root, "ws_a", "thr_1")) {
+		t.Errorf("path = %s", d)
+	}
+	st, err := os.Stat(d)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if !st.IsDir() {
+		t.Fatal("not a dir")
+	}
+	if st.Mode().Perm() != 0o700 {
+		t.Errorf("perm = %v", st.Mode().Perm())
+	}
+}
+
+func TestManager_RemoveTmpDir(t *testing.T) {
+	root := t.TempDir()
+	m := NewManager(root)
+	d, err := m.NewTmpDir("ws_a", "thr_1")
+	if err != nil {
+		t.Fatalf("NewTmpDir: %v", err)
+	}
+	if err := m.RemoveTmpDir(d); err != nil {
+		t.Fatalf("RemoveTmpDir: %v", err)
+	}
+	if _, err := os.Stat(d); !os.IsNotExist(err) {
+		t.Errorf("dir still exists: %v", err)
+	}
+}
+
+func TestRenderConfigTOML_DisablesBuiltinShellAndRegistersMCPServers(t *testing.T) {
+	cfg := ConfigInput{
+		ModelProvider: "modelserver",
+		Model:         "gpt-5.5",
+		ModelProviders: map[string]ModelProvider{
+			"modelserver": {
+				Name:    "modelserver",
+				BaseURL: "http://llmproxy:8085/v1",
+				EnvKey:  "CODEX_API_KEY",
+				WireAPI: "responses",
+			},
+		},
+		Executors: []ExecutorEntry{
+			{
+				ID:        "exe_alpha",
+				BridgeURL: "ws://exec-gw:6060/bridge/exe_alpha",
+				TokenEnv:  "CXG_BRIDGE_TOKEN_EXE_ALPHA",
+				TokenVal:  "tok-alpha",
+				Desc:      "Daisy's MacBook",
+				CodexBin:  "/usr/local/bin/codex-app-gateway",
+				TurnID:    "trn_xxx",
+			},
+			{
+				ID:        "exe_beta",
+				BridgeURL: "ws://exec-gw:6060/bridge/exe_beta",
+				TokenEnv:  "CXG_BRIDGE_TOKEN_EXE_BETA",
+				TokenVal:  "tok-beta",
+				Desc:      "EC2 us-east-1",
+				CodexBin:  "/usr/local/bin/codex-app-gateway",
+				TurnID:    "trn_xxx",
+			},
+		},
+		ProjectTrustedPaths: []string{"/tmp"},
+	}
+	out, err := RenderConfigTOML(cfg)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	for _, want := range []string{
+		`model_provider = "modelserver"`,
+		`shell_tool = false`,
+		`unified_exec = false`,
+		`apply_patch_freeform = false`,
+		`[mcp_servers.exe_alpha]`,
+		`"--exe-id"`, `"exe_alpha"`,
+		`"--bridge-url"`, `"ws://exec-gw:6060/bridge/exe_alpha"`,
+		`"--token-env"`, `"CXG_BRIDGE_TOKEN_EXE_ALPHA"`,
+		`[mcp_servers.exe_beta]`,
+		`[projects."/tmp"]`,
+		`trust_level = "trusted"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestManager_WriteConfig_ProducesUsableTOML(t *testing.T) {
+	root := t.TempDir()
+	m := NewManager(root)
+	d, _ := m.NewTmpDir("ws_a", "thr_1")
+	cfg := ConfigInput{
+		ModelProvider: "p",
+		Model:         "m",
+		ModelProviders: map[string]ModelProvider{
+			"p": {Name: "p", BaseURL: "http://x", EnvKey: "K", WireAPI: "responses"},
+		},
+	}
+	if err := m.WriteConfig(d, cfg); err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(d, "config.toml"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(b), `model = "m"`) {
+		t.Errorf("config missing model: %s", b)
+	}
+}

--- a/internal/codexappgateway/codexhome/s3.go
+++ b/internal/codexappgateway/codexhome/s3.go
@@ -1,0 +1,152 @@
+package codexhome
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ErrObjectNotFound is returned by ObjectStore.Get when a key is absent.
+var ErrObjectNotFound = errors.New("codexhome: object not found")
+
+// ObjectStore is the seam between codexhome and the S3 client. Real
+// callers wire in a thin wrapper around aws-sdk-go-v2; tests use a
+// map-backed fake.
+type ObjectStore interface {
+	Put(ctx context.Context, key string, data []byte) error
+	Get(ctx context.Context, key string) ([]byte, error)
+	Delete(ctx context.Context, key string) error
+}
+
+// S3Backend round-trips a single (workspace, thread) CODEX_HOME tree.
+type S3Backend struct {
+	store       ObjectStore
+	workspaceID string
+	threadID    string
+}
+
+func NewS3Backend(store ObjectStore, workspaceID, threadID string) *S3Backend {
+	return &S3Backend{store: store, workspaceID: workspaceID, threadID: threadID}
+}
+
+// Key is the S3 key. Exposed so callers (and tests) can introspect.
+func (b *S3Backend) Key() string {
+	return fmt.Sprintf("codex-app-gateway/%s/%s.tar.gz", b.workspaceID, b.threadID)
+}
+
+// Upload tars+gzips the directory tree at src and writes it to S3.
+func (b *S3Backend) Upload(ctx context.Context, src string) error {
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	err := filepath.WalkDir(src, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, p)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		hdr, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return err
+		}
+		hdr.Name = rel
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		f, err := os.Open(p)
+		if err != nil {
+			return err
+		}
+		_, copyErr := io.Copy(tw, f)
+		_ = f.Close()
+		return copyErr
+	})
+	if err != nil {
+		return fmt.Errorf("tar walk: %w", err)
+	}
+	if err := tw.Close(); err != nil {
+		return fmt.Errorf("tar close: %w", err)
+	}
+	if err := gz.Close(); err != nil {
+		return fmt.Errorf("gz close: %w", err)
+	}
+	return b.store.Put(ctx, b.Key(), buf.Bytes())
+}
+
+// Download fetches the tarball and untars into dst (which must exist
+// and be owned by the caller).
+func (b *S3Backend) Download(ctx context.Context, dst string) error {
+	data, err := b.store.Get(ctx, b.Key())
+	if err != nil {
+		return err
+	}
+	gz, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return fmt.Errorf("gzip reader: %w", err)
+	}
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("tar next: %w", err)
+		}
+		if strings.Contains(hdr.Name, "..") {
+			return fmt.Errorf("untrusted path: %s", hdr.Name)
+		}
+		target := filepath.Join(dst, hdr.Name)
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			mode := fs.FileMode(hdr.Mode) & 0o700
+			if mode == 0 {
+				mode = 0o700
+			}
+			if err := os.MkdirAll(target, mode); err != nil {
+				return fmt.Errorf("mkdir %s: %w", target, err)
+			}
+		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(target), 0o700); err != nil {
+				return fmt.Errorf("mkdir parent of %s: %w", target, err)
+			}
+			mode := fs.FileMode(hdr.Mode) & 0o600
+			if mode == 0 {
+				mode = 0o600
+			}
+			f, err := os.OpenFile(target, os.O_RDWR|os.O_CREATE|os.O_TRUNC, mode)
+			if err != nil {
+				return fmt.Errorf("open %s: %w", target, err)
+			}
+			if _, err := io.Copy(f, tr); err != nil {
+				_ = f.Close()
+				return fmt.Errorf("copy %s: %w", target, err)
+			}
+			_ = f.Close()
+		default:
+			// Skip symlinks / fifo / devices — codex doesn't write them.
+		}
+	}
+	return nil
+}

--- a/internal/codexappgateway/codexhome/s3_test.go
+++ b/internal/codexappgateway/codexhome/s3_test.go
@@ -1,0 +1,94 @@
+package codexhome
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+)
+
+// fakeS3 is an in-memory ObjectStore used by the test suite.
+type fakeS3 struct {
+	mu      sync.Mutex
+	objects map[string][]byte
+}
+
+func newFakeS3() *fakeS3 { return &fakeS3{objects: map[string][]byte{}} }
+
+func (f *fakeS3) Put(_ context.Context, key string, data []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.objects[key] = append([]byte(nil), data...)
+	return nil
+}
+
+func (f *fakeS3) Get(_ context.Context, key string) ([]byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	b, ok := f.objects[key]
+	if !ok {
+		return nil, ErrObjectNotFound
+	}
+	return append([]byte(nil), b...), nil
+}
+
+func (f *fakeS3) Delete(_ context.Context, key string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.objects, key)
+	return nil
+}
+
+func TestS3RoundTrip_TarUntarPreservesContents(t *testing.T) {
+	root := t.TempDir()
+	m := NewManager(root)
+	src, err := m.NewTmpDir("ws_a", "thr_1")
+	if err != nil {
+		t.Fatalf("NewTmpDir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "config.toml"), []byte("model = \"m\"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(src, "sessions"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "sessions", "x.jsonl"), []byte(`{"a":1}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	store := newFakeS3()
+	backend := NewS3Backend(store, "ws_a", "thr_1")
+	if err := backend.Upload(context.Background(), src); err != nil {
+		t.Fatalf("Upload: %v", err)
+	}
+	if _, ok := store.objects[backend.Key()]; !ok {
+		t.Fatalf("object missing: %v", store.objects)
+	}
+
+	// Recreate empty dir; download should re-populate.
+	dst := filepath.Join(t.TempDir(), "ws_a", "thr_1")
+	if err := os.MkdirAll(dst, 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := backend.Download(context.Background(), dst); err != nil {
+		t.Fatalf("Download: %v", err)
+	}
+	if got, _ := os.ReadFile(filepath.Join(dst, "config.toml")); string(got) != "model = \"m\"\n" {
+		t.Errorf("config.toml = %q", got)
+	}
+	if got, _ := os.ReadFile(filepath.Join(dst, "sessions", "x.jsonl")); string(got) != `{"a":1}`+"\n" {
+		t.Errorf("sessions/x.jsonl = %q", got)
+	}
+}
+
+func TestS3Backend_Download_NotFound_IsRecognizable(t *testing.T) {
+	store := newFakeS3()
+	backend := NewS3Backend(store, "ws_a", "thr_missing")
+	err := backend.Download(context.Background(), t.TempDir())
+	if !errors.Is(err, ErrObjectNotFound) {
+		t.Fatalf("want ErrObjectNotFound, got %v", err)
+	}
+}

--- a/internal/codexappgateway/config.go
+++ b/internal/codexappgateway/config.go
@@ -3,11 +3,15 @@ package codexappgateway
 import (
 	"fmt"
 	"log/slog"
+	"net/url"
 	"os"
 	"strings"
 	"time"
 )
 
+// S3Config matches the shape used by internal/ccbroker/workspace/s3store.go;
+// dedup into a shared storage package is a known follow-up. Until then,
+// keep validation here in sync with ccbroker's.
 type S3Config struct {
 	Endpoint        string
 	Region          string
@@ -53,6 +57,11 @@ func LoadServeConfigFromEnv() (ServeConfig, error) {
 	}
 	if cfg.S3.Endpoint == "" {
 		return cfg, fmt.Errorf("CXG_S3_ENDPOINT is required")
+	}
+	if u, err := url.Parse(cfg.S3.Endpoint); err != nil {
+		return cfg, fmt.Errorf("CXG_S3_ENDPOINT not a valid URL: %w", err)
+	} else if u.Scheme != "http" && u.Scheme != "https" {
+		return cfg, fmt.Errorf("CXG_S3_ENDPOINT must use http:// or https:// scheme, got %q", cfg.S3.Endpoint)
 	}
 	if cfg.S3.Bucket == "" {
 		return cfg, fmt.Errorf("CXG_S3_BUCKET is required")

--- a/internal/codexappgateway/config.go
+++ b/internal/codexappgateway/config.go
@@ -1,0 +1,97 @@
+package codexappgateway
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+)
+
+type S3Config struct {
+	Endpoint        string
+	Region          string
+	Bucket          string
+	AccessKeyID     string
+	SecretAccessKey string
+	PathStyle       bool
+}
+
+type ServeConfig struct {
+	InboundHMACSecret         []byte
+	S3                        S3Config
+	TmpRoot                   string
+	IdleShutdown              time.Duration
+	ExecGatewayWSURL          string
+	ExecGatewayInternalURL    string
+	ExecGatewayInternalSecret string
+	CapTokenHMACSecret        []byte
+	LogLevel                  slog.Level
+}
+
+func LoadServeConfigFromEnv() (ServeConfig, error) {
+	cfg := ServeConfig{
+		TmpRoot:      envOr("CXG_TMP_ROOT", "/tmp/codex-app-gateway"),
+		IdleShutdown: 30 * time.Minute,
+		LogLevel:     slog.LevelInfo,
+		S3: S3Config{
+			Endpoint:        os.Getenv("CXG_S3_ENDPOINT"),
+			Region:          envOr("CXG_S3_REGION", "us-east-1"),
+			Bucket:          os.Getenv("CXG_S3_BUCKET"),
+			AccessKeyID:     os.Getenv("CXG_S3_ACCESS_KEY_ID"),
+			SecretAccessKey: os.Getenv("CXG_S3_SECRET_ACCESS_KEY"),
+			PathStyle:       strings.EqualFold(os.Getenv("CXG_S3_PATH_STYLE"), "true"),
+		},
+		InboundHMACSecret:         []byte(os.Getenv("CXG_INBOUND_HMAC_SECRET")),
+		ExecGatewayWSURL:          os.Getenv("CXG_EXEC_GATEWAY_URL"),
+		ExecGatewayInternalURL:    os.Getenv("CXG_EXEC_GATEWAY_INTERNAL_URL"),
+		ExecGatewayInternalSecret: os.Getenv("CXG_EXEC_GATEWAY_INTERNAL_SECRET"),
+		CapTokenHMACSecret:        []byte(os.Getenv("CXG_CAPTOKEN_HMAC_SECRET")),
+	}
+	if len(cfg.InboundHMACSecret) == 0 {
+		return cfg, fmt.Errorf("CXG_INBOUND_HMAC_SECRET is required")
+	}
+	if cfg.S3.Endpoint == "" {
+		return cfg, fmt.Errorf("CXG_S3_ENDPOINT is required")
+	}
+	if cfg.S3.Bucket == "" {
+		return cfg, fmt.Errorf("CXG_S3_BUCKET is required")
+	}
+	if cfg.ExecGatewayWSURL == "" {
+		return cfg, fmt.Errorf("CXG_EXEC_GATEWAY_URL is required")
+	}
+	if cfg.ExecGatewayInternalURL == "" {
+		return cfg, fmt.Errorf("CXG_EXEC_GATEWAY_INTERNAL_URL is required")
+	}
+	if cfg.ExecGatewayInternalSecret == "" {
+		return cfg, fmt.Errorf("CXG_EXEC_GATEWAY_INTERNAL_SECRET is required")
+	}
+	if len(cfg.CapTokenHMACSecret) == 0 {
+		return cfg, fmt.Errorf("CXG_CAPTOKEN_HMAC_SECRET is required")
+	}
+	if v := os.Getenv("CXG_IDLE_SHUTDOWN"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return cfg, fmt.Errorf("parse CXG_IDLE_SHUTDOWN: %w", err)
+		}
+		cfg.IdleShutdown = d
+	}
+	if v := strings.ToLower(os.Getenv("CXG_LOG_LEVEL")); v != "" {
+		switch v {
+		case "debug":
+			cfg.LogLevel = slog.LevelDebug
+		case "warn":
+			cfg.LogLevel = slog.LevelWarn
+		case "error":
+			cfg.LogLevel = slog.LevelError
+		}
+	}
+	return cfg, nil
+}
+
+func envOr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}

--- a/internal/codexappgateway/config_test.go
+++ b/internal/codexappgateway/config_test.go
@@ -52,6 +52,15 @@ func TestLoadServeConfig_RequiresExecGatewayURL(t *testing.T) {
 	}
 }
 
+func TestLoadServeConfig_RejectsBadS3Endpoint(t *testing.T) {
+	setRequired(t)
+	t.Setenv("CXG_S3_ENDPOINT", "no-scheme.example.com")
+	_, err := LoadServeConfigFromEnv()
+	if err == nil || !strings.Contains(err.Error(), "scheme") {
+		t.Fatalf("want scheme error, got %v", err)
+	}
+}
+
 func TestLoadServeConfig_OverridesIdleShutdown(t *testing.T) {
 	setRequired(t)
 	t.Setenv("CXG_IDLE_SHUTDOWN", "5m")

--- a/internal/codexappgateway/config_test.go
+++ b/internal/codexappgateway/config_test.go
@@ -1,0 +1,65 @@
+package codexappgateway
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+func setRequired(t *testing.T) {
+	t.Helper()
+	t.Setenv("CXG_INBOUND_HMAC_SECRET", "in-sec")
+	t.Setenv("CXG_S3_ENDPOINT", "http://s3")
+	t.Setenv("CXG_S3_BUCKET", "buck")
+	t.Setenv("CXG_EXEC_GATEWAY_URL", "ws://exec-gw:6060")
+	t.Setenv("CXG_EXEC_GATEWAY_INTERNAL_URL", "http://exec-gw:6060")
+	t.Setenv("CXG_EXEC_GATEWAY_INTERNAL_SECRET", "internal-sec")
+	t.Setenv("CXG_CAPTOKEN_HMAC_SECRET", "captok-sec")
+}
+
+func TestLoadServeConfig_Defaults(t *testing.T) {
+	setRequired(t)
+	cfg, err := LoadServeConfigFromEnv()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.TmpRoot != "/tmp/codex-app-gateway" {
+		t.Errorf("TmpRoot = %q", cfg.TmpRoot)
+	}
+	if cfg.IdleShutdown != 30*time.Minute {
+		t.Errorf("IdleShutdown = %v", cfg.IdleShutdown)
+	}
+	if cfg.S3.Region != "us-east-1" {
+		t.Errorf("S3 default region = %q", cfg.S3.Region)
+	}
+}
+
+func TestLoadServeConfig_RequiresInboundSecret(t *testing.T) {
+	setRequired(t)
+	t.Setenv("CXG_INBOUND_HMAC_SECRET", "")
+	_, err := LoadServeConfigFromEnv()
+	if err == nil || !strings.Contains(err.Error(), "CXG_INBOUND_HMAC_SECRET") {
+		t.Fatalf("want secret-required error, got %v", err)
+	}
+}
+
+func TestLoadServeConfig_RequiresExecGatewayURL(t *testing.T) {
+	setRequired(t)
+	t.Setenv("CXG_EXEC_GATEWAY_URL", "")
+	_, err := LoadServeConfigFromEnv()
+	if err == nil || !strings.Contains(err.Error(), "CXG_EXEC_GATEWAY_URL") {
+		t.Fatalf("want exec-gateway-url-required, got %v", err)
+	}
+}
+
+func TestLoadServeConfig_OverridesIdleShutdown(t *testing.T) {
+	setRequired(t)
+	t.Setenv("CXG_IDLE_SHUTDOWN", "5m")
+	cfg, err := LoadServeConfigFromEnv()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.IdleShutdown != 5*time.Minute {
+		t.Errorf("IdleShutdown = %v", cfg.IdleShutdown)
+	}
+}

--- a/internal/codexappgateway/envmcp/bridge.go
+++ b/internal/codexappgateway/envmcp/bridge.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -28,6 +29,7 @@ type BridgeClient struct {
 	closed   chan struct{}
 	closeErr error
 	cancel   context.CancelFunc
+	logger   *slog.Logger
 }
 
 // DialBridge dials wsURL and, when authToken is non-empty, sets
@@ -38,7 +40,7 @@ type BridgeClient struct {
 // nhooyr.io/websocket does NOT request `permessage-deflate` by default —
 // we rely on that, because codex's exec-server closes connections that
 // do (see spec § PoC #2 gotchas).
-func DialBridge(ctx context.Context, wsURL, authToken string) (*BridgeClient, error) {
+func DialBridge(ctx context.Context, wsURL, authToken string, logger *slog.Logger) (*BridgeClient, error) {
 	opts := &websocket.DialOptions{}
 	if authToken != "" {
 		opts.HTTPHeader = http.Header{"Authorization": []string{"Bearer " + authToken}}
@@ -49,12 +51,16 @@ func DialBridge(ctx context.Context, wsURL, authToken string) (*BridgeClient, er
 	}
 	ws.SetReadLimit(-1) // exec-server can stream large process/read responses
 
+	if logger == nil {
+		logger = slog.Default()
+	}
 	loopCtx, cancel := context.WithCancel(context.Background())
 	bc := &BridgeClient{
 		ws:      ws,
 		pending: make(map[int64]chan *JSONRPCMessage),
 		closed:  make(chan struct{}),
 		cancel:  cancel,
+		logger:  logger,
 	}
 	go bc.readLoop(loopCtx)
 	return bc, nil
@@ -163,6 +169,7 @@ func (bc *BridgeClient) readLoop(ctx context.Context) {
 		}
 		var msg JSONRPCMessage
 		if err := json.Unmarshal(data, &msg); err != nil {
+			bc.logger.Warn("bridge: dropping malformed frame", "err", err, "len", len(data))
 			continue
 		}
 		if msg.ID == nil {

--- a/internal/codexappgateway/envmcp/bridge_test.go
+++ b/internal/codexappgateway/envmcp/bridge_test.go
@@ -67,7 +67,7 @@ func TestBridgeClient_DialAndCall(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	bc, err := DialBridge(ctx, f.wsURL(), "tok-123")
+	bc, err := DialBridge(ctx, f.wsURL(), "tok-123", nil)
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
@@ -91,7 +91,7 @@ func TestBridgeClient_Notify_NoReply(t *testing.T) {
 	defer f.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	bc, err := DialBridge(ctx, f.wsURL(), "")
+	bc, err := DialBridge(ctx, f.wsURL(), "", nil)
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
@@ -106,7 +106,7 @@ func TestBridgeClient_Call_AfterClose_Errors(t *testing.T) {
 	defer f.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	bc, err := DialBridge(ctx, f.wsURL(), "")
+	bc, err := DialBridge(ctx, f.wsURL(), "", nil)
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
@@ -134,7 +134,7 @@ func TestBridgeClient_Call_ServerClosesMidCall(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	bc, err := DialBridge(ctx, wsURL, "")
+	bc, err := DialBridge(ctx, wsURL, "", nil)
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
@@ -162,7 +162,7 @@ func TestBridgeClient_Call_CtxCancel(t *testing.T) {
 
 	dialCtx, dialCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer dialCancel()
-	bc, err := DialBridge(dialCtx, wsURL, "")
+	bc, err := DialBridge(dialCtx, wsURL, "", nil)
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
@@ -209,7 +209,7 @@ func TestBridgeClient_Call_ServerErrorResponse(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	bc, err := DialBridge(ctx, wsURL, "")
+	bc, err := DialBridge(ctx, wsURL, "", nil)
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
@@ -228,7 +228,7 @@ func TestBridgeClient_Close_Idempotent(t *testing.T) {
 	defer f.Close()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	bc, err := DialBridge(ctx, f.wsURL(), "")
+	bc, err := DialBridge(ctx, f.wsURL(), "", nil)
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}

--- a/internal/codexappgateway/envmcp/envmcp.go
+++ b/internal/codexappgateway/envmcp/envmcp.go
@@ -41,7 +41,7 @@ func Run(ctx context.Context, args RunArgs, stdin io.Reader, stdout, stderr io.W
 		"turn_id", args.TurnID,
 	)
 
-	bc, err := DialBridge(ctx, args.BridgeURL, token)
+	bc, err := DialBridge(ctx, args.BridgeURL, token, logger)
 	if err != nil {
 		return fmt.Errorf("dial bridge: %w", err)
 	}
@@ -56,7 +56,7 @@ func Run(ctx context.Context, args RunArgs, stdin io.Reader, stdout, stderr io.W
 	}
 
 	tr := NewTranslator(bc)
-	srv := NewMCPServer(args.ExeDesc, tr)
+	srv := NewMCPServer(args.ExeDesc, tr, logger)
 	if err := srv.Serve(ctx, stdin, stdout); err != nil {
 		// EOF on stdin is the normal exit path (codex's MCP host
 		// closed); io.EOF surfaces as nil from bufio.Scanner.Err(), so

--- a/internal/codexappgateway/envmcp/mcp_server.go
+++ b/internal/codexappgateway/envmcp/mcp_server.go
@@ -7,7 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"sync"
+	"unicode/utf8"
 )
 
 // ShellRunner is the slice of Translator that MCPServer uses.
@@ -25,10 +27,28 @@ type MCPServer struct {
 	exeDesc string
 	tr      ShellRunner
 	writeMu sync.Mutex
+	logger  *slog.Logger
 }
 
-func NewMCPServer(exeDesc string, tr ShellRunner) *MCPServer {
-	return &MCPServer{exeDesc: exeDesc, tr: tr}
+func NewMCPServer(exeDesc string, tr ShellRunner, logger *slog.Logger) *MCPServer {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &MCPServer{exeDesc: exeDesc, tr: tr, logger: logger}
+}
+
+// previewLine returns up to 200 bytes of line as a string, truncating safely.
+func previewLine(line []byte) string {
+	const max = 200
+	if len(line) <= max {
+		return string(line)
+	}
+	// Truncate at a valid UTF-8 boundary.
+	truncated := line[:max]
+	for !utf8.Valid(truncated) {
+		truncated = truncated[:len(truncated)-1]
+	}
+	return string(truncated) + "…"
 }
 
 // Serve reads requests from in until EOF and writes responses to out.
@@ -46,8 +66,7 @@ func (s *MCPServer) Serve(ctx context.Context, in io.Reader, out io.Writer) erro
 		}
 		var req JSONRPCMessage
 		if err := json.Unmarshal(line, &req); err != nil {
-			// Malformed input; per JSON-RPC 2.0, parse errors on a
-			// notification have no reply target so we log+drop.
+			s.logger.Warn("mcp: dropping malformed JSON-RPC line", "err", err, "preview", previewLine(line))
 			continue
 		}
 		if err := s.dispatch(ctx, &req, out); err != nil {

--- a/internal/codexappgateway/envmcp/mcp_server_test.go
+++ b/internal/codexappgateway/envmcp/mcp_server_test.go
@@ -43,7 +43,7 @@ func driveServer(t *testing.T, srv *MCPServer, lines ...string) []map[string]any
 }
 
 func TestMCPServer_InitializeAndToolsList(t *testing.T) {
-	srv := NewMCPServer("Daisy's MacBook", &stubTranslator{})
+	srv := NewMCPServer("Daisy's MacBook", &stubTranslator{}, nil)
 	got := driveServer(t, srv,
 		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`,
 		`{"jsonrpc":"2.0","id":2,"method":"tools/list"}`,
@@ -71,7 +71,7 @@ func TestMCPServer_InitializeAndToolsList(t *testing.T) {
 
 func TestMCPServer_ToolsCallShell_DispatchesToTranslator(t *testing.T) {
 	tr := &stubTranslator{out: ShellResult{Text: "ok\n[exit_code=0]", IsError: false}}
-	srv := NewMCPServer("desc", tr)
+	srv := NewMCPServer("desc", tr, nil)
 	got := driveServer(t, srv,
 		`{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`,
 		`{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"shell","arguments":{"command":["ls","-la"],"cwd":"/srv"}}}`,
@@ -96,7 +96,7 @@ func TestMCPServer_ToolsCallShell_DispatchesToTranslator(t *testing.T) {
 }
 
 func TestMCPServer_ToolsCall_UnknownTool_Error(t *testing.T) {
-	srv := NewMCPServer("desc", &stubTranslator{})
+	srv := NewMCPServer("desc", &stubTranslator{}, nil)
 	got := driveServer(t, srv,
 		`{"jsonrpc":"2.0","id":1,"method":"tools/call","params":{"name":"bogus","arguments":{}}}`,
 	)
@@ -106,7 +106,7 @@ func TestMCPServer_ToolsCall_UnknownTool_Error(t *testing.T) {
 }
 
 func TestMCPServer_PromptsAndResources_EmptyLists(t *testing.T) {
-	srv := NewMCPServer("desc", &stubTranslator{})
+	srv := NewMCPServer("desc", &stubTranslator{}, nil)
 	got := driveServer(t, srv,
 		`{"jsonrpc":"2.0","id":1,"method":"prompts/list"}`,
 		`{"jsonrpc":"2.0","id":2,"method":"resources/list"}`,
@@ -125,7 +125,7 @@ func TestMCPServer_PromptsAndResources_EmptyLists(t *testing.T) {
 }
 
 func TestMCPServer_NotificationProducesNoReply(t *testing.T) {
-	srv := NewMCPServer("desc", &stubTranslator{})
+	srv := NewMCPServer("desc", &stubTranslator{}, nil)
 	got := driveServer(t, srv,
 		`{"jsonrpc":"2.0","method":"notifications/initialized"}`,
 		`{"jsonrpc":"2.0","id":1,"method":"tools/list"}`,

--- a/internal/codexappgateway/integration_test.go
+++ b/internal/codexappgateway/integration_test.go
@@ -1,0 +1,107 @@
+//go:build integration
+
+package codexappgateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentserver/agentserver/internal/codexappgateway/auth"
+	"github.com/agentserver/agentserver/internal/codexappgateway/codexhome"
+	"github.com/agentserver/agentserver/internal/codexappgateway/supervisor"
+
+	"nhooyr.io/websocket"
+)
+
+// TestServer_RealCodexAppServer_FullRPCRoundtrip is opt-in: build with
+// `-tags integration`. Requires `codex` (>= 0.130.0) on PATH.
+func TestServer_RealCodexAppServer_FullRPCRoundtrip(t *testing.T) {
+	if _, err := exec.LookPath("codex"); err != nil {
+		t.Skip("codex not on PATH")
+	}
+
+	root := t.TempDir()
+	store := makeFakeStore(t) // from server_testhelper_test.go
+	mgr := codexhome.NewManager(root)
+	sup := supervisor.NewSupervisor(supervisor.SupervisorConfig{
+		CodexBin: "codex",
+		HomeMgr:  mgr,
+		Store:    store,
+	})
+	t.Cleanup(func() { sup.ShutdownAll(context.Background()) })
+
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	s := &Server{
+		cfg:     ServeConfig{InboundHMACSecret: []byte("int")},
+		auth:    auth.NewHMAC([]byte("int")),
+		sup:     sup,
+		homeMgr: mgr,
+		logger:  logger,
+		buildConfig: func(ws, thr string) (codexhome.ConfigInput, error) {
+			return codexhome.ConfigInput{
+				ModelProvider: "modelserver",
+				Model:         "gpt-5.5",
+				ModelProviders: map[string]codexhome.ModelProvider{
+					"modelserver": {Name: "modelserver", BaseURL: "https://code.ai.cs.ac.cn/v1", EnvKey: "OPENAI_API_KEY", WireAPI: "responses"},
+				},
+				ProjectTrustedPaths: []string{"/tmp"},
+			}, nil
+		},
+	}
+	srv := httptest.NewServer(s.Routes())
+	defer srv.Close()
+
+	tok := auth.NewHMAC([]byte("int")).Mint("ws_int", "thr_1")
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/codex-app/ws"
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+	c, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
+		HTTPHeader: http.Header{"Authorization": []string{"Bearer " + tok}},
+		// codex app-server doesn't accept permessage-deflate.
+		CompressionMode: websocket.CompressionDisabled,
+	})
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close(websocket.StatusNormalClosure, "")
+
+	send := func(payload string) {
+		if err := c.Write(ctx, websocket.MessageText, []byte(payload)); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	expectReply := func(label string) map[string]any {
+		_, raw, err := c.Read(ctx)
+		if err != nil {
+			t.Fatalf("%s read: %v", label, err)
+		}
+		var resp map[string]any
+		if err := json.Unmarshal(raw, &resp); err != nil {
+			t.Fatalf("%s decode: %v", label, err)
+		}
+		if resp["error"] != nil {
+			t.Fatalf("%s errored: %v", label, resp["error"])
+		}
+		return resp
+	}
+
+	send(`{"id":1,"method":"initialize","params":{"clientInfo":{"name":"int","title":"int","version":"0"},"capabilities":{"experimentalApi":true,"requestAttestation":false,"optOutNotificationMethods":[]}}}`)
+	resp := expectReply("initialize")
+	if resp["id"] == nil {
+		t.Fatalf("no id in initialize reply: %v", resp)
+	}
+	t.Logf("initialize reply ok: %v", resp["result"])
+
+	send(`{"method":"initialized"}`)
+	send(`{"id":2,"method":"thread/start","params":{}}`)
+	resp = expectReply("thread/start")
+	t.Logf("thread/start ok: %v", resp["result"])
+}

--- a/internal/codexappgateway/proxy/proxy.go
+++ b/internal/codexappgateway/proxy/proxy.go
@@ -11,12 +11,14 @@ import (
 
 // RunProxy starts two pumps in parallel and returns when either side
 // closes or errors. Both ws conns are left open for the caller to close.
-func RunProxy(ctx context.Context, userWS, childWS *websocket.Conn) error {
+// onFrame is called on every successfully read frame (from either direction);
+// pass nil if no callback is needed.
+func RunProxy(ctx context.Context, userWS, childWS *websocket.Conn, onFrame func()) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	errCh := make(chan error, 2)
-	go func() { errCh <- pump(ctx, userWS, childWS) }()
-	go func() { errCh <- pump(ctx, childWS, userWS) }()
+	go func() { errCh <- pump(ctx, userWS, childWS, onFrame) }()
+	go func() { errCh <- pump(ctx, childWS, userWS, onFrame) }()
 	err := <-errCh
 	cancel()
 	<-errCh
@@ -26,11 +28,14 @@ func RunProxy(ctx context.Context, userWS, childWS *websocket.Conn) error {
 	return err
 }
 
-func pump(ctx context.Context, src, dst *websocket.Conn) error {
+func pump(ctx context.Context, src, dst *websocket.Conn, onFrame func()) error {
 	for {
 		typ, data, err := src.Read(ctx)
 		if err != nil {
 			return err
+		}
+		if onFrame != nil {
+			onFrame()
 		}
 		if err := dst.Write(ctx, typ, data); err != nil {
 			return err

--- a/internal/codexappgateway/proxy/proxy.go
+++ b/internal/codexappgateway/proxy/proxy.go
@@ -1,0 +1,39 @@
+// Package proxy bidirectionally forwards ws frames between a user-side
+// ws and a child-side ws. Frame-level: doesn't parse JSON-RPC.
+package proxy
+
+import (
+	"context"
+	"errors"
+
+	"nhooyr.io/websocket"
+)
+
+// RunProxy starts two pumps in parallel and returns when either side
+// closes or errors. Both ws conns are left open for the caller to close.
+func RunProxy(ctx context.Context, userWS, childWS *websocket.Conn) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	errCh := make(chan error, 2)
+	go func() { errCh <- pump(ctx, userWS, childWS) }()
+	go func() { errCh <- pump(ctx, childWS, userWS) }()
+	err := <-errCh
+	cancel()
+	<-errCh
+	if errors.Is(err, context.Canceled) {
+		return nil
+	}
+	return err
+}
+
+func pump(ctx context.Context, src, dst *websocket.Conn) error {
+	for {
+		typ, data, err := src.Read(ctx)
+		if err != nil {
+			return err
+		}
+		if err := dst.Write(ctx, typ, data); err != nil {
+			return err
+		}
+	}
+}

--- a/internal/codexappgateway/proxy/proxy_test.go
+++ b/internal/codexappgateway/proxy/proxy_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -48,7 +49,7 @@ func TestRunProxy_BidirectionalForwarding(t *testing.T) {
 			return
 		}
 		defer childWS.Close(websocket.StatusNormalClosure, "")
-		_ = RunProxy(r.Context(), userWS, childWS)
+		_ = RunProxy(r.Context(), userWS, childWS, nil)
 	})
 	gateway := httptest.NewServer(mux)
 	defer gateway.Close()
@@ -69,5 +70,54 @@ func TestRunProxy_BidirectionalForwarding(t *testing.T) {
 	}
 	if string(got) != "HELLO" {
 		t.Errorf("got %q", got)
+	}
+}
+
+func TestRunProxy_OnFrameInvokedPerFrame(t *testing.T) {
+	upstream := pairServer(t)
+	defer upstream.Close()
+	wsURL := "ws" + strings.TrimPrefix(upstream.URL, "http")
+
+	var frameCount atomic.Int64
+	mux := http.NewServeMux()
+	mux.HandleFunc("/proxy", func(w http.ResponseWriter, r *http.Request) {
+		userWS, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer userWS.Close(websocket.StatusNormalClosure, "")
+		childWS, _, err := websocket.Dial(r.Context(), wsURL, nil)
+		if err != nil {
+			t.Errorf("dial child: %v", err)
+			return
+		}
+		defer childWS.Close(websocket.StatusNormalClosure, "")
+		_ = RunProxy(r.Context(), userWS, childWS, func() { frameCount.Add(1) })
+	})
+	gateway := httptest.NewServer(mux)
+	defer gateway.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	c, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(gateway.URL, "http")+"/proxy", nil)
+	if err != nil {
+		t.Fatalf("dial gateway: %v", err)
+	}
+	defer c.Close(websocket.StatusNormalClosure, "")
+
+	if err := c.Write(ctx, websocket.MessageText, []byte("ping")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, _, err = c.Read(ctx)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	// Give the second pump's onFrame call time to fire.
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) && frameCount.Load() < 2 {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := frameCount.Load(); got < 2 {
+		t.Fatalf("frameCount = %d, want >= 2 (one per direction)", got)
 	}
 }

--- a/internal/codexappgateway/proxy/proxy_test.go
+++ b/internal/codexappgateway/proxy/proxy_test.go
@@ -1,0 +1,73 @@
+package proxy
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+)
+
+func pairServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer c.Close(websocket.StatusNormalClosure, "")
+		ctx := r.Context()
+		for {
+			typ, data, err := c.Read(ctx)
+			if err != nil {
+				return
+			}
+			_ = c.Write(ctx, typ, []byte(strings.ToUpper(string(data))))
+		}
+	}))
+}
+
+func TestRunProxy_BidirectionalForwarding(t *testing.T) {
+	upstream := pairServer(t)
+	defer upstream.Close()
+	wsURL := "ws" + strings.TrimPrefix(upstream.URL, "http")
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/proxy", func(w http.ResponseWriter, r *http.Request) {
+		userWS, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer userWS.Close(websocket.StatusNormalClosure, "")
+		childWS, _, err := websocket.Dial(r.Context(), wsURL, nil)
+		if err != nil {
+			t.Errorf("dial child: %v", err)
+			return
+		}
+		defer childWS.Close(websocket.StatusNormalClosure, "")
+		_ = RunProxy(r.Context(), userWS, childWS)
+	})
+	gateway := httptest.NewServer(mux)
+	defer gateway.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	c, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(gateway.URL, "http")+"/proxy", nil)
+	if err != nil {
+		t.Fatalf("dial gateway: %v", err)
+	}
+	defer c.Close(websocket.StatusNormalClosure, "")
+	if err := c.Write(ctx, websocket.MessageText, []byte("hello")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, got, err := c.Read(ctx)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if string(got) != "HELLO" {
+		t.Errorf("got %q", got)
+	}
+}

--- a/internal/codexappgateway/s3_store.go
+++ b/internal/codexappgateway/s3_store.go
@@ -1,0 +1,61 @@
+package codexappgateway
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+
+	"github.com/agentserver/agentserver/internal/codexappgateway/codexhome"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/credentials"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+)
+
+type s3Store struct {
+	client *s3.Client
+	bucket string
+}
+
+func newS3Store(cfg S3Config) (codexhome.ObjectStore, error) {
+	if cfg.Endpoint == "" || cfg.Bucket == "" {
+		return nil, errors.New("s3: endpoint + bucket required")
+	}
+	awsCfg := aws.Config{
+		Region:      cfg.Region,
+		Credentials: credentials.NewStaticCredentialsProvider(cfg.AccessKeyID, cfg.SecretAccessKey, ""),
+	}
+	cli := s3.NewFromConfig(awsCfg, func(o *s3.Options) {
+		o.BaseEndpoint = &cfg.Endpoint
+		o.UsePathStyle = cfg.PathStyle
+	})
+	return &s3Store{client: cli, bucket: cfg.Bucket}, nil
+}
+
+func (s *s3Store) Put(ctx context.Context, key string, data []byte) error {
+	_, err := s.client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: &s.bucket,
+		Key:    &key,
+		Body:   bytes.NewReader(data),
+	})
+	return err
+}
+
+func (s *s3Store) Get(ctx context.Context, key string) ([]byte, error) {
+	out, err := s.client.GetObject(ctx, &s3.GetObjectInput{Bucket: &s.bucket, Key: &key})
+	if err != nil {
+		var nsk *s3types.NoSuchKey
+		if errors.As(err, &nsk) {
+			return nil, codexhome.ErrObjectNotFound
+		}
+		return nil, err
+	}
+	defer out.Body.Close()
+	return io.ReadAll(out.Body)
+}
+
+func (s *s3Store) Delete(ctx context.Context, key string) error {
+	_, err := s.client.DeleteObject(ctx, &s3.DeleteObjectInput{Bucket: &s.bucket, Key: &key})
+	return err
+}

--- a/internal/codexappgateway/server.go
+++ b/internal/codexappgateway/server.go
@@ -67,7 +67,7 @@ func NewServer(cfg ServeConfig, codexBin string, logger *slog.Logger) (*Server, 
 // Run serves HTTP until ctx is done.
 func (s *Server) Run(ctx context.Context, listenAddr string) error {
 	httpSrv := &http.Server{Addr: listenAddr, Handler: s.Routes()}
-	reaper := supervisor.NewIdleReaper(s.sup, 1*time.Minute, s.cfg.IdleShutdown)
+	reaper := supervisor.NewIdleReaper(s.sup, 1*time.Minute, s.cfg.IdleShutdown, s.logger)
 	reaperCtx, reaperCancel := context.WithCancel(context.Background())
 	defer reaperCancel()
 	go reaper.Run(reaperCtx)

--- a/internal/codexappgateway/server.go
+++ b/internal/codexappgateway/server.go
@@ -147,6 +147,17 @@ func (s *Server) handleCodexAppWS(w http.ResponseWriter, r *http.Request) {
 	s.sup.Touch(key)
 }
 
+// handleAdminRestart shuts down the codex app-server subprocess for a
+// given (workspaceId, threadId), forcing a fresh spawn (and S3 reload)
+// on the next ws connect. Used by operators after executor-binding
+// changes; see spec § Subsystem 2 "Per-turn config refresh".
+//
+// AUTHORIZATION (phase 1): the bearer token's identity is checked only
+// to authenticate the caller as a valid token holder. The (workspaceId,
+// threadId) to restart is taken from the request body, allowing
+// cross-thread restarts by any authenticated caller. This matches the
+// operator-scoped intent of an admin endpoint. Phase 2 may tighten to
+// require token-identity == body-identity for self-service restarts.
 func (s *Server) handleAdminRestart(w http.ResponseWriter, r *http.Request) {
 	tok, ok := auth.ExtractBearer(r)
 	if !ok {

--- a/internal/codexappgateway/server.go
+++ b/internal/codexappgateway/server.go
@@ -129,7 +129,10 @@ func (s *Server) handleCodexAppWS(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	childWS, _, err := websocket.Dial(ctx, handle.WSURL, nil)
+	childWS, _, err := websocket.Dial(ctx, handle.WSURL, &websocket.DialOptions{
+		// codex app-server rejects connections that request permessage-deflate.
+		CompressionMode: websocket.CompressionDisabled,
+	})
 	if err != nil {
 		s.logger.Error("dial child", "err", err, "url", handle.WSURL)
 		_ = userWS.Close(websocket.StatusInternalError, "subprocess dial failed")

--- a/internal/codexappgateway/server.go
+++ b/internal/codexappgateway/server.go
@@ -141,10 +141,9 @@ func (s *Server) handleCodexAppWS(w http.ResponseWriter, r *http.Request) {
 	defer childWS.Close(websocket.StatusNormalClosure, "gateway closing")
 
 	s.sup.Touch(key)
-	if err := proxy.RunProxy(ctx, userWS, childWS); err != nil {
+	if err := proxy.RunProxy(ctx, userWS, childWS, func() { s.sup.Touch(key) }); err != nil {
 		s.logger.Info("proxy ended", "err", err, "key", key)
 	}
-	s.sup.Touch(key)
 }
 
 // handleAdminRestart shuts down the codex app-server subprocess for a

--- a/internal/codexappgateway/server.go
+++ b/internal/codexappgateway/server.go
@@ -2,22 +2,173 @@ package codexappgateway
 
 import (
 	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
 	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/agentserver/agentserver/internal/codexappgateway/auth"
+	"github.com/agentserver/agentserver/internal/codexappgateway/codexhome"
+	"github.com/agentserver/agentserver/internal/codexappgateway/proxy"
+	"github.com/agentserver/agentserver/internal/codexappgateway/supervisor"
+
+	"github.com/go-chi/chi/v5"
+	"nhooyr.io/websocket"
 )
 
+// Server is the codex-app-gateway HTTP/WS server.
 type Server struct {
-	cfg      ServeConfig
-	codexBin string
-	logger   *slog.Logger
+	cfg     ServeConfig
+	auth    auth.Authenticator
+	sup     *supervisor.Supervisor
+	homeMgr *codexhome.Manager
+	logger  *slog.Logger
+
+	// buildConfig produces the per-thread config.toml input. Allowed to
+	// hit the network. Errors abort the spawn.
+	buildConfig func(workspaceID, threadID string) (codexhome.ConfigInput, error)
 }
 
+// NewServer wires up the production server.
 func NewServer(cfg ServeConfig, codexBin string, logger *slog.Logger) (*Server, error) {
-	return &Server{cfg: cfg, codexBin: codexBin, logger: logger}, nil
+	store, err := newS3Store(cfg.S3)
+	if err != nil {
+		return nil, fmt.Errorf("s3 store: %w", err)
+	}
+	mgr := codexhome.NewManager(cfg.TmpRoot)
+	sup := supervisor.NewSupervisor(supervisor.SupervisorConfig{
+		CodexBin: codexBin,
+		HomeMgr:  mgr,
+		Store:    store,
+	})
+	return &Server{
+		cfg:     cfg,
+		auth:    auth.NewHMAC(cfg.InboundHMACSecret),
+		sup:     sup,
+		homeMgr: mgr,
+		logger:  logger,
+		buildConfig: func(workspaceID, threadID string) (codexhome.ConfigInput, error) {
+			// Phase-1 default: minimal config from env. Real exec-gw fetch
+			// is wired in a follow-up task that reads CXG_EXEC_GATEWAY_*
+			// and mints per-turn cap tokens; until then, no executors.
+			return codexhome.ConfigInput{
+				ModelProvider: "modelserver",
+				Model:         "gpt-5.5",
+				ModelProviders: map[string]codexhome.ModelProvider{
+					"modelserver": {Name: "modelserver", BaseURL: "http://llmproxy:8085/v1", EnvKey: "CODEX_API_KEY", WireAPI: "responses"},
+				},
+			}, nil
+		},
+	}, nil
 }
 
-// Run is a stub; Task 8 replaces it.
+// Run serves HTTP until ctx is done.
 func (s *Server) Run(ctx context.Context, listenAddr string) error {
-	s.logger.Info("server stub Run; sleeping until ctx done", "listen_addr", listenAddr)
-	<-ctx.Done()
-	return nil
+	httpSrv := &http.Server{Addr: listenAddr, Handler: s.Routes()}
+	reaper := supervisor.NewIdleReaper(s.sup, 1*time.Minute, s.cfg.IdleShutdown)
+	reaperCtx, reaperCancel := context.WithCancel(context.Background())
+	defer reaperCancel()
+	go reaper.Run(reaperCtx)
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- httpSrv.ListenAndServe() }()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = httpSrv.Shutdown(shutdownCtx)
+		s.sup.ShutdownAll(shutdownCtx)
+		return nil
+	case err := <-errCh:
+		s.sup.ShutdownAll(context.Background())
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return err
+	}
+}
+
+// Routes builds the chi router. Public for tests.
+func (s *Server) Routes() http.Handler {
+	r := chi.NewRouter()
+	r.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(200) })
+	r.Get("/codex-app/ws", s.handleCodexAppWS)
+	r.Post("/admin/threads/restart", s.handleAdminRestart)
+	return r
+}
+
+func (s *Server) handleCodexAppWS(w http.ResponseWriter, r *http.Request) {
+	tok, ok := auth.ExtractBearer(r)
+	if !ok {
+		http.Error(w, "missing Bearer", http.StatusUnauthorized)
+		return
+	}
+	id, err := s.auth.Verify(tok)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+	userWS, err := websocket.Accept(w, r, nil)
+	if err != nil {
+		s.logger.Warn("ws accept failed", "err", err)
+		return
+	}
+	defer userWS.Close(websocket.StatusNormalClosure, "client closing")
+
+	key := supervisor.Key{WorkspaceID: id.WorkspaceID, ThreadID: id.ThreadID}
+	ctx := r.Context()
+	handle, err := s.sup.EnsureSubprocess(ctx, key, func() (codexhome.ConfigInput, error) {
+		return s.buildConfig(id.WorkspaceID, id.ThreadID)
+	})
+	if err != nil {
+		s.logger.Error("ensure subprocess", "err", err, "key", key)
+		_ = userWS.Close(websocket.StatusInternalError, "subprocess unavailable")
+		return
+	}
+
+	childWS, _, err := websocket.Dial(ctx, handle.WSURL, nil)
+	if err != nil {
+		s.logger.Error("dial child", "err", err, "url", handle.WSURL)
+		_ = userWS.Close(websocket.StatusInternalError, "subprocess dial failed")
+		return
+	}
+	defer childWS.Close(websocket.StatusNormalClosure, "gateway closing")
+
+	s.sup.Touch(key)
+	if err := proxy.RunProxy(ctx, userWS, childWS); err != nil {
+		s.logger.Info("proxy ended", "err", err, "key", key)
+	}
+	s.sup.Touch(key)
+}
+
+func (s *Server) handleAdminRestart(w http.ResponseWriter, r *http.Request) {
+	tok, ok := auth.ExtractBearer(r)
+	if !ok {
+		http.Error(w, "missing Bearer", http.StatusUnauthorized)
+		return
+	}
+	if _, err := s.auth.Verify(tok); err != nil {
+		http.Error(w, err.Error(), http.StatusUnauthorized)
+		return
+	}
+	var body struct {
+		WorkspaceID string `json:"workspaceId"`
+		ThreadID    string `json:"threadId"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "bad body", http.StatusBadRequest)
+		return
+	}
+	if body.WorkspaceID == "" || body.ThreadID == "" {
+		http.Error(w, "workspaceId and threadId required", http.StatusBadRequest)
+		return
+	}
+	if err := s.sup.Shutdown(r.Context(), supervisor.Key{WorkspaceID: body.WorkspaceID, ThreadID: body.ThreadID}); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/codexappgateway/server.go
+++ b/internal/codexappgateway/server.go
@@ -1,0 +1,23 @@
+package codexappgateway
+
+import (
+	"context"
+	"log/slog"
+)
+
+type Server struct {
+	cfg      ServeConfig
+	codexBin string
+	logger   *slog.Logger
+}
+
+func NewServer(cfg ServeConfig, codexBin string, logger *slog.Logger) (*Server, error) {
+	return &Server{cfg: cfg, codexBin: codexBin, logger: logger}, nil
+}
+
+// Run is a stub; Task 8 replaces it.
+func (s *Server) Run(ctx context.Context, listenAddr string) error {
+	s.logger.Info("server stub Run; sleeping until ctx done", "listen_addr", listenAddr)
+	<-ctx.Done()
+	return nil
+}

--- a/internal/codexappgateway/server_test.go
+++ b/internal/codexappgateway/server_test.go
@@ -1,0 +1,114 @@
+package codexappgateway
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentserver/agentserver/internal/codexappgateway/auth"
+	"github.com/agentserver/agentserver/internal/codexappgateway/codexhome"
+	"github.com/agentserver/agentserver/internal/codexappgateway/supervisor"
+
+	"nhooyr.io/websocket"
+)
+
+func TestServer_WSEndpoint_AuthRequired(t *testing.T) {
+	srv := makeTestServer(t)
+	defer srv.Close()
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/codex-app/ws"
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_, resp, err := websocket.Dial(ctx, wsURL, nil)
+	if err == nil {
+		t.Fatal("expected dial to fail without Bearer")
+	}
+	if resp == nil || resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %v", resp)
+	}
+}
+
+func TestServer_WSEndpoint_HappyPath_ProxiesToFakeChild(t *testing.T) {
+	srv := makeTestServer(t)
+	defer srv.Close()
+
+	authHelper := auth.NewHMAC([]byte("test-secret"))
+	tok := authHelper.Mint("ws_a", "thr_1")
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/codex-app/ws"
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	c, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
+		HTTPHeader: http.Header{"Authorization": []string{"Bearer " + tok}},
+	})
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close(websocket.StatusNormalClosure, "")
+	// fake codex doesn't reply to RPC; just verify we can write a frame
+	// without immediate error (proxy is alive).
+	if err := c.Write(ctx, websocket.MessageText, []byte(`{"id":1,"method":"ping"}`)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+}
+
+func TestServer_AdminRestart_KillsSubprocess(t *testing.T) {
+	srv := makeTestServer(t)
+	defer srv.Close()
+
+	authHelper := auth.NewHMAC([]byte("test-secret"))
+	tok := authHelper.Mint("ws_b", "thr_42")
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/codex-app/ws"
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	c, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
+		HTTPHeader: http.Header{"Authorization": []string{"Bearer " + tok}},
+	})
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	c.Close(websocket.StatusNormalClosure, "")
+
+	req, _ := http.NewRequestWithContext(ctx, "POST", srv.URL+"/admin/threads/restart",
+		strings.NewReader(`{"workspaceId":"ws_b","threadId":"thr_42"}`))
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("admin: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 204 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Errorf("status = %d, body = %s", resp.StatusCode, body)
+	}
+}
+
+func makeTestServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	bin := makeFakeCodex(t)
+	store := makeFakeStore(t)
+	mgr := codexhome.NewManager(t.TempDir())
+	sup := supervisor.NewSupervisor(supervisor.SupervisorConfig{CodexBin: bin, HomeMgr: mgr, Store: store})
+	t.Cleanup(func() { sup.ShutdownAll(context.Background()) })
+
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	srv := &Server{
+		cfg:     ServeConfig{InboundHMACSecret: []byte("test-secret")},
+		auth:    auth.NewHMAC([]byte("test-secret")),
+		sup:     sup,
+		homeMgr: mgr,
+		logger:  logger,
+		buildConfig: func(ws, thr string) (codexhome.ConfigInput, error) {
+			return codexhome.ConfigInput{
+				ModelProvider:  "p", Model: "m",
+				ModelProviders: map[string]codexhome.ModelProvider{"p": {Name: "p", BaseURL: "http://x", EnvKey: "K", WireAPI: "responses"}},
+			}, nil
+		},
+	}
+	return httptest.NewServer(srv.Routes())
+}

--- a/internal/codexappgateway/server_testhelper_test.go
+++ b/internal/codexappgateway/server_testhelper_test.go
@@ -1,4 +1,4 @@
-package supervisor
+package codexappgateway
 
 import (
 	"context"
@@ -6,15 +6,16 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
-	"strings"
+	"sync"
 	"testing"
-	"time"
+
+	"github.com/agentserver/agentserver/internal/codexappgateway/codexhome"
 )
 
-// BuildFakeCodexForTest compiles a small Go program that mimics the bits of
+// makeFakeCodex compiles a small Go program that mimics the bits of
 // `codex app-server` we depend on: print "ws://127.0.0.1:PORT" on
 // stdout, then serve /readyz on that port.
-func BuildFakeCodexForTest(t *testing.T) string {
+func makeFakeCodex(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	src := filepath.Join(dir, "main.go")
@@ -50,28 +51,34 @@ func main() {
 	return bin
 }
 
-func TestSpawnCodexAppServer_HappyPath(t *testing.T) {
-	bin := BuildFakeCodexForTest(t)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
-	h, err := spawnCodexAppServer(ctx, bin, t.TempDir(), nil)
-	if err != nil {
-		t.Fatalf("spawn: %v", err)
-	}
-	defer h.Stop(context.Background())
-	if !strings.HasPrefix(h.WSURL, "ws://127.0.0.1:") {
-		t.Errorf("WSURL = %s", h.WSURL)
-	}
-	if !strings.HasPrefix(h.HTTPURL, "http://127.0.0.1:") {
-		t.Errorf("HTTPURL = %s", h.HTTPURL)
-	}
+// inMemStore implements codexhome.ObjectStore in-memory for tests.
+type inMemStore struct {
+	mu sync.Mutex
+	m  map[string][]byte
 }
 
-func TestSpawnCodexAppServer_BadBinary(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	_, err := spawnCodexAppServer(ctx, "/no/such/binary", t.TempDir(), nil)
-	if err == nil {
-		t.Fatal("want spawn error")
+func (f *inMemStore) Put(_ context.Context, k string, d []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.m[k] = append([]byte(nil), d...)
+	return nil
+}
+func (f *inMemStore) Get(_ context.Context, k string) ([]byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	d, ok := f.m[k]
+	if !ok {
+		return nil, codexhome.ErrObjectNotFound
 	}
+	return append([]byte(nil), d...), nil
+}
+func (f *inMemStore) Delete(_ context.Context, k string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.m, k)
+	return nil
+}
+
+func makeFakeStore(_ *testing.T) codexhome.ObjectStore {
+	return &inMemStore{m: map[string][]byte{}}
 }

--- a/internal/codexappgateway/supervisor/reaper.go
+++ b/internal/codexappgateway/supervisor/reaper.go
@@ -2,6 +2,7 @@ package supervisor
 
 import (
 	"context"
+	"log/slog"
 	"time"
 )
 
@@ -11,10 +12,14 @@ type IdleReaper struct {
 	sup       *Supervisor
 	interval  time.Duration
 	idleAfter time.Duration
+	logger    *slog.Logger
 }
 
-func NewIdleReaper(sup *Supervisor, interval, idleAfter time.Duration) *IdleReaper {
-	return &IdleReaper{sup: sup, interval: interval, idleAfter: idleAfter}
+func NewIdleReaper(sup *Supervisor, interval, idleAfter time.Duration, logger *slog.Logger) *IdleReaper {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &IdleReaper{sup: sup, interval: interval, idleAfter: idleAfter, logger: logger}
 }
 
 // Run blocks until ctx is done, ticking every interval and shutting
@@ -29,7 +34,9 @@ func (r *IdleReaper) Run(ctx context.Context) {
 		case now := <-t.C:
 			for key, last := range r.sup.snapshot() {
 				if now.Sub(last) >= r.idleAfter {
-					_ = r.sup.Shutdown(ctx, key)
+					if err := r.sup.Shutdown(ctx, key); err != nil {
+						r.logger.Error("idle reap: subprocess shutdown failed (CODEX_HOME may not be saved to S3)", "key", key, "err", err)
+					}
 				}
 			}
 		}

--- a/internal/codexappgateway/supervisor/reaper.go
+++ b/internal/codexappgateway/supervisor/reaper.go
@@ -1,0 +1,37 @@
+package supervisor
+
+import (
+	"context"
+	"time"
+)
+
+// IdleReaper periodically scans the Supervisor and shuts down entries
+// idle for longer than idleAfter.
+type IdleReaper struct {
+	sup       *Supervisor
+	interval  time.Duration
+	idleAfter time.Duration
+}
+
+func NewIdleReaper(sup *Supervisor, interval, idleAfter time.Duration) *IdleReaper {
+	return &IdleReaper{sup: sup, interval: interval, idleAfter: idleAfter}
+}
+
+// Run blocks until ctx is done, ticking every interval and shutting
+// down idle entries.
+func (r *IdleReaper) Run(ctx context.Context) {
+	t := time.NewTicker(r.interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-t.C:
+			for key, last := range r.sup.snapshot() {
+				if now.Sub(last) >= r.idleAfter {
+					_ = r.sup.Shutdown(ctx, key)
+				}
+			}
+		}
+	}
+}

--- a/internal/codexappgateway/supervisor/reaper_test.go
+++ b/internal/codexappgateway/supervisor/reaper_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestReaper_RetiresIdleSubprocess(t *testing.T) {
-	bin := BuildFakeCodexForTest(t)
+	bin := buildFakeCodex(t)
 	root := t.TempDir()
 	store := newFakeStore()
 	mgr := codexhome.NewManager(root)
@@ -40,7 +40,7 @@ func TestReaper_RetiresIdleSubprocess(t *testing.T) {
 }
 
 func TestReaper_KeepsActiveSubprocess(t *testing.T) {
-	bin := BuildFakeCodexForTest(t)
+	bin := buildFakeCodex(t)
 	root := t.TempDir()
 	store := newFakeStore()
 	mgr := codexhome.NewManager(root)

--- a/internal/codexappgateway/supervisor/reaper_test.go
+++ b/internal/codexappgateway/supervisor/reaper_test.go
@@ -22,7 +22,7 @@ func TestReaper_RetiresIdleSubprocess(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := NewIdleReaper(sup, 50*time.Millisecond, 100*time.Millisecond)
+	r := NewIdleReaper(sup, 50*time.Millisecond, 100*time.Millisecond, nil)
 	rctx, rcancel := context.WithCancel(context.Background())
 	defer rcancel()
 	go r.Run(rctx)
@@ -55,7 +55,7 @@ func TestReaper_KeepsActiveSubprocess(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	r := NewIdleReaper(sup, 30*time.Millisecond, 200*time.Millisecond)
+	r := NewIdleReaper(sup, 30*time.Millisecond, 200*time.Millisecond, nil)
 	rctx, rcancel := context.WithCancel(context.Background())
 	defer rcancel()
 	go r.Run(rctx)

--- a/internal/codexappgateway/supervisor/reaper_test.go
+++ b/internal/codexappgateway/supervisor/reaper_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestReaper_RetiresIdleSubprocess(t *testing.T) {
-	bin := buildFakeCodex(t)
+	bin := BuildFakeCodexForTest(t)
 	root := t.TempDir()
 	store := newFakeStore()
 	mgr := codexhome.NewManager(root)
@@ -40,7 +40,7 @@ func TestReaper_RetiresIdleSubprocess(t *testing.T) {
 }
 
 func TestReaper_KeepsActiveSubprocess(t *testing.T) {
-	bin := buildFakeCodex(t)
+	bin := BuildFakeCodexForTest(t)
 	root := t.TempDir()
 	store := newFakeStore()
 	mgr := codexhome.NewManager(root)

--- a/internal/codexappgateway/supervisor/reaper_test.go
+++ b/internal/codexappgateway/supervisor/reaper_test.go
@@ -1,0 +1,71 @@
+package supervisor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/agentserver/agentserver/internal/codexappgateway/codexhome"
+)
+
+func TestReaper_RetiresIdleSubprocess(t *testing.T) {
+	bin := buildFakeCodex(t)
+	root := t.TempDir()
+	store := newFakeStore()
+	mgr := codexhome.NewManager(root)
+	sup := NewSupervisor(SupervisorConfig{CodexBin: bin, HomeMgr: mgr, Store: store})
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	build := func() (codexhome.ConfigInput, error) { return defaultConfigInput(), nil }
+	if _, err := sup.EnsureSubprocess(ctx, Key{WorkspaceID: "ws_a", ThreadID: "thr_1"}, build); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewIdleReaper(sup, 50*time.Millisecond, 100*time.Millisecond)
+	rctx, rcancel := context.WithCancel(context.Background())
+	defer rcancel()
+	go r.Run(rctx)
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if len(sup.snapshot()) == 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if got := sup.snapshot(); len(got) != 0 {
+		t.Fatalf("expected empty after reap, got %v", got)
+	}
+}
+
+func TestReaper_KeepsActiveSubprocess(t *testing.T) {
+	bin := buildFakeCodex(t)
+	root := t.TempDir()
+	store := newFakeStore()
+	mgr := codexhome.NewManager(root)
+	sup := NewSupervisor(SupervisorConfig{CodexBin: bin, HomeMgr: mgr, Store: store})
+	defer sup.ShutdownAll(context.Background())
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	build := func() (codexhome.ConfigInput, error) { return defaultConfigInput(), nil }
+	key := Key{WorkspaceID: "ws_a", ThreadID: "thr_keep"}
+	if _, err := sup.EnsureSubprocess(ctx, key, build); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewIdleReaper(sup, 30*time.Millisecond, 200*time.Millisecond)
+	rctx, rcancel := context.WithCancel(context.Background())
+	defer rcancel()
+	go r.Run(rctx)
+
+	end := time.Now().Add(600 * time.Millisecond)
+	for time.Now().Before(end) {
+		sup.Touch(key)
+		time.Sleep(50 * time.Millisecond)
+	}
+	if got := sup.snapshot(); len(got) != 1 {
+		t.Fatalf("expected entry to survive, got %v", got)
+	}
+}

--- a/internal/codexappgateway/supervisor/spawn.go
+++ b/internal/codexappgateway/supervisor/spawn.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"os/exec"
 	"strings"
 	"sync"
@@ -86,7 +87,7 @@ func (h *ChildHandle) Stop(ctx context.Context) error {
 // streams concurrently and extract the first line containing "ws://".
 func spawnCodexAppServer(ctx context.Context, codexBin, codexHome string, extraEnv []string) (*ChildHandle, error) {
 	cmd := exec.Command(codexBin, "app-server", "--listen", "ws://127.0.0.1:0")
-	cmd.Env = append(append([]string{}, extraEnv...), "CODEX_HOME="+codexHome)
+	cmd.Env = append(append(os.Environ(), extraEnv...), "CODEX_HOME="+codexHome)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		return nil, fmt.Errorf("stdout pipe: %w", err)

--- a/internal/codexappgateway/supervisor/spawn.go
+++ b/internal/codexappgateway/supervisor/spawn.go
@@ -10,38 +10,64 @@ import (
 	"net/http"
 	"os/exec"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 )
 
 // ChildHandle is what spawnCodexAppServer returns.
 type ChildHandle struct {
-	Cmd       *exec.Cmd
+	cmd       *exec.Cmd
 	WSURL     string // ws://127.0.0.1:PORT
 	HTTPURL   string // http://127.0.0.1:PORT  (for /readyz, /healthz)
 	CodexHome string
+	done      chan struct{} // closed after cmd.Wait returns
+	waitErr   error        // set before done is closed
+	waitMu    sync.Mutex   // guards waitErr
 }
+
+// IsAlive reports whether the subprocess is still running. Cheap;
+// suitable for calling on every EnsureSubprocess hit.
+func (h *ChildHandle) IsAlive() bool {
+	if h == nil || h.done == nil {
+		return false
+	}
+	select {
+	case <-h.done:
+		return false
+	default:
+		return true
+	}
+}
+
+// Done returns a channel closed after the subprocess exits. Useful for
+// callers that want to be notified of unexpected termination.
+func (h *ChildHandle) Done() <-chan struct{} { return h.done }
 
 // Stop sends SIGTERM, waits up to 10s, then SIGKILLs.
 func (h *ChildHandle) Stop(ctx context.Context) error {
-	if h.Cmd == nil || h.Cmd.Process == nil {
+	if h.cmd == nil || h.cmd.Process == nil {
 		return nil
 	}
-	if err := h.Cmd.Process.Signal(syscall.SIGTERM); err != nil {
-		return fmt.Errorf("SIGTERM: %w", err)
+	if err := h.cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		// Process may already have exited; treat as success.
+		select {
+		case <-h.done:
+			return nil
+		default:
+			return fmt.Errorf("SIGTERM: %w", err)
+		}
 	}
-	done := make(chan error, 1)
-	go func() { done <- h.Cmd.Wait() }()
 	select {
-	case <-done:
+	case <-h.done:
 		return nil
 	case <-time.After(10 * time.Second):
-		_ = h.Cmd.Process.Signal(syscall.SIGKILL)
-		<-done
+		_ = h.cmd.Process.Signal(syscall.SIGKILL)
+		<-h.done
 		return nil
 	case <-ctx.Done():
-		_ = h.Cmd.Process.Signal(syscall.SIGKILL)
-		<-done
+		_ = h.cmd.Process.Signal(syscall.SIGKILL)
+		<-h.done
 		return ctx.Err()
 	}
 }
@@ -149,5 +175,19 @@ func spawnCodexAppServer(ctx context.Context, codexBin, codexHome string, extraE
 		}
 	}
 
-	return &ChildHandle{Cmd: cmd, WSURL: wsURL, HTTPURL: httpURL, CodexHome: codexHome}, nil
+	handle := &ChildHandle{
+		cmd:       cmd,
+		WSURL:     wsURL,
+		HTTPURL:   httpURL,
+		CodexHome: codexHome,
+		done:      make(chan struct{}),
+	}
+	go func() {
+		err := cmd.Wait()
+		handle.waitMu.Lock()
+		handle.waitErr = err
+		handle.waitMu.Unlock()
+		close(handle.done)
+	}()
+	return handle, nil
 }

--- a/internal/codexappgateway/supervisor/spawn.go
+++ b/internal/codexappgateway/supervisor/spawn.go
@@ -47,7 +47,17 @@ func (h *ChildHandle) Stop(ctx context.Context) error {
 }
 
 // spawnCodexAppServer launches `codexBin app-server --listen ws://127.0.0.1:0`,
-// reads the listen URL from stdout, polls /readyz, and returns a handle.
+// reads the listen URL from its output, polls /readyz, and returns a handle.
+//
+// The real `codex` binary writes a multi-line startup banner to stderr:
+//
+//	codex app-server (WebSockets)
+//	  listening on: ws://127.0.0.1:PORT
+//	  readyz: http://127.0.0.1:PORT/readyz
+//	  ...
+//
+// Test fakes write a bare "ws://127.0.0.1:PORT\n" to stdout. We scan both
+// streams concurrently and extract the first line containing "ws://".
 func spawnCodexAppServer(ctx context.Context, codexBin, codexHome string, extraEnv []string) (*ChildHandle, error) {
 	cmd := exec.Command(codexBin, "app-server", "--listen", "ws://127.0.0.1:0")
 	cmd.Env = append(append([]string{}, extraEnv...), "CODEX_HOME="+codexHome)
@@ -55,24 +65,66 @@ func spawnCodexAppServer(ctx context.Context, codexBin, codexHome string, extraE
 	if err != nil {
 		return nil, fmt.Errorf("stdout pipe: %w", err)
 	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stderr pipe: %w", err)
+	}
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("start: %w", err)
 	}
-	br := bufio.NewReader(stdout)
-	line, err := br.ReadString('\n')
-	if err != nil {
-		_ = cmd.Process.Kill()
-		return nil, fmt.Errorf("read listen line: %w", err)
+
+	// Scan both stdout and stderr concurrently for a line containing "ws://".
+	// Real codex writes the URL to stderr; test fakes write it to stdout.
+	type result struct {
+		url string
+		err error
 	}
-	wsURL := strings.TrimSpace(line)
+	urlCh := make(chan result, 1)
+	scanStream := func(r io.Reader) {
+		br := bufio.NewReader(r)
+		for {
+			line, err := br.ReadString('\n')
+			trimmed := strings.TrimSpace(line)
+			if idx := strings.Index(trimmed, "ws://"); idx >= 0 {
+				select {
+				case urlCh <- result{url: trimmed[idx:]}:
+				default:
+				}
+				// Drain remainder in background.
+				go func() { _, _ = io.Copy(io.Discard, br) }()
+				return
+			}
+			if err != nil {
+				select {
+				case urlCh <- result{err: err}:
+				default:
+				}
+				return
+			}
+		}
+	}
+	go scanStream(stdout)
+	go scanStream(stderr)
+
+	var wsURL string
+	select {
+	case r := <-urlCh:
+		if r.err != nil {
+			_ = cmd.Process.Kill()
+			return nil, fmt.Errorf("read listen line: %w", r.err)
+		}
+		wsURL = r.url
+	case <-ctx.Done():
+		_ = cmd.Process.Kill()
+		return nil, ctx.Err()
+	}
+
 	if !strings.HasPrefix(wsURL, "ws://") {
 		_ = cmd.Process.Kill()
-		return nil, fmt.Errorf("unexpected first stdout line %q", wsURL)
+		return nil, fmt.Errorf("unexpected listen line %q", wsURL)
 	}
 	httpURL := "http://" + strings.TrimPrefix(wsURL, "ws://")
-	// Drain remaining stdout in the background so the pipe doesn't fill
-	// (real codex keeps logging readyz/healthz/notes after the URL line).
-	go func() { _, _ = io.Copy(io.Discard, br) }()
+	// Both pipes are drained in background goroutines already.
 
 	deadline := time.Now().Add(5 * time.Second)
 	for {

--- a/internal/codexappgateway/supervisor/spawn.go
+++ b/internal/codexappgateway/supervisor/spawn.go
@@ -1,0 +1,101 @@
+// Package supervisor spawns and tracks per-thread `codex app-server`
+// subprocesses inside the codex-app-gateway pod.
+package supervisor
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os/exec"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// ChildHandle is what spawnCodexAppServer returns.
+type ChildHandle struct {
+	Cmd       *exec.Cmd
+	WSURL     string // ws://127.0.0.1:PORT
+	HTTPURL   string // http://127.0.0.1:PORT  (for /readyz, /healthz)
+	CodexHome string
+}
+
+// Stop sends SIGTERM, waits up to 10s, then SIGKILLs.
+func (h *ChildHandle) Stop(ctx context.Context) error {
+	if h.Cmd == nil || h.Cmd.Process == nil {
+		return nil
+	}
+	if err := h.Cmd.Process.Signal(syscall.SIGTERM); err != nil {
+		return fmt.Errorf("SIGTERM: %w", err)
+	}
+	done := make(chan error, 1)
+	go func() { done <- h.Cmd.Wait() }()
+	select {
+	case <-done:
+		return nil
+	case <-time.After(10 * time.Second):
+		_ = h.Cmd.Process.Signal(syscall.SIGKILL)
+		<-done
+		return nil
+	case <-ctx.Done():
+		_ = h.Cmd.Process.Signal(syscall.SIGKILL)
+		<-done
+		return ctx.Err()
+	}
+}
+
+// spawnCodexAppServer launches `codexBin app-server --listen ws://127.0.0.1:0`,
+// reads the listen URL from stdout, polls /readyz, and returns a handle.
+func spawnCodexAppServer(ctx context.Context, codexBin, codexHome string, extraEnv []string) (*ChildHandle, error) {
+	cmd := exec.Command(codexBin, "app-server", "--listen", "ws://127.0.0.1:0")
+	cmd.Env = append(append([]string{}, extraEnv...), "CODEX_HOME="+codexHome)
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, fmt.Errorf("stdout pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, fmt.Errorf("start: %w", err)
+	}
+	br := bufio.NewReader(stdout)
+	line, err := br.ReadString('\n')
+	if err != nil {
+		_ = cmd.Process.Kill()
+		return nil, fmt.Errorf("read listen line: %w", err)
+	}
+	wsURL := strings.TrimSpace(line)
+	if !strings.HasPrefix(wsURL, "ws://") {
+		_ = cmd.Process.Kill()
+		return nil, fmt.Errorf("unexpected first stdout line %q", wsURL)
+	}
+	httpURL := "http://" + strings.TrimPrefix(wsURL, "ws://")
+	// Drain remaining stdout in the background so the pipe doesn't fill
+	// (real codex keeps logging readyz/healthz/notes after the URL line).
+	go func() { _, _ = io.Copy(io.Discard, br) }()
+
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		req, _ := http.NewRequestWithContext(ctx, "GET", httpURL+"/readyz", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil && resp.StatusCode == 200 {
+			_ = resp.Body.Close()
+			break
+		}
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+		if time.Now().After(deadline) {
+			_ = cmd.Process.Kill()
+			return nil, fmt.Errorf("readyz never returned 200: last err=%v", err)
+		}
+		select {
+		case <-ctx.Done():
+			_ = cmd.Process.Kill()
+			return nil, ctx.Err()
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+
+	return &ChildHandle{Cmd: cmd, WSURL: wsURL, HTTPURL: httpURL, CodexHome: codexHome}, nil
+}

--- a/internal/codexappgateway/supervisor/spawn_test.go
+++ b/internal/codexappgateway/supervisor/spawn_test.go
@@ -11,10 +11,10 @@ import (
 	"time"
 )
 
-// BuildFakeCodexForTest compiles a small Go program that mimics the bits of
+// buildFakeCodex compiles a small Go program that mimics the bits of
 // `codex app-server` we depend on: print "ws://127.0.0.1:PORT" on
 // stdout, then serve /readyz on that port.
-func BuildFakeCodexForTest(t *testing.T) string {
+func buildFakeCodex(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
 	src := filepath.Join(dir, "main.go")
@@ -51,7 +51,7 @@ func main() {
 }
 
 func TestSpawnCodexAppServer_HappyPath(t *testing.T) {
-	bin := BuildFakeCodexForTest(t)
+	bin := buildFakeCodex(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	h, err := spawnCodexAppServer(ctx, bin, t.TempDir(), nil)

--- a/internal/codexappgateway/supervisor/spawn_test.go
+++ b/internal/codexappgateway/supervisor/spawn_test.go
@@ -1,0 +1,77 @@
+package supervisor
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// buildFakeCodex compiles a small Go program that mimics the bits of
+// `codex app-server` we depend on: print "ws://127.0.0.1:PORT" on
+// stdout, then serve /readyz on that port.
+func buildFakeCodex(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	src := filepath.Join(dir, "main.go")
+	const program = `package main
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+)
+
+func main() {
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil { fmt.Fprintln(os.Stderr, err); os.Exit(1) }
+	addr := l.Addr().(*net.TCPAddr)
+	fmt.Printf("ws://%s\n", addr.String())
+	http.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) { w.WriteHeader(200) })
+	_ = http.Serve(l, nil)
+}
+`
+	if err := os.WriteFile(src, []byte(program), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bin := filepath.Join(dir, "fake-codex")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
+	out, err := exec.Command("go", "build", "-o", bin, src).CombinedOutput()
+	if err != nil {
+		t.Fatalf("build fake codex: %v\n%s", err, out)
+	}
+	return bin
+}
+
+func TestSpawnCodexAppServer_HappyPath(t *testing.T) {
+	bin := buildFakeCodex(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	h, err := spawnCodexAppServer(ctx, bin, t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("spawn: %v", err)
+	}
+	defer h.Stop(context.Background())
+	if !strings.HasPrefix(h.WSURL, "ws://127.0.0.1:") {
+		t.Errorf("WSURL = %s", h.WSURL)
+	}
+	if !strings.HasPrefix(h.HTTPURL, "http://127.0.0.1:") {
+		t.Errorf("HTTPURL = %s", h.HTTPURL)
+	}
+}
+
+func TestSpawnCodexAppServer_BadBinary(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	_, err := spawnCodexAppServer(ctx, "/no/such/binary", t.TempDir(), nil)
+	if err == nil {
+		t.Fatal("want spawn error")
+	}
+}

--- a/internal/codexappgateway/supervisor/supervisor.go
+++ b/internal/codexappgateway/supervisor/supervisor.go
@@ -49,15 +49,32 @@ func NewSupervisor(cfg SupervisorConfig) *Supervisor {
 // EnsureSubprocess returns a live ChildHandle for key, spawning one if
 // necessary. Concurrent EnsureSubprocess calls for the same key see
 // the same handle (one-spawn-per-key invariant; loser of the race
-// discards their spawn).
+// discards their spawn). If a cached entry's subprocess has crashed,
+// it is evicted and a fresh subprocess is spawned.
 func (s *Supervisor) EnsureSubprocess(ctx context.Context, key Key, build ConfigBuilder) (*ChildHandle, error) {
 	s.mu.Lock()
 	if e, ok := s.children[key]; ok {
-		e.lastActive = time.Now()
+		if e.handle.IsAlive() {
+			e.lastActive = time.Now()
+			s.mu.Unlock()
+			return e.handle, nil
+		}
+		// Subprocess crashed since the entry was last seen. Drop it; we'll
+		// respawn below. Try to upload its CODEX_HOME state first so the
+		// freshly-spawned successor can resume from where the dead one
+		// left off (sqlite WAL may still be flushable).
+		deadHome := e.codexHome
+		delete(s.children, key)
 		s.mu.Unlock()
-		return e.handle, nil
+		backend := codexhome.NewS3Backend(s.cfg.Store, key.WorkspaceID, key.ThreadID)
+		// Best-effort: ignore upload error here — the dead-process cleanup
+		// path can't usefully retry, and we'd rather respawn than block.
+		_ = backend.Upload(ctx, deadHome)
+		_ = s.cfg.HomeMgr.RemoveTmpDir(deadHome)
+		// Fall through to the spawn path below.
+	} else {
+		s.mu.Unlock()
 	}
-	s.mu.Unlock()
 
 	cfg, err := build()
 	if err != nil {
@@ -84,20 +101,34 @@ func (s *Supervisor) EnsureSubprocess(ctx context.Context, key Key, build Config
 	}
 
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	if e, ok := s.children[key]; ok {
 		// Lost the race; discard our spawn and return theirs.
-		_ = handle.Stop(ctx)
-		_ = s.cfg.HomeMgr.RemoveTmpDir(codexHome)
 		e.lastActive = time.Now()
-		return e.handle, nil
+		winner := e.handle
+		s.mu.Unlock()
+		// Clean up our discarded spawn out-of-band so the lock isn't held
+		// during the SIGTERM→SIGKILL window.
+		go func() {
+			if err := handle.Stop(context.Background()); err != nil {
+				// Batch B adds the logger; until then, swallow with a defensive
+				// no-op + a comment noting the discarded error.
+				_ = err
+			}
+			if err := s.cfg.HomeMgr.RemoveTmpDir(codexHome); err != nil {
+				_ = err
+			}
+		}()
+		return winner, nil
 	}
 	s.children[key] = &entry{handle: handle, codexHome: codexHome, lastActive: time.Now()}
+	s.mu.Unlock()
 	return handle, nil
 }
 
-// Touch bumps the last-active timestamp for a key. Called by the proxy
-// pump on every frame so the reaper sees fresh activity.
+// Touch bumps the last-active timestamp for a key. Callers must invoke
+// it on every proxied frame (see proxy.RunProxy's onFrame callback) so
+// the IdleReaper sees fresh activity for the duration of an active
+// session, not just at connect/disconnect.
 func (s *Supervisor) Touch(key Key) {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/internal/codexappgateway/supervisor/supervisor.go
+++ b/internal/codexappgateway/supervisor/supervisor.go
@@ -120,12 +120,13 @@ func (s *Supervisor) Shutdown(ctx context.Context, key Key) error {
 
 	// Continue uploading even if Stop errors — flushed sqlite is still useful.
 	_ = e.handle.Stop(ctx)
+	// Always reclaim disk before returning, even if S3 upload fails.
+	// (S3 upload failure is transient; leaking the tmpdir would compound on
+	// long-running pods with intermittent S3 connectivity.)
+	defer func() { _ = s.cfg.HomeMgr.RemoveTmpDir(e.codexHome) }()
 	backend := codexhome.NewS3Backend(s.cfg.Store, key.WorkspaceID, key.ThreadID)
 	if err := backend.Upload(ctx, e.codexHome); err != nil {
 		return fmt.Errorf("S3 upload: %w", err)
-	}
-	if err := s.cfg.HomeMgr.RemoveTmpDir(e.codexHome); err != nil {
-		return fmt.Errorf("remove tmpdir: %w", err)
 	}
 	return nil
 }

--- a/internal/codexappgateway/supervisor/supervisor.go
+++ b/internal/codexappgateway/supervisor/supervisor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"sync"
 	"time"
 
@@ -21,12 +22,14 @@ type SupervisorConfig struct {
 	CodexBin string
 	HomeMgr  *codexhome.Manager
 	Store    codexhome.ObjectStore
-	ExtraEnv []string // forwarded to every spawned subprocess
+	ExtraEnv []string     // forwarded to every spawned subprocess
+	Logger   *slog.Logger // defaults to slog.Default() if nil
 }
 
 // Supervisor owns the in-memory (workspace, thread) → subprocess map.
 type Supervisor struct {
-	cfg SupervisorConfig
+	cfg    SupervisorConfig
+	logger *slog.Logger
 
 	mu       sync.Mutex
 	children map[Key]*entry
@@ -43,7 +46,11 @@ type entry struct {
 type ConfigBuilder func() (codexhome.ConfigInput, error)
 
 func NewSupervisor(cfg SupervisorConfig) *Supervisor {
-	return &Supervisor{cfg: cfg, children: map[Key]*entry{}}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Supervisor{cfg: cfg, logger: logger, children: map[Key]*entry{}}
 }
 
 // EnsureSubprocess returns a live ChildHandle for key, spawning one if
@@ -69,8 +76,12 @@ func (s *Supervisor) EnsureSubprocess(ctx context.Context, key Key, build Config
 		backend := codexhome.NewS3Backend(s.cfg.Store, key.WorkspaceID, key.ThreadID)
 		// Best-effort: ignore upload error here — the dead-process cleanup
 		// path can't usefully retry, and we'd rather respawn than block.
-		_ = backend.Upload(ctx, deadHome)
-		_ = s.cfg.HomeMgr.RemoveTmpDir(deadHome)
+		if err := backend.Upload(ctx, deadHome); err != nil {
+			s.logger.Warn("dead-subprocess CODEX_HOME upload failed", "key", key, "err", err)
+		}
+		if err := s.cfg.HomeMgr.RemoveTmpDir(deadHome); err != nil {
+			s.logger.Warn("dead-subprocess tmpdir cleanup failed", "key", key, "err", err)
+		}
 		// Fall through to the spawn path below.
 	} else {
 		s.mu.Unlock()
@@ -110,12 +121,10 @@ func (s *Supervisor) EnsureSubprocess(ctx context.Context, key Key, build Config
 		// during the SIGTERM→SIGKILL window.
 		go func() {
 			if err := handle.Stop(context.Background()); err != nil {
-				// Batch B adds the logger; until then, swallow with a defensive
-				// no-op + a comment noting the discarded error.
-				_ = err
+				s.logger.Warn("race-loser subprocess stop failed", "key", key, "err", err)
 			}
 			if err := s.cfg.HomeMgr.RemoveTmpDir(codexHome); err != nil {
-				_ = err
+				s.logger.Warn("race-loser tmpdir cleanup failed", "key", key, "err", err)
 			}
 		}()
 		return winner, nil
@@ -150,11 +159,17 @@ func (s *Supervisor) Shutdown(ctx context.Context, key Key) error {
 	s.mu.Unlock()
 
 	// Continue uploading even if Stop errors — flushed sqlite is still useful.
-	_ = e.handle.Stop(ctx)
+	if err := e.handle.Stop(ctx); err != nil {
+		s.logger.Warn("subprocess stop failed", "key", key, "err", err)
+	}
 	// Always reclaim disk before returning, even if S3 upload fails.
 	// (S3 upload failure is transient; leaking the tmpdir would compound on
 	// long-running pods with intermittent S3 connectivity.)
-	defer func() { _ = s.cfg.HomeMgr.RemoveTmpDir(e.codexHome) }()
+	defer func() {
+		if err := s.cfg.HomeMgr.RemoveTmpDir(e.codexHome); err != nil {
+			s.logger.Warn("tmpdir cleanup failed", "key", key, "err", err)
+		}
+	}()
 	backend := codexhome.NewS3Backend(s.cfg.Store, key.WorkspaceID, key.ThreadID)
 	if err := backend.Upload(ctx, e.codexHome); err != nil {
 		return fmt.Errorf("S3 upload: %w", err)
@@ -171,7 +186,9 @@ func (s *Supervisor) ShutdownAll(ctx context.Context) {
 	}
 	s.mu.Unlock()
 	for _, k := range keys {
-		_ = s.Shutdown(ctx, k)
+		if err := s.Shutdown(ctx, k); err != nil {
+			s.logger.Error("ShutdownAll: subprocess shutdown failed (CODEX_HOME may not be saved to S3)", "key", k, "err", err)
+		}
 	}
 }
 

--- a/internal/codexappgateway/supervisor/supervisor.go
+++ b/internal/codexappgateway/supervisor/supervisor.go
@@ -1,0 +1,155 @@
+package supervisor
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/agentserver/agentserver/internal/codexappgateway/codexhome"
+)
+
+// Key identifies one (workspace, thread) subprocess slot.
+type Key struct {
+	WorkspaceID string
+	ThreadID    string
+}
+
+// SupervisorConfig holds the static dependencies.
+type SupervisorConfig struct {
+	CodexBin string
+	HomeMgr  *codexhome.Manager
+	Store    codexhome.ObjectStore
+	ExtraEnv []string // forwarded to every spawned subprocess
+}
+
+// Supervisor owns the in-memory (workspace, thread) → subprocess map.
+type Supervisor struct {
+	cfg SupervisorConfig
+
+	mu       sync.Mutex
+	children map[Key]*entry
+}
+
+type entry struct {
+	handle     *ChildHandle
+	codexHome  string
+	lastActive time.Time
+}
+
+// ConfigBuilder produces a fresh ConfigInput at spawn time. Allowed to
+// hit the network; errors propagate.
+type ConfigBuilder func() (codexhome.ConfigInput, error)
+
+func NewSupervisor(cfg SupervisorConfig) *Supervisor {
+	return &Supervisor{cfg: cfg, children: map[Key]*entry{}}
+}
+
+// EnsureSubprocess returns a live ChildHandle for key, spawning one if
+// necessary. Concurrent EnsureSubprocess calls for the same key see
+// the same handle (one-spawn-per-key invariant; loser of the race
+// discards their spawn).
+func (s *Supervisor) EnsureSubprocess(ctx context.Context, key Key, build ConfigBuilder) (*ChildHandle, error) {
+	s.mu.Lock()
+	if e, ok := s.children[key]; ok {
+		e.lastActive = time.Now()
+		s.mu.Unlock()
+		return e.handle, nil
+	}
+	s.mu.Unlock()
+
+	cfg, err := build()
+	if err != nil {
+		return nil, fmt.Errorf("config builder: %w", err)
+	}
+	codexHome, err := s.cfg.HomeMgr.NewTmpDir(key.WorkspaceID, key.ThreadID)
+	if err != nil {
+		return nil, fmt.Errorf("new tmpdir: %w", err)
+	}
+	backend := codexhome.NewS3Backend(s.cfg.Store, key.WorkspaceID, key.ThreadID)
+	if err := backend.Download(ctx, codexHome); err != nil && !errors.Is(err, codexhome.ErrObjectNotFound) {
+		_ = s.cfg.HomeMgr.RemoveTmpDir(codexHome)
+		return nil, fmt.Errorf("S3 download: %w", err)
+	}
+	if err := s.cfg.HomeMgr.WriteConfig(codexHome, cfg); err != nil {
+		_ = s.cfg.HomeMgr.RemoveTmpDir(codexHome)
+		return nil, fmt.Errorf("write config: %w", err)
+	}
+
+	handle, err := spawnCodexAppServer(ctx, s.cfg.CodexBin, codexHome, s.cfg.ExtraEnv)
+	if err != nil {
+		_ = s.cfg.HomeMgr.RemoveTmpDir(codexHome)
+		return nil, fmt.Errorf("spawn: %w", err)
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if e, ok := s.children[key]; ok {
+		// Lost the race; discard our spawn and return theirs.
+		_ = handle.Stop(ctx)
+		_ = s.cfg.HomeMgr.RemoveTmpDir(codexHome)
+		e.lastActive = time.Now()
+		return e.handle, nil
+	}
+	s.children[key] = &entry{handle: handle, codexHome: codexHome, lastActive: time.Now()}
+	return handle, nil
+}
+
+// Touch bumps the last-active timestamp for a key. Called by the proxy
+// pump on every frame so the reaper sees fresh activity.
+func (s *Supervisor) Touch(key Key) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if e, ok := s.children[key]; ok {
+		e.lastActive = time.Now()
+	}
+}
+
+// Shutdown terminates the subprocess for key, uploads its CODEX_HOME to
+// S3, and drops the in-memory entry. Safe on missing keys.
+func (s *Supervisor) Shutdown(ctx context.Context, key Key) error {
+	s.mu.Lock()
+	e, ok := s.children[key]
+	if !ok {
+		s.mu.Unlock()
+		return nil
+	}
+	delete(s.children, key)
+	s.mu.Unlock()
+
+	// Continue uploading even if Stop errors — flushed sqlite is still useful.
+	_ = e.handle.Stop(ctx)
+	backend := codexhome.NewS3Backend(s.cfg.Store, key.WorkspaceID, key.ThreadID)
+	if err := backend.Upload(ctx, e.codexHome); err != nil {
+		return fmt.Errorf("S3 upload: %w", err)
+	}
+	if err := s.cfg.HomeMgr.RemoveTmpDir(e.codexHome); err != nil {
+		return fmt.Errorf("remove tmpdir: %w", err)
+	}
+	return nil
+}
+
+// ShutdownAll shuts down every active subprocess.
+func (s *Supervisor) ShutdownAll(ctx context.Context) {
+	s.mu.Lock()
+	keys := make([]Key, 0, len(s.children))
+	for k := range s.children {
+		keys = append(keys, k)
+	}
+	s.mu.Unlock()
+	for _, k := range keys {
+		_ = s.Shutdown(ctx, k)
+	}
+}
+
+// snapshot returns the keys + last-active times. Used by the reaper.
+func (s *Supervisor) snapshot() map[Key]time.Time {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make(map[Key]time.Time, len(s.children))
+	for k, e := range s.children {
+		out[k] = e.lastActive
+	}
+	return out
+}

--- a/internal/codexappgateway/supervisor/supervisor_test.go
+++ b/internal/codexappgateway/supervisor/supervisor_test.go
@@ -164,6 +164,46 @@ func TestSupervisor_Ensure_BuildError_PropagatesAndDoesNotSpawn(t *testing.T) {
 	}
 }
 
+func TestSupervisor_EnsureSubprocess_RespawnsAfterCrash(t *testing.T) {
+	bin := buildFakeCodex(t)
+	root := t.TempDir()
+	store := newFakeStore()
+	mgr := codexhome.NewManager(root)
+	sup := NewSupervisor(SupervisorConfig{CodexBin: bin, HomeMgr: mgr, Store: store})
+	defer sup.ShutdownAll(context.Background())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	build := func() (codexhome.ConfigInput, error) { return defaultConfigInput(), nil }
+	key := Key{WorkspaceID: "ws_a", ThreadID: "thr_crash"}
+
+	h1, err := sup.EnsureSubprocess(ctx, key, build)
+	if err != nil {
+		t.Fatalf("ensure 1: %v", err)
+	}
+	// Simulate crash: SIGKILL the fake-codex process.
+	if err := h1.cmd.Process.Kill(); err != nil {
+		t.Fatalf("kill: %v", err)
+	}
+	// Wait for the done channel to close (the wait goroutine in spawn.go
+	// observes the exit and closes done).
+	<-h1.Done()
+	if h1.IsAlive() {
+		t.Fatal("IsAlive returned true after kill+Done")
+	}
+
+	h2, err := sup.EnsureSubprocess(ctx, key, build)
+	if err != nil {
+		t.Fatalf("ensure 2 (after crash): %v", err)
+	}
+	if h1.WSURL == h2.WSURL {
+		t.Errorf("expected fresh subprocess, got same URL %s", h1.WSURL)
+	}
+	if !h2.IsAlive() {
+		t.Error("respawned handle should be alive")
+	}
+}
+
 func keysOf(m map[string][]byte) []string {
 	var ks []string
 	for k := range m {

--- a/internal/codexappgateway/supervisor/supervisor_test.go
+++ b/internal/codexappgateway/supervisor/supervisor_test.go
@@ -19,10 +19,6 @@ type fakeStore struct {
 
 func newFakeStore() *fakeStore { return &fakeStore{m: map[string][]byte{}} }
 
-// NewFakeStoreForTest is the exported wrapper used by other test packages.
-func NewFakeStoreForTest(_ *testing.T) codexhome.ObjectStore {
-	return newFakeStore()
-}
 func (f *fakeStore) Put(_ context.Context, k string, d []byte) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -54,7 +50,7 @@ func defaultConfigInput() codexhome.ConfigInput {
 }
 
 func TestSupervisor_EnsureSubprocess_SpawnsOnce(t *testing.T) {
-	bin := BuildFakeCodexForTest(t)
+	bin := buildFakeCodex(t)
 	root := t.TempDir()
 	store := newFakeStore()
 	mgr := codexhome.NewManager(root)
@@ -84,7 +80,7 @@ func TestSupervisor_EnsureSubprocess_SpawnsOnce(t *testing.T) {
 }
 
 func TestSupervisor_Shutdown_UploadsToS3(t *testing.T) {
-	bin := BuildFakeCodexForTest(t)
+	bin := buildFakeCodex(t)
 	root := t.TempDir()
 	store := newFakeStore()
 	mgr := codexhome.NewManager(root)
@@ -115,7 +111,7 @@ func TestSupervisor_Shutdown_UploadsToS3(t *testing.T) {
 }
 
 func TestSupervisor_EnsureSubprocess_RestoresFromS3(t *testing.T) {
-	bin := BuildFakeCodexForTest(t)
+	bin := buildFakeCodex(t)
 	store := newFakeStore()
 
 	{
@@ -152,7 +148,7 @@ func TestSupervisor_EnsureSubprocess_RestoresFromS3(t *testing.T) {
 }
 
 func TestSupervisor_Ensure_BuildError_PropagatesAndDoesNotSpawn(t *testing.T) {
-	bin := BuildFakeCodexForTest(t)
+	bin := buildFakeCodex(t)
 	root := t.TempDir()
 	store := newFakeStore()
 	mgr := codexhome.NewManager(root)

--- a/internal/codexappgateway/supervisor/supervisor_test.go
+++ b/internal/codexappgateway/supervisor/supervisor_test.go
@@ -18,6 +18,11 @@ type fakeStore struct {
 }
 
 func newFakeStore() *fakeStore { return &fakeStore{m: map[string][]byte{}} }
+
+// NewFakeStoreForTest is the exported wrapper used by other test packages.
+func NewFakeStoreForTest(_ *testing.T) codexhome.ObjectStore {
+	return newFakeStore()
+}
 func (f *fakeStore) Put(_ context.Context, k string, d []byte) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
@@ -49,7 +54,7 @@ func defaultConfigInput() codexhome.ConfigInput {
 }
 
 func TestSupervisor_EnsureSubprocess_SpawnsOnce(t *testing.T) {
-	bin := buildFakeCodex(t)
+	bin := BuildFakeCodexForTest(t)
 	root := t.TempDir()
 	store := newFakeStore()
 	mgr := codexhome.NewManager(root)
@@ -79,7 +84,7 @@ func TestSupervisor_EnsureSubprocess_SpawnsOnce(t *testing.T) {
 }
 
 func TestSupervisor_Shutdown_UploadsToS3(t *testing.T) {
-	bin := buildFakeCodex(t)
+	bin := BuildFakeCodexForTest(t)
 	root := t.TempDir()
 	store := newFakeStore()
 	mgr := codexhome.NewManager(root)
@@ -110,7 +115,7 @@ func TestSupervisor_Shutdown_UploadsToS3(t *testing.T) {
 }
 
 func TestSupervisor_EnsureSubprocess_RestoresFromS3(t *testing.T) {
-	bin := buildFakeCodex(t)
+	bin := BuildFakeCodexForTest(t)
 	store := newFakeStore()
 
 	{
@@ -147,7 +152,7 @@ func TestSupervisor_EnsureSubprocess_RestoresFromS3(t *testing.T) {
 }
 
 func TestSupervisor_Ensure_BuildError_PropagatesAndDoesNotSpawn(t *testing.T) {
-	bin := buildFakeCodex(t)
+	bin := BuildFakeCodexForTest(t)
 	root := t.TempDir()
 	store := newFakeStore()
 	mgr := codexhome.NewManager(root)

--- a/internal/codexappgateway/supervisor/supervisor_test.go
+++ b/internal/codexappgateway/supervisor/supervisor_test.go
@@ -1,0 +1,172 @@
+package supervisor
+
+import (
+	"context"
+	"errors"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/agentserver/agentserver/internal/codexappgateway/codexhome"
+)
+
+// fakeStore implements codexhome.ObjectStore in-memory.
+type fakeStore struct {
+	mu sync.Mutex
+	m  map[string][]byte
+}
+
+func newFakeStore() *fakeStore { return &fakeStore{m: map[string][]byte{}} }
+func (f *fakeStore) Put(_ context.Context, k string, d []byte) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.m[k] = append([]byte(nil), d...)
+	return nil
+}
+func (f *fakeStore) Get(_ context.Context, k string) ([]byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	d, ok := f.m[k]
+	if !ok {
+		return nil, codexhome.ErrObjectNotFound
+	}
+	return append([]byte(nil), d...), nil
+}
+func (f *fakeStore) Delete(_ context.Context, k string) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.m, k)
+	return nil
+}
+
+func defaultConfigInput() codexhome.ConfigInput {
+	return codexhome.ConfigInput{
+		ModelProvider:  "p",
+		Model:          "m",
+		ModelProviders: map[string]codexhome.ModelProvider{"p": {Name: "p", BaseURL: "http://x", EnvKey: "K", WireAPI: "responses"}},
+	}
+}
+
+func TestSupervisor_EnsureSubprocess_SpawnsOnce(t *testing.T) {
+	bin := buildFakeCodex(t)
+	root := t.TempDir()
+	store := newFakeStore()
+	mgr := codexhome.NewManager(root)
+	sup := NewSupervisor(SupervisorConfig{
+		CodexBin: bin,
+		HomeMgr:  mgr,
+		Store:    store,
+	})
+	defer sup.ShutdownAll(context.Background())
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	build := func() (codexhome.ConfigInput, error) { return defaultConfigInput(), nil }
+	key := Key{WorkspaceID: "ws_a", ThreadID: "thr_1"}
+	h1, err := sup.EnsureSubprocess(ctx, key, build)
+	if err != nil {
+		t.Fatalf("ensure 1: %v", err)
+	}
+	h2, err := sup.EnsureSubprocess(ctx, key, build)
+	if err != nil {
+		t.Fatalf("ensure 2: %v", err)
+	}
+	if h1.WSURL != h2.WSURL {
+		t.Errorf("two ensures returned different handles: %s vs %s", h1.WSURL, h2.WSURL)
+	}
+}
+
+func TestSupervisor_Shutdown_UploadsToS3(t *testing.T) {
+	bin := buildFakeCodex(t)
+	root := t.TempDir()
+	store := newFakeStore()
+	mgr := codexhome.NewManager(root)
+	sup := NewSupervisor(SupervisorConfig{CodexBin: bin, HomeMgr: mgr, Store: store})
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	build := func() (codexhome.ConfigInput, error) { return defaultConfigInput(), nil }
+	key := Key{WorkspaceID: "ws_a", ThreadID: "thr_1"}
+	h, err := sup.EnsureSubprocess(ctx, key, build)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(h.CodexHome+"/sessions", 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(h.CodexHome+"/sessions/x.jsonl", []byte("ok"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := sup.Shutdown(ctx, key); err != nil {
+		t.Fatalf("shutdown: %v", err)
+	}
+	wantKey := "codex-app-gateway/ws_a/thr_1.tar.gz"
+	if _, ok := store.m[wantKey]; !ok {
+		t.Fatalf("no S3 object at %s; have: %v", wantKey, keysOf(store.m))
+	}
+}
+
+func TestSupervisor_EnsureSubprocess_RestoresFromS3(t *testing.T) {
+	bin := buildFakeCodex(t)
+	store := newFakeStore()
+
+	{
+		mgr := codexhome.NewManager(t.TempDir())
+		sup := NewSupervisor(SupervisorConfig{CodexBin: bin, HomeMgr: mgr, Store: store})
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		build := func() (codexhome.ConfigInput, error) { return defaultConfigInput(), nil }
+		key := Key{WorkspaceID: "ws_a", ThreadID: "thr_1"}
+		h, err := sup.EnsureSubprocess(ctx, key, build)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = os.WriteFile(h.CodexHome+"/marker.txt", []byte("from-pass-1"), 0o600)
+		_ = sup.Shutdown(ctx, key)
+	}
+
+	sup2 := NewSupervisor(SupervisorConfig{CodexBin: bin, HomeMgr: codexhome.NewManager(t.TempDir()), Store: store})
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	build := func() (codexhome.ConfigInput, error) { return defaultConfigInput(), nil }
+	h, err := sup2.EnsureSubprocess(ctx, Key{WorkspaceID: "ws_a", ThreadID: "thr_1"}, build)
+	if err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	defer sup2.ShutdownAll(context.Background())
+	got, err := os.ReadFile(h.CodexHome + "/marker.txt")
+	if err != nil {
+		t.Fatalf("marker: %v", err)
+	}
+	if string(got) != "from-pass-1" {
+		t.Errorf("marker = %q", got)
+	}
+}
+
+func TestSupervisor_Ensure_BuildError_PropagatesAndDoesNotSpawn(t *testing.T) {
+	bin := buildFakeCodex(t)
+	root := t.TempDir()
+	store := newFakeStore()
+	mgr := codexhome.NewManager(root)
+	sup := NewSupervisor(SupervisorConfig{CodexBin: bin, HomeMgr: mgr, Store: store})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	wantErr := errors.New("nope")
+	_, err := sup.EnsureSubprocess(ctx, Key{WorkspaceID: "ws_a", ThreadID: "thr_1"}, func() (codexhome.ConfigInput, error) {
+		return codexhome.ConfigInput{}, wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("want wantErr, got %v", err)
+	}
+}
+
+func keysOf(m map[string][]byte) []string {
+	var ks []string
+	for k := range m {
+		ks = append(ks, k)
+	}
+	return ks
+}


### PR DESCRIPTION
**Stacked on top of #78** (env-mcp). Merging #78 first will auto-rebase this PR's base to \`main\`.

## Summary

Implements Subsystem 2 of the codex gateway: codex-app-gateway as a thin auth-proxy + per-thread \`codex app-server\` subprocess manager + transparent ws frame proxy. Replaces the now-superseded "hand-write 17 v2 RPCs in Go" approach with "spawn upstream \`codex app-server\` per thread, byte-for-byte forward ws frames between the user's TUI and the subprocess".

- New: \`internal/codexappgateway/{auth,codexhome,supervisor,proxy}/\` packages + \`server.go\` + \`s3_store.go\`.
- Modified: \`cmd/codex-app-gateway/main.go\` (wires \`serve\` subcommand previously stubbed in #78).
- 57 unit tests + 1 integration test against real \`codex\` 0.130.0; race-clean, vet-clean.

## Spec / Plan

- Spec: \`docs/superpowers/specs/2026-05-10-codex-app-gateway-subprocess.md\` (refines Subsystem 2 of \`2026-05-10-codex-gateway-mcp-rewrite.md\`).
- Plan: \`docs/superpowers/plans/2026-05-11-codex-app-gateway-subprocess.md\` — 9 TDD tasks, all complete.

Two real-world wire-protocol issues caught by the integration test:
- \`af90b6a\` — disable \`permessage-deflate\` on subprocess ws dial (codex closes deflate-requesting peers).
- \`611f138\` — scan **both** stdout and stderr for the \`ws://\` listen URL (real codex banner spans both streams; PoC #2 only saw stdout because the fake codex was simpler).

## Test Plan

- [x] \`go test ./internal/codexappgateway/... ./cmd/codex-app-gateway/\` — 57/57 PASS, all 7 packages
- [x] \`go test -race ./internal/codexappgateway/...\` — clean
- [x] \`go test -tags integration -run TestServer_RealCodexAppServer ./internal/codexappgateway/\` — PASS against codex 0.130.0 (full \`initialize → thread/start\` round-trip via the gateway proxy)
- [x] \`go vet ./...\` — clean
- [x] Smoke: \`codex-app-gateway serve --help\` exits 0 with usage block; missing required CXG_* env vars exits 2 with the specific missing var named
- [ ] Reviewer: confirm the 4 final-review fixes (\`c24a84e\`) match the reviewer's intent — tmpdir-leak-on-S3-fail, dotted-ID auth parsing, dead test exports removed, admin-restart auth model documented.
- [ ] Reviewer: confirm the phase-1 \`buildConfig\` stub (in \`server.go\` \`NewServer\`) is acceptable — currently returns a hardcoded model+provider with no executors; the real exec-gateway-fetch + per-turn cap-token mint lands in a follow-up task that depends on Subsystem 3 being implemented.

## Notes for the reviewer

- All 12 commits preserved as separate units (9 task commits + 2 wire-protocol fixes from integration testing + 1 final-review-fixes commit). Squash or rebase at your discretion before landing.
- Stacked on #78 — both branches need to land before this code reaches \`main\`. Merging #78 first will GitHub-auto-rebase this PR's base.