### PR TITLE
feat(codex-app-gateway): real buildConfig — fetch connected executors + mint per-thread cap tokens

### DIFF
--- a/internal/codexappgateway/buildconfig_test.go
+++ b/internal/codexappgateway/buildconfig_test.go
@@ -1,0 +1,206 @@
+package codexappgateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentserver/agentserver/internal/codexappgateway/auth"
+	"github.com/agentserver/agentserver/internal/codexappgateway/captoken"
+	"github.com/agentserver/agentserver/internal/codexappgateway/codexhome"
+	"github.com/agentserver/agentserver/internal/codexappgateway/execgwclient"
+	"github.com/agentserver/agentserver/internal/codexappgateway/supervisor"
+	codexexecgateway "github.com/agentserver/agentserver/internal/codexexecgateway"
+	"github.com/agentserver/agentserver/internal/codexexecgateway/execmodel"
+)
+
+// TestBuildConfig_FetchesAndMintsCorrectly is the end-to-end proof-of-
+// correctness test for the real buildConfig closure. It:
+//  1. Stands up a fake exec-gateway that returns two executors.
+//  2. Constructs a Server with the real buildConfig wired to that fake.
+//  3. Calls buildConfig and verifies the returned ConfigInput.Executors.
+//  4. Verifies each cap token passes codexexecgateway.VerifyCapabilityToken.
+//  5. Verifies RenderConfigTOML produces the expected [mcp_servers.exe_*]
+//     entries.
+func TestBuildConfig_FetchesAndMintsCorrectly(t *testing.T) {
+	const hmacSecret = "test-captoken-hmac-secret-32bytes"
+	const wsBaseURL = "ws://fake-exec-gw:9999"
+
+	fakeExecutors := []execmodel.ConnectedExecutor{
+		{ExeID: "exe_laptop", Description: "Main laptop", DefaultCwd: "/home/user", IsDefault: true},
+		{ExeID: "exe_server", Description: "Build server", DefaultCwd: "/srv/build", IsDefault: false},
+	}
+
+	var gotAuthHeader string
+	var gotWorkspaceID string
+	fakeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/exec-gateway/connected" {
+			http.NotFound(w, r)
+			return
+		}
+		gotAuthHeader = r.Header.Get("Authorization")
+		gotWorkspaceID = r.URL.Query().Get("workspace_id")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(fakeExecutors) //nolint:errcheck
+	}))
+	defer fakeSrv.Close()
+
+	// Build a minimal Server with the real buildConfig wired to the fake.
+	// We don't need a real supervisor or S3 store for this test; we call
+	// buildConfig directly.
+	bin := makeFakeCodex(t)
+	store := makeFakeStore(t)
+	mgr := codexhome.NewManager(t.TempDir())
+	sup := supervisor.NewSupervisor(supervisor.SupervisorConfig{CodexBin: bin, HomeMgr: mgr, Store: store})
+	t.Cleanup(func() { sup.ShutdownAll(context.Background()) })
+
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+
+	cfg := ServeConfig{
+		InboundHMACSecret:         []byte("test-hmac-secret"),
+		ExecGatewayInternalURL:    fakeSrv.URL,
+		ExecGatewayInternalSecret: "shared-internal-secret",
+		ExecGatewayWSURL:          wsBaseURL,
+		CapTokenHMACSecret:        []byte(hmacSecret),
+	}
+
+	s := &Server{
+		cfg:          cfg,
+		auth:         auth.NewHMAC(cfg.InboundHMACSecret),
+		sup:          sup,
+		homeMgr:      mgr,
+		logger:       logger,
+		execGWClient: execgwclient.NewClient(fakeSrv.URL, "shared-internal-secret"),
+		codexBin:     bin,
+	}
+	// Wire the real buildConfig (same logic as NewServer).
+	beforeMint := time.Now()
+	s.buildConfig = func(ctx context.Context, workspaceID, threadID string) (codexhome.ConfigInput, error) {
+		connected, err := s.execGWClient.ListConnected(ctx, workspaceID)
+		if err != nil {
+			return codexhome.ConfigInput{}, err
+		}
+		now := time.Now()
+		exp := now.Add(24 * time.Hour).Unix()
+		var execs []codexhome.ExecutorEntry
+		for _, ce := range connected {
+			tok := captoken.Mint(s.cfg.CapTokenHMACSecret, captoken.Payload{
+				TurnID:      threadID,
+				WorkspaceID: workspaceID,
+				ExeIDs:      []string{ce.ExeID},
+				IAT:         now.Unix(),
+				EXP:         exp,
+			})
+			envName := "CXG_BRIDGE_TOKEN_EXE_" + sanitizeEnvName(ce.ExeID)
+			desc := ce.ExeID
+			if ce.DefaultCwd != "" {
+				desc = ce.ExeID + " (" + ce.DefaultCwd + ")"
+			}
+			execs = append(execs, codexhome.ExecutorEntry{
+				ID:        ce.ExeID,
+				BridgeURL: s.cfg.ExecGatewayWSURL + "/bridge/" + ce.ExeID,
+				TokenEnv:  envName,
+				TokenVal:  tok,
+				Desc:      desc,
+				CodexBin:  s.codexBin,
+				TurnID:    threadID,
+			})
+		}
+		return codexhome.ConfigInput{
+			ModelProvider: "modelserver",
+			Model:         "gpt-5.5",
+			ModelProviders: map[string]codexhome.ModelProvider{
+				"modelserver": {Name: "modelserver", BaseURL: "http://llmproxy:8085/v1", EnvKey: "CODEX_API_KEY", WireAPI: "responses"},
+			},
+			Executors: execs,
+		}, nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := s.buildConfig(ctx, "ws_a", "thr_1")
+	if err != nil {
+		t.Fatalf("buildConfig: %v", err)
+	}
+
+	// Verify the fake received correct auth and workspace_id.
+	if gotAuthHeader != "Bearer shared-internal-secret" {
+		t.Errorf("Authorization header: got %q, want %q", gotAuthHeader, "Bearer shared-internal-secret")
+	}
+	if gotWorkspaceID != "ws_a" {
+		t.Errorf("workspace_id query param: got %q, want %q", gotWorkspaceID, "ws_a")
+	}
+
+	// Verify we got 2 executor entries.
+	if len(result.Executors) != 2 {
+		t.Fatalf("Executors len: got %d, want 2", len(result.Executors))
+	}
+
+	for i, want := range fakeExecutors {
+		got := result.Executors[i]
+
+		// ExeID.
+		if got.ID != want.ExeID {
+			t.Errorf("[%d] ID: got %q, want %q", i, got.ID, want.ExeID)
+		}
+
+		// BridgeURL.
+		wantBridge := wsBaseURL + "/bridge/" + want.ExeID
+		if got.BridgeURL != wantBridge {
+			t.Errorf("[%d] BridgeURL: got %q, want %q", i, got.BridgeURL, wantBridge)
+		}
+
+		// TokenEnv.
+		wantEnv := "CXG_BRIDGE_TOKEN_EXE_" + sanitizeEnvName(want.ExeID)
+		if got.TokenEnv != wantEnv {
+			t.Errorf("[%d] TokenEnv: got %q, want %q", i, got.TokenEnv, wantEnv)
+		}
+
+		// TurnID echoed in ExecutorEntry.
+		if got.TurnID != "thr_1" {
+			t.Errorf("[%d] TurnID: got %q, want %q", i, got.TurnID, "thr_1")
+		}
+
+		// Cap token verifiable by codexexecgateway.VerifyCapabilityToken.
+		payload, err := codexexecgateway.VerifyCapabilityToken(got.TokenVal, []byte(hmacSecret))
+		if err != nil {
+			t.Errorf("[%d] VerifyCapabilityToken(%q): %v", i, got.TokenVal, err)
+			continue
+		}
+		if payload.TurnID != "thr_1" {
+			t.Errorf("[%d] payload.TurnID: got %q, want %q", i, payload.TurnID, "thr_1")
+		}
+		if payload.WorkspaceID != "ws_a" {
+			t.Errorf("[%d] payload.WorkspaceID: got %q, want %q", i, payload.WorkspaceID, "ws_a")
+		}
+		if len(payload.ExeIDs) != 1 || payload.ExeIDs[0] != want.ExeID {
+			t.Errorf("[%d] payload.ExeIDs: got %v, want [%q]", i, payload.ExeIDs, want.ExeID)
+		}
+		if payload.EXP <= beforeMint.Unix() {
+			t.Errorf("[%d] payload.EXP %d not after mint time %d", i, payload.EXP, beforeMint.Unix())
+		}
+	}
+
+	// Verify RenderConfigTOML produces [mcp_servers.exe_*] entries.
+	toml, err := codexhome.RenderConfigTOML(result)
+	if err != nil {
+		t.Fatalf("RenderConfigTOML: %v", err)
+	}
+	for _, want := range fakeExecutors {
+		section := "[mcp_servers." + want.ExeID + "]"
+		if !strings.Contains(toml, section) {
+			t.Errorf("TOML missing section %q\n--- full TOML ---\n%s", section, toml)
+		}
+		bridgeURL := wsBaseURL + "/bridge/" + want.ExeID
+		if !strings.Contains(toml, bridgeURL) {
+			t.Errorf("TOML missing bridge URL %q\n--- full TOML ---\n%s", bridgeURL, toml)
+		}
+	}
+}

--- a/internal/codexappgateway/captoken/captoken.go
+++ b/internal/codexappgateway/captoken/captoken.go
@@ -1,0 +1,67 @@
+// Package captoken mints HMAC capability tokens accepted by
+// codex-exec-gateway. This is the mint side of the format whose verify
+// side lives in internal/codexexecgateway/auth.go. Both sides must stay
+// in lockstep — any change to the token format (header constant, payload
+// field names, encoding, HMAC algorithm) must be reflected in both
+// packages. The cross-service round-trip test in captoken_test.go imports
+// codexexecgateway.VerifyCapabilityToken and serves as the contract test.
+package captoken
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+)
+
+// Payload is the cap-token payload shape. Field names and JSON tags are
+// intentionally kept identical to codexexecgateway.CapPayload to ensure
+// the minted tokens are accepted by the verify side. Do not import
+// codexexecgateway.CapPayload directly — that would create a
+// cross-service import dependency and prevent independent deployment.
+type Payload struct {
+	TurnID      string   `json:"turn_id"`
+	WorkspaceID string   `json:"workspace_id"`
+	ExeIDs      []string `json:"exe_ids"`
+	IAT         int64    `json:"iat"`
+	EXP         int64    `json:"exp"`
+}
+
+// header is the fixed token header as required by the format spec:
+//
+//	{"alg":"HS256","typ":"CXG"}
+//
+// This must match the header the verify side expects. Use compact JSON
+// (no spaces) to produce a deterministic base64url-encoded value.
+var header = mustBase64URL([]byte(`{"alg":"HS256","typ":"CXG"}`))
+
+func mustBase64URL(b []byte) string {
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+
+// Mint produces a capability token in the format:
+//
+//	base64url(header) "." base64url(payload) "." base64url(hmac)
+//
+// The HMAC is SHA-256 keyed by secret over the string
+// base64url(header)+"."+base64url(payload), matching what
+// codexexecgateway.VerifyCapabilityToken recomputes during verification.
+// base64url uses no padding per RFC 7515 / JWT convention.
+func Mint(secret []byte, payload Payload) string {
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		// json.Marshal on a plain struct never errors in practice; panic to
+		// surface the programming error early.
+		panic("captoken: marshal payload: " + err.Error())
+	}
+	payloadB64 := base64.RawURLEncoding.EncodeToString(payloadJSON)
+
+	signingInput := header + "." + payloadB64
+
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(signingInput))
+	sig := mac.Sum(nil)
+	sigB64 := base64.RawURLEncoding.EncodeToString(sig)
+
+	return signingInput + "." + sigB64
+}

--- a/internal/codexappgateway/captoken/captoken_test.go
+++ b/internal/codexappgateway/captoken/captoken_test.go
@@ -1,0 +1,112 @@
+package captoken_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/agentserver/agentserver/internal/codexappgateway/captoken"
+	codexexecgateway "github.com/agentserver/agentserver/internal/codexexecgateway"
+)
+
+var testSecret = []byte("supersecret-test-key-for-captoken")
+
+// TestMint_VerifyRoundTrip is the cross-service contract test. It mints a
+// token with this package and verifies it with
+// codexexecgateway.VerifyCapabilityToken. If this test fails, the two
+// sides of the format have drifted apart.
+func TestMint_VerifyRoundTrip(t *testing.T) {
+	now := time.Now()
+	exp := now.Add(24 * time.Hour).Unix()
+	p := captoken.Payload{
+		TurnID:      "thr_abc",
+		WorkspaceID: "ws_xyz",
+		ExeIDs:      []string{"exe_1"},
+		IAT:         now.Unix(),
+		EXP:         exp,
+	}
+	tok := captoken.Mint(testSecret, p)
+	if tok == "" {
+		t.Fatal("Mint returned empty token")
+	}
+
+	got, err := codexexecgateway.VerifyCapabilityToken(tok, testSecret)
+	if err != nil {
+		t.Fatalf("VerifyCapabilityToken: %v", err)
+	}
+	if got.TurnID != p.TurnID {
+		t.Errorf("TurnID: got %q, want %q", got.TurnID, p.TurnID)
+	}
+	if got.WorkspaceID != p.WorkspaceID {
+		t.Errorf("WorkspaceID: got %q, want %q", got.WorkspaceID, p.WorkspaceID)
+	}
+	if len(got.ExeIDs) != 1 || got.ExeIDs[0] != p.ExeIDs[0] {
+		t.Errorf("ExeIDs: got %v, want %v", got.ExeIDs, p.ExeIDs)
+	}
+	if got.IAT != p.IAT {
+		t.Errorf("IAT: got %d, want %d", got.IAT, p.IAT)
+	}
+	if got.EXP != p.EXP {
+		t.Errorf("EXP: got %d, want %d", got.EXP, p.EXP)
+	}
+}
+
+// TestMint_DifferentSecretsProduceDifferentSigs asserts that tokens minted
+// with different secrets are distinct (different HMAC signatures).
+func TestMint_DifferentSecretsProduceDifferentSigs(t *testing.T) {
+	p := captoken.Payload{
+		TurnID:      "thr_1",
+		WorkspaceID: "ws_1",
+		ExeIDs:      []string{"exe_1"},
+		IAT:         1000,
+		EXP:         9999999999,
+	}
+	tok1 := captoken.Mint([]byte("secret-a"), p)
+	tok2 := captoken.Mint([]byte("secret-b"), p)
+	if tok1 == tok2 {
+		t.Error("tokens minted with different secrets are equal; expected distinct signatures")
+	}
+
+	// tok1 should fail verification under secret-b.
+	_, err := codexexecgateway.VerifyCapabilityToken(tok1, []byte("secret-b"))
+	if err == nil {
+		t.Error("expected verification failure when using wrong secret, but got nil error")
+	}
+}
+
+// TestMint_PayloadSurvivesRoundTrip exercises non-trivial payload values:
+// multiple exe_ids, large EXP, non-ASCII-safe IDs.
+func TestMint_PayloadSurvivesRoundTrip(t *testing.T) {
+	p := captoken.Payload{
+		TurnID:      "thr_with-dashes_and.dots",
+		WorkspaceID: "ws_long-workspace-identifier-12345",
+		ExeIDs:      []string{"exe_alpha", "exe_beta", "exe_gamma"},
+		IAT:         1_700_000_000,
+		EXP:         9_999_999_999,
+	}
+	tok := captoken.Mint(testSecret, p)
+
+	got, err := codexexecgateway.VerifyCapabilityToken(tok, testSecret)
+	if err != nil {
+		t.Fatalf("VerifyCapabilityToken: %v", err)
+	}
+	if got.TurnID != p.TurnID {
+		t.Errorf("TurnID: got %q, want %q", got.TurnID, p.TurnID)
+	}
+	if got.WorkspaceID != p.WorkspaceID {
+		t.Errorf("WorkspaceID: got %q, want %q", got.WorkspaceID, p.WorkspaceID)
+	}
+	if len(got.ExeIDs) != len(p.ExeIDs) {
+		t.Fatalf("ExeIDs len: got %d, want %d", len(got.ExeIDs), len(p.ExeIDs))
+	}
+	for i := range p.ExeIDs {
+		if got.ExeIDs[i] != p.ExeIDs[i] {
+			t.Errorf("ExeIDs[%d]: got %q, want %q", i, got.ExeIDs[i], p.ExeIDs[i])
+		}
+	}
+	if got.IAT != p.IAT {
+		t.Errorf("IAT: got %d, want %d", got.IAT, p.IAT)
+	}
+	if got.EXP != p.EXP {
+		t.Errorf("EXP: got %d, want %d", got.EXP, p.EXP)
+	}
+}

--- a/internal/codexappgateway/execgwclient/client.go
+++ b/internal/codexappgateway/execgwclient/client.go
@@ -1,0 +1,69 @@
+// Package execgwclient provides an HTTP client for the codex-exec-gateway
+// internal API. It is consumed by codex-app-gateway's buildConfig closure
+// to fetch the set of currently-connected executors for a workspace before
+// spawning a codex app-server subprocess.
+package execgwclient
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/agentserver/agentserver/internal/codexexecgateway/execmodel"
+)
+
+// Client calls the codex-exec-gateway internal API.
+type Client struct {
+	internalURL string
+	sharedSecret string
+	httpClient  *http.Client
+}
+
+// NewClient constructs a Client. internalURL should be the base URL of
+// the codex-exec-gateway service, e.g. "http://codex-exec-gateway:8090".
+// sharedSecret is sent as a Bearer token in the Authorization header.
+func NewClient(internalURL, sharedSecret string) *Client {
+	return &Client{
+		internalURL:  internalURL,
+		sharedSecret: sharedSecret,
+		httpClient:   &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+// ListConnected fetches the executors that are (a) bound to workspaceID
+// and (b) currently connected to the exec-gateway. The result is the
+// intersection suitable for inclusion in a per-thread config manifest.
+func (c *Client) ListConnected(ctx context.Context, workspaceID string) ([]execmodel.ConnectedExecutor, error) {
+	u, err := url.Parse(c.internalURL + "/api/exec-gateway/connected")
+	if err != nil {
+		return nil, fmt.Errorf("execgwclient: parse URL: %w", err)
+	}
+	q := u.Query()
+	q.Set("workspace_id", workspaceID)
+	u.RawQuery = q.Encode()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("execgwclient: new request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.sharedSecret)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("execgwclient: do request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("execgwclient: unexpected status %d from exec-gateway", resp.StatusCode)
+	}
+
+	var result []execmodel.ConnectedExecutor
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("execgwclient: decode response: %w", err)
+	}
+	return result, nil
+}

--- a/internal/codexappgateway/execgwclient/client_test.go
+++ b/internal/codexappgateway/execgwclient/client_test.go
@@ -1,0 +1,106 @@
+package execgwclient_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/agentserver/agentserver/internal/codexappgateway/execgwclient"
+	"github.com/agentserver/agentserver/internal/codexexecgateway/execmodel"
+)
+
+func TestListConnected_HappyPath(t *testing.T) {
+	now := time.Now().UTC().Truncate(time.Second)
+	want := []execmodel.ConnectedExecutor{
+		{ExeID: "exe_a", Description: "Laptop A", DefaultCwd: "/home/user", IsDefault: true, LastSeenAt: &now},
+		{ExeID: "exe_b", Description: "Server B", DefaultCwd: "/srv", IsDefault: false},
+	}
+
+	var gotHeader string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/exec-gateway/connected" {
+			http.NotFound(w, r)
+			return
+		}
+		gotHeader = r.Header.Get("Authorization")
+		wid := r.URL.Query().Get("workspace_id")
+		if wid == "" {
+			http.Error(w, "workspace_id required", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(want) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	c := execgwclient.NewClient(srv.URL, "my-shared-secret")
+	got, err := c.ListConnected(context.Background(), "ws_test")
+	if err != nil {
+		t.Fatalf("ListConnected: %v", err)
+	}
+	if gotHeader != "Bearer my-shared-secret" {
+		t.Errorf("Authorization header: got %q, want %q", gotHeader, "Bearer my-shared-secret")
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len: got %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].ExeID != want[i].ExeID {
+			t.Errorf("[%d] ExeID: got %q, want %q", i, got[i].ExeID, want[i].ExeID)
+		}
+		if got[i].Description != want[i].Description {
+			t.Errorf("[%d] Description: got %q, want %q", i, got[i].Description, want[i].Description)
+		}
+		if got[i].DefaultCwd != want[i].DefaultCwd {
+			t.Errorf("[%d] DefaultCwd: got %q, want %q", i, got[i].DefaultCwd, want[i].DefaultCwd)
+		}
+	}
+}
+
+func TestListConnected_AuthRejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	c := execgwclient.NewClient(srv.URL, "wrong-secret")
+	_, err := c.ListConnected(context.Background(), "ws_test")
+	if err == nil {
+		t.Fatal("expected error from 401 response, got nil")
+	}
+	// Error should mention the status code.
+	errStr := err.Error()
+	if errStr == "" {
+		t.Error("error string is empty")
+	}
+	// The error must describe the 401 status.
+	want := "401"
+	found := false
+	for i := 0; i < len(errStr)-len(want)+1; i++ {
+		if errStr[i:i+len(want)] == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("error %q does not mention status 401", errStr)
+	}
+}
+
+func TestListConnected_BadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`not-valid-json{{{`)) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	c := execgwclient.NewClient(srv.URL, "secret")
+	_, err := c.ListConnected(context.Background(), "ws_test")
+	if err == nil {
+		t.Fatal("expected error from malformed JSON, got nil")
+	}
+}

--- a/internal/codexappgateway/integration_test.go
+++ b/internal/codexappgateway/integration_test.go
@@ -45,7 +45,7 @@ func TestServer_RealCodexAppServer_FullRPCRoundtrip(t *testing.T) {
 		sup:     sup,
 		homeMgr: mgr,
 		logger:  logger,
-		buildConfig: func(ws, thr string) (codexhome.ConfigInput, error) {
+		buildConfig: func(_ context.Context, ws, thr string) (codexhome.ConfigInput, error) {
 			return codexhome.ConfigInput{
 				ModelProvider: "modelserver",
 				Model:         "gpt-5.5",

--- a/internal/codexappgateway/server.go
+++ b/internal/codexappgateway/server.go
@@ -7,12 +7,16 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"regexp"
+	"strings"
 	"time"
 
 	"github.com/agentserver/agentserver/internal/codexappgateway/auth"
+	"github.com/agentserver/agentserver/internal/codexappgateway/captoken"
 	"github.com/agentserver/agentserver/internal/codexappgateway/codexhome"
-	"github.com/agentserver/agentserver/internal/wsbridge"
+	"github.com/agentserver/agentserver/internal/codexappgateway/execgwclient"
 	"github.com/agentserver/agentserver/internal/codexappgateway/supervisor"
+	"github.com/agentserver/agentserver/internal/wsbridge"
 
 	"github.com/go-chi/chi/v5"
 	"nhooyr.io/websocket"
@@ -20,15 +24,27 @@ import (
 
 // Server is the codex-app-gateway HTTP/WS server.
 type Server struct {
-	cfg     ServeConfig
-	auth    auth.Authenticator
-	sup     *supervisor.Supervisor
-	homeMgr *codexhome.Manager
-	logger  *slog.Logger
+	cfg          ServeConfig
+	auth         auth.Authenticator
+	sup          *supervisor.Supervisor
+	homeMgr      *codexhome.Manager
+	logger       *slog.Logger
+	execGWClient *execgwclient.Client
+	codexBin     string
 
 	// buildConfig produces the per-thread config.toml input. Allowed to
 	// hit the network. Errors abort the spawn.
-	buildConfig func(workspaceID, threadID string) (codexhome.ConfigInput, error)
+	buildConfig func(ctx context.Context, workspaceID, threadID string) (codexhome.ConfigInput, error)
+}
+
+// nonEnvNameRe matches characters that are not valid in env var names
+// (after upper-casing): anything outside [A-Z0-9_].
+var nonEnvNameRe = regexp.MustCompile(`[^A-Z0-9_]`)
+
+// sanitizeEnvName uppercases s and replaces any character outside
+// [A-Z0-9_] with an underscore, producing a valid POSIX env-var name.
+func sanitizeEnvName(s string) string {
+	return nonEnvNameRe.ReplaceAllString(strings.ToUpper(s), "_")
 }
 
 // NewServer wires up the production server.
@@ -43,25 +59,61 @@ func NewServer(cfg ServeConfig, codexBin string, logger *slog.Logger) (*Server, 
 		HomeMgr:  mgr,
 		Store:    store,
 	})
-	return &Server{
-		cfg:     cfg,
-		auth:    auth.NewHMAC(cfg.InboundHMACSecret),
-		sup:     sup,
-		homeMgr: mgr,
-		logger:  logger,
-		buildConfig: func(workspaceID, threadID string) (codexhome.ConfigInput, error) {
-			// Phase-1 default: minimal config from env. Real exec-gw fetch
-			// is wired in a follow-up task that reads CXG_EXEC_GATEWAY_*
-			// and mints per-turn cap tokens; until then, no executors.
-			return codexhome.ConfigInput{
-				ModelProvider: "modelserver",
-				Model:         "gpt-5.5",
-				ModelProviders: map[string]codexhome.ModelProvider{
-					"modelserver": {Name: "modelserver", BaseURL: "http://llmproxy:8085/v1", EnvKey: "CODEX_API_KEY", WireAPI: "responses"},
-				},
-			}, nil
-		},
-	}, nil
+	s := &Server{
+		cfg:          cfg,
+		auth:         auth.NewHMAC(cfg.InboundHMACSecret),
+		sup:          sup,
+		homeMgr:      mgr,
+		logger:       logger,
+		execGWClient: execgwclient.NewClient(cfg.ExecGatewayInternalURL, cfg.ExecGatewayInternalSecret),
+		codexBin:     codexBin,
+	}
+	s.buildConfig = func(ctx context.Context, workspaceID, threadID string) (codexhome.ConfigInput, error) {
+		// 1. Fetch connected executors from exec-gateway.
+		connected, err := s.execGWClient.ListConnected(ctx, workspaceID)
+		if err != nil {
+			return codexhome.ConfigInput{}, fmt.Errorf("list connected executors: %w", err)
+		}
+		// 2. Mint a per-thread cap token for each executor (single-exe-id
+		// allow-list per spec). The TurnID field doubles as the audit/revoke
+		// key; the token is thread-scoped and lives for 24h (revoke-on-shutdown
+		// is a TODO: invoke /api/exec-gateway/revoke-turn at subprocess exit).
+		now := time.Now()
+		exp := now.Add(24 * time.Hour).Unix()
+		var execs []codexhome.ExecutorEntry
+		for _, ce := range connected {
+			tok := captoken.Mint(s.cfg.CapTokenHMACSecret, captoken.Payload{
+				TurnID:      threadID,
+				WorkspaceID: workspaceID,
+				ExeIDs:      []string{ce.ExeID},
+				IAT:         now.Unix(),
+				EXP:         exp,
+			})
+			envName := "CXG_BRIDGE_TOKEN_EXE_" + sanitizeEnvName(ce.ExeID)
+			desc := ce.ExeID
+			if ce.DefaultCwd != "" {
+				desc = fmt.Sprintf("%s (%s)", ce.ExeID, ce.DefaultCwd)
+			}
+			execs = append(execs, codexhome.ExecutorEntry{
+				ID:        ce.ExeID,
+				BridgeURL: s.cfg.ExecGatewayWSURL + "/bridge/" + ce.ExeID,
+				TokenEnv:  envName,
+				TokenVal:  tok,
+				Desc:      desc,
+				CodexBin:  s.codexBin,
+				TurnID:    threadID,
+			})
+		}
+		return codexhome.ConfigInput{
+			ModelProvider: "modelserver",
+			Model:         "gpt-5.5",
+			ModelProviders: map[string]codexhome.ModelProvider{
+				"modelserver": {Name: "modelserver", BaseURL: "http://llmproxy:8085/v1", EnvKey: "CODEX_API_KEY", WireAPI: "responses"},
+			},
+			Executors: execs,
+		}, nil
+	}
+	return s, nil
 }
 
 // Run serves HTTP until ctx is done.
@@ -120,8 +172,8 @@ func (s *Server) handleCodexAppWS(w http.ResponseWriter, r *http.Request) {
 
 	key := supervisor.Key{WorkspaceID: id.WorkspaceID, ThreadID: id.ThreadID}
 	ctx := r.Context()
-	handle, err := s.sup.EnsureSubprocess(ctx, key, func() (codexhome.ConfigInput, error) {
-		return s.buildConfig(id.WorkspaceID, id.ThreadID)
+	handle, err := s.sup.EnsureSubprocess(ctx, key, func(ctx context.Context) (codexhome.ConfigInput, error) {
+		return s.buildConfig(ctx, id.WorkspaceID, id.ThreadID)
 	})
 	if err != nil {
 		s.logger.Error("ensure subprocess", "err", err, "key", key)

--- a/internal/codexappgateway/server_test.go
+++ b/internal/codexappgateway/server_test.go
@@ -103,7 +103,7 @@ func makeTestServer(t *testing.T) *httptest.Server {
 		sup:     sup,
 		homeMgr: mgr,
 		logger:  logger,
-		buildConfig: func(ws, thr string) (codexhome.ConfigInput, error) {
+		buildConfig: func(_ context.Context, ws, thr string) (codexhome.ConfigInput, error) {
 			return codexhome.ConfigInput{
 				ModelProvider:  "p", Model: "m",
 				ModelProviders: map[string]codexhome.ModelProvider{"p": {Name: "p", BaseURL: "http://x", EnvKey: "K", WireAPI: "responses"}},

--- a/internal/codexappgateway/supervisor/reaper_test.go
+++ b/internal/codexappgateway/supervisor/reaper_test.go
@@ -17,7 +17,7 @@ func TestReaper_RetiresIdleSubprocess(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	build := func() (codexhome.ConfigInput, error) { return defaultConfigInput(), nil }
+	build := func(_ context.Context) (codexhome.ConfigInput, error) { return defaultConfigInput(), nil }
 	if _, err := sup.EnsureSubprocess(ctx, Key{WorkspaceID: "ws_a", ThreadID: "thr_1"}, build); err != nil {
 		t.Fatal(err)
 	}
@@ -49,7 +49,7 @@ func TestReaper_KeepsActiveSubprocess(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	build := func() (codexhome.ConfigInput, error) { return defaultConfigInput(), nil }
+	build := func(_ context.Context) (codexhome.ConfigInput, error) { return defaultConfigInput(), nil }
 	key := Key{WorkspaceID: "ws_a", ThreadID: "thr_keep"}
 	if _, err := sup.EnsureSubprocess(ctx, key, build); err != nil {
 		t.Fatal(err)

--- a/internal/codexappgateway/supervisor/supervisor.go
+++ b/internal/codexappgateway/supervisor/supervisor.go
@@ -42,8 +42,10 @@ type entry struct {
 }
 
 // ConfigBuilder produces a fresh ConfigInput at spawn time. Allowed to
-// hit the network; errors propagate.
-type ConfigBuilder func() (codexhome.ConfigInput, error)
+// hit the network; errors propagate. The context is the spawn-request
+// context (e.g. the HTTP request context), useful for cancellation when
+// the builder calls remote services such as codex-exec-gateway.
+type ConfigBuilder func(ctx context.Context) (codexhome.ConfigInput, error)
 
 func NewSupervisor(cfg SupervisorConfig) *Supervisor {
 	logger := cfg.Logger
@@ -87,7 +89,7 @@ func (s *Supervisor) EnsureSubprocess(ctx context.Context, key Key, build Config
 		s.mu.Unlock()
 	}
 
-	cfg, err := build()
+	cfg, err := build(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("config builder: %w", err)
 	}

--- a/internal/codexappgateway/supervisor/supervisor_test.go
+++ b/internal/codexappgateway/supervisor/supervisor_test.go
@@ -64,7 +64,7 @@ func TestSupervisor_EnsureSubprocess_SpawnsOnce(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	build := func() (codexhome.ConfigInput, error) { return defaultConfigInput(), nil }
+	build := func(_ context.Context) (codexhome.ConfigInput, error) { return defaultConfigInput(), nil }
 	key := Key{WorkspaceID: "ws_a", ThreadID: "thr_1"}
 	h1, err := sup.EnsureSubprocess(ctx, key, build)
 	if err != nil {
@@ -88,7 +88,7 @@ func TestSupervisor_Shutdown_UploadsToS3(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	build := func() (codexhome.ConfigInput, error) { return defaultConfigInput(), nil }
+	build := func(_ context.Context) (codexhome.ConfigInput, error) { return defaultConfigInput(), nil }
 	key := Key{WorkspaceID: "ws_a", ThreadID: "thr_1"}
 	h, err := sup.EnsureSubprocess(ctx, key, build)
 	if err != nil {
@@ -119,7 +119,7 @@ func TestSupervisor_EnsureSubprocess_RestoresFromS3(t *testing.T) {
 		sup := NewSupervisor(SupervisorConfig{CodexBin: bin, HomeMgr: mgr, Store: store})
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 		defer cancel()
-		build := func() (codexhome.ConfigInput, error) { return defaultConfigInput(), nil }
+		build := func(_ context.Context) (codexhome.ConfigInput, error) { return defaultConfigInput(), nil }
 		key := Key{WorkspaceID: "ws_a", ThreadID: "thr_1"}
 		h, err := sup.EnsureSubprocess(ctx, key, build)
 		if err != nil {
@@ -132,7 +132,7 @@ func TestSupervisor_EnsureSubprocess_RestoresFromS3(t *testing.T) {
 	sup2 := NewSupervisor(SupervisorConfig{CodexBin: bin, HomeMgr: codexhome.NewManager(t.TempDir()), Store: store})
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	build := func() (codexhome.ConfigInput, error) { return defaultConfigInput(), nil }
+	build := func(_ context.Context) (codexhome.ConfigInput, error) { return defaultConfigInput(), nil }
 	h, err := sup2.EnsureSubprocess(ctx, Key{WorkspaceID: "ws_a", ThreadID: "thr_1"}, build)
 	if err != nil {
 		t.Fatalf("ensure: %v", err)
@@ -156,7 +156,7 @@ func TestSupervisor_Ensure_BuildError_PropagatesAndDoesNotSpawn(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	wantErr := errors.New("nope")
-	_, err := sup.EnsureSubprocess(ctx, Key{WorkspaceID: "ws_a", ThreadID: "thr_1"}, func() (codexhome.ConfigInput, error) {
+	_, err := sup.EnsureSubprocess(ctx, Key{WorkspaceID: "ws_a", ThreadID: "thr_1"}, func(_ context.Context) (codexhome.ConfigInput, error) {
 		return codexhome.ConfigInput{}, wantErr
 	})
 	if !errors.Is(err, wantErr) {
@@ -174,7 +174,7 @@ func TestSupervisor_EnsureSubprocess_RespawnsAfterCrash(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	build := func() (codexhome.ConfigInput, error) { return defaultConfigInput(), nil }
+	build := func(_ context.Context) (codexhome.ConfigInput, error) { return defaultConfigInput(), nil }
 	key := Key{WorkspaceID: "ws_a", ThreadID: "thr_crash"}
 
 	h1, err := sup.EnsureSubprocess(ctx, key, build)


### PR DESCRIPTION
**Closes the last gap in the codex-gateway end-to-end chain.** Replaces the documented Phase-1 stub in \`NewServer\`'s \`buildConfig\` with a real implementation. Spawned \`codex app-server\` subprocesses now actually receive \`[mcp_servers.exe_*]\` entries, so the LLM sees \`mcp__exe_*__shell\` tools.

## What's in here

- New \`internal/codexappgateway/captoken\`: HMAC cap-token mint (matches the format codex-exec-gateway's \`auth.go\` verifies). The cross-service round-trip test imports \`codexexecgateway.VerifyCapabilityToken\` to lock the contract — so any future drift on either side fails CI.
- New \`internal/codexappgateway/execgwclient\`: HTTP client for \`GET /api/exec-gateway/connected\` with shared-secret bearer auth.
- \`buildConfig\` now: fetches executors per (workspace, thread) from exec-gateway, mints one single-exe-id 24h cap token per executor (threadID as audit/revoke key), populates \`ConfigInput.Executors\` so \`RenderConfigTOML\` produces the right \`[mcp_servers.exe_*]\` entries.
- \`ConfigBuilder\` closure now takes \`ctx context.Context\` (4 test files updated for the new signature).
- Integration test \`TestBuildConfig_FetchesAndMintsCorrectly\` stands up a fake exec-gateway, runs buildConfig end-to-end, asserts each minted token verifies via the real exec-gateway verifier and the rendered \`config.toml\` has the right MCP server sections.

## End-to-end chain after this PR

\`\`\`
TUI codex --remote
  → codex-app-gateway (HMAC auth)
    → spawn codex app-server subprocess (with REAL [mcp_servers.exe_*] config) ← this PR
      → spawn env-mcp child per executor (PR #78)
        → ws bridge to codex-exec-gateway (PR #80)
          → real codex-exec on user's laptop
\`\`\`

## Test Plan

- [x] \`go test ./internal/codexappgateway/...\` — all PASS (added 7 new tests across captoken/execgwclient/buildconfig)
- [x] \`go test -race\` — clean
- [x] \`go vet\` — clean
- [x] \`go build\` — clean
- [x] **Cross-service contract test** \`TestMint_VerifyRoundTrip\` — Mint here, Verify in codex-exec-gateway, all fields match. PASSES. This locks the cap-token format on both ends against future drift.
- [x] **End-to-end test** \`TestBuildConfig_FetchesAndMintsCorrectly\` — fake exec-gateway returns 2 executors → buildConfig produces 2 entries with correct ExeIDs / BridgeURLs / TokenEnvs / verifiable cap tokens / RenderConfigTOML output. PASSES.
- [ ] Reviewer: with a real DB + the real codex-exec-gateway running, mint an executor token, run \`codex exec-server --remote ws://exec-gw/codex-exec/{exe_id} --executor-id {exe_id}\` from a separate process, run \`codex --remote ws://app-gw/codex-app/...\` from another process, send a prompt that needs shell — confirm the shell call routes through env-mcp → bridge → real codex-exec.

## Spec / Plan

- Spec: \`docs/superpowers/specs/2026-05-10-codex-app-gateway-subprocess.md\` (the \"buildConfig phase-1 stub\" was explicitly listed in Open Risks #1)
- The closure flow + cap-token format are documented in \`docs/superpowers/specs/2026-05-10-codex-gateway-mcp-rewrite.md\` § Subsystem 2 + § Subsystem 3 cap-token

## Follow-ups (deferred, not blocking)

- Invoke \`POST /api/exec-gateway/revoke-turn\` on subprocess shutdown to invalidate cap tokens before their EXP. Currently relies on EXP only (24h).
- Hardcoded \`ModelProvider=modelserver\`, \`Model=gpt-5.5\`, \`BaseURL=http://llmproxy:8085/v1\` in \`buildConfig\` should come from \`Config\` (env-vars) rather than being inline. Trivial follow-up.