### PR TITLE
feat(deploy): k8s helm chart + CI for codex-app-gateway + codex-exec-gateway

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -257,6 +257,76 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  build-codex-app-gateway:
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v6
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/agentserver/codex-app-gateway
+          tags: |
+            type=sha,prefix=
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile.codex-app-gateway
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-codex-exec-gateway:
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v6
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/agentserver/codex-exec-gateway
+          tags: |
+            type=sha,prefix=
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile.codex-exec-gateway
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   build-credentialproxy:
     runs-on: ubuntu-latest
     needs: [test]
@@ -401,7 +471,7 @@ jobs:
 
   publish-helm:
     runs-on: ubuntu-latest
-    needs: [build-server, build-opencode, build-llmproxy, build-imbridge, build-cc-broker, build-executor-registry, build-credentialproxy, build-sandboxproxy, build-nanoclaw, build-claudecode]
+    needs: [build-server, build-opencode, build-llmproxy, build-imbridge, build-cc-broker, build-executor-registry, build-codex-app-gateway, build-codex-exec-gateway, build-credentialproxy, build-sandboxproxy, build-nanoclaw, build-claudecode]
     steps:
       - uses: actions/checkout@v6
 
@@ -419,7 +489,7 @@ jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    needs: [build-server, build-opencode, build-llmproxy, build-imbridge, build-cc-broker, build-executor-registry, build-credentialproxy, build-sandboxproxy, build-nanoclaw, build-claudecode]
+    needs: [build-server, build-opencode, build-llmproxy, build-imbridge, build-cc-broker, build-executor-registry, build-codex-app-gateway, build-codex-exec-gateway, build-credentialproxy, build-sandboxproxy, build-nanoclaw, build-claudecode]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/Dockerfile.codex-app-gateway
+++ b/Dockerfile.codex-app-gateway
@@ -8,8 +8,15 @@ RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' \
     -o /out/codex-app-gateway ./cmd/codex-app-gateway
 
 FROM debian:trixie-slim
+# Pin codex npm package version; override at build time with:
+#   docker build --build-arg CODEX_VERSION=0.131.0 ...
+ARG CODEX_VERSION=0.130.0
 RUN apt-get update \
- && apt-get install -y --no-install-recommends ca-certificates \
+ && apt-get install -y --no-install-recommends ca-certificates curl gnupg \
+ && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+ && apt-get install -y --no-install-recommends nodejs \
+ && npm install -g @openai/codex@${CODEX_VERSION} \
+ && apt-get purge -y curl gnupg && apt-get autoremove -y \
  && rm -rf /var/lib/apt/lists/*
 COPY --from=build /out/codex-app-gateway /usr/local/bin/codex-app-gateway
 ENTRYPOINT ["/usr/local/bin/codex-app-gateway"]

--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.47.0
-appVersion: "0.47.0"
+version: 0.48.0
+appVersion: "0.48.0"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/deploy/helm/agentserver/templates/_helpers.tpl
+++ b/deploy/helm/agentserver/templates/_helpers.tpl
@@ -73,3 +73,18 @@ Construct the executor-registry DATABASE_URL.
 postgres://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Release.Name }}-postgresql:5432/{{ $dbName }}?sslmode=disable
 {{- end -}}
 {{- end -}}
+
+{{/*
+Construct the codex-exec-gateway DATABASE_URL.
+- Shared PG: same instance, separate database (default: codexexecgateway)
+- External: codexExecGateway.database.externalUrl
+*/}}
+{{- define "agentserver.codexExecGatewayDatabaseUrl" -}}
+{{- $extUrl := (dig "database" "externalUrl" "" .Values.codexExecGateway) -}}
+{{- $dbName := (dig "database" "name" "codexexecgateway" .Values.codexExecGateway) -}}
+{{- if $extUrl -}}
+{{ $extUrl }}
+{{- else -}}
+postgres://{{ .Values.postgresql.auth.username }}:{{ .Values.postgresql.auth.password }}@{{ .Release.Name }}-postgresql:5432/{{ $dbName }}?sslmode=disable
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/agentserver/templates/codex-app-gateway.yaml
+++ b/deploy/helm/agentserver/templates/codex-app-gateway.yaml
@@ -1,0 +1,148 @@
+{{- if .Values.codexAppGateway.enabled }}
+{{- $_ := required "codexAppGateway.s3.existingSecret is required when codexAppGateway.enabled is true (k8s secret with keys: access_key_id, secret_access_key)" .Values.codexAppGateway.s3.existingSecret }}
+{{- $existingSecret := (lookup "v1" "Secret" .Release.Namespace (printf "%s-codex-app-gateway-secret" .Release.Name)) }}
+{{- $sharedSecret := (lookup "v1" "Secret" .Release.Namespace (printf "%s-codex-shared-secret" .Release.Name)) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-codex-app-gateway-secret
+  labels:
+    app: {{ .Release.Name }}-codex-app-gateway
+type: Opaque
+stringData:
+  {{- if .Values.codexAppGateway.inboundHmacSecret }}
+  inbound-hmac-secret: {{ .Values.codexAppGateway.inboundHmacSecret | quote }}
+  {{- else if $existingSecret }}
+  inbound-hmac-secret: {{ index $existingSecret.data "inbound-hmac-secret" | b64dec | quote }}
+  {{- else }}
+  inbound-hmac-secret: {{ randAlphaNum 48 | quote }}
+  {{- end }}
+---
+{{- /* Shared secret: created here (codex-app-gateway sorts before codex-exec-gateway).
+       codex-exec-gateway reads from the same secret by name lookup. */}}
+{{- $existingSharedSecret := (lookup "v1" "Secret" .Release.Namespace (printf "%s-codex-shared-secret" .Release.Name)) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-codex-shared-secret
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+type: Opaque
+stringData:
+  {{- if .Values.codexShared.capTokenHmacSecret }}
+  captoken-hmac-secret: {{ .Values.codexShared.capTokenHmacSecret | quote }}
+  {{- else if $existingSharedSecret }}
+  captoken-hmac-secret: {{ index $existingSharedSecret.data "captoken-hmac-secret" | b64dec | quote }}
+  {{- else }}
+  captoken-hmac-secret: {{ randAlphaNum 48 | quote }}
+  {{- end }}
+  {{- if .Values.codexShared.internalSharedSecret }}
+  internal-shared-secret: {{ .Values.codexShared.internalSharedSecret | quote }}
+  {{- else if $existingSharedSecret }}
+  internal-shared-secret: {{ index $existingSharedSecret.data "internal-shared-secret" | b64dec | quote }}
+  {{- else }}
+  internal-shared-secret: {{ randAlphaNum 48 | quote }}
+  {{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-codex-app-gateway
+  labels:
+    app: {{ .Release.Name }}-codex-app-gateway
+spec:
+  replicas: {{ .Values.codexAppGateway.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-codex-app-gateway
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-codex-app-gateway
+    spec:
+      serviceAccountName: {{ .Release.Name }}
+      containers:
+        - name: codex-app-gateway
+          image: "{{ .Values.codexAppGateway.image.repository }}:{{ .Values.codexAppGateway.image.tag }}"
+          imagePullPolicy: {{ .Values.codexAppGateway.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.codexAppGateway.port }}
+              protocol: TCP
+          env:
+            - name: CXG_INBOUND_HMAC_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-codex-app-gateway-secret
+                  key: inbound-hmac-secret
+            - name: CXG_CAPTOKEN_HMAC_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-codex-shared-secret
+                  key: captoken-hmac-secret
+            - name: CXG_EXEC_GATEWAY_INTERNAL_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-codex-shared-secret
+                  key: internal-shared-secret
+            - name: CXG_S3_ENDPOINT
+              value: {{ .Values.codexAppGateway.s3.endpoint | quote }}
+            - name: CXG_S3_REGION
+              value: {{ .Values.codexAppGateway.s3.region | quote }}
+            - name: CXG_S3_BUCKET
+              value: {{ .Values.codexAppGateway.s3.bucket | quote }}
+            - name: CXG_S3_PATH_STYLE
+              value: {{ .Values.codexAppGateway.s3.pathStyle | quote }}
+            - name: CXG_S3_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.codexAppGateway.s3.existingSecret }}
+                  key: access_key_id
+            - name: CXG_S3_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.codexAppGateway.s3.existingSecret }}
+                  key: secret_access_key
+            - name: CXG_TMP_ROOT
+              value: {{ .Values.codexAppGateway.tmpRoot | quote }}
+            - name: CXG_IDLE_SHUTDOWN
+              value: {{ .Values.codexAppGateway.idleShutdown | quote }}
+            - name: CXG_EXEC_GATEWAY_URL
+              value: "ws://{{ .Release.Name }}-codex-exec-gateway:{{ .Values.codexExecGateway.port }}"
+            - name: CXG_EXEC_GATEWAY_INTERNAL_URL
+              value: "http://{{ .Release.Name }}-codex-exec-gateway:{{ .Values.codexExecGateway.port }}"
+            {{- if .Values.codexAppGateway.logLevel }}
+            - name: CXG_LOG_LEVEL
+              value: {{ .Values.codexAppGateway.logLevel | quote }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.codexAppGateway.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.codexAppGateway.port }}
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          {{- with .Values.codexAppGateway.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-codex-app-gateway
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.codexAppGateway.port }}
+      targetPort: {{ .Values.codexAppGateway.port }}
+      protocol: TCP
+  selector:
+    app: {{ .Release.Name }}-codex-app-gateway
+{{- end }}

--- a/deploy/helm/agentserver/templates/codex-exec-gateway.yaml
+++ b/deploy/helm/agentserver/templates/codex-exec-gateway.yaml
@@ -1,0 +1,116 @@
+{{- if .Values.codexExecGateway.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-codex-exec-gateway-secret
+  labels:
+    app: {{ .Release.Name }}-codex-exec-gateway
+type: Opaque
+stringData:
+  database-url: {{ include "agentserver.codexExecGatewayDatabaseUrl" . | quote }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-codex-exec-gateway
+  labels:
+    app: {{ .Release.Name }}-codex-exec-gateway
+spec:
+  replicas: {{ .Values.codexExecGateway.replicaCount }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-codex-exec-gateway
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-codex-exec-gateway
+    spec:
+      serviceAccountName: {{ .Release.Name }}
+      initContainers:
+        {{- if .Values.postgresql.enabled }}
+        - name: wait-for-postgresql
+          image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          command:
+            - sh
+            - -c
+            - |
+              until pg_isready -h {{ .Release.Name }}-postgresql -p 5432 -U {{ .Values.postgresql.auth.username }}; do
+                echo "Waiting for PostgreSQL to be ready..."
+                sleep 2
+              done
+        - name: create-codex-exec-gateway-database
+          image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          command:
+            - sh
+            - -c
+            - |
+              {{- $dbName := (dig "database" "name" "codexexecgateway" .Values.codexExecGateway) }}
+              PGPASSWORD="$PG_PASSWORD" psql -h {{ .Release.Name }}-postgresql -U {{ .Values.postgresql.auth.username }} -d {{ .Values.postgresql.auth.database }} -tc "SELECT 1 FROM pg_database WHERE datname='{{ $dbName }}'" | grep -q 1 || \
+              PGPASSWORD="$PG_PASSWORD" createdb -h {{ .Release.Name }}-postgresql -U {{ .Values.postgresql.auth.username }} {{ $dbName }}
+          env:
+            - name: PG_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-postgresql
+                  key: POSTGRES_PASSWORD
+        {{- end }}
+      containers:
+        - name: codex-exec-gateway
+          image: "{{ .Values.codexExecGateway.image.repository }}:{{ .Values.codexExecGateway.image.tag }}"
+          imagePullPolicy: {{ .Values.codexExecGateway.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.codexExecGateway.port }}
+              name: http
+              protocol: TCP
+          env:
+            - name: CXG_DATABASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-codex-exec-gateway-secret
+                  key: database-url
+            - name: CXG_CAPTOKEN_HMAC_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-codex-shared-secret
+                  key: captoken-hmac-secret
+            - name: CXG_INTERNAL_SHARED_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-codex-shared-secret
+                  key: internal-shared-secret
+            {{- if .Values.codexExecGateway.logLevel }}
+            - name: CXG_LOG_LEVEL
+              value: {{ .Values.codexExecGateway.logLevel | quote }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.codexExecGateway.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.codexExecGateway.port }}
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          {{- with .Values.codexExecGateway.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-codex-exec-gateway
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.codexExecGateway.port }}
+      targetPort: {{ .Values.codexExecGateway.port }}
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ .Release.Name }}-codex-exec-gateway
+{{- end }}

--- a/deploy/helm/agentserver/templates/ingress.yaml
+++ b/deploy/helm/agentserver/templates/ingress.yaml
@@ -32,6 +32,31 @@ spec:
                 name: {{ .Release.Name }}
                 port:
                   number: {{ .Values.service.port }}
+          {{- if .Values.codexAppGateway.enabled }}
+          - path: /codex-app/
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}-codex-app-gateway
+                port:
+                  number: {{ .Values.codexAppGateway.port }}
+          {{- end }}
+          {{- if .Values.codexExecGateway.enabled }}
+          - path: /codex-exec/
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}-codex-exec-gateway
+                port:
+                  number: {{ .Values.codexExecGateway.port }}
+          - path: /api/codex-exec/
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}-codex-exec-gateway
+                port:
+                  number: {{ .Values.codexExecGateway.port }}
+          {{- end }}
     {{- if .Values.sandbox.baseDomain }}
     - host: {{ printf "*.%s" .Values.sandbox.baseDomain | quote }}
       http:

--- a/deploy/helm/agentserver/values.yaml
+++ b/deploy/helm/agentserver/values.yaml
@@ -249,6 +249,68 @@ ccbroker:
   # `models.anthropicBaseUrl` / `models.anthropicAuthToken` above).
   resources: {}
 
+# codex-app-gateway: TUI-side authoritative gateway. Per-thread codex
+# app-server subprocess + ws frame proxy. Requires S3 for per-thread
+# CODEX_HOME persistence.
+codexAppGateway:
+  enabled: false
+  image:
+    repository: ghcr.io/agentserver/codex-app-gateway
+    tag: latest
+    pullPolicy: Always
+  replicaCount: 1
+  port: 8086
+  logLevel: info
+  idleShutdown: "30m"
+  tmpRoot: "/tmp/codex-app-gateway"
+  # Inbound auth secret. The token format is
+  # `<workspace_id>.<thread_id>.<HMAC-SHA256>` where the HMAC is keyed
+  # by this secret. Generated at install time if blank; supply your own
+  # for stable values across re-installs.
+  inboundHmacSecret: ""
+  # S3-compatible object store for per-thread CODEX_HOME tarballs.
+  # Required when enabled is true. Same shape as ccbroker.s3.
+  s3:
+    endpoint: ""
+    region: ""
+    bucket: ""
+    pathStyle: false
+    existingSecret: ""    # k8s secret with keys: access_key_id, secret_access_key
+  resources: {}
+
+# codex-exec-gateway: executor-side gateway. Pairs codex-exec WebSocket
+# inbounds with bridge connections from env-mcp children. Requires
+# Postgres for executor identity + workspace bindings.
+codexExecGateway:
+  enabled: false
+  image:
+    repository: ghcr.io/agentserver/codex-exec-gateway
+    tag: latest
+    pullPolicy: Always
+  replicaCount: 1
+  port: 6060
+  logLevel: info
+  database:
+    name: codexexecgateway
+    externalUrl: ""
+  resources: {}
+
+# Shared secrets between codex-app-gateway and codex-exec-gateway.
+# These MUST match across both services: cap tokens minted by app-gateway
+# are verified by exec-gateway using capTokenHmacSecret; the internal HTTP
+# calls from app-gateway to exec-gateway are authenticated with
+# internalSharedSecret.
+# Both values are auto-generated (randAlphaNum 48) and persisted via Secret
+# lookup if left empty. Supply explicit values for stable cross-reinstall
+# behaviour or when pre-sharing secrets out-of-band.
+codexShared:
+  # Cap-token HMAC secret. App-gateway mints; exec-gateway verifies.
+  # Generated if blank.
+  capTokenHmacSecret: ""
+  # Internal-API shared secret for app-gateway → exec-gateway HTTP calls
+  # (/api/exec-gateway/connected etc.). Generated if blank.
+  internalSharedSecret: ""
+
 # executor-registry: tracks local tool-executor agents and routes remote_*
 # tool calls to them over WebSocket + yamux tunnels.
 executorRegistry:


### PR DESCRIPTION
Adds **deploy infrastructure** for the codex-gateway service trio (env-mcp PR #78, codex-app-gateway PR #79, codex-exec-gateway PR #80) so an operator can \`helm install\` the chart and have the new services running alongside cc-broker / executor-registry / imbridge.

## What's in here

- **2 new Helm templates** following the existing per-service pattern:
  - \`templates/codex-app-gateway.yaml\` — Secret + Deployment + Service. No Postgres (S3 + sqlite-in-CODEX_HOME). Pulls S3 creds from \`existingSecret\` (same shape as ccbroker.s3).
  - \`templates/codex-exec-gateway.yaml\` — Secret + Deployment + Service + Postgres init containers. Same shape as executor-registry.yaml.
- **Shared-secret pattern** — single \`{{ .Release.Name }}-codex-shared-secret\` k8s Secret holds the captoken HMAC + internal-API shared-secret values that both gateways must agree on. Created by codex-app-gateway template (alphabetically first), referenced by name in codex-exec-gateway. \`randAlphaNum 48\` + \`lookup\` for stable values across \`helm upgrade\`.
- **\`_helpers.tpl\`**: \`agentserver.codexExecGatewayDatabaseUrl\` helper following the same \`dig\`-safe pattern.
- **\`values.yaml\`**: \`codexAppGateway:\`, \`codexExecGateway:\`, \`codexShared:\` blocks with operator-friendly comments. Both disabled by default.
- **\`ingress.yaml\`**: routes \`/codex-app/\`, \`/codex-exec/\`, \`/api/codex-exec/\` to the respective Services. \`/bridge/\` and \`/api/exec-gateway/\` intentionally stay in-cluster only (defense in depth).
- **\`Dockerfile.codex-app-gateway\`**: installs \`codex\` (npm \`@openai/codex\`, pinned via \`CODEX_VERSION\` build-arg, default 0.130.0). Without this, \`spawnCodexAppServer()\` fails at the first ws connect with \`exec: codex: not found\`.
- **\`.github/workflows/build.yml\`**: \`build-codex-app-gateway\` and \`build-codex-exec-gateway\` jobs (cc-broker pattern). \`publish-helm\` and \`release\` \`needs:\` updated.
- **\`Chart.yaml\`**: 0.47.0 → 0.48.0.

## Verification

- \`helm template\` renders cleanly with the gateways enabled — 30 resource documents, all expected k8s objects present, ingress paths correct.
- All Go tests still pass (chart changes don't touch code, but ran the suite for sanity).
- \`go vet\` clean.

## Operator quickstart (after this lands + PR #81)

\`\`\`yaml
# values.yaml additions
codexAppGateway:
  enabled: true
  s3:
    endpoint: http://minio:9000
    region: us-east-1
    bucket: codex-app-gateway
    pathStyle: true
    existingSecret: minio-creds   # k8s secret with access_key_id, secret_access_key

codexExecGateway:
  enabled: true   # uses the in-chart Postgres by default
\`\`\`

Then enable the chart's ingress with whatever \`host:\` you want, deploy, and the laptop side runs:

\`\`\`bash
# laptop A — register an executor (needs HMAC token from agentserver auth — see follow-ups)
curl -X POST https://agentserver.example.com/api/codex-exec/register \\
     -H 'X-User-Id: alice' \\
     -d '{"display_name":"Alice MacBook","default_cwd":"/home/alice/projects"}'
# returns {exe_id, registration_token}; bind to workspace, then:
codex exec-server --remote wss://agentserver.example.com/codex-exec/\$EXE_ID \\
                  --executor-id \$EXE_ID --auth-token-env CODEX_EXEC_TOKEN

# laptop B — connect TUI
export CODEX_APP_TOKEN=\$(printf '%s\\0%s' ws_alice thr_001 | openssl dgst -sha256 -hmac \$INBOUND_HMAC_SECRET | awk '{print "ws_alice.thr_001."\$2}')
codex --remote wss://agentserver.example.com/codex-app/ws --remote-auth-token-env CODEX_APP_TOKEN
\`\`\`

## Outstanding pre-deploy items NOT addressed

- **PR #81** (\`buildConfig\` real-ification) must be merged for the spawned codex app-server to actually receive \`[mcp_servers.exe_*]\` entries. Without #81 the chart deploys cleanly and the connection loop runs, but the LLM sees no executor shell tools.
- **HMAC inbound token issuance UX** — currently power-user-only (hand-mint with shared secret). Wiring to agentserver's existing user-JWT system is a follow-up.
- **Executor-register endpoint** trusts the \`X-User-Id\` header without verifying — needs to be wired to agentserver auth before public exposure (or rely on ingress-level auth filter).
- **revoke-turn on subprocess shutdown** — only EXP-based invalidation today (24h).

## Spec / Plan

Architecture: \`docs/superpowers/specs/2026-05-10-codex-gateway-mcp-rewrite.md\` (spec) and \`2026-05-10-codex-app-gateway-subprocess.md\` (Subsystem 2 refinement). Charts/CI follow this repo's existing per-service pattern (cc-broker, executor-registry).