### PR TITLE
feat(server): operation log infrastructure (Plan 2)

### DIFF
--- a/cmd/codex-app-gateway/main.go
+++ b/cmd/codex-app-gateway/main.go
@@ -90,6 +90,15 @@ func runServe(rawArgs []string) {
 		os.Exit(2)
 	}
 	cfg.ListenAddr = args.ListenAddr
+	if args.OperationLogURL != "" {
+		cfg.OperationLogURL = args.OperationLogURL
+	}
+	if args.OperationLogSecret != "" {
+		cfg.OperationLogSecret = args.OperationLogSecret
+	}
+	if args.OperationLogChan > 0 {
+		cfg.OperationLogChan = args.OperationLogChan
+	}
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: cfg.LogLevel}))
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()

--- a/cmd/codex-app-gateway/serve_args.go
+++ b/cmd/codex-app-gateway/serve_args.go
@@ -4,11 +4,15 @@ import (
 	"flag"
 	"io"
 	"os"
+	"strconv"
 )
 
 type serveArgs struct {
-	ListenAddr string
-	CodexBin   string
+	ListenAddr         string
+	CodexBin           string
+	OperationLogURL    string
+	OperationLogSecret string
+	OperationLogChan   int
 }
 
 func parseServeArgs(rawArgs []string) (serveArgs, error) {
@@ -16,6 +20,9 @@ func parseServeArgs(rawArgs []string) (serveArgs, error) {
 	fs.SetOutput(io.Discard)
 	listen := fs.String("listen-addr", ":8086", "HTTP listen address (env CXG_LISTEN_ADDR)")
 	codexBin := fs.String("codex-bin", "codex", "path to codex binary used for `codex app-server` (env CXG_CODEX_BIN)")
+	opLogURL := fs.String("oplog-url", "", "agentserver /internal/operations URL (env CXG_OPLOG_URL)")
+	opLogSecret := fs.String("oplog-secret", "", "X-Internal-Secret header value (env CXG_OPLOG_SECRET)")
+	opLogChan := fs.Int("oplog-chan", 1024, "bounded channel capacity (env CXG_OPLOG_CHAN)")
 	if err := fs.Parse(rawArgs); err != nil {
 		return serveArgs{}, err
 	}
@@ -25,5 +32,23 @@ func parseServeArgs(rawArgs []string) (serveArgs, error) {
 	if envBin := os.Getenv("CXG_CODEX_BIN"); envBin != "" && *codexBin == "codex" {
 		*codexBin = envBin
 	}
-	return serveArgs{ListenAddr: *listen, CodexBin: *codexBin}, nil
+	if envURL := os.Getenv("CXG_OPLOG_URL"); envURL != "" && *opLogURL == "" {
+		*opLogURL = envURL
+	}
+	if envSec := os.Getenv("CXG_OPLOG_SECRET"); envSec != "" && *opLogSecret == "" {
+		*opLogSecret = envSec
+	}
+	if envChan := os.Getenv("CXG_OPLOG_CHAN"); envChan != "" && *opLogChan == 1024 {
+		n, err := strconv.Atoi(envChan)
+		if err == nil && n > 0 {
+			*opLogChan = n
+		}
+	}
+	return serveArgs{
+		ListenAddr:         *listen,
+		CodexBin:           *codexBin,
+		OperationLogURL:    *opLogURL,
+		OperationLogSecret: *opLogSecret,
+		OperationLogChan:   *opLogChan,
+	}, nil
 }

--- a/cmd/codex-app-gateway/serve_args_test.go
+++ b/cmd/codex-app-gateway/serve_args_test.go
@@ -3,6 +3,9 @@ package main
 import "testing"
 
 func TestParseServeArgs_Defaults(t *testing.T) {
+	t.Setenv("CXG_OPLOG_URL", "")
+	t.Setenv("CXG_OPLOG_SECRET", "")
+	t.Setenv("CXG_OPLOG_CHAN", "")
 	args, err := parseServeArgs([]string{})
 	if err != nil {
 		t.Fatalf("parse: %v", err)
@@ -13,17 +16,60 @@ func TestParseServeArgs_Defaults(t *testing.T) {
 	if args.CodexBin != "codex" {
 		t.Errorf("CodexBin = %q", args.CodexBin)
 	}
+	if args.OperationLogURL != "" {
+		t.Errorf("OperationLogURL = %q, want empty", args.OperationLogURL)
+	}
+	if args.OperationLogSecret != "" {
+		t.Errorf("OperationLogSecret = %q, want empty", args.OperationLogSecret)
+	}
+	if args.OperationLogChan != 1024 {
+		t.Errorf("OperationLogChan = %d, want 1024", args.OperationLogChan)
+	}
 }
 
 func TestParseServeArgs_Overrides(t *testing.T) {
+	t.Setenv("CXG_OPLOG_URL", "")
+	t.Setenv("CXG_OPLOG_SECRET", "")
+	t.Setenv("CXG_OPLOG_CHAN", "")
 	args, err := parseServeArgs([]string{
 		"--listen-addr", ":9090",
 		"--codex-bin", "/usr/local/bin/codex",
+		"--oplog-url", "http://agentserver:8080/internal/operations",
+		"--oplog-secret", "topsecret",
+		"--oplog-chan", "4096",
 	})
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
 	if args.ListenAddr != ":9090" || args.CodexBin != "/usr/local/bin/codex" {
 		t.Errorf("got %+v", args)
+	}
+	if args.OperationLogURL != "http://agentserver:8080/internal/operations" {
+		t.Errorf("OperationLogURL = %q", args.OperationLogURL)
+	}
+	if args.OperationLogSecret != "topsecret" {
+		t.Errorf("OperationLogSecret = %q", args.OperationLogSecret)
+	}
+	if args.OperationLogChan != 4096 {
+		t.Errorf("OperationLogChan = %d", args.OperationLogChan)
+	}
+}
+
+func TestParseServeArgs_EnvFallback(t *testing.T) {
+	t.Setenv("CXG_OPLOG_URL", "http://env-url/ops")
+	t.Setenv("CXG_OPLOG_SECRET", "env-secret")
+	t.Setenv("CXG_OPLOG_CHAN", "2048")
+	args, err := parseServeArgs([]string{})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if args.OperationLogURL != "http://env-url/ops" {
+		t.Errorf("OperationLogURL = %q", args.OperationLogURL)
+	}
+	if args.OperationLogSecret != "env-secret" {
+		t.Errorf("OperationLogSecret = %q", args.OperationLogSecret)
+	}
+	if args.OperationLogChan != 2048 {
+		t.Errorf("OperationLogChan = %d", args.OperationLogChan)
 	}
 }

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -234,6 +234,18 @@ var serveCmd = &cobra.Command{
 		}
 		srv.CodexExecGatewayPublicHost = os.Getenv("CODEX_EXEC_GATEWAY_PUBLIC_HOST")
 
+		// Operations retention TTL — 90 days default, 0 disables. Env var
+		// AGENTSERVER_OPERATIONS_RETENTION_DAYS overrides.
+		retentionDays := 90
+		if v := os.Getenv("AGENTSERVER_OPERATIONS_RETENTION_DAYS"); v != "" {
+			if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+				retentionDays = n
+			} else {
+				log.Printf("Warning: AGENTSERVER_OPERATIONS_RETENTION_DAYS=%q invalid, using default %d", v, retentionDays)
+			}
+		}
+		srv.OperationsRetention = time.Duration(retentionDays) * 24 * time.Hour
+
 		// Hydra OAuth2 for agent Device Flow.
 		hydraAdminURL := os.Getenv("HYDRA_ADMIN_URL")
 		hydraPublicURL := os.Getenv("HYDRA_PUBLIC_URL")
@@ -284,6 +296,9 @@ var serveCmd = &cobra.Command{
 		// Leak worker: cleans up stale active turns and responders.
 		lw := server.NewLeakWorker(srv, server.LeakWorkerConfig{})
 		go lw.Run(healthCtx)
+
+		// Operations retention background loop. Disabled when TTL is 0.
+		go srv.StartRetentionLoop(healthCtx, srv.OperationsRetention, time.Hour)
 
 		httpServer := &http.Server{Addr: addr, Handler: srv.Router()}
 

--- a/deploy/helm/agentserver/templates/codex-app-gateway.yaml
+++ b/deploy/helm/agentserver/templates/codex-app-gateway.yaml
@@ -121,6 +121,14 @@ spec:
               value: "http://{{ .Release.Name }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}"
             - name: CXG_AGENTSERVER_INTERNAL_SECRET
               value: {{ required "internal.apiSecret is required when codexAppGateway.enabled is true" .Values.internal.apiSecret | quote }}
+            {{- if .Values.operations.enabled }}
+            - name: CXG_OPLOG_URL
+              value: "http://{{ .Release.Name }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}/internal/operations"
+            - name: CXG_OPLOG_SECRET
+              value: {{ .Values.internal.apiSecret | quote }}
+            - name: CXG_OPLOG_CHAN
+              value: {{ .Values.operations.channelCapacity | quote }}
+            {{- end }}
           # CODEX_HOME tmpdirs (sqlite + session jsonl) live here. emptyDir
           # is sufficient because state is round-tripped to S3 on idle
           # shutdown — pod restart loses no data.

--- a/deploy/helm/agentserver/templates/deployment.yaml
+++ b/deploy/helm/agentserver/templates/deployment.yaml
@@ -189,6 +189,8 @@ spec:
             - name: INTERNAL_API_SECRET
               value: {{ .Values.internal.apiSecret | quote }}
             {{- end }}
+            - name: AGENTSERVER_OPERATIONS_RETENTION_DAYS
+              value: {{ .Values.operations.retentionDays | quote }}
             {{- if .Values.codexExecGateway.enabled }}
             - name: CODEX_EXEC_GATEWAY_INTERNAL_URL
               value: "http://{{ .Release.Name }}-codex-exec-gateway.{{ .Release.Namespace }}.svc:{{ .Values.codexExecGateway.port }}"

--- a/deploy/helm/agentserver/values.yaml
+++ b/deploy/helm/agentserver/values.yaml
@@ -215,6 +215,18 @@ credentialproxy:
 internal:
   apiSecret: ""
 
+# Operation log (Plan 2): codex-app-gateway records every MCP tool call to
+# agentserver's /internal/operations endpoint for audit + replay.
+operations:
+  # When true, codex-app-gateway POSTs every mcpServer/tool/call to
+  # agentserver's /internal/operations. Disable to revert to pre-Plan-2
+  # behavior (no logging).
+  enabled: true
+  # Retention in days. 0 disables the cleanup loop.
+  retentionDays: 90
+  # Bounded channel capacity inside the gateway. Drops on overflow.
+  channelCapacity: 1024
+
 # cc-broker: runs Claude Code workers on demand and exposes the bridge +
 # MCP server used by stateless-CC sessions.
 ccbroker:

--- a/docs/superpowers/plans/2026-05-18-operation-log.md
+++ b/docs/superpowers/plans/2026-05-18-operation-log.md
@@ -1,0 +1,2596 @@
+# Operation Log Implementation Plan (Plan 2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every `mcpServer/tool/call` going through `codex-app-gateway` (SDK or TUI sourced) gets append-only logged to a new `operations` PostgreSQL table; `agentserver_sdk`'s `await ctx.history(...)` returns real records via gateway-side `operations/list` interception.
+
+**Architecture:** Three pieces. (1) `operations` table + agentserver `/internal/operations` POST/GET handlers (write + filtered list) + hourly retention goroutine. (2) `codex-app-gateway` `oplog` package: HTTP client that fire-and-forget POSTs to agentserver, and JSON-RPC frame Interceptor that decodes `mcpServer/tool/call` request/response pairs and submits. (3) New `/notebook/ws` route on the gateway for SDK traffic (source-tagged `sdk`); existing `/codex-app/ws` keeps TUI traffic (source-tagged `tui`). The Interceptor also intercepts `operations/list` SDK requests and serves them by calling agentserver — without forwarding to `codex app-server` (which has no such method).
+
+**Tech Stack:** Go 1.26 · `database/sql` + `lib/pq` (matches existing agentserver pattern) · chi/v5 router · `nhooyr.io/websocket` · embedded migrations via `embed.FS` · agentserver `AgentserverInternalSecret` shared bearer for gateway→agentserver auth.
+
+**Out of scope for this plan (separate work):**
+- Web UI `<OperationsPanel />` (Plan 3)
+- LLM-initiated tool call logging (v1.5 — env-mcp itself emits log records)
+- Cell/notebook attribution (`notebook_path`, `cell_id` columns) — schema has the columns, kept NULL for v1
+- Per-workspace retention overrides — uses the global default; pluggable later
+
+---
+
+## File Structure
+
+```
+internal/db/migrations/023_operations.sql                                       # NEW
+internal/db/operations.go                                                       # NEW (Insert/List/PruneOlderThan/typed row)
+internal/db/operations_test.go                                                  # NEW
+
+internal/server/operations.go                                                   # NEW (POST + GET /internal/operations handlers; bearer-auth)
+internal/server/operations_test.go                                              # NEW
+internal/server/operations_retention.go                                         # NEW (StartRetention(ctx, db, ttl, every))
+internal/server/operations_retention_test.go                                    # NEW
+
+internal/codexappgateway/oplog/                                                 # NEW package
+├── doc.go                                                                      # package summary
+├── client.go                                                                   # HTTP client; async Submit(); bounded channel; drop+metric on overflow
+├── client_test.go                                                              # httptest server
+├── interceptor.go                                                              # JSON-RPC frame parser; per-conn pending map; source/user tag; truncation
+├── interceptor_test.go
+├── operations_list.go                                                          # intercept SDK 'operations/list' → call client.List → respond on ws
+└── operations_list_test.go
+
+internal/wsbridge/wsbridge.go                                                   # MODIFIED — add RunProxyWithInterceptor + Interceptor type
+internal/wsbridge/wsbridge_test.go                                              # MODIFIED — cover new variant
+
+internal/codexappgateway/server.go                                              # MODIFIED — /notebook/ws route + wire oplog
+internal/codexappgateway/server_test.go                                         # MODIFIED — assert source tagging via test stub
+internal/codexappgateway/config.go                                              # MODIFIED — new oplog config fields
+internal/codexappgateway/buildconfig_test.go                                    # MODIFIED — covers new fields
+
+deploy/helm/agentserver/values.yaml                                             # MODIFIED — oplog enable flag + retention days
+deploy/helm/agentserver/templates/codex-app-gateway.yaml                        # MODIFIED — env vars for oplog endpoint + secret reference
+```
+
+---
+
+## Design Decisions Locked Before Tasks
+
+These come up across tasks. Capturing once.
+
+**1. Gateway writes via HTTP, not direct PG.** Gateway is a separate pod with no DB credentials. agentserver owns the DB. Gateway POSTs `/internal/operations` with `Authorization: Bearer <AgentserverInternalSecret>` — same auth pattern already used for `/internal/auth/verify` etc. Keeps the gateway stateless and avoids leaking PG creds into a second service.
+
+**2. `operations/list` intercepted in gateway (does NOT reach `codex app-server`).** codex has no such method; if forwarded it would error. Interceptor recognises the method on the request-direction frame, calls agentserver `/internal/operations` (GET with workspace_id + filters), writes the response back on the ws using the same JSON-RPC id. The client-direction frame for that request id is suppressed so it never tries to reach codex.
+
+**3. Async oplog writes — fire-and-forget bounded channel (capacity 1024).** Submit returns immediately. A single background goroutine drains the channel and POSTs to agentserver. If channel is full → drop + bump a counter metric. Tool calls never block on logging. agentserver downtime is observable via the drop metric.
+
+**4. Path-based source tagging.** New ws route `/notebook/ws` for SDK traffic; source = `"sdk"`. Existing `/codex-app/ws` route used by TUI; source = `"tui"`. Source is captured at proxy construction, not from any client-supplied tag. Avoids spoofing.
+
+**5. user_id / workspace_id sourced from auth context.** workspace_id comes from `Identity.WorkspaceID` (already set by the bearer auth verifier, see `server.go:249`). user_id comes from the request's `_meta.agentserver_user_id` field if present (gateway trusts it because the workspace_id boundary is enforced upstream by the bearer); else NULL.
+
+**6. Payload truncation:**
+- `arguments` > 64 KiB JSON → store `NULL` and `arguments_meta = {"truncated":true,"size_bytes":N,"sha256":"…"}`
+- `result.content[].text` joined → first 4 KiB → `result_summary`; remainder dropped, `result_meta = {"truncated":true,"total_bytes":N}`
+- Non-text content blocks (image/resource_link) → not in `result_summary`; only sha256 + size recorded
+- Apply BEFORE submitting to the bounded channel (truncate in the request goroutine, channel carries small structs)
+
+**7. Retention.** Hourly goroutine in agentserver web. `DELETE FROM operations WHERE started_at < NOW() - INTERVAL '90 days'`. Default 90d, configurable via `helm values.operations.retentionDays`. Goroutine started in `main.go`'s server boot; cancelled on shutdown.
+
+**8. Schema includes v1.5 columns from day one** (`notebook_path`, `cell_id`, `thread_id`). All nullable. v1 leaves them NULL — saves a future migration.
+
+**9. JSON-RPC frame parsing is best-effort and non-fatal.** Interceptor never breaks frame forwarding. If a frame can't be parsed (binary, malformed JSON, unknown shape), it passes through untouched and is not logged. The `pump` keeps running.
+
+**10. operations_list pagination:** SDK passes `limit` (default 100, max 1000). Server returns `{"operations": [...]}`. No cursor pagination in v1 (added when v1.5 cell_id filter lands).
+
+**11. Go 1.26 + database/sql + lib/pq.** Matches the rest of agentserver. No new dep.
+
+**12. Test isolation.** DB layer tests use a real PG via testcontainers OR an existing repo helper. Check `internal/db/` for the pattern before writing tests.
+
+---
+
+## Task 1: DB migration + queries
+
+**Files:**
+- Create: `internal/db/migrations/023_operations.sql`
+- Create: `internal/db/operations.go`
+- Create: `internal/db/operations_test.go`
+
+- [ ] **Step 1: Inspect existing DB test pattern**
+
+Read `internal/db/*_test.go` (pick one with table tests) to learn how tests get a `*DB`. Likely one of:
+- `testutil`/`testdb` helper spinning up a PG via testcontainers or temp DB
+- Skip-if-no-DSN env-var pattern
+
+If the repo uses an env-var skip pattern, follow that for `operations_test.go`. If it uses a helper, import the helper. Document the choice in a comment at top of the test file.
+
+- [ ] **Step 2: Write the migration**
+
+Create `internal/db/migrations/023_operations.sql`:
+
+```sql
+-- v1 operation log. Written by codex-app-gateway via POST /internal/operations
+-- whenever an mcpServer/tool/call request/response pair completes.
+--
+-- Columns marked v1.5 are populated only when env-mcp itself emits the record
+-- (LLM-initiated calls) or when the IPython kernel attribution metadata is
+-- wired up. v1 leaves them NULL.
+
+CREATE TABLE operations (
+  id              UUID PRIMARY KEY,
+  workspace_id    TEXT NOT NULL,
+  user_id         TEXT,
+  source          TEXT NOT NULL,
+  thread_id       TEXT,
+  request_id      TEXT,
+
+  env_id          TEXT NOT NULL,
+  tool            TEXT NOT NULL,
+  arguments       JSONB,
+  arguments_meta  JSONB,
+
+  is_error        BOOLEAN NOT NULL,
+  result_summary  TEXT,
+  result_meta     JSONB,
+
+  started_at      TIMESTAMPTZ NOT NULL,
+  completed_at    TIMESTAMPTZ NOT NULL,
+  duration_ms     INTEGER NOT NULL,
+
+  -- v1.5
+  notebook_path   TEXT,
+  cell_id         TEXT
+);
+
+CREATE INDEX ops_ws_time   ON operations (workspace_id, started_at DESC);
+CREATE INDEX ops_ws_env    ON operations (workspace_id, env_id, started_at DESC);
+CREATE INDEX ops_ws_source ON operations (workspace_id, source, started_at DESC);
+```
+
+- [ ] **Step 3: Write failing test for Insert + List**
+
+Create `internal/db/operations_test.go`:
+
+```go
+package db
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestOperationsInsertAndList(t *testing.T) {
+	d := openTestDB(t) // adopt whatever helper you confirmed in Step 1
+	defer d.Close()
+
+	op := Operation{
+		ID:            uuid.NewString(),
+		WorkspaceID:   "ws-1",
+		UserID:        ptr("u-1"),
+		Source:        "sdk",
+		ThreadID:      ptr("th-1"),
+		RequestID:     ptr("rpc-1"),
+		EnvID:         "alpha",
+		Tool:          "shell",
+		Arguments:     json.RawMessage(`{"command":"ls"}`),
+		IsError:       false,
+		ResultSummary: ptr("ok"),
+		StartedAt:     time.Now().UTC().Truncate(time.Microsecond),
+		CompletedAt:   time.Now().UTC().Truncate(time.Microsecond),
+		DurationMs:    7,
+	}
+	if err := d.InsertOperation(op); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	rows, err := d.ListOperations(OperationFilter{WorkspaceID: "ws-1", Limit: 10})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	got := rows[0]
+	if got.ID != op.ID || got.EnvID != "alpha" || got.Tool != "shell" {
+		t.Fatalf("got = %+v", got)
+	}
+}
+
+func TestOperationsFilterByEnv(t *testing.T) {
+	d := openTestDB(t)
+	defer d.Close()
+
+	must := func(env string) {
+		err := d.InsertOperation(Operation{
+			ID: uuid.NewString(), WorkspaceID: "ws-1", Source: "sdk",
+			EnvID: env, Tool: "shell", IsError: false,
+			Arguments: json.RawMessage(`{}`),
+			StartedAt: time.Now().UTC(), CompletedAt: time.Now().UTC(),
+			DurationMs: 1,
+		})
+		if err != nil {
+			t.Fatalf("insert(%s): %v", env, err)
+		}
+	}
+	must("alpha")
+	must("alpha")
+	must("beta")
+
+	rows, err := d.ListOperations(OperationFilter{WorkspaceID: "ws-1", EnvID: "alpha", Limit: 10})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("alpha rows = %d, want 2", len(rows))
+	}
+}
+
+func TestOperationsPruneOlderThan(t *testing.T) {
+	d := openTestDB(t)
+	defer d.Close()
+
+	oldT := time.Now().UTC().Add(-100 * 24 * time.Hour)
+	newT := time.Now().UTC()
+	for _, st := range []time.Time{oldT, newT} {
+		err := d.InsertOperation(Operation{
+			ID: uuid.NewString(), WorkspaceID: "ws", Source: "sdk",
+			EnvID: "a", Tool: "shell", IsError: false,
+			Arguments: json.RawMessage(`{}`),
+			StartedAt: st, CompletedAt: st, DurationMs: 1,
+		})
+		if err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+	n, err := d.PruneOperationsOlderThan(time.Now().Add(-90 * 24 * time.Hour))
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("pruned = %d, want 1", n)
+	}
+}
+
+func ptr[T any](v T) *T { return &v }
+```
+
+If the existing DB tests don't have a helper named `openTestDB`, substitute the name the repo actually uses (e.g. `dbtest.Open(t)`).
+
+- [ ] **Step 4: Run test to verify failure**
+
+Run: `go test ./internal/db -run 'TestOperations' -v`
+Expected: FAIL with compilation errors (`Operation`, `InsertOperation`, etc. undefined).
+
+- [ ] **Step 5: Implement operations.go**
+
+Create `internal/db/operations.go`:
+
+```go
+package db
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Operation is one row of the operations table — a single completed
+// mcpServer/tool/call observed by codex-app-gateway.
+type Operation struct {
+	ID             string
+	WorkspaceID    string
+	UserID         *string
+	Source         string // "sdk" | "tui" | (v1.5) "llm"
+	ThreadID       *string
+	RequestID      *string
+
+	EnvID          string
+	Tool           string
+	Arguments      json.RawMessage // nil if truncated
+	ArgumentsMeta  json.RawMessage // {"truncated":true,"size_bytes":N,"sha256":"..."} if so
+
+	IsError        bool
+	ResultSummary  *string
+	ResultMeta     json.RawMessage
+
+	StartedAt      time.Time
+	CompletedAt    time.Time
+	DurationMs     int32
+
+	NotebookPath   *string // v1.5
+	CellID         *string // v1.5
+}
+
+// OperationFilter is the optional filter set for ListOperations.
+type OperationFilter struct {
+	WorkspaceID string // REQUIRED — server-side enforced
+	EnvID       string // optional
+	Tool        string // optional
+	Source      string // optional
+	IsError     *bool  // optional
+	Since       *time.Time
+	ID          string // optional: exact match (returns 0 or 1 rows)
+	Limit       int    // default 100, max 1000
+}
+
+func (db *DB) InsertOperation(o Operation) error {
+	const q = `
+INSERT INTO operations (
+  id, workspace_id, user_id, source, thread_id, request_id,
+  env_id, tool, arguments, arguments_meta,
+  is_error, result_summary, result_meta,
+  started_at, completed_at, duration_ms,
+  notebook_path, cell_id
+) VALUES (
+  $1,$2,$3,$4,$5,$6, $7,$8,$9,$10, $11,$12,$13, $14,$15,$16, $17,$18
+)`
+	_, err := db.Exec(q,
+		o.ID, o.WorkspaceID, o.UserID, o.Source, o.ThreadID, o.RequestID,
+		o.EnvID, o.Tool, nullableJSON(o.Arguments), nullableJSON(o.ArgumentsMeta),
+		o.IsError, o.ResultSummary, nullableJSON(o.ResultMeta),
+		o.StartedAt, o.CompletedAt, o.DurationMs,
+		o.NotebookPath, o.CellID,
+	)
+	return err
+}
+
+func nullableJSON(b json.RawMessage) any {
+	if len(b) == 0 {
+		return nil
+	}
+	return []byte(b)
+}
+
+const defaultListLimit = 100
+const maxListLimit = 1000
+
+func (db *DB) ListOperations(f OperationFilter) ([]Operation, error) {
+	if f.WorkspaceID == "" {
+		return nil, fmt.Errorf("ListOperations: WorkspaceID required")
+	}
+	if f.Limit <= 0 {
+		f.Limit = defaultListLimit
+	}
+	if f.Limit > maxListLimit {
+		f.Limit = maxListLimit
+	}
+
+	var (
+		args  []any
+		where []string
+	)
+	pushArg := func(v any) string {
+		args = append(args, v)
+		return fmt.Sprintf("$%d", len(args))
+	}
+	where = append(where, "workspace_id = "+pushArg(f.WorkspaceID))
+	if f.ID != "" {
+		where = append(where, "id = "+pushArg(f.ID))
+	}
+	if f.EnvID != "" {
+		where = append(where, "env_id = "+pushArg(f.EnvID))
+	}
+	if f.Tool != "" {
+		where = append(where, "tool = "+pushArg(f.Tool))
+	}
+	if f.Source != "" {
+		where = append(where, "source = "+pushArg(f.Source))
+	}
+	if f.IsError != nil {
+		where = append(where, "is_error = "+pushArg(*f.IsError))
+	}
+	if f.Since != nil {
+		where = append(where, "started_at >= "+pushArg(*f.Since))
+	}
+	limit := pushArg(f.Limit)
+
+	q := `SELECT id, workspace_id, user_id, source, thread_id, request_id,
+		env_id, tool, arguments, arguments_meta,
+		is_error, result_summary, result_meta,
+		started_at, completed_at, duration_ms,
+		notebook_path, cell_id
+		FROM operations WHERE ` + strings.Join(where, " AND ") +
+		" ORDER BY started_at DESC LIMIT " + limit
+	rows, err := db.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Operation
+	for rows.Next() {
+		var o Operation
+		var args, argsMeta, resMeta sql.NullString
+		err := rows.Scan(
+			&o.ID, &o.WorkspaceID, &o.UserID, &o.Source, &o.ThreadID, &o.RequestID,
+			&o.EnvID, &o.Tool, &args, &argsMeta,
+			&o.IsError, &o.ResultSummary, &resMeta,
+			&o.StartedAt, &o.CompletedAt, &o.DurationMs,
+			&o.NotebookPath, &o.CellID,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if args.Valid {
+			o.Arguments = json.RawMessage(args.String)
+		}
+		if argsMeta.Valid {
+			o.ArgumentsMeta = json.RawMessage(argsMeta.String)
+		}
+		if resMeta.Valid {
+			o.ResultMeta = json.RawMessage(resMeta.String)
+		}
+		out = append(out, o)
+	}
+	return out, rows.Err()
+}
+
+// PruneOperationsOlderThan deletes operations whose started_at is strictly
+// before cutoff. Returns the number of rows deleted.
+func (db *DB) PruneOperationsOlderThan(cutoff time.Time) (int64, error) {
+	res, err := db.Exec("DELETE FROM operations WHERE started_at < $1", cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+```
+
+- [ ] **Step 6: Run tests to verify pass**
+
+Run: `go test ./internal/db -run 'TestOperations' -v`
+Expected: 3 passed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /root/agentserver
+git add internal/db/migrations/023_operations.sql \
+        internal/db/operations.go \
+        internal/db/operations_test.go
+git commit -m "feat(db): operations table + insert/list/prune queries
+
+Plan 2 schema for the operation log. Columns include v1.5 nullable
+notebook_path/cell_id so we don't need a follow-up migration."
+```
+
+---
+
+## Task 2: agentserver `/internal/operations` handlers
+
+**Files:**
+- Create: `internal/server/operations.go`
+- Create: `internal/server/operations_test.go`
+- Modify: `internal/server/server.go` — wire the new routes (find the chi router setup, add `/internal/operations` POST + GET; reuse the existing internal-secret middleware)
+
+- [ ] **Step 1: Inspect how other /internal/* routes are wired**
+
+Read enough of `internal/server/server.go` to find the chi router setup and identify the middleware used for bearer-auth on `/internal/*`. Typical name: `requireInternalSecret` or similar. If unclear, grep:
+
+```bash
+grep -rn "AgentserverInternalSecret\|internal.*Bearer\|requireInternal" /root/agentserver/internal/server/ | head -10
+```
+
+Adopt whatever pattern is already in use. Don't invent new middleware.
+
+- [ ] **Step 2: Write failing handler tests**
+
+Create `internal/server/operations_test.go`:
+
+```go
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestPostInternalOperations_WritesRow(t *testing.T) {
+	s := newTestServer(t) // reuse whatever existing test helper builds *Server with a real DB
+	defer s.Close()
+
+	body := map[string]any{
+		"id":            uuid.NewString(),
+		"workspace_id":  "ws-1",
+		"user_id":       "u-1",
+		"source":        "sdk",
+		"env_id":        "alpha",
+		"tool":          "shell",
+		"arguments":     map[string]any{"command": "ls"},
+		"is_error":      false,
+		"result_summary": "ok",
+		"started_at":    time.Now().UTC().Format(time.RFC3339Nano),
+		"completed_at":  time.Now().UTC().Format(time.RFC3339Nano),
+		"duration_ms":   8,
+	}
+	buf, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/internal/operations", bytes.NewReader(buf))
+	req.Header.Set("Authorization", "Bearer "+s.internalSecretForTests())
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	s.routerForTests().ServeHTTP(rr, req)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status %d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+func TestPostInternalOperations_Unauthorized(t *testing.T) {
+	s := newTestServer(t)
+	defer s.Close()
+
+	req := httptest.NewRequest(http.MethodPost, "/internal/operations", bytes.NewReader([]byte(`{}`)))
+	// no Authorization header
+	rr := httptest.NewRecorder()
+	s.routerForTests().ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status %d, want 401", rr.Code)
+	}
+}
+
+func TestGetInternalOperations_FiltersByWorkspaceAndTool(t *testing.T) {
+	s := newTestServer(t)
+	defer s.Close()
+
+	post := func(wsID, env, tool string) {
+		body := map[string]any{
+			"id":           uuid.NewString(),
+			"workspace_id": wsID,
+			"source":       "sdk",
+			"env_id":       env,
+			"tool":         tool,
+			"arguments":    map[string]any{},
+			"is_error":     false,
+			"started_at":   time.Now().UTC().Format(time.RFC3339Nano),
+			"completed_at": time.Now().UTC().Format(time.RFC3339Nano),
+			"duration_ms":  1,
+		}
+		buf, _ := json.Marshal(body)
+		req := httptest.NewRequest(http.MethodPost, "/internal/operations", bytes.NewReader(buf))
+		req.Header.Set("Authorization", "Bearer "+s.internalSecretForTests())
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		s.routerForTests().ServeHTTP(rr, req)
+		if rr.Code != http.StatusNoContent {
+			t.Fatalf("post: %d %s", rr.Code, rr.Body.String())
+		}
+	}
+	post("ws-1", "alpha", "shell")
+	post("ws-1", "alpha", "read_file")
+	post("ws-2", "alpha", "shell")
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/internal/operations?workspace_id=ws-1&tool=shell&limit=50", nil)
+	req.Header.Set("Authorization", "Bearer "+s.internalSecretForTests())
+	rr := httptest.NewRecorder()
+	s.routerForTests().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("get: %d %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Operations []map[string]any `json:"operations"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Operations) != 1 {
+		t.Fatalf("rows = %d, want 1", len(resp.Operations))
+	}
+	if resp.Operations[0]["workspace_id"] != "ws-1" || resp.Operations[0]["tool"] != "shell" {
+		t.Fatalf("row = %+v", resp.Operations[0])
+	}
+}
+```
+
+If `newTestServer` / `routerForTests` / `internalSecretForTests` aren't existing helpers, use the closest equivalents (look at how `handler_tui_internal_test.go` already builds `internalRouter(s)` — pattern is `internalRouter(s).ServeHTTP(...)`).
+
+- [ ] **Step 3: Run to verify failure**
+
+```bash
+go test ./internal/server -run 'TestPostInternalOperations|TestGetInternalOperations' -v
+```
+Expected: FAIL — handler not registered.
+
+- [ ] **Step 4: Implement handlers**
+
+Create `internal/server/operations.go`:
+
+```go
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/agentserver/agentserver/internal/db"
+)
+
+// postInternalOperations is POST /internal/operations.
+// Body is a JSON object matching the agentserver "operation record" shape.
+// Auth: AgentserverInternalSecret bearer (via existing internal middleware).
+func (s *Server) postInternalOperations(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		ID            string          `json:"id"`
+		WorkspaceID   string          `json:"workspace_id"`
+		UserID        *string         `json:"user_id,omitempty"`
+		Source        string          `json:"source"`
+		ThreadID      *string         `json:"thread_id,omitempty"`
+		RequestID     *string         `json:"request_id,omitempty"`
+		EnvID         string          `json:"env_id"`
+		Tool          string          `json:"tool"`
+		Arguments     json.RawMessage `json:"arguments,omitempty"`
+		ArgumentsMeta json.RawMessage `json:"arguments_meta,omitempty"`
+		IsError       bool            `json:"is_error"`
+		ResultSummary *string         `json:"result_summary,omitempty"`
+		ResultMeta    json.RawMessage `json:"result_meta,omitempty"`
+		StartedAt     time.Time       `json:"started_at"`
+		CompletedAt   time.Time       `json:"completed_at"`
+		DurationMs    int32           `json:"duration_ms"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid json: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if body.ID == "" || body.WorkspaceID == "" || body.Source == "" || body.EnvID == "" || body.Tool == "" {
+		http.Error(w, "missing required fields", http.StatusBadRequest)
+		return
+	}
+	op := db.Operation{
+		ID: body.ID, WorkspaceID: body.WorkspaceID, UserID: body.UserID,
+		Source: body.Source, ThreadID: body.ThreadID, RequestID: body.RequestID,
+		EnvID: body.EnvID, Tool: body.Tool,
+		Arguments: body.Arguments, ArgumentsMeta: body.ArgumentsMeta,
+		IsError: body.IsError, ResultSummary: body.ResultSummary, ResultMeta: body.ResultMeta,
+		StartedAt: body.StartedAt, CompletedAt: body.CompletedAt, DurationMs: body.DurationMs,
+	}
+	if err := s.db.InsertOperation(op); err != nil {
+		s.log.Warn("operations: insert failed", "err", err, "workspace_id", op.WorkspaceID)
+		http.Error(w, "insert failed", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// getInternalOperations is GET /internal/operations.
+// Query params: workspace_id (required), env_id, tool, source, is_error, since
+// (RFC3339), id, limit (default 100, max 1000).
+func (s *Server) getInternalOperations(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	wsID := q.Get("workspace_id")
+	if wsID == "" {
+		http.Error(w, "workspace_id required", http.StatusBadRequest)
+		return
+	}
+	f := db.OperationFilter{
+		WorkspaceID: wsID,
+		EnvID:       q.Get("env_id"),
+		Tool:        q.Get("tool"),
+		Source:      q.Get("source"),
+		ID:          q.Get("id"),
+	}
+	if v := q.Get("is_error"); v != "" {
+		b := v == "true" || v == "1"
+		f.IsError = &b
+	}
+	if v := q.Get("since"); v != "" {
+		t, err := time.Parse(time.RFC3339Nano, v)
+		if err != nil {
+			http.Error(w, "since: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		f.Since = &t
+	}
+	if v := q.Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			http.Error(w, "limit: invalid", http.StatusBadRequest)
+			return
+		}
+		f.Limit = n
+	}
+	rows, err := s.db.ListOperations(f)
+	if err != nil {
+		s.log.Warn("operations: list failed", "err", err)
+		http.Error(w, "list failed", http.StatusInternalServerError)
+		return
+	}
+	type respRow struct {
+		ID            string          `json:"id"`
+		WorkspaceID   string          `json:"workspace_id"`
+		UserID        *string         `json:"user_id,omitempty"`
+		Source        string          `json:"source"`
+		ThreadID      *string         `json:"thread_id,omitempty"`
+		EnvID         string          `json:"env_id"`
+		Tool          string          `json:"tool"`
+		Arguments     json.RawMessage `json:"arguments,omitempty"`
+		ArgumentsMeta json.RawMessage `json:"arguments_meta,omitempty"`
+		IsError       bool            `json:"is_error"`
+		ResultSummary *string         `json:"result_summary,omitempty"`
+		ResultMeta    json.RawMessage `json:"result_meta,omitempty"`
+		StartedAt     time.Time       `json:"started_at"`
+		CompletedAt   time.Time       `json:"completed_at"`
+		DurationMs    int32           `json:"duration_ms"`
+	}
+	out := make([]respRow, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, respRow{
+			ID: r.ID, WorkspaceID: r.WorkspaceID, UserID: r.UserID,
+			Source: r.Source, ThreadID: r.ThreadID,
+			EnvID: r.EnvID, Tool: r.Tool,
+			Arguments: r.Arguments, ArgumentsMeta: r.ArgumentsMeta,
+			IsError: r.IsError, ResultSummary: r.ResultSummary, ResultMeta: r.ResultMeta,
+			StartedAt: r.StartedAt, CompletedAt: r.CompletedAt, DurationMs: r.DurationMs,
+		})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"operations": out})
+}
+```
+
+- [ ] **Step 5: Wire routes in `server.go`**
+
+Find where `internal/*` routes are mounted on the chi router. Add:
+
+```go
+r.Post("/internal/operations", s.postInternalOperations)
+r.Get("/internal/operations",  s.getInternalOperations)
+```
+
+Both should sit behind the existing internal-secret middleware.
+
+- [ ] **Step 6: Run tests, confirm pass**
+
+```bash
+go test ./internal/server -run 'TestPostInternalOperations|TestGetInternalOperations' -v
+```
+Expected: 3 passed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /root/agentserver
+git add internal/server/operations.go internal/server/operations_test.go internal/server/server.go
+git commit -m "feat(server): /internal/operations POST + GET handlers
+
+bearer-secret authed; POST is fire-and-forget for the gateway; GET
+supports workspace_id+env/tool/source/is_error/since/id+limit filters."
+```
+
+---
+
+## Task 3: agentserver retention goroutine
+
+**Files:**
+- Create: `internal/server/operations_retention.go`
+- Create: `internal/server/operations_retention_test.go`
+- Modify: `internal/server/server.go` — start retention loop in server boot; cancel on shutdown
+- Modify: `main.go` — pass retention config (TTL + interval) through
+
+- [ ] **Step 1: Write failing test**
+
+Create `internal/server/operations_retention_test.go`:
+
+```go
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/agentserver/agentserver/internal/db"
+)
+
+func TestStartRetention_DeletesOldRows(t *testing.T) {
+	s := newTestServer(t)
+	defer s.Close()
+
+	// Seed old + new
+	old := time.Now().UTC().Add(-100 * 24 * time.Hour)
+	now := time.Now().UTC()
+	for _, ts := range []time.Time{old, now} {
+		err := s.db.InsertOperation(db.Operation{
+			ID: uuid.NewString(), WorkspaceID: "ws", Source: "sdk",
+			EnvID: "a", Tool: "shell", IsError: false,
+			Arguments: json.RawMessage(`{}`),
+			StartedAt: ts, CompletedAt: ts, DurationMs: 1,
+		})
+		if err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	// Run a single iteration explicitly (test exposes the inner step)
+	n, err := s.runRetentionOnce(90 * 24 * time.Hour)
+	if err != nil {
+		t.Fatalf("retention: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("deleted = %d, want 1", n)
+	}
+
+	// Confirm the new row survived
+	rows, err := s.db.ListOperations(db.OperationFilter{WorkspaceID: "ws", Limit: 10})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("remaining = %d, want 1", len(rows))
+	}
+
+	_ = ctx
+}
+
+func TestStartRetention_TickerStops(t *testing.T) {
+	s := newTestServer(t)
+	defer s.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		s.startRetentionLoop(ctx, 90*24*time.Hour, 50*time.Millisecond)
+		close(done)
+	}()
+	time.Sleep(150 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("retention loop did not exit after ctx cancel")
+	}
+}
+```
+
+- [ ] **Step 2: Run to confirm failure**
+
+```bash
+go test ./internal/server -run 'TestStartRetention' -v
+```
+Expected: FAIL — `runRetentionOnce` / `startRetentionLoop` undefined.
+
+- [ ] **Step 3: Implement retention loop**
+
+Create `internal/server/operations_retention.go`:
+
+```go
+package server
+
+import (
+	"context"
+	"time"
+)
+
+// runRetentionOnce deletes operations older than ttl. Exposed for tests.
+func (s *Server) runRetentionOnce(ttl time.Duration) (int64, error) {
+	cutoff := time.Now().Add(-ttl)
+	return s.db.PruneOperationsOlderThan(cutoff)
+}
+
+// startRetentionLoop ticks every `every` and prunes operations older
+// than ttl. Returns when ctx is cancelled. Errors are logged, not
+// propagated — a transient PG failure shouldn't kill the loop.
+func (s *Server) startRetentionLoop(ctx context.Context, ttl time.Duration, every time.Duration) {
+	if every <= 0 {
+		every = time.Hour
+	}
+	if ttl <= 0 {
+		return // disabled
+	}
+	t := time.NewTicker(every)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			n, err := s.runRetentionOnce(ttl)
+			if err != nil {
+				s.log.Warn("operations retention: prune failed", "err", err)
+				continue
+			}
+			if n > 0 {
+				s.log.Info("operations retention: pruned", "rows", n)
+			}
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Wire startup in server.go**
+
+In `server.go` (or wherever the server `Run`/`Serve` lifecycle lives), launch the retention goroutine bound to the server's lifetime context with the configured TTL + interval. Default TTL: 90 days. Default interval: 1 hour. If `ttl == 0`, skip the loop (retention disabled).
+
+Read the surrounding code first to choose the right insertion point — likely near where other background goroutines are started (look for `go s.Something`).
+
+- [ ] **Step 5: Run tests, confirm pass**
+
+```bash
+go test ./internal/server -run 'TestStartRetention' -v
+```
+Expected: 2 passed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /root/agentserver
+git add internal/server/operations_retention.go \
+        internal/server/operations_retention_test.go \
+        internal/server/server.go
+git commit -m "feat(server): hourly operations retention loop
+
+prunes operations older than configured TTL (default 90 days). Loop
+exits cleanly on context cancel; transient errors logged not fatal."
+```
+
+---
+
+## Task 4: `oplog.Client` — async HTTP submitter
+
+**Files:**
+- Create: `internal/codexappgateway/oplog/doc.go`
+- Create: `internal/codexappgateway/oplog/client.go`
+- Create: `internal/codexappgateway/oplog/client_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `internal/codexappgateway/oplog/client_test.go`:
+
+```go
+package oplog
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestClient_Submit_FireAndForgetPOST(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		bodies  [][]byte
+		gotAuth string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		buf := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(buf)
+		mu.Lock()
+		bodies = append(bodies, buf)
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL+"/internal/operations", "secret-x", 16)
+	defer c.Close()
+
+	op := Operation{
+		ID: "op-1", WorkspaceID: "ws", Source: "sdk",
+		EnvID: "alpha", Tool: "shell", IsError: false,
+		StartedAt: time.Now().UTC(), CompletedAt: time.Now().UTC(),
+		DurationMs: 1,
+	}
+	c.Submit(op) // non-blocking
+	c.Submit(op)
+
+	// Wait for the background drainer to flush
+	if !waitFor(2*time.Second, func() bool {
+		mu.Lock(); defer mu.Unlock()
+		return len(bodies) == 2
+	}) {
+		t.Fatalf("flushed %d, want 2", len(bodies))
+	}
+	if gotAuth != "Bearer secret-x" {
+		t.Fatalf("auth header = %q", gotAuth)
+	}
+}
+
+func TestClient_Submit_BoundedDropsOnFull(t *testing.T) {
+	// Stall the server forever; channel fills, Submit must NOT block.
+	block := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-block
+	}))
+	defer srv.Close()
+	defer close(block)
+
+	c := NewClient(srv.URL+"/", "s", 2) // tiny channel
+	defer c.Close()
+
+	op := Operation{
+		ID: "op", WorkspaceID: "ws", Source: "sdk",
+		EnvID: "a", Tool: "shell",
+		StartedAt: time.Now().UTC(), CompletedAt: time.Now().UTC(),
+	}
+	// Fire many; should not block even when channel is full.
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 50; i++ {
+			c.Submit(op)
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Submit blocked")
+	}
+	if c.Dropped() == 0 {
+		t.Fatalf("expected drops, got %d", c.Dropped())
+	}
+}
+
+func TestClient_Submit_DoesNotBlockOnServerError(t *testing.T) {
+	hits := int64(0)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&hits, 1)
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL+"/", "s", 16)
+	defer c.Close()
+
+	op := Operation{
+		ID: "x", WorkspaceID: "ws", Source: "sdk",
+		EnvID: "a", Tool: "shell",
+		StartedAt: time.Now().UTC(), CompletedAt: time.Now().UTC(),
+	}
+	c.Submit(op)
+	if !waitFor(time.Second, func() bool { return atomic.LoadInt64(&hits) >= 1 }) {
+		t.Fatal("server never received the post")
+	}
+	// Server returned 500; client must keep accepting more submits.
+	c.Submit(op)
+	if !waitFor(time.Second, func() bool { return atomic.LoadInt64(&hits) >= 2 }) {
+		t.Fatal("client stopped sending after server error")
+	}
+}
+
+func waitFor(timeout time.Duration, cond func() bool) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return cond()
+}
+
+func TestOperation_MarshalJSON(t *testing.T) {
+	o := Operation{
+		ID: "x", WorkspaceID: "w", Source: "sdk",
+		EnvID: "a", Tool: "shell", IsError: false,
+		Arguments: json.RawMessage(`{"a":1}`),
+		StartedAt: time.Unix(1700000000, 0).UTC(),
+		CompletedAt: time.Unix(1700000001, 0).UTC(),
+		DurationMs: 5,
+	}
+	b, err := json.Marshal(o)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !contains(b, `"workspace_id":"w"`) || !contains(b, `"arguments":{"a":1}`) {
+		t.Fatalf("body = %s", b)
+	}
+}
+
+func contains(b []byte, s string) bool { return string(b)[:0] == "" && bytesIndex(b, s) >= 0 }
+func bytesIndex(b []byte, s string) int {
+	for i := 0; i+len(s) <= len(b); i++ {
+		if string(b[i:i+len(s)]) == s {
+			return i
+		}
+	}
+	return -1
+}
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+```bash
+go test ./internal/codexappgateway/oplog/ -v
+```
+Expected: FAIL — package missing.
+
+- [ ] **Step 3: Implement package**
+
+Create `internal/codexappgateway/oplog/doc.go`:
+
+```go
+// Package oplog publishes per-call operation records from codex-app-gateway
+// to agentserver's /internal/operations POST endpoint. Submit is async and
+// fire-and-forget; tool calls never block on log delivery.
+package oplog
+```
+
+Create `internal/codexappgateway/oplog/client.go`:
+
+```go
+package oplog
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"sync/atomic"
+	"time"
+)
+
+// Operation is what we POST to agentserver /internal/operations.
+// Field shapes match internal/server/operations.go's request struct.
+type Operation struct {
+	ID            string          `json:"id"`
+	WorkspaceID   string          `json:"workspace_id"`
+	UserID        *string         `json:"user_id,omitempty"`
+	Source        string          `json:"source"`
+	ThreadID      *string         `json:"thread_id,omitempty"`
+	RequestID     *string         `json:"request_id,omitempty"`
+
+	EnvID         string          `json:"env_id"`
+	Tool          string          `json:"tool"`
+	Arguments     json.RawMessage `json:"arguments,omitempty"`
+	ArgumentsMeta json.RawMessage `json:"arguments_meta,omitempty"`
+
+	IsError       bool            `json:"is_error"`
+	ResultSummary *string         `json:"result_summary,omitempty"`
+	ResultMeta    json.RawMessage `json:"result_meta,omitempty"`
+
+	StartedAt     time.Time       `json:"started_at"`
+	CompletedAt   time.Time       `json:"completed_at"`
+	DurationMs    int32           `json:"duration_ms"`
+}
+
+// Client posts Operations to agentserver. Submit is non-blocking; one
+// background goroutine drains a bounded channel and POSTs each one.
+type Client struct {
+	url     string
+	secret  string
+	ch      chan Operation
+	hc      *http.Client
+	logger  *slog.Logger
+	dropped uint64
+	cancel  context.CancelFunc
+	done    chan struct{}
+}
+
+// NewClient starts the background drainer immediately. Capacity bounds
+// how many Operations can queue before Submit starts dropping.
+func NewClient(url, secret string, capacity int) *Client {
+	if capacity <= 0 {
+		capacity = 1024
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &Client{
+		url:    url,
+		secret: secret,
+		ch:     make(chan Operation, capacity),
+		hc:     &http.Client{Timeout: 5 * time.Second},
+		logger: slog.Default().With("component", "oplog"),
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}
+	go c.drain(ctx)
+	return c
+}
+
+// Submit enqueues op. Never blocks. Drops on full channel and bumps the
+// `dropped` counter, which a metrics exporter can read via Dropped().
+func (c *Client) Submit(op Operation) {
+	select {
+	case c.ch <- op:
+	default:
+		atomic.AddUint64(&c.dropped, 1)
+	}
+}
+
+// Dropped is the cumulative number of Submit calls that hit a full channel.
+func (c *Client) Dropped() uint64 { return atomic.LoadUint64(&c.dropped) }
+
+// Close stops the drainer. Already-queued ops are abandoned.
+func (c *Client) Close() {
+	c.cancel()
+	<-c.done
+}
+
+func (c *Client) drain(ctx context.Context) {
+	defer close(c.done)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case op := <-c.ch:
+			c.post(ctx, op)
+		}
+	}
+}
+
+func (c *Client) post(ctx context.Context, op Operation) {
+	buf, err := json.Marshal(op)
+	if err != nil {
+		c.logger.Warn("oplog: marshal failed", "id", op.ID, "err", err)
+		return
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url, bytes.NewReader(buf))
+	if err != nil {
+		c.logger.Warn("oplog: build request failed", "err", err)
+		return
+	}
+	req.Header.Set("Authorization", "Bearer "+c.secret)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		c.logger.Warn("oplog: POST failed", "err", err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		c.logger.Warn("oplog: agentserver non-2xx",
+			"status", resp.StatusCode, "body", string(body))
+	}
+}
+
+// ListClient is the synchronous read-side: used by the gateway's
+// operations/list RPC interceptor. Separate type so the async/sync
+// surfaces don't share channels.
+type ListClient struct {
+	url    string
+	secret string
+	hc     *http.Client
+}
+
+func NewListClient(url, secret string) *ListClient {
+	return &ListClient{
+		url: url, secret: secret,
+		hc: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+// List forwards filter params to agentserver and returns the decoded
+// `operations` slice (raw, so the gateway can re-encode into the ws frame).
+func (c *ListClient) List(ctx context.Context, params map[string]string) (json.RawMessage, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url, nil)
+	if err != nil {
+		return nil, err
+	}
+	q := req.URL.Query()
+	for k, v := range params {
+		if v != "" {
+			q.Set(k, v)
+		}
+	}
+	req.URL.RawQuery = q.Encode()
+	req.Header.Set("Authorization", "Bearer "+c.secret)
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("operations list: %d %s", resp.StatusCode, string(body))
+	}
+	return body, nil
+}
+```
+
+The test file uses some helpers (`contains`, `bytesIndex`) that I inlined to avoid an extra import. Feel free to replace with `strings.Contains(string(b), s)` after the test passes — equivalent.
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+```bash
+go test ./internal/codexappgateway/oplog/ -v
+```
+Expected: 4 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /root/agentserver
+git add internal/codexappgateway/oplog/
+git commit -m "feat(oplog): async HTTP client + sync ListClient
+
+Submit is fire-and-forget over bounded channel (default 1024); drops
+counted. Sync ListClient is used by the gateway's operations/list
+interceptor (Task 6)."
+```
+
+---
+
+## Task 5: `oplog.Interceptor` — JSON-RPC frame parsing
+
+**Files:**
+- Create: `internal/codexappgateway/oplog/interceptor.go`
+- Create: `internal/codexappgateway/oplog/interceptor_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `internal/codexappgateway/oplog/interceptor_test.go`:
+
+```go
+package oplog
+
+import (
+	"encoding/json"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type captureClient struct {
+	mu  sync.Mutex
+	ops []Operation
+}
+
+func (c *captureClient) Submit(op Operation) {
+	c.mu.Lock(); defer c.mu.Unlock()
+	c.ops = append(c.ops, op)
+}
+func (c *captureClient) Dropped() uint64 { return 0 }
+
+// Pairs request + response into one Operation.
+func TestInterceptor_ParesRequestAndResponse(t *testing.T) {
+	cc := &captureClient{}
+	i := NewInterceptor(cc, Config{Source: "sdk", WorkspaceID: "ws-1"})
+
+	req := []byte(`{"jsonrpc":"2.0","id":7,"method":"mcpServer/tool/call","params":{
+		"thread_id":"th-1","server":"env_mcp","tool":"shell",
+		"arguments":{"environment_id":"alpha","command":"ls"},
+		"_meta":{"agentserver_user_id":"u-1"}}}`)
+	resp := []byte(`{"jsonrpc":"2.0","id":7,"result":{
+		"content":[{"type":"text","text":"hi"}],"isError":false}}`)
+
+	i.OnClientFrame(req)
+	i.OnServerFrame(resp)
+
+	if len(cc.ops) != 1 {
+		t.Fatalf("ops = %d", len(cc.ops))
+	}
+	op := cc.ops[0]
+	if op.WorkspaceID != "ws-1" || op.Source != "sdk" ||
+		op.EnvID != "alpha" || op.Tool != "shell" || op.IsError {
+		t.Fatalf("op = %+v", op)
+	}
+	if op.UserID == nil || *op.UserID != "u-1" {
+		t.Fatalf("user_id = %v", op.UserID)
+	}
+	if op.ThreadID == nil || *op.ThreadID != "th-1" {
+		t.Fatalf("thread_id = %v", op.ThreadID)
+	}
+	if op.ResultSummary == nil || *op.ResultSummary != "hi" {
+		t.Fatalf("result_summary = %v", op.ResultSummary)
+	}
+}
+
+// Frames that aren't tool/call (other methods, notifications, malformed) pass
+// without being logged.
+func TestInterceptor_IgnoresIrrelevantFrames(t *testing.T) {
+	cc := &captureClient{}
+	i := NewInterceptor(cc, Config{Source: "sdk", WorkspaceID: "ws-1"})
+
+	i.OnClientFrame([]byte(`{"method":"initialized"}`)) // notification, no id
+	i.OnClientFrame([]byte(`{"jsonrpc":"2.0","id":1,"method":"thread/start","params":{}}`))
+	i.OnServerFrame([]byte(`{"jsonrpc":"2.0","id":1,"result":{"thread_id":"x"}}`))
+	i.OnServerFrame([]byte(`not json`))
+
+	if len(cc.ops) != 0 {
+		t.Fatalf("logged unrelated frames: %+v", cc.ops)
+	}
+}
+
+// isError=true is captured.
+func TestInterceptor_RecordsIsError(t *testing.T) {
+	cc := &captureClient{}
+	i := NewInterceptor(cc, Config{Source: "sdk", WorkspaceID: "ws"})
+	i.OnClientFrame([]byte(`{"jsonrpc":"2.0","id":3,"method":"mcpServer/tool/call","params":{
+		"thread_id":"t","server":"env_mcp","tool":"shell",
+		"arguments":{"environment_id":"a","command":"bad"}}}`))
+	i.OnServerFrame([]byte(`{"jsonrpc":"2.0","id":3,"result":{
+		"content":[{"type":"text","text":"oops"}],"isError":true}}`))
+
+	if len(cc.ops) != 1 || !cc.ops[0].IsError {
+		t.Fatalf("ops = %+v", cc.ops)
+	}
+}
+
+// Arguments larger than the threshold are replaced with arguments_meta.
+func TestInterceptor_TruncatesLargeArguments(t *testing.T) {
+	cc := &captureClient{}
+	i := NewInterceptor(cc, Config{Source: "sdk", WorkspaceID: "ws", ArgsMaxBytes: 50})
+
+	big := make([]byte, 200)
+	for x := range big {
+		big[x] = 'a'
+	}
+	args, _ := json.Marshal(map[string]any{"data": string(big), "environment_id": "a"})
+	frame := append([]byte(`{"jsonrpc":"2.0","id":11,"method":"mcpServer/tool/call","params":{
+		"server":"env_mcp","tool":"write_file","arguments":`), args...)
+	frame = append(frame, '}', '}')
+	i.OnClientFrame(frame)
+	i.OnServerFrame([]byte(`{"jsonrpc":"2.0","id":11,"result":{"content":[],"isError":false}}`))
+
+	if len(cc.ops) != 1 {
+		t.Fatalf("ops = %d", len(cc.ops))
+	}
+	op := cc.ops[0]
+	if op.Arguments != nil {
+		t.Fatal("arguments should be nil when truncated")
+	}
+	if op.ArgumentsMeta == nil {
+		t.Fatal("arguments_meta missing")
+	}
+	var m map[string]any
+	_ = json.Unmarshal(op.ArgumentsMeta, &m)
+	if m["truncated"] != true {
+		t.Fatalf("arguments_meta = %v", m)
+	}
+}
+
+// Long text results are truncated; result_meta records total size.
+func TestInterceptor_TruncatesLargeTextResult(t *testing.T) {
+	cc := &captureClient{}
+	i := NewInterceptor(cc, Config{Source: "sdk", WorkspaceID: "ws", ResultMaxBytes: 10})
+
+	long := make([]byte, 100)
+	for x := range long {
+		long[x] = 'z'
+	}
+	i.OnClientFrame([]byte(`{"jsonrpc":"2.0","id":4,"method":"mcpServer/tool/call","params":{
+		"server":"env_mcp","tool":"read_file","arguments":{"environment_id":"a","path":"/x"}}}`))
+	resp, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0", "id": 4,
+		"result": map[string]any{
+			"content": []map[string]any{{"type": "text", "text": string(long)}},
+			"isError": false,
+		},
+	})
+	i.OnServerFrame(resp)
+
+	op := cc.ops[0]
+	if op.ResultSummary == nil || len(*op.ResultSummary) > 10 {
+		t.Fatalf("result_summary = %v", op.ResultSummary)
+	}
+	if op.ResultMeta == nil {
+		t.Fatal("result_meta missing")
+	}
+}
+
+// Concurrent request/response handling — id-keyed pending map.
+func TestInterceptor_ConcurrentPairs(t *testing.T) {
+	cc := &captureClient{}
+	i := NewInterceptor(cc, Config{Source: "sdk", WorkspaceID: "ws"})
+
+	var wg sync.WaitGroup
+	var sent int64
+	for n := 0; n < 50; n++ {
+		wg.Add(1)
+		id := n + 1
+		go func() {
+			defer wg.Done()
+			req := []byte(`{"jsonrpc":"2.0","id":` + itoa(id) + `,"method":"mcpServer/tool/call","params":{
+				"server":"env_mcp","tool":"shell","arguments":{"environment_id":"a","command":"x"}}}`)
+			resp := []byte(`{"jsonrpc":"2.0","id":` + itoa(id) + `,"result":{"content":[],"isError":false}}`)
+			i.OnClientFrame(req)
+			i.OnServerFrame(resp)
+			atomic.AddInt64(&sent, 1)
+		}()
+	}
+	wg.Wait()
+	if !waitFor(2*time.Second, func() bool {
+		cc.mu.Lock(); defer cc.mu.Unlock()
+		return len(cc.ops) == 50
+	}) {
+		t.Fatalf("ops = %d, want 50", len(cc.ops))
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b [16]byte
+	i := len(b)
+	for n > 0 {
+		i--
+		b[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(b[i:])
+}
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+```bash
+go test ./internal/codexappgateway/oplog/ -run TestInterceptor -v
+```
+Expected: FAIL — `Interceptor`, `NewInterceptor`, `Config` undefined.
+
+- [ ] **Step 3: Implement Interceptor**
+
+Create `internal/codexappgateway/oplog/interceptor.go`:
+
+```go
+package oplog
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	defaultArgsMaxBytes   = 64 * 1024
+	defaultResultMaxBytes = 4 * 1024
+)
+
+// Submitter is the subset of Client that the Interceptor needs. Lets
+// tests pass a capture stub.
+type Submitter interface {
+	Submit(Operation)
+}
+
+// Config tunes the Interceptor at construction.
+type Config struct {
+	Source         string // "sdk" | "tui"
+	WorkspaceID    string // pinned from the ws Identity
+	ArgsMaxBytes   int    // 0 → 64 KiB
+	ResultMaxBytes int    // 0 → 4 KiB
+}
+
+// Interceptor parses JSON-RPC frames as they cross the ws bridge. On a
+// matched request+response for mcpServer/tool/call, it emits one
+// Operation to the Submitter.
+type Interceptor struct {
+	sub Submitter
+	cfg Config
+
+	mu      sync.Mutex
+	pending map[any]pendingReq
+}
+
+type pendingReq struct {
+	startedAt time.Time
+	env       string
+	tool      string
+	threadID  string
+	userID    string
+	args      json.RawMessage
+	argsSize  int
+}
+
+func NewInterceptor(s Submitter, cfg Config) *Interceptor {
+	if cfg.ArgsMaxBytes <= 0 {
+		cfg.ArgsMaxBytes = defaultArgsMaxBytes
+	}
+	if cfg.ResultMaxBytes <= 0 {
+		cfg.ResultMaxBytes = defaultResultMaxBytes
+	}
+	return &Interceptor{sub: s, cfg: cfg, pending: map[any]pendingReq{}}
+}
+
+// OnClientFrame is called on every client→server frame BEFORE it's forwarded.
+// Never blocks. Errors are silent — parsing failures are not Interceptor's
+// problem; the underlying pump still forwards the bytes.
+func (i *Interceptor) OnClientFrame(frame []byte) {
+	var msg struct {
+		ID     any             `json:"id"`
+		Method string          `json:"method"`
+		Params json.RawMessage `json:"params"`
+	}
+	if err := json.Unmarshal(frame, &msg); err != nil {
+		return
+	}
+	if msg.ID == nil || msg.Method != "mcpServer/tool/call" {
+		return
+	}
+	var p struct {
+		ThreadID  string          `json:"thread_id"`
+		Server    string          `json:"server"`
+		Tool      string          `json:"tool"`
+		Arguments json.RawMessage `json:"arguments"`
+		Meta      struct {
+			UserID string `json:"agentserver_user_id"`
+		} `json:"_meta"`
+	}
+	if err := json.Unmarshal(msg.Params, &p); err != nil {
+		return
+	}
+	var envID string
+	if len(p.Arguments) > 0 {
+		var args struct {
+			EnvironmentID string `json:"environment_id"`
+		}
+		_ = json.Unmarshal(p.Arguments, &args)
+		envID = args.EnvironmentID
+	}
+
+	i.mu.Lock()
+	i.pending[msg.ID] = pendingReq{
+		startedAt: time.Now().UTC(),
+		env:       envID,
+		tool:      p.Tool,
+		threadID:  p.ThreadID,
+		userID:    p.Meta.UserID,
+		args:      p.Arguments,
+		argsSize:  len(p.Arguments),
+	}
+	i.mu.Unlock()
+}
+
+// OnServerFrame is called on every server→client frame. If it pairs with
+// a pending request, emits an Operation.
+func (i *Interceptor) OnServerFrame(frame []byte) {
+	var msg struct {
+		ID     any             `json:"id"`
+		Result json.RawMessage `json:"result"`
+		Error  json.RawMessage `json:"error"`
+	}
+	if err := json.Unmarshal(frame, &msg); err != nil {
+		return
+	}
+	if msg.ID == nil {
+		return
+	}
+	i.mu.Lock()
+	pr, ok := i.pending[msg.ID]
+	if ok {
+		delete(i.pending, msg.ID)
+	}
+	i.mu.Unlock()
+	if !ok {
+		return
+	}
+
+	op := Operation{
+		ID:          uuid.NewString(),
+		WorkspaceID: i.cfg.WorkspaceID,
+		Source:      i.cfg.Source,
+		EnvID:       pr.env,
+		Tool:        pr.tool,
+		StartedAt:   pr.startedAt,
+		CompletedAt: time.Now().UTC(),
+	}
+	if pr.threadID != "" {
+		t := pr.threadID
+		op.ThreadID = &t
+	}
+	if pr.userID != "" {
+		u := pr.userID
+		op.UserID = &u
+	}
+	op.DurationMs = int32(op.CompletedAt.Sub(op.StartedAt) / time.Millisecond)
+
+	// Arguments — truncate if oversized
+	if pr.argsSize > i.cfg.ArgsMaxBytes {
+		sum := sha256.Sum256(pr.args)
+		op.ArgumentsMeta = mustJSON(map[string]any{
+			"truncated":   true,
+			"size_bytes":  pr.argsSize,
+			"sha256":      hex.EncodeToString(sum[:]),
+		})
+	} else {
+		op.Arguments = pr.args
+	}
+
+	// Result — pull text content as result_summary; record error flag
+	if len(msg.Error) > 0 {
+		op.IsError = true
+		// Use the rpc error message as result_summary
+		var er struct{ Message string `json:"message"` }
+		_ = json.Unmarshal(msg.Error, &er)
+		s := er.Message
+		op.ResultSummary = &s
+	} else if len(msg.Result) > 0 {
+		var r struct {
+			Content []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+			IsError bool `json:"isError"`
+		}
+		_ = json.Unmarshal(msg.Result, &r)
+		op.IsError = r.IsError
+		var b []byte
+		for _, c := range r.Content {
+			if c.Type == "text" {
+				b = append(b, c.Text...)
+			}
+		}
+		total := len(b)
+		if total > i.cfg.ResultMaxBytes {
+			truncated := string(b[:i.cfg.ResultMaxBytes])
+			op.ResultSummary = &truncated
+			op.ResultMeta = mustJSON(map[string]any{
+				"truncated":   true,
+				"total_bytes": total,
+			})
+		} else if total > 0 {
+			s := string(b)
+			op.ResultSummary = &s
+		}
+	}
+
+	i.sub.Submit(op)
+}
+
+func mustJSON(v any) json.RawMessage {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil
+	}
+	return b
+}
+```
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+```bash
+go test ./internal/codexappgateway/oplog/ -v
+```
+Expected: 10 passed (4 client + 6 interceptor).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /root/agentserver
+git add internal/codexappgateway/oplog/interceptor.go \
+        internal/codexappgateway/oplog/interceptor_test.go
+git commit -m "feat(oplog): JSON-RPC frame Interceptor
+
+pending-map pairs request+response by JSON-RPC id; truncation of
+oversized args/results; UTF-8 text content collected as result_summary.
+Non-tool/call frames pass through untouched (never breaks the pump)."
+```
+
+---
+
+## Task 6: `oplog.operations/list` SDK request handler
+
+**Files:**
+- Create: `internal/codexappgateway/oplog/operations_list.go`
+- Create: `internal/codexappgateway/oplog/operations_list_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+Create `internal/codexappgateway/oplog/operations_list_test.go`:
+
+```go
+package oplog
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHandleOperationsList_ForwardsAndReturns(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("workspace_id") != "ws-1" {
+			t.Fatalf("ws=%q", q.Get("workspace_id"))
+		}
+		if q.Get("limit") != "10" {
+			t.Fatalf("limit=%q", q.Get("limit"))
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"operations": []map[string]any{
+				{"id": "op_1", "env_id": "a", "tool": "shell", "is_error": false},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	lc := NewListClient(srv.URL+"/", "s")
+	frame, ok := TryHandleOperationsList(context.Background(), lc, "ws-1",
+		[]byte(`{"jsonrpc":"2.0","id":42,"method":"operations/list","params":{"limit":10}}`))
+	if !ok {
+		t.Fatal("not handled")
+	}
+	var resp struct {
+		ID     int             `json:"id"`
+		Result json.RawMessage `json:"result"`
+	}
+	if err := json.Unmarshal(frame, &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ID != 42 {
+		t.Fatalf("id=%d", resp.ID)
+	}
+	if !contains(resp.Result, `"op_1"`) {
+		t.Fatalf("result=%s", resp.Result)
+	}
+}
+
+func TestTryHandleOperationsList_OtherMethodsIgnored(t *testing.T) {
+	frame, ok := TryHandleOperationsList(context.Background(), nil, "ws",
+		[]byte(`{"jsonrpc":"2.0","id":1,"method":"mcpServer/tool/call"}`))
+	if ok || frame != nil {
+		t.Fatalf("should not handle")
+	}
+}
+
+func TestTryHandleOperationsList_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	lc := NewListClient(srv.URL+"/", "s")
+
+	frame, ok := TryHandleOperationsList(context.Background(), lc, "ws",
+		[]byte(`{"jsonrpc":"2.0","id":7,"method":"operations/list","params":{}}`))
+	if !ok {
+		t.Fatal("should handle, but produce error response")
+	}
+	var resp struct {
+		ID    int `json:"id"`
+		Error struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(frame, &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ID != 7 || resp.Error.Code == 0 {
+		t.Fatalf("resp = %+v", resp)
+	}
+}
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+```bash
+go test ./internal/codexappgateway/oplog/ -run OperationsList -v
+```
+Expected: FAIL — `TryHandleOperationsList` undefined.
+
+- [ ] **Step 3: Implement**
+
+Create `internal/codexappgateway/oplog/operations_list.go`:
+
+```go
+package oplog
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// TryHandleOperationsList inspects a client→server frame. If it's an
+// `operations/list` JSON-RPC request, it forwards the filters to
+// agentserver via the ListClient and returns a complete JSON-RPC response
+// frame to send back to the client (ok=true). For any other frame,
+// returns (nil, false) — caller forwards the frame normally.
+//
+// Designed to be called from the gateway's outbound proxy path so the
+// request never reaches the codex app-server (which has no operations/list
+// method).
+func TryHandleOperationsList(
+	ctx context.Context,
+	lc *ListClient,
+	workspaceID string,
+	frame []byte,
+) ([]byte, bool) {
+	var msg struct {
+		ID     any             `json:"id"`
+		Method string          `json:"method"`
+		Params json.RawMessage `json:"params"`
+	}
+	if err := json.Unmarshal(frame, &msg); err != nil {
+		return nil, false
+	}
+	if msg.Method != "operations/list" || msg.ID == nil {
+		return nil, false
+	}
+
+	params := map[string]string{"workspace_id": workspaceID}
+	var p struct {
+		Limit   *int    `json:"limit"`
+		EnvID   *string `json:"env_id"`
+		Tool    *string `json:"tool"`
+		Source  *string `json:"source"`
+		IsError *bool   `json:"is_error"`
+		Since   *string `json:"since"`
+		ID      *string `json:"id"`
+	}
+	_ = json.Unmarshal(msg.Params, &p)
+	if p.Limit != nil {
+		params["limit"] = fmt.Sprintf("%d", *p.Limit)
+	}
+	if p.EnvID != nil {
+		params["env_id"] = *p.EnvID
+	}
+	if p.Tool != nil {
+		params["tool"] = *p.Tool
+	}
+	if p.Source != nil {
+		params["source"] = *p.Source
+	}
+	if p.IsError != nil {
+		params["is_error"] = fmt.Sprintf("%t", *p.IsError)
+	}
+	if p.Since != nil {
+		params["since"] = *p.Since
+	}
+	if p.ID != nil {
+		params["id"] = *p.ID
+	}
+
+	body, err := lc.List(ctx, params)
+	if err != nil {
+		errResp, _ := json.Marshal(map[string]any{
+			"jsonrpc": "2.0", "id": msg.ID,
+			"error": map[string]any{"code": -32603, "message": err.Error()},
+		})
+		return errResp, true
+	}
+	resp, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0", "id": msg.ID,
+		"result": json.RawMessage(body),
+	})
+	return resp, true
+}
+```
+
+- [ ] **Step 4: Run, confirm pass**
+
+```bash
+go test ./internal/codexappgateway/oplog/ -v
+```
+Expected: 13 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /root/agentserver
+git add internal/codexappgateway/oplog/operations_list.go \
+        internal/codexappgateway/oplog/operations_list_test.go
+git commit -m "feat(oplog): operations/list SDK request handler
+
+intercepts operations/list before it reaches codex app-server,
+delegates to agentserver, returns a JSON-RPC response frame for the
+gateway to write back on the same ws."
+```
+
+---
+
+## Task 7: `wsbridge.RunProxyWithInterceptor`
+
+**Files:**
+- Modify: `internal/wsbridge/wsbridge.go`
+- Modify: `internal/wsbridge/wsbridge_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+Append to `internal/wsbridge/wsbridge_test.go`:
+
+```go
+func TestRunProxyWithInterceptor_CallbacksAndRewrite(t *testing.T) {
+	// a := client-facing; b := server-facing
+	a, b := newWSPair(t) // adopt whatever helper the existing tests use
+	defer a.Close(websocket.StatusNormalClosure, "")
+	defer b.Close(websocket.StatusNormalClosure, "")
+
+	var (
+		ctc, stc [][]byte
+		mu       sync.Mutex
+		rewrite  = []byte(`{"intercepted":true}`)
+	)
+	intc := wsbridge.Interceptor{
+		OnClientFrame: func(frame []byte) []byte {
+			mu.Lock(); defer mu.Unlock()
+			ctc = append(ctc, append([]byte(nil), frame...))
+			return nil // forward unchanged
+		},
+		OnServerFrame: func(frame []byte) []byte {
+			mu.Lock(); defer mu.Unlock()
+			stc = append(stc, append([]byte(nil), frame...))
+			if string(frame) == "swap-me" {
+				return rewrite
+			}
+			return nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go wsbridge.RunProxyWithInterceptor(ctx, a, b, intc, nil)
+
+	// Send a frame from client to server, verify echoed
+	if err := writeText(a, "hello-server"); err != nil { t.Fatal(err) }
+	if got := readText(t, b); got != "hello-server" {
+		t.Fatalf("server got %q", got)
+	}
+
+	// Send a frame from server to client; intercept rewrites
+	if err := writeText(b, "swap-me"); err != nil { t.Fatal(err) }
+	if got := readText(t, a); got != `{"intercepted":true}` {
+		t.Fatalf("client got %q", got)
+	}
+
+	mu.Lock(); defer mu.Unlock()
+	if len(ctc) != 1 || string(ctc[0]) != "hello-server" {
+		t.Fatalf("ctc=%q", ctc)
+	}
+	if len(stc) != 1 || string(stc[0]) != "swap-me" {
+		t.Fatalf("stc=%q", stc)
+	}
+}
+```
+
+The helpers `newWSPair`, `writeText`, `readText` are already in `wsbridge_test.go` — verify before using.
+
+- [ ] **Step 2: Run, confirm failure**
+
+```bash
+go test ./internal/wsbridge -run TestRunProxyWithInterceptor -v
+```
+Expected: FAIL — `RunProxyWithInterceptor` / `Interceptor` undefined.
+
+- [ ] **Step 3: Add the new type + function**
+
+Append to `internal/wsbridge/wsbridge.go`:
+
+```go
+// Interceptor lets a caller observe and optionally rewrite frames as
+// they cross the bridge. Both callbacks may be nil. Returning a non-nil
+// slice replaces the frame written downstream; returning nil forwards
+// the original frame untouched. Callbacks MUST NOT block.
+type Interceptor struct {
+	OnClientFrame func(frame []byte) []byte // a → b direction
+	OnServerFrame func(frame []byte) []byte // b → a direction
+}
+
+// RunProxyWithInterceptor is like RunProxy but lets the caller observe
+// and rewrite frames. `onFrame` is invoked on every successfully forwarded
+// frame (pass nil to skip).
+//
+// `intc.OnClientFrame` runs in the a→b direction; `OnServerFrame` runs
+// in the b→a direction. Returning nil from either callback forwards the
+// original frame unchanged; returning a non-nil slice replaces it.
+func RunProxyWithInterceptor(ctx context.Context, a, b *websocket.Conn, intc Interceptor, onFrame func()) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	errCh := make(chan error, 2)
+	go func() { errCh <- pumpWithIntercept(ctx, a, b, intc.OnClientFrame, onFrame) }()
+	go func() { errCh <- pumpWithIntercept(ctx, b, a, intc.OnServerFrame, onFrame) }()
+	go keepAlive(ctx, a)
+	err := <-errCh
+	cancel()
+	<-errCh
+	if errors.Is(err, context.Canceled) {
+		return nil
+	}
+	return err
+}
+
+func pumpWithIntercept(
+	ctx context.Context,
+	src, dst *websocket.Conn,
+	onFrameBytes func([]byte) []byte,
+	onTick func(),
+) error {
+	for {
+		mt, data, err := src.Read(ctx)
+		if err != nil {
+			closeErr := websocket.CloseStatus(err)
+			if closeErr == websocket.StatusNormalClosure || closeErr == websocket.StatusGoingAway {
+				return nil
+			}
+			if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) {
+				return nil
+			}
+			return err
+		}
+		out := data
+		if onFrameBytes != nil {
+			if rewritten := onFrameBytes(data); rewritten != nil {
+				out = rewritten
+			}
+		}
+		if onTick != nil {
+			onTick()
+		}
+		if err := dst.Write(ctx, mt, out); err != nil {
+			return err
+		}
+	}
+}
+```
+
+- [ ] **Step 4: Run, confirm pass**
+
+```bash
+go test ./internal/wsbridge -v
+```
+Expected: all existing + new test pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /root/agentserver
+git add internal/wsbridge/wsbridge.go internal/wsbridge/wsbridge_test.go
+git commit -m "feat(wsbridge): RunProxyWithInterceptor
+
+callbacks observe + may rewrite frames per direction. Returning nil
+forwards untouched. Existing RunProxy behaviour unchanged."
+```
+
+---
+
+## Task 8: Gateway `/notebook/ws` route + Interceptor wiring
+
+**Files:**
+- Modify: `internal/codexappgateway/server.go`
+- Modify: `internal/codexappgateway/config.go`
+- Modify: `internal/codexappgateway/server_test.go`
+- Modify: `internal/codexappgateway/buildconfig_test.go`
+
+- [ ] **Step 1: Extend ServeConfig with oplog fields**
+
+In `internal/codexappgateway/config.go`, add to the `ServeConfig` struct:
+
+```go
+// OperationLog endpoint + auth. When both are empty, oplog is disabled
+// (the Interceptor still parses frames but Submit is a no-op).
+OperationLogURL    string // e.g. "http://agentserver.svc.cluster.local:8080/internal/operations"
+OperationLogSecret string // AgentserverInternalSecret
+OperationLogChan   int    // bounded channel capacity, default 1024
+```
+
+Update `parseServeArgs` (or equivalent) to read corresponding env vars:
+`CXG_OPLOG_URL`, `CXG_OPLOG_SECRET`, `CXG_OPLOG_CHAN`. Apply env-fallback pattern.
+
+Update `buildconfig_test.go` to cover the new env vars.
+
+- [ ] **Step 2: Add `/notebook/ws` route**
+
+In `server.go`, the existing `Routes()` registers `/` and `/codex-app/ws`. Add:
+
+```go
+r.Get("/notebook/ws", s.handleNotebookWS)
+```
+
+- [ ] **Step 3: Implement handleNotebookWS**
+
+Add to `server.go`. The TUI path uses `wsbridge.RunProxy`; the SDK path uses `RunProxyWithInterceptor` with oplog wired in:
+
+```go
+func (s *Server) handleNotebookWS(w http.ResponseWriter, r *http.Request) {
+	tok, ok := auth.ExtractBearer(r)
+	if !ok {
+		http.Error(w, "missing Bearer", http.StatusUnauthorized)
+		return
+	}
+	id, err := s.auth.Verify(r.Context(), tok)
+	if err != nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	userWS, err := websocket.Accept(w, r, nil)
+	if err != nil {
+		s.logger.Warn("notebook ws accept", "err", err)
+		return
+	}
+	userWS.SetReadLimit(maxWSFrameBytes)
+	defer userWS.Close(websocket.StatusNormalClosure, "client closing")
+
+	ctx := r.Context()
+	key := supervisor.Key{WorkspaceID: id.WorkspaceID}
+	handle, err := s.sup.EnsureSubprocess(ctx, key, func(loopbackToken string) (supervisor.SpawnConfig, error) {
+		return s.buildConfig(ctx, id.WorkspaceID, loopbackToken)
+	})
+	if err != nil {
+		s.logger.Error("ensure subprocess", "err", err, "key", key)
+		_ = userWS.Close(websocket.StatusInternalError, "subprocess unavailable")
+		return
+	}
+
+	childWS, _, err := websocket.Dial(ctx, handle.WSURL, &websocket.DialOptions{
+		CompressionMode: websocket.CompressionDisabled,
+	})
+	if err != nil {
+		s.logger.Error("dial child", "err", err, "url", handle.WSURL)
+		_ = userWS.Close(websocket.StatusInternalError, "subprocess dial failed")
+		return
+	}
+	childWS.SetReadLimit(maxWSFrameBytes)
+	defer childWS.Close(websocket.StatusNormalClosure, "gateway closing")
+
+	// Per-connection Interceptor — workspaceID is pinned from the
+	// verified bearer Identity, not from any client-supplied tag.
+	// nil when oplog is disabled (CXG_OPLOG_URL empty); the proxy still
+	// runs without logging.
+	var perConn *oplog.Interceptor
+	if s.oplogClient != nil {
+		perConn = oplog.NewInterceptor(s.oplogClient, oplog.Config{
+			Source: "sdk", WorkspaceID: id.WorkspaceID,
+		})
+	}
+
+	intc := wsbridge.Interceptor{
+		OnClientFrame: func(frame []byte) []byte {
+			// 1) Intercept operations/list — handled by gateway, never
+			//    forwarded to codex (which has no such method).
+			if s.oplogList != nil {
+				if resp, handled := oplog.TryHandleOperationsList(ctx, s.oplogList, id.WorkspaceID, frame); handled {
+					// Write response straight back on userWS; tell the
+					// pump to drop the original outgoing frame.
+					_ = userWS.Write(ctx, websocket.MessageText, resp)
+					return wsbridge.DropFrame
+				}
+			}
+			// 2) Otherwise observe for oplog write side.
+			if perConn != nil {
+				perConn.OnClientFrame(frame)
+			}
+			return nil
+		},
+		OnServerFrame: func(frame []byte) []byte {
+			if perConn != nil {
+				perConn.OnServerFrame(frame)
+			}
+			return nil
+		},
+	}
+
+	s.sup.Touch(key)
+	if err := wsbridge.RunProxyWithInterceptor(ctx, userWS, childWS, intc, func() {
+		s.sup.Touch(key)
+	}); err != nil {
+		s.logger.Info("notebook proxy ended", "err", err, "key", key)
+	}
+}
+```
+
+- [ ] **Step 4: Teach wsbridge to swallow frames (DropFrame sentinel)**
+
+Edit `internal/wsbridge/wsbridge.go`. Add at package scope:
+
+```go
+import "bytes"
+
+// DropFrame is returned by an Interceptor callback to indicate the frame
+// should NOT be forwarded downstream. Distinct from returning nil
+// (forward unchanged) and from returning a rewritten slice (forward
+// replacement).
+var DropFrame = []byte("__wsbridge_drop_frame__")
+```
+
+Update `pumpWithIntercept` (added in Step 3) to honor it:
+
+```go
+func pumpWithIntercept(
+	ctx context.Context,
+	src, dst *websocket.Conn,
+	onFrameBytes func([]byte) []byte,
+	onTick func(),
+) error {
+	for {
+		mt, data, err := src.Read(ctx)
+		if err != nil {
+			closeErr := websocket.CloseStatus(err)
+			if closeErr == websocket.StatusNormalClosure || closeErr == websocket.StatusGoingAway {
+				return nil
+			}
+			if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) {
+				return nil
+			}
+			return err
+		}
+		out := data
+		if onFrameBytes != nil {
+			if rewritten := onFrameBytes(data); rewritten != nil {
+				if bytes.Equal(rewritten, DropFrame) {
+					if onTick != nil {
+						onTick()
+					}
+					continue // do not forward
+				}
+				out = rewritten
+			}
+		}
+		if onTick != nil {
+			onTick()
+		}
+		if err := dst.Write(ctx, mt, out); err != nil {
+			return err
+		}
+	}
+}
+```
+
+Add a test for the drop path. Append to `wsbridge_test.go`:
+
+```go
+func TestRunProxyWithInterceptor_DropFrameSwallows(t *testing.T) {
+	a, b := newWSPair(t)
+	defer a.Close(websocket.StatusNormalClosure, "")
+	defer b.Close(websocket.StatusNormalClosure, "")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go wsbridge.RunProxyWithInterceptor(ctx, a, b, wsbridge.Interceptor{
+		OnClientFrame: func(frame []byte) []byte {
+			if string(frame) == "drop-me" {
+				return wsbridge.DropFrame
+			}
+			return nil
+		},
+	}, nil)
+
+	if err := writeText(a, "drop-me"); err != nil {
+		t.Fatal(err)
+	}
+	// b must not receive within a short window
+	bctx, bcancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer bcancel()
+	_, _, err := b.Read(bctx)
+	if err == nil {
+		t.Fatal("b should not have received the dropped frame")
+	}
+}
+```
+
+- [ ] **Step 5: Boot wires oplog client + list-client on Server**
+
+In `server.go` `New`/constructor (whatever exists), add fields and init:
+
+```go
+type Server struct {
+    // ...existing
+    oplogClient   *oplog.Client      // nil if disabled
+    oplogList     *oplog.ListClient  // nil if disabled
+}
+
+func New(cfg ServeConfig, ...) *Server {
+    s := &Server{...}
+    if cfg.OperationLogURL != "" && cfg.OperationLogSecret != "" {
+        s.oplogClient = oplog.NewClient(cfg.OperationLogURL, cfg.OperationLogSecret, cfg.OperationLogChan)
+        s.oplogList   = oplog.NewListClient(cfg.OperationLogURL, cfg.OperationLogSecret)
+    }
+    return s
+}
+```
+
+Add a `Close()` method (or extend existing) that calls `s.oplogClient.Close()`.
+
+- [ ] **Step 6: Integration test via existing server_test.go pattern**
+
+Update `internal/codexappgateway/server_test.go` to add a test that drives `/notebook/ws` with a stub agentserver oplog endpoint (httptest). Assert the stub received a POST after a single `mcpServer/tool/call` round-trip. Use the same testing harness already present (the existing test boots the gateway against a stub auth verifier — extend it).
+
+- [ ] **Step 7: Run all gateway tests**
+
+```bash
+go test ./internal/codexappgateway/... -v
+go test ./internal/wsbridge -v
+```
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /root/agentserver
+git add internal/codexappgateway/server.go \
+        internal/codexappgateway/config.go \
+        internal/codexappgateway/server_test.go \
+        internal/codexappgateway/buildconfig_test.go \
+        internal/wsbridge/wsbridge.go \
+        internal/wsbridge/wsbridge_test.go
+git commit -m "feat(gateway): /notebook/ws route + oplog interceptor wiring
+
+new route path = source 'sdk'; per-connection Interceptor with workspaceID;
+operations/list intercepted and served from agentserver without reaching
+codex app-server. wsbridge.DropFrame lets the interceptor swallow frames."
+```
+
+---
+
+## Task 9: Helm + values plumbing
+
+**Files:**
+- Modify: `deploy/helm/agentserver/values.yaml`
+- Modify: `deploy/helm/agentserver/templates/codex-app-gateway.yaml`
+- Modify: `deploy/helm/agentserver/templates/_helpers.tpl` if a helper for the internal secret already exists
+
+- [ ] **Step 1: Add values block**
+
+Append to `values.yaml`:
+
+```yaml
+operations:
+  # When true, codex-app-gateway POSTs every mcpServer/tool/call to
+  # agentserver's /internal/operations. Disable to revert to pre-Plan-2
+  # behavior.
+  enabled: true
+  # Retention in days. 0 disables the cleanup loop.
+  retentionDays: 90
+  # Bounded channel capacity inside the gateway. Drops on overflow.
+  channelCapacity: 1024
+```
+
+- [ ] **Step 2: Project values into gateway env**
+
+Edit `templates/codex-app-gateway.yaml` Deployment env block:
+
+```yaml
+{{- if .Values.operations.enabled }}
+- name: CXG_OPLOG_URL
+  value: "http://{{ include "agentserver.fullname" . }}:8080/internal/operations"
+- name: CXG_OPLOG_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ include "agentserver.fullname" . }}-internal
+      key: internal-secret
+- name: CXG_OPLOG_CHAN
+  value: "{{ .Values.operations.channelCapacity }}"
+{{- end }}
+```
+
+Use whatever helper / secret name the existing chart already uses for the agentserver internal secret. If unsure, grep:
+
+```bash
+grep -rn "internal-secret\|AGENTSERVER_INTERNAL_SECRET" /root/agentserver/deploy/helm/
+```
+
+- [ ] **Step 3: Pass retention via agentserver env**
+
+Add to `templates/deployment.yaml` (the agentserver web deployment) env:
+
+```yaml
+- name: AGENTSERVER_OPERATIONS_RETENTION_DAYS
+  value: "{{ .Values.operations.retentionDays }}"
+```
+
+Then in `main.go` (agentserver), read this env var and pass to `startRetentionLoop`. Default to 90 if unset.
+
+- [ ] **Step 4: helm lint + template sanity**
+
+```bash
+cd /root/agentserver
+helm lint deploy/helm/agentserver
+helm template deploy/helm/agentserver | grep -A 5 CXG_OPLOG_URL | head -20
+```
+
+Expected: lint clean; rendered Deployment contains the new env vars.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add deploy/helm/agentserver/values.yaml \
+        deploy/helm/agentserver/templates/codex-app-gateway.yaml \
+        deploy/helm/agentserver/templates/deployment.yaml \
+        main.go
+git commit -m "feat(helm): wire operation log config
+
+values.operations.{enabled, retentionDays, channelCapacity}; gateway
+gets CXG_OPLOG_{URL,SECRET,CHAN}; agentserver gets retention env var."
+```
+
+---
+
+## Task 10: SDK e2e smoke against real-shape stub
+
+**Files:**
+- Modify: `notebook/stub_gateway_runner.py` (add a tiny operations/list handler with real data shape so SDK's `ctx.history()` returns non-empty)
+- Modify: `notebook/README.md` — Cell 4 expectation now shows real records
+
+- [ ] **Step 1: Update stub to return operations**
+
+Edit `/root/agentserver/notebook/stub_gateway_runner.py`. Replace the empty `operations/list` handler with one that returns a few synthetic ops mirroring what Plan 2 will produce in real life:
+
+```python
+import uuid, datetime
+def operations_list(p):
+    now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+    return {"operations": [
+        {"id": str(uuid.uuid4()), "env_id": "alpha", "tool": "shell",
+         "is_error": False, "started_at": now, "duration_ms": 7,
+         "source": "sdk", "user_id": "smoke-user"},
+        {"id": str(uuid.uuid4()), "env_id": "hpc",   "tool": "submit_task",
+         "is_error": False, "started_at": now, "duration_ms": 320,
+         "source": "sdk", "user_id": "smoke-user"},
+    ]}
+g.on("operations/list", operations_list)
+```
+
+- [ ] **Step 2: Bring up smoke + manual verify**
+
+```bash
+cd /root/agentserver
+docker compose -f notebook/docker-compose.smoke.yml up --build -d
+sleep 10
+docker compose -f notebook/docker-compose.smoke.yml logs notebook | grep "running"
+```
+
+Manual:
+1. Open <http://localhost:8888/lab>
+2. Cell: `ops = await ctx.history(limit=5); ops`
+3. Expect: 2 OperationRecord objects, env_id={alpha,hpc}
+
+Teardown:
+```bash
+docker compose -f notebook/docker-compose.smoke.yml down -v
+```
+
+- [ ] **Step 3: Update README**
+
+In `notebook/README.md` Cell 4 expectation, change from "returns [] until Plan 2 lands" to:
+
+```
+# Cell 4 — operations history (real records once Plan 2 is deployed)
+await ctx.history(limit=5)
+# stub returns 2 fake records; real backend returns rows from the
+# operations table written by every previous SDK call.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /root/agentserver
+git add notebook/stub_gateway_runner.py notebook/README.md
+git commit -m "test(notebook): stub returns synthetic operations for smoke
+
+Cell 4 in the walkthrough now returns 2 records, exercising ctx.history
+end-to-end through the stub."
+```
+
+---
+
+## Self-review checklist (for the implementer)
+
+After all tasks done:
+
+- [ ] All spec § 7 schema columns present in 023_operations.sql
+- [ ] Gateway never blocks on logging (verified: `TestClient_Submit_BoundedDropsOnFull`)
+- [ ] Source tag derived from ws path, not client-supplied (verified by code review of server.go diff)
+- [ ] `operations/list` does NOT reach `codex app-server` (verified by code review: `TryHandleOperationsList` returns frame that's written directly back, and `DropFrame` is returned to swallow the original from going downstream)
+- [ ] Payload truncation thresholds 64KiB args / 4KiB result enforced; sha256 + size recorded when truncated
+- [ ] Retention loop exits on context cancel
+- [ ] Helm renders cleanly + env vars correct
+- [ ] Notebook smoke walkthrough still works after stub update
+
+## After this plan
+
+When Plan 2 is merged:
+- `ctx.history(...)` returns real data
+- Web UI `<OperationsPanel />` (Plan 3) only needs a frontend; backend `GET /internal/operations` is ready
+- LLM-call logging (v1.5): env-mcp emits `Operation` records via the same `/internal/operations` POST endpoint — no new infra needed
+- Per-workspace retention overrides: extend `OperationFilter` / add new column `workspace_settings.retention_days`

--- a/docs/superpowers/plans/2026-05-18-python-env-sdk.md
+++ b/docs/superpowers/plans/2026-05-18-python-env-sdk.md
@@ -1,0 +1,2493 @@
+# Python env SDK + Notebook Image — Implementation Plan (Plan 1)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the `agentserver_sdk` Python package + `Dockerfile.notebook` image so that a developer running the image locally with a stub gateway can `await ctx.envs()` and `await alpha.shell("…")` from a Jupyter cell.
+
+**Architecture:** Pure async/await Python SDK (`Ctx` → workspace handle, `Env` → executor handle, `Process` → long-running cmd) speaking JSON-RPC over a single WebSocket to the gateway. All env-mcp tools reachable via typed core methods or dynamic `env.call(name, args)` / `__getattr__`. Image bundles SDK + Jupyter + an IPython startup file that injects `ctx` on kernel boot. A reusable Python stub gateway lives in tests so SDK can be developed and validated end-to-end without the real backend.
+
+**Tech Stack:** Python 3.12 · `websockets` ~14 · pytest + pytest-asyncio · jupyter-server ~2.14 · jupyterlab ~4.2 · ipykernel ~6.29 · Docker · docker-compose
+
+**Out of scope for this plan (separate plans later):**
+- Operation log DB write path + Interceptor (Plan 2)
+- Notebook supervisor + k8s spawn + jupyter proxy (Plan 3)
+- Web UI panels (part of Plan 3)
+- env-mcp per-env capability reporting (separate spec follow-up)
+
+For Plan 1 staging:
+- All envs assumed to expose the same workspace-wide tool set (current env-mcp behaviour)
+- `ctx.history(...)` issues `operations/list` RPC, but the real gateway doesn't implement it yet → tests mock it via stub gateway; real wiring lands in Plan 2
+- `__getattr__` dynamic dispatch is implemented and tested with mock per-env tools metadata, but real metadata depends on env-mcp work
+
+---
+
+## File Structure
+
+```
+sdk/python/                                  # NEW Python package
+├── pyproject.toml
+├── README.md
+├── src/agentserver_sdk/
+│   ├── __init__.py                          # re-exports
+│   ├── errors.py                            # ToolError, ConnectionError, NotConnectedError
+│   ├── types.py                             # ShellResult, ToolMetadata, OperationRecord, Patch
+│   ├── client.py                            # WSClient: ws connect + initialize + request/response
+│   ├── env.py                               # Env: typed methods + dynamic dispatch
+│   ├── process.py                           # Process: async context manager over exec_command tools
+│   ├── ctx.py                               # Ctx: from_env, envs, env, copy, history
+│   └── _repr.py                             # _repr_html_ implementations (jupyter rendering)
+└── tests/
+    ├── conftest.py                          # pytest fixtures: stub gateway, ctx
+    ├── stub_gateway.py                      # reusable WS stub for tests + manual smoke
+    ├── test_client.py
+    ├── test_env.py
+    ├── test_process.py
+    ├── test_ctx.py
+    ├── test_types.py
+    └── test_repr.py
+
+Dockerfile.notebook                          # NEW image at repo root
+notebook/                                    # NEW config + startup files
+├── ipython_startup/
+│   └── 00-ctx.py
+├── jupyter_server_config.py
+├── docker-compose.smoke.yml                 # local smoke: jupyter + stub gateway
+└── README.md                                # how to run smoke locally
+
+Makefile                                     # MODIFY: add `notebook-image` + `sdk-test` targets
+```
+
+---
+
+## Design Decisions Locked Before Tasks
+
+These come up across multiple tasks. Capturing once so they're not re-invented per task.
+
+**1. One WS connection per `Ctx`, lazy.** `Ctx.from_env()` is sync; `await ctx.envs()` (or any first call) triggers connect: open ws → `initialize` → `initialized` notification → `thread/start` to get a thread_id → cache. Reuse on subsequent calls. Lock around connect to serialise concurrent first-call races.
+
+**2. One thread per `Ctx`.** Real codex threads carry LLM conversation; SDK never sends turns, so a single throwaway thread is enough as a routing key for `mcpServer/tool/call`. Thread_id cached on `Ctx`; not user-visible.
+
+**3. Bearer auth via `AGENTSERVER_WORKSPACE_TOKEN`.** `Ctx.from_env()` reads `AGENTSERVER_GATEWAY_URL` (default `ws://localhost:8086/notebook/ws`), `AGENTSERVER_WORKSPACE_TOKEN`, `AGENTSERVER_WORKSPACE_ID`, `AGENTSERVER_USER_ID`. Token sent as `Authorization: Bearer …` on WS connect. user_id forwarded in every `mcpServer/tool/call` `_meta.user_id` for attribution (no signing — gateway trusts the workspace token).
+
+**4. JSON-RPC framing.** Outgoing requests: `{"jsonrpc": "2.0", "id": <int>, "method": …, "params": …}`. Notifications: same minus `id`. Each request increments an `_next_id` counter. Pending map `id → asyncio.Future` resolves on matching response.
+
+**5. Stub gateway shape.** `tests/stub_gateway.py` exposes a `StubGateway` class with `.on(method, handler)`. Defaults respond to `initialize` and `thread/start`. Test cases register handlers for `mcpServer/tool/call`, `operations/list`, etc. Records every received frame for assertions.
+
+**6. Core tools list (typed wrappers in SDK):**
+```
+shell, read_file, write_file, apply_patch,
+exec_command, write_stdin, read_output, terminate,
+copy_path
+```
+Anything not in this list → `Env.call(name, args)` or `__getattr__`.
+
+**7. `Env.call` argument shape.** `Env.call("submit_task", {...})` translates to MCP `mcpServer/tool/call` with `params = {server: "env_mcp", tool: "submit_task", arguments: {environment_id: env.name, ...args}}`. The `environment_id` injection is automatic.
+
+**8. Result parsing.** MCP `CallToolResult` has `content[]` (text/image items), `structuredContent` (jsonb), `isError`. Typed wrappers (`ShellResult.from_mcp`) extract well-known fields. `Env.call(...)` returns the raw dict.
+
+**9. Errors.** `isError=true` → raise `ToolError(tool, env, message, raw)`. JSON-RPC error → same. Network failure → `ConnectionError`. Pre-connect call → `NotConnectedError` (shouldn't happen with lazy connect, but defensive).
+
+**10. Dynamic dispatch.** On first `await ctx.envs()` SDK calls `env/capabilities { env_id }` (stub or future real). For each non-core tool in the metadata, `setattr(env, tool_name, generated_method)`. `__getattr__` is a safety net for tools not in metadata (raises `AttributeError`).
+
+**11. Python version pin: 3.12.** Matches image. Use only stdlib + `websockets`. No `httpx`, no `pydantic`.
+
+**12. Spec deviation — `env.tools` as field, not async method.** The design spec example reads `print(await hpc.tools())`. Plan 1 exposes `env.tools` as a sync `list[ToolMetadata]` field (populated at `Ctx.envs()` time via `env/capabilities`). Rationale: tools are already in-memory after env construction; making them awaitable adds round-trip cost for no benefit. Refresh via `await ctx.refresh()` if the workspace's tool catalogue changes mid-session. Documented here so reviewers don't flag it.
+
+---
+
+## Task 1: Repository skeleton
+
+**Files:**
+- Create: `sdk/python/pyproject.toml`
+- Create: `sdk/python/README.md`
+- Create: `sdk/python/src/agentserver_sdk/__init__.py`
+- Create: `sdk/python/tests/conftest.py`
+- Create: `sdk/python/tests/test_smoke.py`
+
+- [ ] **Step 1: Create pyproject.toml**
+
+Create `sdk/python/pyproject.toml`:
+
+```toml
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "agentserver-sdk"
+version = "0.1.0"
+description = "Async Python SDK for agentserver envs (env-mcp)"
+requires-python = ">=3.12"
+dependencies = [
+    "websockets~=14.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest~=8.0",
+    "pytest-asyncio~=0.24",
+    "ruff~=0.6",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/agentserver_sdk"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
+testpaths = ["tests"]
+```
+
+- [ ] **Step 2: Create empty package + readme**
+
+Create `sdk/python/src/agentserver_sdk/__init__.py`:
+
+```python
+"""agentserver_sdk — Python SDK for agentserver envs."""
+
+__version__ = "0.1.0"
+```
+
+Create `sdk/python/README.md`:
+
+```markdown
+# agentserver-sdk
+
+Async Python SDK for agentserver envs. Lets developers operate on workspace envs (executors) from Python — same env-mcp tools the LLM uses, just without going through prompts.
+
+See `docs/superpowers/specs/2026-05-18-python-env-sdk-design.md` for design.
+
+## Install (development)
+
+```
+cd sdk/python
+pip install -e ".[dev]"
+pytest
+```
+
+## Usage (in a kernel where ctx is pre-loaded)
+
+```python
+envs = await ctx.envs()
+alpha = await ctx.env("alpha")
+r = await alpha.shell("uname -a")
+print(r.stdout)
+```
+```
+
+- [ ] **Step 3: Empty conftest + smoke test**
+
+Create `sdk/python/tests/conftest.py`:
+
+```python
+"""Shared pytest fixtures for agentserver_sdk tests."""
+```
+
+Create `sdk/python/tests/test_smoke.py`:
+
+```python
+import agentserver_sdk
+
+
+def test_package_importable():
+    assert agentserver_sdk.__version__ == "0.1.0"
+```
+
+- [ ] **Step 4: Install + run tests**
+
+Run:
+```bash
+cd sdk/python
+pip install -e ".[dev]"
+pytest -v
+```
+
+Expected: `1 passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sdk/python/
+git commit -m "feat(sdk): python package skeleton
+
+scaffolding for agentserver_sdk: pyproject, package init, smoke test."
+```
+
+---
+
+## Task 2: Stub gateway fixture
+
+**Files:**
+- Create: `sdk/python/tests/stub_gateway.py`
+- Modify: `sdk/python/tests/conftest.py`
+- Create: `sdk/python/tests/test_stub.py`
+
+- [ ] **Step 1: Write the failing test for stub gateway**
+
+Create `sdk/python/tests/test_stub.py`:
+
+```python
+import json
+import pytest
+import websockets
+
+
+async def test_stub_responds_to_initialize(stub):
+    """Stub answers initialize with a default reply and records the frame."""
+    async with websockets.connect(stub.url) as ws:
+        await ws.send(json.dumps({
+            "jsonrpc": "2.0", "id": 1,
+            "method": "initialize",
+            "params": {"clientInfo": {"name": "t", "title": "t", "version": "0"},
+                       "capabilities": {}},
+        }))
+        raw = await ws.recv()
+        resp = json.loads(raw)
+
+    assert resp["id"] == 1
+    assert "result" in resp
+    assert resp["result"]["protocolVersion"] == "1.0"
+    assert any(m.get("method") == "initialize" for m in stub.received)
+
+
+async def test_stub_custom_handler_overrides_default(stub):
+    """on(method, handler) wins over defaults."""
+    stub.on("initialize", lambda params: {"protocolVersion": "9.9"})
+    async with websockets.connect(stub.url) as ws:
+        await ws.send(json.dumps({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}}))
+        resp = json.loads(await ws.recv())
+    assert resp["result"]["protocolVersion"] == "9.9"
+
+
+async def test_stub_unknown_method_returns_error(stub):
+    async with websockets.connect(stub.url) as ws:
+        await ws.send(json.dumps({"jsonrpc": "2.0", "id": 1, "method": "nope", "params": {}}))
+        resp = json.loads(await ws.recv())
+    assert resp["error"]["code"] == -32601
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+Run: `pytest tests/test_stub.py -v`
+Expected: FAIL — `stub` fixture not found.
+
+- [ ] **Step 3: Implement stub gateway**
+
+Create `sdk/python/tests/stub_gateway.py`:
+
+```python
+"""Reusable WS stub gateway for tests + manual smoke.
+
+Implements JSON-RPC 2.0 over WebSocket. By default answers `initialize`
+and `thread/start`. Register more methods via `.on(method, handler)`.
+
+Handler signature: `handler(params: dict) -> result_dict | {"error": {...}}`.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any, Callable
+
+import websockets
+
+
+HandlerResult = dict[str, Any]
+Handler = Callable[[dict[str, Any]], HandlerResult]
+
+
+class StubGateway:
+    def __init__(self) -> None:
+        self._handlers: dict[str, Handler] = {}
+        self._server: websockets.Server | None = None
+        self.port: int = 0
+        self.received: list[dict[str, Any]] = []
+        self.connections: int = 0
+        self.last_headers: dict[str, str] = {}
+
+        # Defaults
+        self.on("initialize", lambda p: {
+            "protocolVersion": "1.0",
+            "serverInfo": {"name": "stub", "version": "0"},
+            "capabilities": {},
+        })
+        self.on("thread/start", lambda p: {"thread_id": "stub-thread-1"})
+
+    def on(self, method: str, handler: Handler) -> None:
+        self._handlers[method] = handler
+
+    @property
+    def url(self) -> str:
+        if self.port == 0:
+            raise RuntimeError("StubGateway not started")
+        return f"ws://127.0.0.1:{self.port}"
+
+    async def start(self) -> None:
+        self._server = await websockets.serve(
+            self._handle, "127.0.0.1", 0,
+            process_request=self._capture_headers,
+        )
+        # websockets >=14 exposes sockets via .sockets
+        self.port = self._server.sockets[0].getsockname()[1]
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+
+    async def _capture_headers(self, conn, request):
+        # websockets >=14: request.headers is a Headers obj
+        self.last_headers = {k.lower(): v for k, v in request.headers.raw_items()}
+        return None  # accept
+
+    async def _handle(self, ws) -> None:
+        self.connections += 1
+        try:
+            async for raw in ws:
+                msg = json.loads(raw)
+                self.received.append(msg)
+                mid = msg.get("id")
+                method = msg.get("method")
+                if mid is None:
+                    # notification (e.g. "initialized")
+                    continue
+                handler = self._handlers.get(method)
+                if handler is None:
+                    resp = {
+                        "jsonrpc": "2.0",
+                        "id": mid,
+                        "error": {"code": -32601, "message": f"Method not found: {method}"},
+                    }
+                else:
+                    try:
+                        out = handler(msg.get("params", {}) or {})
+                    except Exception as e:
+                        resp = {"jsonrpc": "2.0", "id": mid,
+                                "error": {"code": -32603, "message": str(e)}}
+                    else:
+                        if isinstance(out, dict) and "error" in out and "code" in out["error"]:
+                            resp = {"jsonrpc": "2.0", "id": mid, "error": out["error"]}
+                        else:
+                            resp = {"jsonrpc": "2.0", "id": mid, "result": out}
+                await ws.send(json.dumps(resp))
+        except websockets.ConnectionClosed:
+            pass
+```
+
+- [ ] **Step 4: Wire the fixture**
+
+Replace `sdk/python/tests/conftest.py` with:
+
+```python
+"""Shared pytest fixtures for agentserver_sdk tests."""
+import pytest_asyncio
+
+from tests.stub_gateway import StubGateway
+
+
+@pytest_asyncio.fixture
+async def stub():
+    g = StubGateway()
+    await g.start()
+    try:
+        yield g
+    finally:
+        await g.stop()
+```
+
+- [ ] **Step 5: Run tests, confirm pass**
+
+Run: `pytest tests/test_stub.py -v`
+Expected: `3 passed`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add sdk/python/tests/
+git commit -m "test(sdk): stub gateway fixture + self-tests
+
+reusable WS stub answering JSON-RPC; defaults for initialize / thread/start;
+records received frames + headers for assertions."
+```
+
+---
+
+## Task 3: WSClient — connect + handshake
+
+**Files:**
+- Create: `sdk/python/src/agentserver_sdk/errors.py`
+- Create: `sdk/python/src/agentserver_sdk/client.py`
+- Create: `sdk/python/tests/test_client.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `sdk/python/tests/test_client.py`:
+
+```python
+import pytest
+
+from agentserver_sdk.client import WSClient
+from agentserver_sdk.errors import ConnectionError as SdkConnectionError
+
+
+async def test_connect_sends_initialize_and_initialized(stub):
+    c = WSClient(stub.url, token="t-1", workspace_id="ws-1", user_id="u-1")
+    await c.connect()
+    try:
+        assert c.thread_id == "stub-thread-1"
+        # First frame is initialize request
+        init = stub.received[0]
+        assert init["method"] == "initialize"
+        assert init["id"] == 1
+        # Next is initialized notification (no id)
+        assert stub.received[1]["method"] == "initialized"
+        assert "id" not in stub.received[1]
+        # Then thread/start request
+        ts = stub.received[2]
+        assert ts["method"] == "thread/start"
+        assert ts["id"] == 2
+    finally:
+        await c.close()
+
+
+async def test_connect_sends_bearer_header(stub):
+    c = WSClient(stub.url, token="bearer-xyz", workspace_id="ws", user_id="u")
+    await c.connect()
+    try:
+        assert stub.last_headers.get("authorization") == "Bearer bearer-xyz"
+    finally:
+        await c.close()
+
+
+async def test_connect_is_idempotent(stub):
+    c = WSClient(stub.url, token="t", workspace_id="ws", user_id="u")
+    await c.connect()
+    await c.connect()
+    try:
+        # Only one initialize / initialized / thread-start cycle
+        assert stub.connections == 1
+        methods = [m.get("method") for m in stub.received]
+        assert methods.count("initialize") == 1
+        assert methods.count("thread/start") == 1
+    finally:
+        await c.close()
+
+
+async def test_connect_failure_raises_sdk_error():
+    c = WSClient("ws://127.0.0.1:1", token="t", workspace_id="w", user_id="u")
+    with pytest.raises(SdkConnectionError):
+        await c.connect()
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+Run: `pytest tests/test_client.py -v`
+Expected: FAIL — `agentserver_sdk.client` not found.
+
+- [ ] **Step 3: Implement errors module**
+
+Create `sdk/python/src/agentserver_sdk/errors.py`:
+
+```python
+"""SDK exception hierarchy."""
+from __future__ import annotations
+
+from typing import Any
+
+
+class SdkError(Exception):
+    """Base class for all SDK errors."""
+
+
+class ConnectionError(SdkError):
+    """Failure to establish or maintain the WS connection to the gateway."""
+
+
+class NotConnectedError(SdkError):
+    """Operation attempted before the client was connected."""
+
+
+class ToolError(SdkError):
+    """An env-mcp tool returned isError=true or the RPC errored."""
+
+    def __init__(self, tool: str, env: str | None, message: str, raw: Any = None):
+        super().__init__(f"{env or '?'}/{tool}: {message}")
+        self.tool = tool
+        self.env = env
+        self.message = message
+        self.raw = raw
+```
+
+- [ ] **Step 4: Implement WSClient (connect-only)**
+
+Create `sdk/python/src/agentserver_sdk/client.py`:
+
+```python
+"""WebSocket JSON-RPC client to the agentserver codex-app-gateway.
+
+One connection per Ctx. Connection is lazy: `connect()` is a no-op if
+already connected. Bearer auth via constructor; user_id is forwarded
+on every tool/call's _meta for attribution.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from typing import Any
+
+import websockets
+
+from .errors import ConnectionError as SdkConnectionError
+
+
+class WSClient:
+    def __init__(
+        self,
+        url: str,
+        *,
+        token: str,
+        workspace_id: str,
+        user_id: str | None,
+    ) -> None:
+        self.url = url
+        self.token = token
+        self.workspace_id = workspace_id
+        self.user_id = user_id
+
+        self._ws: websockets.ClientConnection | None = None
+        self._next_id = 0
+        self._pending: dict[int, asyncio.Future[dict[str, Any]]] = {}
+        self._reader_task: asyncio.Task | None = None
+        self._connect_lock = asyncio.Lock()
+        self.thread_id: str | None = None
+
+    @property
+    def is_connected(self) -> bool:
+        return self._ws is not None and self.thread_id is not None
+
+    async def connect(self) -> None:
+        async with self._connect_lock:
+            if self.is_connected:
+                return
+            try:
+                self._ws = await websockets.connect(
+                    self.url,
+                    additional_headers={"Authorization": f"Bearer {self.token}"},
+                    compression=None,  # codex app-server rejects permessage-deflate
+                    max_size=64 * 1024 * 1024,
+                )
+            except Exception as e:
+                raise SdkConnectionError(f"dial {self.url}: {e}") from e
+
+            self._reader_task = asyncio.create_task(self._reader())
+
+            await self._request("initialize", {
+                "clientInfo": {"name": "agentserver-sdk", "title": "agentserver-sdk",
+                               "version": "0"},
+                "capabilities": {
+                    "experimentalApi": True,
+                    "requestAttestation": False,
+                    "optOutNotificationMethods": [],
+                },
+            })
+            await self._notify("initialized")
+            ts = await self._request("thread/start", {})
+            self.thread_id = ts["thread_id"]
+
+    async def close(self) -> None:
+        if self._reader_task is not None:
+            self._reader_task.cancel()
+            try:
+                await self._reader_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._reader_task = None
+        if self._ws is not None:
+            await self._ws.close()
+            self._ws = None
+        self.thread_id = None
+        # Fail any pending requests
+        for fut in self._pending.values():
+            if not fut.done():
+                fut.set_exception(SdkConnectionError("connection closed"))
+        self._pending.clear()
+
+    async def _request(self, method: str, params: dict[str, Any]) -> dict[str, Any]:
+        if self._ws is None:
+            raise SdkConnectionError("not connected")
+        self._next_id += 1
+        rid = self._next_id
+        fut: asyncio.Future[dict[str, Any]] = asyncio.get_running_loop().create_future()
+        self._pending[rid] = fut
+        try:
+            await self._ws.send(json.dumps({
+                "jsonrpc": "2.0", "id": rid, "method": method, "params": params,
+            }))
+            return await fut
+        finally:
+            self._pending.pop(rid, None)
+
+    async def _notify(self, method: str, params: dict[str, Any] | None = None) -> None:
+        if self._ws is None:
+            raise SdkConnectionError("not connected")
+        frame: dict[str, Any] = {"jsonrpc": "2.0", "method": method}
+        if params is not None:
+            frame["params"] = params
+        await self._ws.send(json.dumps(frame))
+
+    async def _reader(self) -> None:
+        assert self._ws is not None
+        try:
+            async for raw in self._ws:
+                msg = json.loads(raw)
+                rid = msg.get("id")
+                if rid is None:
+                    # server notification or request from server — ignore in v1
+                    continue
+                fut = self._pending.get(rid)
+                if fut is None or fut.done():
+                    continue
+                if "error" in msg:
+                    err = msg["error"]
+                    fut.set_exception(
+                        SdkConnectionError(
+                            f"rpc {err.get('code')}: {err.get('message')}"
+                        )
+                    )
+                else:
+                    fut.set_result(msg.get("result", {}))
+        except websockets.ConnectionClosed:
+            pass
+```
+
+- [ ] **Step 5: Run tests, confirm pass**
+
+Run: `pytest tests/test_client.py -v`
+Expected: `4 passed`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add sdk/python/src/agentserver_sdk/errors.py \
+        sdk/python/src/agentserver_sdk/client.py \
+        sdk/python/tests/test_client.py
+git commit -m "feat(sdk): WSClient connect + handshake
+
+opens ws with Bearer auth, runs initialize / initialized / thread/start,
+caches thread_id, idempotent reconnect. Errors mapped to SdkError."
+```
+
+---
+
+## Task 4: WSClient — `mcp_tool_call`
+
+**Files:**
+- Modify: `sdk/python/src/agentserver_sdk/client.py`
+- Modify: `sdk/python/tests/test_client.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `sdk/python/tests/test_client.py`:
+
+```python
+async def test_mcp_tool_call_round_trip(stub):
+    stub.on("mcpServer/tool/call", lambda p: {
+        "content": [{"type": "text", "text": "hello"}],
+        "structuredContent": {"k": "v"},
+        "isError": False,
+    })
+    c = WSClient(stub.url, token="t", workspace_id="ws-1", user_id="u-1")
+    await c.connect()
+    try:
+        result = await c.mcp_tool_call(
+            server="env_mcp",
+            tool="shell",
+            arguments={"environment_id": "alpha", "command": "ls"},
+        )
+        assert result["content"][0]["text"] == "hello"
+        # Find the tool/call frame
+        call = next(m for m in stub.received if m.get("method") == "mcpServer/tool/call")
+        assert call["params"]["thread_id"] == "stub-thread-1"
+        assert call["params"]["server"] == "env_mcp"
+        assert call["params"]["tool"] == "shell"
+        assert call["params"]["arguments"]["command"] == "ls"
+        assert call["params"]["_meta"]["agentserver_user_id"] == "u-1"
+        assert call["params"]["_meta"]["agentserver_workspace_id"] == "ws-1"
+    finally:
+        await c.close()
+
+
+async def test_mcp_tool_call_concurrent_dont_cross_streams(stub):
+    """Two concurrent calls must each get their own response by id."""
+    counter = {"n": 0}
+    def handler(p):
+        counter["n"] += 1
+        return {"content": [{"type": "text", "text": f"call-{counter['n']}"}], "isError": False}
+    stub.on("mcpServer/tool/call", handler)
+
+    c = WSClient(stub.url, token="t", workspace_id="ws", user_id="u")
+    await c.connect()
+    try:
+        import asyncio
+        r1, r2 = await asyncio.gather(
+            c.mcp_tool_call(server="s", tool="t", arguments={"environment_id": "a"}),
+            c.mcp_tool_call(server="s", tool="t", arguments={"environment_id": "a"}),
+        )
+        # Both got valid distinct responses
+        texts = {r1["content"][0]["text"], r2["content"][0]["text"]}
+        assert texts == {"call-1", "call-2"}
+    finally:
+        await c.close()
+
+
+async def test_mcp_tool_call_rpc_error_raises(stub):
+    stub.on("mcpServer/tool/call", lambda p: {"error": {"code": -32602, "message": "bad params"}})
+    c = WSClient(stub.url, token="t", workspace_id="ws", user_id="u")
+    await c.connect()
+    try:
+        with pytest.raises(SdkConnectionError, match="bad params"):
+            await c.mcp_tool_call(server="s", tool="t", arguments={"environment_id": "a"})
+    finally:
+        await c.close()
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+Run: `pytest tests/test_client.py::test_mcp_tool_call_round_trip -v`
+Expected: FAIL — `WSClient` has no `mcp_tool_call`.
+
+- [ ] **Step 3: Add `mcp_tool_call` to WSClient**
+
+Append to `sdk/python/src/agentserver_sdk/client.py` inside the `WSClient` class:
+
+```python
+    async def mcp_tool_call(
+        self,
+        *,
+        server: str,
+        tool: str,
+        arguments: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Issue `mcpServer/tool/call`. Returns the raw MCP CallToolResult dict.
+
+        Caller is responsible for interpreting `content` / `structuredContent` /
+        `isError`. RPC-level errors raise SdkConnectionError.
+        """
+        await self.connect()  # lazy
+        assert self.thread_id is not None
+        params: dict[str, Any] = {
+            "thread_id": self.thread_id,
+            "server": server,
+            "tool": tool,
+            "_meta": {
+                "agentserver_user_id": self.user_id,
+                "agentserver_workspace_id": self.workspace_id,
+            },
+        }
+        if arguments is not None:
+            params["arguments"] = arguments
+        return await self._request("mcpServer/tool/call", params)
+```
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+Run: `pytest tests/test_client.py -v`
+Expected: `7 passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sdk/python/src/agentserver_sdk/client.py sdk/python/tests/test_client.py
+git commit -m "feat(sdk): WSClient.mcp_tool_call
+
+issues mcpServer/tool/call with thread_id + _meta (user, workspace);
+concurrent calls dispatched by id; rpc errors raise."
+```
+
+---
+
+## Task 5: Result types — `ShellResult`, `ToolMetadata`, `OperationRecord`
+
+**Files:**
+- Create: `sdk/python/src/agentserver_sdk/types.py`
+- Create: `sdk/python/tests/test_types.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `sdk/python/tests/test_types.py`:
+
+```python
+import pytest
+
+from agentserver_sdk.types import ShellResult, ToolMetadata, OperationRecord
+
+
+def test_shell_result_from_mcp_text_content():
+    raw = {
+        "content": [{"type": "text", "text": "hi"}],
+        "structuredContent": {"stdout": "hi", "stderr": "", "exit_code": 0},
+        "isError": False,
+    }
+    r = ShellResult.from_mcp(raw)
+    assert r.stdout == "hi"
+    assert r.stderr == ""
+    assert r.exit_code == 0
+
+
+def test_shell_result_from_mcp_fallback_when_no_structured():
+    raw = {"content": [{"type": "text", "text": "fallback"}], "isError": False}
+    r = ShellResult.from_mcp(raw)
+    assert r.stdout == "fallback"
+    assert r.stderr == ""
+    assert r.exit_code == 0
+
+
+def test_shell_result_exit_code_nonzero():
+    raw = {
+        "content": [{"type": "text", "text": ""}],
+        "structuredContent": {"stdout": "", "stderr": "boom", "exit_code": 1},
+        "isError": False,
+    }
+    r = ShellResult.from_mcp(raw)
+    assert r.exit_code == 1
+    assert r.stderr == "boom"
+
+
+def test_tool_metadata_from_dict():
+    m = ToolMetadata.from_dict({
+        "name": "submit_task",
+        "description": "submit HPC job",
+        "inputSchema": {"type": "object"},
+    })
+    assert m.name == "submit_task"
+    assert m.description == "submit HPC job"
+    assert m.kind == "custom"  # default for non-core
+
+
+def test_tool_metadata_core_marker():
+    m = ToolMetadata.from_dict({"name": "shell", "description": "x", "inputSchema": {}})
+    assert m.kind == "core"
+
+
+def test_operation_record_from_dict():
+    o = OperationRecord.from_dict({
+        "id": "op_1",
+        "env_id": "alpha",
+        "tool": "shell",
+        "is_error": False,
+        "started_at": "2026-05-18T10:00:00Z",
+        "duration_ms": 42,
+        "user_id": "u",
+        "source": "sdk",
+    })
+    assert o.id == "op_1"
+    assert o.is_error is False
+    assert o.duration_ms == 42
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+Run: `pytest tests/test_types.py -v`
+Expected: FAIL — `agentserver_sdk.types` not found.
+
+- [ ] **Step 3: Implement types**
+
+Create `sdk/python/src/agentserver_sdk/types.py`:
+
+```python
+"""SDK result + metadata types. Pure data; no I/O.
+
+`from_mcp` / `from_dict` constructors take the JSON-shape returned by the
+gateway and produce typed Python objects. Wrappers are minimal — most
+fields are exposed as-is.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+CORE_TOOLS = frozenset({
+    "shell", "read_file", "write_file", "apply_patch",
+    "exec_command", "write_stdin", "read_output", "terminate",
+    "copy_path",
+})
+
+
+@dataclass
+class ShellResult:
+    stdout: str
+    stderr: str
+    exit_code: int
+    raw: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_mcp(cls, raw: dict[str, Any]) -> ShellResult:
+        sc = raw.get("structuredContent") or {}
+        if sc:
+            return cls(
+                stdout=sc.get("stdout", ""),
+                stderr=sc.get("stderr", ""),
+                exit_code=int(sc.get("exit_code", 0)),
+                raw=raw,
+            )
+        # Fallback: join text content as stdout
+        text = "".join(
+            item.get("text", "") for item in raw.get("content", [])
+            if item.get("type") == "text"
+        )
+        return cls(stdout=text, stderr="", exit_code=0, raw=raw)
+
+
+@dataclass
+class ToolMetadata:
+    name: str
+    description: str
+    input_schema: dict[str, Any]
+    kind: str  # "core" | "custom"
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> ToolMetadata:
+        name = d["name"]
+        return cls(
+            name=name,
+            description=d.get("description", ""),
+            input_schema=d.get("inputSchema", {}),
+            kind="core" if name in CORE_TOOLS else "custom",
+        )
+
+
+@dataclass
+class OperationRecord:
+    id: str
+    env_id: str
+    tool: str
+    is_error: bool
+    started_at: str
+    duration_ms: int
+    user_id: str | None
+    source: str
+    arguments: dict[str, Any] | None = None
+    result_summary: str | None = None
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> OperationRecord:
+        return cls(
+            id=d["id"],
+            env_id=d["env_id"],
+            tool=d["tool"],
+            is_error=bool(d.get("is_error", False)),
+            started_at=d.get("started_at", ""),
+            duration_ms=int(d.get("duration_ms", 0)),
+            user_id=d.get("user_id"),
+            source=d.get("source", ""),
+            arguments=d.get("arguments"),
+            result_summary=d.get("result_summary"),
+        )
+```
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+Run: `pytest tests/test_types.py -v`
+Expected: `5 passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sdk/python/src/agentserver_sdk/types.py sdk/python/tests/test_types.py
+git commit -m "feat(sdk): result + metadata types
+
+ShellResult.from_mcp (structuredContent preferred, text fallback),
+ToolMetadata with core/custom classification, OperationRecord."
+```
+
+---
+
+## Task 6: `Env` — core methods (`shell`, `read_file`, `write_file`, `apply_patch`, `call`)
+
+**Files:**
+- Create: `sdk/python/src/agentserver_sdk/env.py`
+- Create: `sdk/python/tests/test_env.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `sdk/python/tests/test_env.py`:
+
+```python
+import base64
+import pytest
+
+from agentserver_sdk.client import WSClient
+from agentserver_sdk.env import Env
+from agentserver_sdk.errors import ToolError
+from agentserver_sdk.types import ShellResult, ToolMetadata
+
+
+async def _connected_client(stub):
+    c = WSClient(stub.url, token="t", workspace_id="ws", user_id="u")
+    await c.connect()
+    return c
+
+
+def _tool(name, desc=""):
+    return ToolMetadata(name=name, description=desc, input_schema={}, kind="core" if name in {
+        "shell", "read_file", "write_file", "apply_patch", "exec_command",
+        "write_stdin", "read_output", "terminate", "copy_path",
+    } else "custom")
+
+
+async def test_env_call_injects_environment_id(stub):
+    stub.on("mcpServer/tool/call", lambda p: {"content": [], "isError": False})
+    c = await _connected_client(stub)
+    env = Env(name="alpha", type="shell", tools=[_tool("shell")], _client=c)
+    try:
+        await env.call("shell", {"command": "ls"})
+        call = next(m for m in stub.received if m.get("method") == "mcpServer/tool/call")
+        assert call["params"]["arguments"]["environment_id"] == "alpha"
+        assert call["params"]["arguments"]["command"] == "ls"
+        assert call["params"]["tool"] == "shell"
+    finally:
+        await c.close()
+
+
+async def test_env_shell_returns_shell_result(stub):
+    stub.on("mcpServer/tool/call", lambda p: {
+        "content": [{"type": "text", "text": "hi"}],
+        "structuredContent": {"stdout": "hi", "stderr": "", "exit_code": 0},
+        "isError": False,
+    })
+    c = await _connected_client(stub)
+    env = Env(name="alpha", type="shell", tools=[_tool("shell")], _client=c)
+    try:
+        r = await env.shell("echo hi")
+        assert isinstance(r, ShellResult)
+        assert r.stdout == "hi"
+        assert r.exit_code == 0
+    finally:
+        await c.close()
+
+
+async def test_env_read_file_returns_bytes(stub):
+    payload = b"hello binary"
+    stub.on("mcpServer/tool/call", lambda p: {
+        "content": [{"type": "text", "text": base64.b64encode(payload).decode()}],
+        "structuredContent": {"encoding": "base64"},
+        "isError": False,
+    })
+    c = await _connected_client(stub)
+    env = Env(name="alpha", type="shell", tools=[_tool("read_file")], _client=c)
+    try:
+        data = await env.read_file("/x")
+        assert data == payload
+    finally:
+        await c.close()
+
+
+async def test_env_is_error_raises_tool_error(stub):
+    stub.on("mcpServer/tool/call", lambda p: {
+        "content": [{"type": "text", "text": "boom"}],
+        "isError": True,
+    })
+    c = await _connected_client(stub)
+    env = Env(name="alpha", type="shell", tools=[_tool("shell")], _client=c)
+    try:
+        with pytest.raises(ToolError) as ei:
+            await env.shell("badcmd")
+        assert ei.value.env == "alpha"
+        assert ei.value.tool == "shell"
+        assert "boom" in ei.value.message
+    finally:
+        await c.close()
+
+
+async def test_env_write_file_passes_bytes_as_b64(stub):
+    stub.on("mcpServer/tool/call", lambda p: {"content": [], "isError": False})
+    c = await _connected_client(stub)
+    env = Env(name="alpha", type="shell", tools=[_tool("write_file")], _client=c)
+    try:
+        await env.write_file("/x", b"\x00\x01\x02")
+        call = next(m for m in stub.received if m.get("method") == "mcpServer/tool/call")
+        args = call["params"]["arguments"]
+        assert args["path"] == "/x"
+        assert base64.b64decode(args["content_b64"]) == b"\x00\x01\x02"
+    finally:
+        await c.close()
+
+
+async def test_env_apply_patch_passes_through(stub):
+    stub.on("mcpServer/tool/call", lambda p: {"content": [], "isError": False})
+    c = await _connected_client(stub)
+    env = Env(name="alpha", type="shell", tools=[_tool("apply_patch")], _client=c)
+    try:
+        await env.apply_patch("*** Patch...")
+        call = next(m for m in stub.received if m.get("method") == "mcpServer/tool/call")
+        assert call["params"]["arguments"]["patch"] == "*** Patch..."
+    finally:
+        await c.close()
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+Run: `pytest tests/test_env.py -v`
+Expected: FAIL — `agentserver_sdk.env` not found.
+
+- [ ] **Step 3: Implement Env (core methods only — dynamic dispatch in Task 8)**
+
+Create `sdk/python/src/agentserver_sdk/env.py`:
+
+```python
+"""Env class — one instance per executor; wraps env-mcp tool calls."""
+from __future__ import annotations
+
+import base64
+from dataclasses import dataclass, field
+from typing import Any, TYPE_CHECKING
+
+from .errors import ToolError
+from .types import CORE_TOOLS, ShellResult, ToolMetadata
+
+if TYPE_CHECKING:
+    from .client import WSClient
+
+
+_TOOL_SERVER = "env_mcp"  # all env-mcp tools live under one MCP server name
+
+
+@dataclass
+class Env:
+    name: str
+    type: str
+    tools: list[ToolMetadata]
+    _client: "WSClient"
+    _tool_index: dict[str, ToolMetadata] = field(init=False)
+
+    def __post_init__(self) -> None:
+        self._tool_index = {t.name: t for t in self.tools}
+
+    # ---------- generic dispatch ----------
+
+    async def call(self, tool: str, arguments: dict[str, Any] | None = None) -> dict[str, Any]:
+        """Universal MCP tool call — even tools the SDK doesn't know about.
+
+        `environment_id` is injected automatically. Raises ToolError on
+        isError=true. Returns the raw MCP result dict.
+        """
+        args = dict(arguments or {})
+        args.setdefault("environment_id", self.name)
+        raw = await self._client.mcp_tool_call(
+            server=_TOOL_SERVER, tool=tool, arguments=args,
+        )
+        if raw.get("isError"):
+            msg = _extract_error_text(raw)
+            raise ToolError(tool=tool, env=self.name, message=msg, raw=raw)
+        return raw
+
+    # ---------- core typed wrappers ----------
+
+    async def shell(self, command: str, *, timeout: int | None = None) -> ShellResult:
+        args: dict[str, Any] = {"command": command}
+        if timeout is not None:
+            args["timeout_s"] = timeout
+        raw = await self.call("shell", args)
+        return ShellResult.from_mcp(raw)
+
+    async def read_file(self, path: str) -> bytes:
+        raw = await self.call("read_file", {"path": path})
+        return _decode_file_content(raw)
+
+    async def write_file(self, path: str, content: bytes) -> None:
+        await self.call("write_file", {
+            "path": path,
+            "content_b64": base64.b64encode(content).decode("ascii"),
+        })
+
+    async def apply_patch(self, patch: str) -> None:
+        await self.call("apply_patch", {"patch": patch})
+
+
+# ---------- helpers ----------
+
+def _extract_error_text(raw: dict[str, Any]) -> str:
+    items = raw.get("content", [])
+    texts = [it.get("text", "") for it in items if it.get("type") == "text"]
+    return " ".join(texts) or "tool reported isError=true"
+
+
+def _decode_file_content(raw: dict[str, Any]) -> bytes:
+    """env-mcp's read_file convention: text content is base64 if
+    structuredContent.encoding == 'base64', else raw text bytes.
+
+    v0 stub mirrors this; real env-mcp may differ — adjust if needed."""
+    sc = raw.get("structuredContent") or {}
+    items = raw.get("content", [])
+    text = "".join(it.get("text", "") for it in items if it.get("type") == "text")
+    if sc.get("encoding") == "base64":
+        return base64.b64decode(text)
+    return text.encode("utf-8")
+```
+
+- [ ] **Step 4: Run tests, confirm pass**
+
+Run: `pytest tests/test_env.py -v`
+Expected: `6 passed`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sdk/python/src/agentserver_sdk/env.py sdk/python/tests/test_env.py
+git commit -m "feat(sdk): Env core typed methods + generic call
+
+shell/read_file/write_file/apply_patch wrappers; isError=true raises
+ToolError with env+tool context; environment_id auto-injected."
+```
+
+---
+
+## Task 7: `Process` — async context manager
+
+**Files:**
+- Create: `sdk/python/src/agentserver_sdk/process.py`
+- Modify: `sdk/python/src/agentserver_sdk/env.py` (add `spawn`)
+- Create: `sdk/python/tests/test_process.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `sdk/python/tests/test_process.py`:
+
+```python
+import pytest
+
+from agentserver_sdk.client import WSClient
+from agentserver_sdk.env import Env
+from agentserver_sdk.types import ToolMetadata
+
+
+def _tool(name): return ToolMetadata(name=name, description="", input_schema={}, kind="core")
+
+
+async def test_spawn_calls_exec_command_and_returns_process(stub):
+    stub.on("mcpServer/tool/call", lambda p: {
+        "content": [],
+        "structuredContent": {"session_id": "sess-1"},
+        "isError": False,
+    })
+    c = WSClient(stub.url, token="t", workspace_id="w", user_id="u")
+    await c.connect()
+    env = Env(name="alpha", type="shell",
+              tools=[_tool("exec_command"), _tool("write_stdin"),
+                     _tool("read_output"), _tool("terminate")],
+              _client=c)
+    try:
+        async with env.spawn("./run.sh") as proc:
+            assert proc.session_id == "sess-1"
+            # exec_command was sent
+            calls = [m for m in stub.received if m.get("method") == "mcpServer/tool/call"]
+            assert calls[0]["params"]["tool"] == "exec_command"
+            assert calls[0]["params"]["arguments"]["command"] == "./run.sh"
+        # On exit, terminate was sent
+        all_tools = [m["params"]["tool"] for m in stub.received if m.get("method") == "mcpServer/tool/call"]
+        assert "terminate" in all_tools
+    finally:
+        await c.close()
+
+
+async def test_process_write_and_read(stub):
+    state = {"step": 0}
+    def handler(p):
+        state["step"] += 1
+        tool = p["tool"]
+        if tool == "exec_command":
+            return {"structuredContent": {"session_id": "s-1"}, "isError": False, "content": []}
+        if tool == "write_stdin":
+            return {"content": [], "isError": False}
+        if tool == "read_output":
+            return {
+                "structuredContent": {"chunk_b64": "aGVsbG8="},  # base64('hello')
+                "isError": False,
+                "content": [{"type": "text", "text": "hello"}],
+            }
+        if tool == "terminate":
+            return {"content": [], "isError": False}
+        return {"error": {"code": -32601, "message": "unknown"}}
+
+    stub.on("mcpServer/tool/call", handler)
+
+    c = WSClient(stub.url, token="t", workspace_id="w", user_id="u")
+    await c.connect()
+    env = Env(name="alpha", type="shell",
+              tools=[_tool("exec_command"), _tool("write_stdin"),
+                     _tool("read_output"), _tool("terminate")],
+              _client=c)
+    try:
+        async with env.spawn("./run.sh") as proc:
+            await proc.write_stdin(b"hi\n")
+            data = await proc.read_output(timeout=1.0)
+            assert data == b"hello"
+    finally:
+        await c.close()
+
+
+async def test_process_terminate_runs_even_on_exception(stub):
+    stub.on("mcpServer/tool/call", lambda p:
+        {"structuredContent": {"session_id": "s"}, "isError": False, "content": []}
+        if p["tool"] == "exec_command"
+        else {"content": [], "isError": False})
+    c = WSClient(stub.url, token="t", workspace_id="w", user_id="u")
+    await c.connect()
+    env = Env(name="alpha", type="shell",
+              tools=[_tool("exec_command"), _tool("terminate"), _tool("write_stdin"), _tool("read_output")],
+              _client=c)
+    try:
+        with pytest.raises(RuntimeError):
+            async with env.spawn("./run.sh"):
+                raise RuntimeError("boom")
+        # terminate happened
+        tools = [m["params"]["tool"] for m in stub.received if m.get("method") == "mcpServer/tool/call"]
+        assert tools.count("terminate") == 1
+    finally:
+        await c.close()
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+Run: `pytest tests/test_process.py -v`
+Expected: FAIL — `Env.spawn` not found.
+
+- [ ] **Step 3: Implement Process**
+
+Create `sdk/python/src/agentserver_sdk/process.py`:
+
+```python
+"""Process — async context manager wrapping exec_command/stdin/output/terminate."""
+from __future__ import annotations
+
+import base64
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from .env import Env
+
+
+class Process:
+    def __init__(self, env: "Env", session_id: str) -> None:
+        self.env = env
+        self.session_id = session_id
+        self._terminated = False
+
+    async def __aenter__(self) -> "Process":
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb) -> None:
+        await self.terminate()
+
+    async def write_stdin(self, data: bytes) -> None:
+        await self.env.call("write_stdin", {
+            "session_id": self.session_id,
+            "data_b64": base64.b64encode(data).decode("ascii"),
+        })
+
+    async def read_output(self, timeout: float | None = None) -> bytes:
+        args: dict[str, Any] = {"session_id": self.session_id}
+        if timeout is not None:
+            args["timeout_ms"] = int(timeout * 1000)
+        raw = await self.env.call("read_output", args)
+        sc = raw.get("structuredContent") or {}
+        b64 = sc.get("chunk_b64")
+        if b64 is not None:
+            return base64.b64decode(b64)
+        # fallback to text content
+        texts = [it.get("text", "") for it in raw.get("content", []) if it.get("type") == "text"]
+        return "".join(texts).encode("utf-8")
+
+    async def terminate(self) -> None:
+        if self._terminated:
+            return
+        self._terminated = True
+        try:
+            await self.env.call("terminate", {"session_id": self.session_id})
+        except Exception:
+            # best-effort; don't mask a user exception
+            pass
+```
+
+- [ ] **Step 4: Add `Env.spawn`**
+
+Append to `sdk/python/src/agentserver_sdk/env.py`:
+
+```python
+    async def spawn(self, command: str) -> "Process":
+        """Start a long-running command. Use as `async with env.spawn(cmd) as proc:`."""
+        from .process import Process  # avoid circular at module load
+        raw = await self.call("exec_command", {"command": command})
+        sc = raw.get("structuredContent") or {}
+        session_id = sc.get("session_id")
+        if not session_id:
+            raise ToolError(tool="exec_command", env=self.name,
+                            message="exec_command did not return session_id", raw=raw)
+        return Process(self, session_id)
+```
+
+- [ ] **Step 5: Run, confirm pass**
+
+Run: `pytest tests/test_process.py -v`
+Expected: `3 passed`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add sdk/python/src/agentserver_sdk/process.py \
+        sdk/python/src/agentserver_sdk/env.py \
+        sdk/python/tests/test_process.py
+git commit -m "feat(sdk): Process async context manager
+
+env.spawn(cmd) returns Process; write_stdin/read_output/terminate;
+auto-terminate on context exit even if cell raises."
+```
+
+---
+
+## Task 8: `Env` — dynamic dispatch via `__getattr__` + `setattr`
+
+**Files:**
+- Modify: `sdk/python/src/agentserver_sdk/env.py`
+- Modify: `sdk/python/tests/test_env.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `sdk/python/tests/test_env.py`:
+
+```python
+async def test_custom_tool_called_via_attribute(stub):
+    """A custom tool surfaced in tools metadata becomes a method on env."""
+    stub.on("mcpServer/tool/call", lambda p: {
+        "content": [{"type": "text", "text": "job-123"}],
+        "isError": False,
+    })
+    c = await _connected_client(stub)
+    custom = ToolMetadata(name="submit_task",
+                          description="submit HPC job",
+                          input_schema={"type": "object"},
+                          kind="custom")
+    env = Env(name="hpc-a", type="hpc", tools=[custom], _client=c)
+    try:
+        # Method exists thanks to setattr in __post_init__
+        assert hasattr(env, "submit_task")
+        result = await env.submit_task(script="x", resources={"gpus": 4})
+        call = next(m for m in stub.received if m.get("method") == "mcpServer/tool/call")
+        assert call["params"]["tool"] == "submit_task"
+        assert call["params"]["arguments"]["environment_id"] == "hpc-a"
+        assert call["params"]["arguments"]["script"] == "x"
+        assert call["params"]["arguments"]["resources"] == {"gpus": 4}
+        assert result["content"][0]["text"] == "job-123"
+    finally:
+        await c.close()
+
+
+async def test_unknown_attribute_raises_attribute_error(stub):
+    c = await _connected_client(stub)
+    env = Env(name="alpha", type="shell", tools=[_tool("shell")], _client=c)
+    try:
+        with pytest.raises(AttributeError):
+            env.nonexistent_tool
+    finally:
+        await c.close()
+
+
+async def test_dir_lists_custom_tools(stub):
+    c = await _connected_client(stub)
+    env = Env(name="hpc", type="hpc",
+              tools=[ToolMetadata(name="submit_task", description="", input_schema={}, kind="custom")],
+              _client=c)
+    try:
+        assert "submit_task" in dir(env)
+    finally:
+        await c.close()
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+Run: `pytest tests/test_env.py -v -k custom`
+Expected: FAIL — `Env` has no `submit_task`.
+
+- [ ] **Step 3: Extend `Env.__post_init__` to bind dynamic methods**
+
+Replace the `__post_init__` in `sdk/python/src/agentserver_sdk/env.py`:
+
+```python
+    def __post_init__(self) -> None:
+        self._tool_index = {t.name: t for t in self.tools}
+        for tool in self.tools:
+            if tool.kind == "core":
+                continue  # core tools have typed wrappers
+            method = self._make_dynamic(tool)
+            object.__setattr__(self, tool.name, method)
+
+    def _make_dynamic(self, tool: ToolMetadata):
+        tool_name = tool.name
+
+        async def method(**kwargs: Any) -> dict[str, Any]:
+            return await self.call(tool_name, kwargs)
+
+        method.__name__ = tool_name
+        method.__doc__ = tool.description or f"Call env-mcp tool {tool_name}."
+        return method
+
+    def __dir__(self) -> list[str]:
+        base = list(super().__dir__())
+        base.extend(t.name for t in self.tools if t.kind == "custom")
+        return base
+```
+
+- [ ] **Step 4: Run, confirm pass**
+
+Run: `pytest tests/test_env.py -v`
+Expected: All env tests pass (6 existing + 3 new = 9).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add sdk/python/src/agentserver_sdk/env.py sdk/python/tests/test_env.py
+git commit -m "feat(sdk): Env dynamic dispatch for custom tools
+
+setattr custom tools at construction; __dir__ surfaces them for
+tab-complete; AttributeError for unknown."
+```
+
+---
+
+## Task 9: `Ctx` — connection, `envs()`, `env()`, `copy()`, `history()`
+
+**Files:**
+- Create: `sdk/python/src/agentserver_sdk/ctx.py`
+- Create: `sdk/python/tests/test_ctx.py`
+- Modify: `sdk/python/src/agentserver_sdk/__init__.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `sdk/python/tests/test_ctx.py`:
+
+```python
+import os
+import pytest
+
+from agentserver_sdk.ctx import Ctx
+
+
+def _setup_stub_envs(stub):
+    """Make stub return two envs (alpha + hpc) via env/capabilities + envs/list."""
+    stub.on("envs/list", lambda p: {"envs": [
+        {"name": "alpha", "type": "shell"},
+        {"name": "hpc",   "type": "hpc"},
+    ]})
+
+    def caps(p):
+        env_id = p["env_id"]
+        if env_id == "alpha":
+            return {"tools": [
+                {"name": "shell", "description": "run sh", "inputSchema": {}},
+                {"name": "read_file", "description": "read", "inputSchema": {}},
+            ]}
+        if env_id == "hpc":
+            return {"tools": [
+                {"name": "shell", "description": "run sh", "inputSchema": {}},
+                {"name": "submit_task", "description": "submit HPC", "inputSchema": {}},
+            ]}
+        return {"error": {"code": -32602, "message": "unknown env"}}
+    stub.on("env/capabilities", caps)
+
+
+async def test_ctx_from_env_reads_env_vars(monkeypatch, stub):
+    monkeypatch.setenv("AGENTSERVER_GATEWAY_URL", stub.url)
+    monkeypatch.setenv("AGENTSERVER_WORKSPACE_TOKEN", "tok")
+    monkeypatch.setenv("AGENTSERVER_WORKSPACE_ID", "ws")
+    monkeypatch.setenv("AGENTSERVER_USER_ID", "u")
+    ctx = Ctx.from_env()
+    assert ctx.gateway_url == stub.url
+    assert ctx.workspace_id == "ws"
+
+
+async def test_ctx_envs_returns_env_objects(monkeypatch, stub):
+    _setup_stub_envs(stub)
+    monkeypatch.setenv("AGENTSERVER_GATEWAY_URL", stub.url)
+    monkeypatch.setenv("AGENTSERVER_WORKSPACE_TOKEN", "tok")
+    monkeypatch.setenv("AGENTSERVER_WORKSPACE_ID", "ws")
+    monkeypatch.setenv("AGENTSERVER_USER_ID", "u")
+    ctx = Ctx.from_env()
+    try:
+        envs = await ctx.envs()
+        assert {e.name for e in envs} == {"alpha", "hpc"}
+        hpc = next(e for e in envs if e.name == "hpc")
+        assert hasattr(hpc, "submit_task")  # custom tool surfaced
+    finally:
+        await ctx.close()
+
+
+async def test_ctx_env_by_name(monkeypatch, stub):
+    _setup_stub_envs(stub)
+    monkeypatch.setenv("AGENTSERVER_GATEWAY_URL", stub.url)
+    monkeypatch.setenv("AGENTSERVER_WORKSPACE_TOKEN", "tok")
+    monkeypatch.setenv("AGENTSERVER_WORKSPACE_ID", "ws")
+    monkeypatch.setenv("AGENTSERVER_USER_ID", "u")
+    ctx = Ctx.from_env()
+    try:
+        alpha = await ctx.env("alpha")
+        assert alpha.name == "alpha"
+        assert alpha.type == "shell"
+    finally:
+        await ctx.close()
+
+
+async def test_ctx_env_missing_raises(monkeypatch, stub):
+    _setup_stub_envs(stub)
+    monkeypatch.setenv("AGENTSERVER_GATEWAY_URL", stub.url)
+    monkeypatch.setenv("AGENTSERVER_WORKSPACE_TOKEN", "tok")
+    monkeypatch.setenv("AGENTSERVER_WORKSPACE_ID", "ws")
+    monkeypatch.setenv("AGENTSERVER_USER_ID", "u")
+    ctx = Ctx.from_env()
+    try:
+        with pytest.raises(KeyError):
+            await ctx.env("nope")
+    finally:
+        await ctx.close()
+
+
+async def test_ctx_copy_uses_copy_path_tool(monkeypatch, stub):
+    _setup_stub_envs(stub)
+    stub.on("mcpServer/tool/call", lambda p: {"content": [], "isError": False})
+    monkeypatch.setenv("AGENTSERVER_GATEWAY_URL", stub.url)
+    monkeypatch.setenv("AGENTSERVER_WORKSPACE_TOKEN", "tok")
+    monkeypatch.setenv("AGENTSERVER_WORKSPACE_ID", "ws")
+    monkeypatch.setenv("AGENTSERVER_USER_ID", "u")
+    ctx = Ctx.from_env()
+    try:
+        alpha = await ctx.env("alpha")
+        hpc = await ctx.env("hpc")
+        await ctx.copy(src=(alpha, "/a/x"), dst=(hpc, "/b/x"))
+        call = next(m for m in stub.received if m.get("method") == "mcpServer/tool/call")
+        assert call["params"]["tool"] == "copy_path"
+        args = call["params"]["arguments"]
+        assert args["src_env"] == "alpha"
+        assert args["src_path"] == "/a/x"
+        assert args["dst_env"] == "hpc"
+        assert args["dst_path"] == "/b/x"
+    finally:
+        await ctx.close()
+
+
+async def test_ctx_history_returns_records(monkeypatch, stub):
+    stub.on("envs/list", lambda p: {"envs": []})
+    stub.on("operations/list", lambda p: {"operations": [
+        {"id": "op_1", "env_id": "alpha", "tool": "shell", "is_error": False,
+         "started_at": "2026-05-18T10:00:00Z", "duration_ms": 5,
+         "user_id": "u", "source": "sdk"},
+    ]})
+    monkeypatch.setenv("AGENTSERVER_GATEWAY_URL", stub.url)
+    monkeypatch.setenv("AGENTSERVER_WORKSPACE_TOKEN", "tok")
+    monkeypatch.setenv("AGENTSERVER_WORKSPACE_ID", "ws")
+    monkeypatch.setenv("AGENTSERVER_USER_ID", "u")
+    ctx = Ctx.from_env()
+    try:
+        ops = await ctx.history(limit=10)
+        assert len(ops) == 1
+        assert ops[0].tool == "shell"
+        # Ensure filter forwarded
+        call = next(m for m in stub.received if m.get("method") == "operations/list")
+        assert call["params"]["limit"] == 10
+    finally:
+        await ctx.close()
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+Run: `pytest tests/test_ctx.py -v`
+Expected: FAIL — `agentserver_sdk.ctx` not found.
+
+- [ ] **Step 3: Implement Ctx**
+
+Create `sdk/python/src/agentserver_sdk/ctx.py`:
+
+```python
+"""Ctx — workspace handle, entry point for the SDK.
+
+`Ctx.from_env()` constructs a lazy handle (no I/O). The first `await`
+on any method triggers WS connect + handshake. One thread per Ctx;
+cached internally.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Any
+
+from .client import WSClient
+from .env import Env
+from .types import OperationRecord, ToolMetadata
+
+
+@dataclass
+class Ctx:
+    gateway_url: str
+    workspace_id: str
+    user_id: str | None
+    _client: WSClient
+
+    @classmethod
+    def from_env(cls) -> "Ctx":
+        url = os.environ.get("AGENTSERVER_GATEWAY_URL",
+                             "ws://localhost:8086/notebook/ws")
+        token = os.environ.get("AGENTSERVER_WORKSPACE_TOKEN", "")
+        workspace_id = os.environ.get("AGENTSERVER_WORKSPACE_ID", "")
+        user_id = os.environ.get("AGENTSERVER_USER_ID")
+        client = WSClient(url, token=token, workspace_id=workspace_id, user_id=user_id)
+        return cls(gateway_url=url, workspace_id=workspace_id,
+                   user_id=user_id, _client=client)
+
+    async def envs(self) -> list[Env]:
+        """List envs in the workspace. Caches inside Ctx for the kernel
+        lifetime — call `refresh()` to refetch."""
+        if self._envs_cache is None:
+            await self._client.connect()
+            listing = await self._client._request("envs/list", {})
+            envs: list[Env] = []
+            for e in listing.get("envs", []):
+                caps = await self._client._request(
+                    "env/capabilities", {"env_id": e["name"]},
+                )
+                tools = [ToolMetadata.from_dict(t) for t in caps.get("tools", [])]
+                envs.append(Env(name=e["name"], type=e.get("type", ""),
+                                tools=tools, _client=self._client))
+            self._envs_cache = envs
+        return list(self._envs_cache)
+
+    async def env(self, name: str) -> Env:
+        for e in await self.envs():
+            if e.name == name:
+                return e
+        raise KeyError(f"env not found: {name}")
+
+    async def refresh(self) -> None:
+        self._envs_cache = None
+        await self.envs()
+
+    async def copy(self, *, src: tuple[Env, str], dst: tuple[Env, str]) -> None:
+        src_env, src_path = src
+        dst_env, dst_path = dst
+        await self._client.mcp_tool_call(
+            server="env_mcp", tool="copy_path",
+            arguments={
+                "src_env": src_env.name, "src_path": src_path,
+                "dst_env": dst_env.name, "dst_path": dst_path,
+            },
+        )
+
+    async def history(
+        self,
+        *,
+        limit: int = 100,
+        env: str | None = None,
+        tool: str | None = None,
+        is_error: bool | None = None,
+        since: str | None = None,
+        id: str | None = None,  # noqa: A002 (shadow of builtin is fine here)
+    ) -> list[OperationRecord]:
+        await self._client.connect()
+        params: dict[str, Any] = {"limit": limit}
+        if env is not None: params["env_id"] = env
+        if tool is not None: params["tool"] = tool
+        if is_error is not None: params["is_error"] = is_error
+        if since is not None: params["since"] = since
+        if id is not None: params["id"] = id
+        resp = await self._client._request("operations/list", params)
+        return [OperationRecord.from_dict(o) for o in resp.get("operations", [])]
+
+    async def close(self) -> None:
+        await self._client.close()
+
+    # ---------- dataclass field default for cache ----------
+
+    def __post_init__(self) -> None:
+        self._envs_cache: list[Env] | None = None
+```
+
+- [ ] **Step 4: Update package exports**
+
+Replace `sdk/python/src/agentserver_sdk/__init__.py`:
+
+```python
+"""agentserver_sdk — Python SDK for agentserver envs."""
+
+from .ctx import Ctx
+from .env import Env
+from .errors import ConnectionError, NotConnectedError, SdkError, ToolError
+from .process import Process
+from .types import OperationRecord, ShellResult, ToolMetadata
+
+__version__ = "0.1.0"
+__all__ = [
+    "Ctx", "Env", "Process",
+    "ShellResult", "ToolMetadata", "OperationRecord",
+    "SdkError", "ConnectionError", "NotConnectedError", "ToolError",
+]
+```
+
+- [ ] **Step 5: Run all tests, confirm pass**
+
+Run: `pytest -v`
+Expected: All previous tests + 6 new ctx tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add sdk/python/src/agentserver_sdk/ctx.py \
+        sdk/python/src/agentserver_sdk/__init__.py \
+        sdk/python/tests/test_ctx.py
+git commit -m "feat(sdk): Ctx workspace handle
+
+from_env constructor; envs() + env() with per-env capability fetch;
+copy() cross-env; history() over operations/list RPC; public exports."
+```
+
+---
+
+## Task 10: Jupyter `_repr_html_` rendering
+
+**Files:**
+- Create: `sdk/python/src/agentserver_sdk/_repr.py`
+- Modify: `sdk/python/src/agentserver_sdk/env.py` (add `_repr_html_`)
+- Modify: `sdk/python/src/agentserver_sdk/types.py` (add `_repr_html_`)
+- Modify: `sdk/python/src/agentserver_sdk/errors.py` (add `_repr_html_` to ToolError)
+- Create: `sdk/python/tests/test_repr.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `sdk/python/tests/test_repr.py`:
+
+```python
+from agentserver_sdk._repr import envs_table_html
+from agentserver_sdk.env import Env
+from agentserver_sdk.errors import ToolError
+from agentserver_sdk.types import ShellResult, ToolMetadata
+
+
+class _FakeClient:
+    pass
+
+
+def _env(name, tools):
+    return Env(name=name, type="shell",
+               tools=[ToolMetadata(name=t, description="", input_schema={},
+                                   kind="core" if t in {"shell"} else "custom") for t in tools],
+               _client=_FakeClient())
+
+
+def test_env_repr_html_contains_name_and_tool_count():
+    e = _env("alpha", ["shell", "submit_task"])
+    html = e._repr_html_()
+    assert "alpha" in html
+    assert "2" in html  # tool count
+
+
+def test_envs_table_html_has_one_row_per_env():
+    envs = [_env("alpha", ["shell"]), _env("beta", ["shell", "submit_task"])]
+    html = envs_table_html(envs)
+    assert html.count("<tr") >= 3  # header + 2 envs
+    assert "alpha" in html
+    assert "beta" in html
+
+
+def test_shell_result_repr_html_shows_exit_code():
+    r = ShellResult(stdout="hi", stderr="", exit_code=0)
+    assert "0" in r._repr_html_()
+    assert "hi" in r._repr_html_()
+    r2 = ShellResult(stdout="", stderr="boom", exit_code=1)
+    assert "boom" in r2._repr_html_()
+
+
+def test_tool_error_repr_html():
+    e = ToolError(tool="shell", env="alpha", message="bad", raw={"isError": True})
+    html = e._repr_html_()
+    assert "alpha" in html
+    assert "shell" in html
+    assert "bad" in html
+```
+
+- [ ] **Step 2: Run, confirm failure**
+
+Run: `pytest tests/test_repr.py -v`
+Expected: FAIL — modules/methods not found.
+
+- [ ] **Step 3: Implement `_repr.py`**
+
+Create `sdk/python/src/agentserver_sdk/_repr.py`:
+
+```python
+"""Jupyter-friendly HTML renderers. Pure functions, no I/O."""
+from __future__ import annotations
+
+import html
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .env import Env
+
+
+def envs_table_html(envs: list["Env"]) -> str:
+    rows = [
+        "<tr><th align='left'>name</th><th align='left'>type</th>"
+        "<th align='left'>tools</th></tr>"
+    ]
+    for e in envs:
+        rows.append(
+            "<tr>"
+            f"<td><code>{html.escape(e.name)}</code></td>"
+            f"<td>{html.escape(e.type)}</td>"
+            f"<td>{len(e.tools)}</td>"
+            "</tr>"
+        )
+    return f"<table>{''.join(rows)}</table>"
+```
+
+- [ ] **Step 4: Add `_repr_html_` to Env, ShellResult, ToolError**
+
+Append to `Env` in `sdk/python/src/agentserver_sdk/env.py`:
+
+```python
+    def _repr_html_(self) -> str:
+        import html as _html
+        return (
+            f"<table>"
+            f"<tr><th>env</th><td><code>{_html.escape(self.name)}</code></td></tr>"
+            f"<tr><th>type</th><td>{_html.escape(self.type)}</td></tr>"
+            f"<tr><th>tools</th><td>{len(self.tools)}</td></tr>"
+            f"</table>"
+        )
+```
+
+Append to `ShellResult` in `sdk/python/src/agentserver_sdk/types.py`:
+
+```python
+    def _repr_html_(self) -> str:
+        import html as _html
+        colour = "green" if self.exit_code == 0 else "red"
+        return (
+            f"<div>exit_code: <b style='color:{colour}'>{self.exit_code}</b></div>"
+            f"<details open><summary>stdout</summary>"
+            f"<pre>{_html.escape(self.stdout)}</pre></details>"
+            + (f"<details><summary>stderr</summary><pre>{_html.escape(self.stderr)}</pre></details>"
+               if self.stderr else "")
+        )
+```
+
+Append to `ToolError` in `sdk/python/src/agentserver_sdk/errors.py`:
+
+```python
+    def _repr_html_(self) -> str:
+        import html as _html
+        return (
+            f"<div style='border-left:3px solid red;padding-left:8px'>"
+            f"<b>ToolError</b> on env <code>{_html.escape(self.env or '?')}</code>, "
+            f"tool <code>{_html.escape(self.tool)}</code><br>"
+            f"<pre>{_html.escape(self.message)}</pre>"
+            f"</div>"
+        )
+```
+
+- [ ] **Step 5: Run tests, confirm pass**
+
+Run: `pytest tests/test_repr.py -v`
+Expected: `4 passed`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add sdk/python/src/agentserver_sdk/_repr.py \
+        sdk/python/src/agentserver_sdk/env.py \
+        sdk/python/src/agentserver_sdk/types.py \
+        sdk/python/src/agentserver_sdk/errors.py \
+        sdk/python/tests/test_repr.py
+git commit -m "feat(sdk): jupyter _repr_html_ for Env / ShellResult / ToolError
+
+table + colour-coded exit code + error styling."
+```
+
+---
+
+## Task 11: Full lint + test pass
+
+**Files:** none new.
+
+- [ ] **Step 1: Add ruff config + run**
+
+Append to `sdk/python/pyproject.toml`:
+
+```toml
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "B", "UP", "SIM"]
+ignore = ["E501"]  # let the formatter handle long lines
+```
+
+Run:
+```bash
+cd sdk/python
+ruff check .
+ruff format --check .
+```
+
+Fix any issues raised (formatting only — substance has tests).
+
+- [ ] **Step 2: Run full test suite**
+
+Run: `pytest -v`
+Expected: All tests pass; no test errors or warnings about the asyncio fixtures.
+
+- [ ] **Step 3: Commit any lint fixups**
+
+```bash
+git add -A
+git commit -m "chore(sdk): ruff config + lint pass" || true  # skip if no diff
+```
+
+---
+
+## Task 12: `Dockerfile.notebook` + IPython startup + Jupyter config
+
+**Files:**
+- Create: `Dockerfile.notebook` (repo root)
+- Create: `notebook/ipython_startup/00-ctx.py`
+- Create: `notebook/jupyter_server_config.py`
+- Create: `notebook/README.md`
+
+- [ ] **Step 1: Create the startup file**
+
+Create `notebook/ipython_startup/00-ctx.py`:
+
+```python
+"""Auto-injected into every ipykernel session inside the notebook image.
+
+Exposes:
+  - ctx: lazy Ctx instance bound to AGENTSERVER_* env vars
+  - asyncio: convenience re-import so users don't need `import asyncio`
+"""
+import asyncio  # noqa: F401  (intentionally injected into kernel namespace)
+from agentserver_sdk import Ctx
+
+ctx = Ctx.from_env()
+```
+
+- [ ] **Step 2: Create jupyter server config (v1 minimal)**
+
+Create `notebook/jupyter_server_config.py`:
+
+```python
+"""Plan 1 minimum config — no IdentityProvider or KernelProvisioner yet
+(those land with notebook hosting plan). Disable jupyter's own token
+auth so the smoke run is just-open-and-go. Real deployment will plug
+in agentserver auth in Plan 3."""
+
+c = get_config()  # type: ignore[name-defined]  # noqa: F821 (provided by jupyter at runtime)
+
+c.ServerApp.ip = "0.0.0.0"
+c.ServerApp.port = 8888
+c.ServerApp.open_browser = False
+c.ServerApp.token = ""       # SECURITY: only safe inside the local smoke env / agentserver-proxied prod
+c.ServerApp.password = ""
+c.ServerApp.disable_check_xsrf = True
+c.ServerApp.allow_origin = "*"
+c.ServerApp.root_dir = "/workspace"
+c.ServerApp.allow_root = True
+```
+
+- [ ] **Step 3: Write Dockerfile**
+
+Create `Dockerfile.notebook`:
+
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+# System deps kept tiny — jupyter is pure-python.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates tini \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install jupyter + ipykernel
+RUN pip install --no-cache-dir \
+      jupyter-server~=2.14 \
+      jupyterlab~=4.2 \
+      ipykernel~=6.29
+
+# Install agentserver-sdk from local source.
+COPY sdk/python /tmp/sdk
+RUN pip install --no-cache-dir /tmp/sdk && rm -rf /tmp/sdk
+
+# IPython startup hook → injects `ctx`
+RUN mkdir -p /etc/ipython/profile_default/startup
+COPY notebook/ipython_startup/00-ctx.py /etc/ipython/profile_default/startup/
+
+# Jupyter config
+COPY notebook/jupyter_server_config.py /etc/jupyter/
+
+# Workspace mount point — host bind or k8s PV later.
+RUN mkdir -p /workspace
+WORKDIR /workspace
+
+ENV IPYTHONDIR=/etc/ipython \
+    JUPYTER_CONFIG_DIR=/etc/jupyter
+
+EXPOSE 8888
+ENTRYPOINT ["tini", "--", "jupyter", "server", "--config=/etc/jupyter/jupyter_server_config.py"]
+```
+
+- [ ] **Step 4: Write notebook/README.md**
+
+Create `notebook/README.md`:
+
+```markdown
+# Notebook image (Plan 1)
+
+`Dockerfile.notebook` at repo root builds a self-contained jupyter image
+with `agentserver_sdk` pre-installed. `ctx` is auto-injected into every
+kernel via `ipython_startup/00-ctx.py`.
+
+## Build
+
+```bash
+docker build -f Dockerfile.notebook -t agentserver-notebook:dev .
+```
+
+## Run (against a stub gateway)
+
+See `docker-compose.smoke.yml`:
+
+```bash
+docker compose -f notebook/docker-compose.smoke.yml up --build
+```
+
+Then open <http://localhost:8888/lab>. In a new notebook:
+
+```python
+envs = await ctx.envs()
+envs   # rendered as table thanks to _repr_html_
+```
+
+## Env vars consumed by `ctx = Ctx.from_env()`
+
+| var | default | purpose |
+|---|---|---|
+| `AGENTSERVER_GATEWAY_URL` | `ws://localhost:8086/notebook/ws` | WS endpoint |
+| `AGENTSERVER_WORKSPACE_TOKEN` | (empty) | Bearer for gateway |
+| `AGENTSERVER_WORKSPACE_ID` | (empty) | workspace key |
+| `AGENTSERVER_USER_ID` | (empty) | attribution only |
+```
+
+- [ ] **Step 5: Build the image**
+
+Run from repo root:
+```bash
+docker build -f Dockerfile.notebook -t agentserver-notebook:dev .
+```
+
+Expected: build succeeds; final image ~250 MB.
+
+- [ ] **Step 6: Smoke test — bare `import` works**
+
+Run:
+```bash
+docker run --rm agentserver-notebook:dev \
+  python -c "from agentserver_sdk import Ctx; print(Ctx.from_env().gateway_url)"
+```
+
+Expected: prints `ws://localhost:8086/notebook/ws`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Dockerfile.notebook notebook/
+git commit -m "feat(notebook): jupyter image with agentserver_sdk pre-installed
+
+- Dockerfile.notebook at repo root following project convention
+- ipython startup injects ctx
+- jupyter config tuned for proxy use (no token, root_dir=/workspace)
+- README documents env vars + smoke run"
+```
+
+---
+
+## Task 13: docker-compose smoke (jupyter + stub gateway)
+
+**Files:**
+- Create: `notebook/docker-compose.smoke.yml`
+- Create: `notebook/stub_gateway_runner.py`
+
+- [ ] **Step 1: Create the stand-alone stub runner**
+
+The pytest `StubGateway` class is import-only. For docker we need a runnable script. Create `notebook/stub_gateway_runner.py`:
+
+```python
+"""Run the test stub gateway as a long-lived process for local smoke.
+
+Listens on 0.0.0.0:8086, path `/notebook/ws`. Responds to:
+  - initialize / initialized (no-op)
+  - thread/start → fake thread id
+  - envs/list → two fake envs
+  - env/capabilities → tools per env
+  - mcpServer/tool/call → for `shell`, returns the command back as stdout
+  - operations/list → empty
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+import os
+
+import websockets
+
+# Reuse the test class — the file lives in sdk/python/tests but is
+# import-safe (no pytest imports at module scope).
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "sdk", "python", "tests"))
+from stub_gateway import StubGateway  # noqa: E402
+
+
+async def main() -> None:
+    g = StubGateway()
+
+    g.on("envs/list", lambda p: {"envs": [
+        {"name": "alpha", "type": "shell"},
+        {"name": "hpc",   "type": "hpc"},
+    ]})
+
+    def caps(p):
+        env_id = p["env_id"]
+        if env_id == "alpha":
+            return {"tools": [
+                {"name": "shell",     "description": "run sh",   "inputSchema": {}},
+                {"name": "read_file", "description": "read",     "inputSchema": {}},
+            ]}
+        return {"tools": [
+            {"name": "shell",        "description": "run sh",        "inputSchema": {}},
+            {"name": "submit_task",  "description": "submit HPC",    "inputSchema": {}},
+        ]}
+    g.on("env/capabilities", caps)
+
+    def tool_call(p):
+        if p["tool"] == "shell":
+            cmd = p["arguments"]["command"]
+            return {
+                "content": [{"type": "text", "text": cmd}],
+                "structuredContent": {"stdout": f"stub ran: {cmd}", "stderr": "", "exit_code": 0},
+                "isError": False,
+            }
+        return {"content": [{"type": "text", "text": f"stub: {p['tool']}"}], "isError": False}
+    g.on("mcpServer/tool/call", tool_call)
+
+    g.on("operations/list", lambda p: {"operations": []})
+
+    # StubGateway uses port=0 by default — override to fixed 8086 + path.
+    async def handle(ws):
+        async for raw in ws:
+            msg = json.loads(raw)
+            g.received.append(msg)
+            mid = msg.get("id")
+            method = msg.get("method")
+            if mid is None:
+                continue
+            h = g._handlers.get(method)
+            if h is None:
+                resp = {"jsonrpc": "2.0", "id": mid,
+                        "error": {"code": -32601, "message": f"Method not found: {method}"}}
+            else:
+                out = h(msg.get("params", {}) or {})
+                if isinstance(out, dict) and "error" in out and "code" in out["error"]:
+                    resp = {"jsonrpc": "2.0", "id": mid, "error": out["error"]}
+                else:
+                    resp = {"jsonrpc": "2.0", "id": mid, "result": out}
+            await ws.send(json.dumps(resp))
+
+    server = await websockets.serve(handle, "0.0.0.0", 8086)
+    print(f"stub-gateway listening on ws://0.0.0.0:8086", flush=True)
+    await server.wait_closed()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())
+```
+
+- [ ] **Step 2: Create docker-compose**
+
+Create `notebook/docker-compose.smoke.yml`:
+
+```yaml
+# Local smoke test: jupyter + stub gateway, no agentserver backend.
+# Run:  docker compose -f notebook/docker-compose.smoke.yml up --build
+# Open: http://localhost:8888/lab
+services:
+  stub-gateway:
+    image: python:3.12-slim
+    working_dir: /app
+    volumes:
+      - ../sdk/python/tests:/app/sdk-tests:ro
+      - ./stub_gateway_runner.py:/app/runner.py:ro
+    command: >
+      sh -c "pip install --quiet websockets~=14.0 &&
+             python /app/runner.py"
+    ports:
+      - "8086:8086"
+
+  notebook:
+    build:
+      context: ..
+      dockerfile: Dockerfile.notebook
+    depends_on:
+      - stub-gateway
+    environment:
+      AGENTSERVER_GATEWAY_URL: ws://stub-gateway:8086
+      AGENTSERVER_WORKSPACE_TOKEN: smoke-token
+      AGENTSERVER_WORKSPACE_ID: smoke-ws
+      AGENTSERVER_USER_ID: smoke-user
+    volumes:
+      - ./smoke-workspace:/workspace
+    ports:
+      - "8888:8888"
+```
+
+- [ ] **Step 3: Bring up the stack**
+
+Run:
+```bash
+mkdir -p notebook/smoke-workspace
+docker compose -f notebook/docker-compose.smoke.yml up --build
+```
+
+Expected: both services come up; jupyter logs show it listening on 0.0.0.0:8888; stub logs show it listening on 8086.
+
+- [ ] **Step 4: Manual notebook validation**
+
+In a separate terminal:
+1. Open <http://localhost:8888/lab>
+2. New Python 3 notebook
+3. Cell 1: `envs = await ctx.envs(); envs`
+   - Expect: table with `alpha` and `hpc` rows
+4. Cell 2: `alpha = await ctx.env("alpha"); r = await alpha.shell("hi"); r`
+   - Expect: rendered ShellResult with green exit_code=0 and "stub ran: hi" stdout
+5. Cell 3: `hpc = await ctx.env("hpc"); await hpc.submit_task(script="x")`
+   - Expect: a dict with `content[0].text == "stub: submit_task"`
+6. Cell 4: `ops = await ctx.history(limit=5); ops`
+   - Expect: `[]` (stub returns empty)
+
+Tear down: `Ctrl-C` then `docker compose -f notebook/docker-compose.smoke.yml down -v`.
+
+- [ ] **Step 5: Document the smoke flow**
+
+Append to `notebook/README.md`:
+
+```markdown
+## Smoke walkthrough (4 cells)
+
+Once `docker compose -f notebook/docker-compose.smoke.yml up --build` is running and you've opened <http://localhost:8888/lab>:
+
+```python
+# Cell 1 — list envs
+envs = await ctx.envs()
+envs
+
+# Cell 2 — typed shell
+alpha = await ctx.env("alpha")
+await alpha.shell("hi")
+
+# Cell 3 — dynamic dispatch (custom HPC tool)
+hpc = await ctx.env("hpc")
+await hpc.submit_task(script="x")
+
+# Cell 4 — operations history (returns [] until Plan 2 lands)
+await ctx.history(limit=5)
+```
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add notebook/docker-compose.smoke.yml \
+        notebook/stub_gateway_runner.py \
+        notebook/README.md
+git commit -m "feat(notebook): docker-compose smoke (jupyter + stub gateway)
+
+local end-to-end without agentserver backend: stub returns canned
+responses for envs/list, env/capabilities, mcpServer/tool/call,
+operations/list. README has 4-cell walkthrough."
+```
+
+---
+
+## Task 14: Makefile targets
+
+**Files:**
+- Modify: `Makefile`
+
+- [ ] **Step 1: Add targets**
+
+Append to `Makefile`:
+
+```makefile
+sdk-test:
+	cd sdk/python && pytest -v
+
+sdk-lint:
+	cd sdk/python && ruff check . && ruff format --check .
+
+notebook-image:
+	docker build -f Dockerfile.notebook -t agentserver-notebook:dev .
+
+notebook-smoke: notebook-image
+	mkdir -p notebook/smoke-workspace
+	docker compose -f notebook/docker-compose.smoke.yml up --build
+```
+
+- [ ] **Step 2: Verify**
+
+Run: `make sdk-test`
+Expected: all tests pass.
+
+Run: `make sdk-lint`
+Expected: no lint errors.
+
+Run: `make notebook-image`
+Expected: image build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Makefile
+git commit -m "build: makefile targets for sdk-test / sdk-lint / notebook-image / notebook-smoke"
+```
+
+---
+
+## Self-review checklist (for the implementer)
+
+After all tasks done:
+
+- [ ] All spec § "Components" items 1, 2 covered (SDK, Dockerfile, ipython startup); 3-7 explicitly deferred to Plan 2/3
+- [ ] All spec § "SDK shape" core methods present: `shell`, `read_file`, `write_file`, `apply_patch`, `spawn` (+ `Process`), `ctx.copy`, `ctx.history`, custom tools via `__getattr__`
+- [ ] `_repr_html_` on Env / ShellResult / ToolError + envs_table_html helper
+- [ ] No TODO/TBD/FIXME left in code
+- [ ] Every PR-equivalent commit is green on its own (run `pytest -v` after each commit)
+- [ ] Smoke flow in `notebook/README.md` actually works on a clean machine
+
+## After this plan
+
+When Plan 1 is merged:
+- Plan 2 (operation log) can start in parallel; it shouldn't require SDK changes beyond pointing `ctx.history()` at the real RPC (already done)
+- Plan 3 (notebook supervisor + web UI panel) can begin; SDK changes needed:
+  - Refresh-token flow for `AGENTSERVER_WORKSPACE_TOKEN`
+  - JWT minting integration
+  - All confined to `client.py`
+- env-mcp per-env capability spec: until it lands, real envs return the same static tool list for all envs, custom tools like `submit_task` would have to be reached via `env.call("submit_task", {...})`. This is acceptable degradation.

--- a/docs/superpowers/specs/2026-05-18-python-env-sdk-design.md
+++ b/docs/superpowers/specs/2026-05-18-python-env-sdk-design.md
@@ -1,0 +1,583 @@
+# Python env SDK + hosted Jupyter — Design
+
+**Status:** draft
+**Date:** 2026-05-18
+**Owner:** agentserver / developer experience
+**Related:**
+- [`2026-05-10-codex-gateway-mcp-rewrite.md`](2026-05-10-codex-gateway-mcp-rewrite.md) — env-mcp per-env tool routing this SDK rides on
+- [`2026-05-16-env-mcp-fixed-tools-redesign.md`](2026-05-16-env-mcp-fixed-tools-redesign.md) — tool inventory the SDK wraps
+- `cmd/astool/` — single-shot CLI counterpart; this spec is the same idea at scale
+
+## Goal
+
+Give developers a way to **write Python code instead of natural-language prompts** to operate on the same env-mcp tools the LLM uses. Surface envs as Python objects in a hosted Jupyter environment integrated into the existing agentserver web UI, with an async/await SDK and a workspace-wide operation log so every call (SDK / TUI / future LLM) is auditable.
+
+Mental model: each connected executor (env) is a Python object; methods on that object are env-mcp tool calls. The notebook is the editor; the gateway is the dispatcher; the operation log is the history.
+
+## Non-goals (v1)
+
+- **Pulumi-style state engine / IaC.** No declarative resource model, no `up` / `preview` / `destroy` lifecycle, no diff-driven apply. Operations are imperative.
+- **Decorators** (`@ctx.task`, `@ctx.parallel_map`, retry, cached, recipe). Pure `async/await` only for v1. Decorators can come back as v1.5 sugar if usage justifies.
+- **Real-time collaboration (Jupyter RTC).** Same workspace ⇒ shared notebook files, but co-editing is by convention; no operational-transform layer.
+- **Per-user kernel isolation via separate containers.** Per-workspace shared Jupyter Server, multiple kernels inside one container. Per-user attribution via env vars on kernel spawn, not container boundary.
+- **Logging LLM-initiated tool calls in v1.** Already recorded in codex thread history; unified logging deferred to v1.5.
+- **In-notebook cell/notebook attribution in operation log.** v1 logs (user, workspace, source). Cell-level metadata is v1.5.
+- **External pip / PyPI publication of the SDK.** Pre-installed into the notebook image, version pinned per image tag.
+- **Static `.pyi` stub generation for custom tools.** v1 relies on `__getattr__` + `dir()` + IPython runtime help. Static-analysis-friendly stubs deferred.
+
+## Architecture
+
+```
+                           ┌────────────────────────────────────────────────┐
+[Browser]                  │  agentserver web (existing React app)          │
+                           │   ┌────────────────────────────────────────┐   │
+  ┌─────────────────┐     │   │ Existing LLM chat / etc panels         │   │
+  │ User session    │────►│   │                                          │   │
+  └─────────────────┘     │   │ NEW: Notebooks panel                     │   │
+                           │   │  → <iframe src="/api/notebooks/{ws}/…"> │   │
+                           │   │                                          │   │
+                           │   │ NEW: Operations panel                    │   │
+                           │   └────────────────────────────────────────┘   │
+                           │              │                                   │
+                           │   ┌──────────▼────────────┐                      │
+                           │   │ Jupyter proxy handler │  auth + per-ws       │
+                           │   │ (new in agentserver)  │  routing             │
+                           │   └──────────┬────────────┘                      │
+                           └──────────────┼────────────────────────────────────┘
+                                          │
+                              ┌───────────▼──────────────┐
+                              │ notebook supervisor      │  k8s Deployment per
+                              │ (new agentserver pkg)    │  workspace, on-demand
+                              └───────────┬──────────────┘
+                                          │ EnsureRunning(workspace_id)
+                              ┌───────────▼──────────────┐
+                              │ jupyter-server container │  one per workspace
+                              │  ┌──────────────────────┐│  multi-kernel
+                              │  │ ipykernel (per-user) ││
+                              │  │   ↓ ctx auto-loaded   ││
+                              │  │ agentserver-sdk       ││
+                              │  └──────────────────────┘│
+                              └───────────┬──────────────┘
+                                          │ ws (workspace token)
+                              ┌───────────▼──────────────┐
+                              │ codex-app-gateway        │  EXISTING
+                              │  + oplog Interceptor     │  NEW thin wrapper
+                              │  (decode mcpServer/tool/ │
+                              │   call frames, log)      │
+                              └───────────┬──────────────┘
+                                          │ stdio
+                              ┌───────────▼──────────────┐
+                              │ codex app-server         │  EXISTING
+                              │  + env-mcp child         │
+                              └──────────────────────────┘
+                                          │
+                              ┌───────────▼──────────────┐
+                              │ agentserver db           │  NEW operations table
+                              │  operations              │
+                              └──────────────────────────┘
+```
+
+## Components
+
+### 1. `agentserver-sdk` (new Python package)
+
+Source: `sdk/python/` at repo root (new top-level dir; pip-installable layout: `pyproject.toml` + `src/agentserver_sdk/`).
+
+Surfaces:
+- `Ctx` — global singleton, loaded from env vars at kernel startup, exposes envs + ops history
+- `Env` — one instance per connected executor; core typed methods + dynamic dispatch for custom tools
+- `Process` — async context manager over `exec_command` / `write_stdin` / `read_output` / `terminate`
+- `ShellResult`, `ToolError`, etc. — result and exception types
+- All methods async; designed for top-level `await` in IPython
+
+Distribution: pre-installed into notebook image, no separate publication for v1.
+
+### 2. `Dockerfile.notebook` (new image)
+
+One image, parameterized by SDK version pin:
+
+```dockerfile
+FROM python:3.12-slim
+RUN pip install --no-cache-dir \
+      jupyter-server~=2.14 \
+      jupyterlab~=4.2 \
+      ipykernel~=6.29
+COPY sdk/python /tmp/sdk
+RUN pip install --no-cache-dir /tmp/sdk && rm -rf /tmp/sdk
+RUN mkdir -p /opt/ipython-startup
+COPY notebook/ipython_startup/00-ctx.py /opt/ipython-startup/
+COPY notebook/jupyter_server_config.py /etc/jupyter/
+ENV IPYTHONDIR=/etc/ipython JUPYTER_CONFIG_DIR=/etc/jupyter \
+    PYTHONSTARTUP=/opt/ipython-startup/00-ctx.py
+EXPOSE 8888
+ENTRYPOINT ["jupyter", "server", "--config=/etc/jupyter/jupyter_server_config.py"]
+```
+
+SDK source lives at `sdk/python/` in the repo (new top-level dir; `cmd/` is reserved for Go binaries). Image build copies it in and installs from source — no PyPI dependency.
+
+The startup file is one line of real work:
+```python
+# 00-ctx.py
+from agentserver_sdk import Ctx
+ctx = Ctx.from_env()
+```
+
+`jupyter_server_config.py` does:
+- Disable jupyter's built-in token auth (we proxy)
+- Plug `AgentserverIdentityProvider` (validates the JWT from query string / header)
+- Plug `AgentserverKernelProvisioner` (per-kernel env injection)
+- `base_url = /api/notebooks/<workspace>/`
+- Bind to `0.0.0.0:8888`
+
+### 3. `internal/notebooksupervisor/` (new agentserver package)
+
+Pattern-for-pattern copy of `internal/codexappgateway/supervisor`:
+
+| | codex supervisor | notebook supervisor |
+|---|---|---|
+| `Key` | `WorkspaceID` | `WorkspaceID` |
+| Managed unit | `codex app-server` subprocess | k8s Deployment running jupyter image |
+| Spawn trigger | First ws to `/codex-app/ws` | First `POST /api/notebooks/{ws}/session` |
+| Idle reap | already in supervisor | same model, default 4h no kernel activity |
+| Lifecycle command | `os.exec` fork | k8s API (apps/v1 Deployment + Service) |
+
+`EnsureRunning(workspaceID)`:
+1. If Deployment exists & healthy → return service URL
+2. Else: create Deployment + Service (idempotent), wait for Ready (timeout 60s)
+3. Update `last_active`
+
+`Reap()`:
+- Background loop, every 5 min
+- For each workspace's deployment, query `last_active` (touched on every proxy request)
+- If idle > 4h, delete Deployment + Service (PV stays)
+
+Resource defaults per workspace deployment: CPU 2c / mem 4GB / ephemeral 5GB.
+
+### 4. Persistence — `workspace volume`
+
+- One PV per workspace, created by agentserver workspace provisioner (existing pattern, not new)
+- Mounted at `/workspace` in notebook container
+- Jupyter `c.ServerApp.root_dir = '/workspace'` → user sees workspace as root
+- `.ipynb` files persist there
+- Backup is storage layer concern (PV snapshot or S3 sync); no app-level versioning
+
+### 5. Jupyter proxy (new agentserver web handler)
+
+`/api/notebooks/{workspace}/*`:
+- HTTP path: reverse-proxy to `notebook-{workspace}.<ns>.svc.cluster.local:8888`
+- WebSocket path: tunnel upgrade through the proxy (jupyter kernel comm uses ws)
+- Auth: verify JWT (from query string `?token=…` or `Authorization` header), populated by step 7 below
+- 404 unless `EnsureRunning(workspace)` returned ready
+
+### 6. Web UI panels (new React components)
+
+`<NotebooksPanel />`:
+```tsx
+function NotebooksPanel() {
+  const { data: session } = useNotebookSession();   // POST /api/notebooks/{ws}/session
+  if (!session) return <Spinner />;
+  return (
+    <iframe
+      src={`${session.url}?token=${session.token}`}
+      sandbox="allow-scripts allow-same-origin allow-forms"
+      className="w-full h-full"
+    />
+  );
+}
+```
+
+Token has 10-min TTL; component refreshes before expiry. Spawn-on-first-load shows a spinner with progress text.
+
+`<OperationsPanel />`:
+- Table view, default sort `started_at desc`
+- Filters: env / tool / source / time range / user / is_error
+- Row → details modal with full args/result (jsonb pretty-rendered)
+- Backend: `GET /api/operations?…`
+
+### 7. Operation log
+
+#### Schema
+
+```sql
+CREATE TABLE operations (
+  id              uuid PRIMARY KEY,
+  workspace_id    text NOT NULL,
+  user_id         text,                       -- NULL for unattributed (LLM in v1.5)
+  source          text NOT NULL,              -- 'sdk' | 'tui'  (v1.5: 'llm')
+  thread_id       text,                       -- codex thread, if applicable
+  request_id      text,                       -- JSON-RPC id for correlation
+
+  env_id          text NOT NULL,
+  tool            text NOT NULL,              -- 'shell', 'submit_task', …
+  arguments       jsonb NOT NULL,             -- truncated if > 64KB
+  arguments_meta  jsonb,                      -- {"truncated":true,"size_bytes":N,"sha256":"..."}
+
+  is_error        boolean NOT NULL,
+  result_summary  text,                       -- first 4KB of text content
+  result_meta     jsonb,                      -- {"truncated":true,"total_bytes":N}
+
+  started_at      timestamptz NOT NULL,
+  completed_at    timestamptz NOT NULL,
+  duration_ms     integer NOT NULL,
+
+  -- v1.5 fields, nullable for v1
+  notebook_path   text,
+  cell_id         text
+);
+
+CREATE INDEX ops_ws_time   ON operations (workspace_id, started_at DESC);
+CREATE INDEX ops_ws_env    ON operations (workspace_id, env_id, started_at DESC);
+CREATE INDEX ops_ws_source ON operations (workspace_id, source, started_at DESC);
+```
+
+Retention: 90 days default TTL via background job; workspace-overridable.
+
+#### Write path — gateway-side Interceptor
+
+`codex-app-gateway`'s current `wsbridge.RunProxy` is dumb byte copy. Add a thin layer in front:
+
+```go
+// internal/codexappgateway/oplog/interceptor.go (new)
+type Interceptor struct {
+    logger OperationLogger   // async Submit(op)
+    source string            // "sdk" or "tui", from ws path
+    userID string            // from _meta on incoming frame
+    workspace string
+}
+func (i *Interceptor) OnClientFrame(frame []byte) []byte {
+    var req map[string]any
+    if json.Unmarshal(frame, &req) == nil && req["method"] == "mcpServer/tool/call" {
+        i.recordRequest(req["id"], req["params"])
+    }
+    return frame
+}
+func (i *Interceptor) OnServerFrame(frame []byte) []byte {
+    var resp map[string]any
+    if json.Unmarshal(frame, &resp) == nil {
+        if id, ok := resp["id"]; ok {
+            i.recordResponse(id, resp["result"], resp["error"])
+        }
+    }
+    return frame
+}
+```
+
+Pending map (`id → started_at + params`) joins request and response into one record. Parse failures or non-tool-call frames pass through with zero impact.
+
+Logger interface allows async fire-and-forget submission. Bounded channel (1024) — if it fills, drop the log and bump a metric. **Tool calls never block on logging.**
+
+#### Source tagging by ws path
+
+SDK uses a separate ws entry on the gateway: **`/notebook/ws`** (vs TUI's existing `/codex-app/ws`). The Interceptor knows `source = "sdk"` because of the path. No reliance on client-supplied tags.
+
+For v1.5 LLM logging, env-mcp itself will emit log records via the existing `/internal/connected` callback path.
+
+#### Payload truncation
+
+| Direction | Threshold | Behavior |
+|---|---|---|
+| `arguments` | > 64 KB | replace with `null`, populate `arguments_meta = {truncated, size, sha256}` |
+| `result.content[].text` | > 4 KB cumulative | truncate to 4 KB into `result_summary`, populate `result_meta` |
+| binary content | always | never logged, only sha256 + size |
+
+#### SDK query API
+
+```python
+ops = await ctx.history(limit=100)
+ops = await ctx.history(env="alpha", is_error=True, since="1h")
+op = await ctx.history(id="op_xxx")  # one item
+```
+
+Backed by new gateway RPC `operations/list { workspace, filters }`, Bearer-auth.
+
+## SDK shape — concrete examples
+
+```python
+# === kernel start: ctx and asyncio pre-loaded ===
+
+# 1. List
+envs = await ctx.envs()                       # [Env(alpha), Env(beta), Env(hpc-a)]
+alpha = await ctx.env("alpha")
+hpc   = await ctx.env("hpc-a")
+
+# 2. Core typed methods
+r = await alpha.shell("ls /tmp")              # ShellResult(stdout, stderr, exit_code)
+content = await alpha.read_file("/path")      # bytes
+await alpha.write_file("/path", b"...")
+await alpha.apply_patch(PATCH)
+
+# Long-running process — async context manager
+async with alpha.spawn("./train.sh") as proc:
+    await proc.write_stdin(b"hyperparams\n")
+    chunk = await proc.read_output(timeout=10)
+    # auto-terminate on exit
+
+# Cross-env
+await ctx.copy(src=(alpha, "/out.tar"), dst=(beta, "/in.tar"))
+
+# 3. Heterogeneous capabilities — discovered at runtime
+print(await hpc.tools())
+# → [
+#     {"name": "shell",       "kind": "core",   "description": "...", "schema": {...}},
+#     {"name": "submit_task", "kind": "custom", "description": "submit HPC job", "schema": {...}},
+#     ...
+#   ]
+
+job = await hpc.submit_task(script="...", resources={"gpus": 4})
+# resolved via __getattr__ → env.call("submit_task", {...})
+
+# Equivalent escape hatch:
+job = await hpc.call("submit_task", {"script": "...", "resources": {"gpus": 4}})
+
+# 4. Parallel — pure asyncio, no decorator
+results = await asyncio.gather(
+    alpha.shell("./test.sh"),
+    beta.shell("./test.sh"),
+    hpc.submit_task(script="./bench.sh"),
+)
+
+# 5. History
+recent = await ctx.history(limit=20)
+errs   = await ctx.history(is_error=True, since="1h")
+```
+
+### `Env` implementation outline
+
+```python
+CORE_TOOLS = {"shell", "read_file", "write_file", "apply_patch",
+              "copy_path", "exec_command", "write_stdin", "read_output", "terminate"}
+
+class Env:
+    def __init__(self, name, type, tools_metadata, _client):
+        self.name = name
+        self.type = type
+        self._tools = {t["name"]: t for t in tools_metadata}
+        self._client = _client
+        for tool_name, meta in self._tools.items():
+            if tool_name in CORE_TOOLS:
+                continue
+            setattr(self, tool_name, self._make_dynamic_method(tool_name, meta))
+
+    def _make_dynamic_method(self, name, meta):
+        async def method(**kwargs):
+            return await self.call(name, kwargs)
+        method.__name__ = name
+        method.__doc__ = meta.get("description", "")
+        return method
+
+    async def call(self, tool: str, arguments: dict | None = None):
+        return await self._client.mcp_tool_call(
+            server="env_mcp",
+            tool=tool,
+            arguments={"environment_id": self.name, **(arguments or {})},
+        )
+
+    async def shell(self, cmd: str, timeout: int | None = None) -> ShellResult:
+        raw = await self.call("shell", {"command": cmd, "timeout_s": timeout})
+        return ShellResult.from_mcp(raw)
+    # ... read_file / write_file / apply_patch / spawn / etc
+```
+
+### Process abstraction
+
+```python
+class Process:
+    def __init__(self, env, session_id): ...
+    async def write_stdin(self, data: bytes): ...
+    async def read_output(self, timeout: float | None = None) -> bytes: ...
+    async def terminate(self): ...
+    async def __aenter__(self): return self
+    async def __aexit__(self, *_): await self.terminate()
+```
+
+`env.spawn(cmd)` returns a `Process`. `async with` ensures `terminate` even on exception.
+
+### Jupyter-friendly rendering
+
+Every return type implements `_repr_html_`:
+- `Env` → table row (name / type / status / supported tool count)
+- list of `Env` → full table
+- `ShellResult` → exit code coloured, stdout/stderr collapsible
+- `ToolError` → message + env + tool + truncated raw payload
+- bytes from `read_file` → preview header + size + lazy "show all" button
+
+## Backend dependency — env-mcp per-env capability reporting
+
+For "heterogeneous resources" (HPC having `submit_task`, normal env not having it) to work end-to-end, **env-mcp must report tool availability per env**, not just globally.
+
+Current state (per `internal/codexappgateway/envmcp/envmcp.go:81`): all envs see all 9 tools. The tools internally route by `environment_id` parameter. Adding a tool that only applies to HPC envs is not expressible.
+
+Required change (separate small spec to follow this one):
+- Executor self-registration includes a list of supported tool kinds (`shell`, `exec`, `hpc-submit`, …)
+- env-mcp tracks `(env_id → supported_tool_kinds)` map
+- New RPC `env/capabilities { env_id } → tools_metadata[]` for SDK to query
+- env-mcp rejects `tools/call` if env doesn't support that tool (clearer error than current implicit failure)
+
+**v0 staging (MVP):**
+- Skip per-env capability reporting initially
+- SDK uses a hard-coded core tool list, plus `env.call(name, ...)` for everything else
+- HPC `submit_task` works via `await hpc.call("submit_task", {...})`
+- `__getattr__` magic and `env.tools()` return a static workspace-wide list
+- Promote to per-env once env-mcp lands the capability work
+
+## Authentication flow
+
+```
+Browser                    agentserver web        notebook supervisor   jupyter-server         SDK in kernel           gateway
+  │                              │                       │                     │                      │                      │
+  ├─1. logged in ───────────────►│                       │                     │                      │                      │
+  ├─2. open Notebooks panel ────►│                       │                     │                      │                      │
+  │                              ├─3. POST /api/.../session►                   │                      │                      │
+  │                              │  (verify user ∈ ws)   │                     │                      │                      │
+  │                              │                       │                     │                      │                      │
+  │                              │                       ├─4. EnsureRunning(ws)─────►                  │                      │
+  │                              │                       │                     │                      │                      │
+  │                              │◄──5. ready ───────────┤                     │                      │                      │
+  │                              │                                              │                      │                      │
+  │                              │ 6. mint JWT           │                     │                      │                      │
+  │                              │   (user_id, ws_id,     │                     │                      │                      │
+  │                              │    exp=10min,          │                     │                      │                      │
+  │                              │    scope=notebook)     │                     │                      │                      │
+  │                              │                                              │                      │                      │
+  │◄─7. {url, token} ────────────┤                                              │                      │                      │
+  │                                                                              │                      │                      │
+  ├─8. iframe → jupyter ──────────────────────────────────────────────────────►│                      │                      │
+  │                                                                              │ 9. IdentityProvider │                      │
+  │                                                                              │    verify JWT       │                      │
+  │                                                                              │    user_id ∈ session│                      │
+  │                                                                              │                      │                      │
+  ├─10. start kernel ──────────────────────────────────────────────────────────►│                      │                      │
+  │                                                                              │ 11. KernelProvisioner│                      │
+  │                                                                              │   ENV={              │                      │
+  │                                                                              │     AGENTSERVER_USER_ID,
+  │                                                                              │     AGENTSERVER_WORKSPACE_TOKEN,
+  │                                                                              │     AGENTSERVER_GATEWAY_URL,
+  │                                                                              │   }                  │                      │
+  │                                                                              │ ──spawn ipykernel──►│                      │
+  │                                                                              │                     │ 12. ctx=Ctx.from_env │
+  │                                                                              │                     │  read ENV, build WS  │
+  │                                                                              │                     │                      │
+  ├─13. cell `await alpha.shell(...)`──────────────────────────────────────────────────────────────►│                      │
+  │                                                                              │                     ├─14. ws.send({       │
+  │                                                                              │                     │  method:"mcpServer/  │
+  │                                                                              │                     │    tool/call",       │
+  │                                                                              │                     │  params:{            │
+  │                                                                              │                     │    _meta:{           │
+  │                                                                              │                     │      user_id:…       │
+  │                                                                              │                     │    }} })             │
+  │                                                                              │                     │ ──────────────────►│
+  │                                                                              │                     │                     │ 15. Interceptor logs
+  │                                                                              │                     │                     │   (source=sdk,user)
+```
+
+### Token model
+
+| Token | Lifetime | Scope | Where stored | Used for |
+|---|---|---|---|---|
+| Browser → jupyter iframe JWT | 10 min, refreshed | (user, workspace, notebook scope) | Web UI memory + query string | jupyter `IdentityProvider` validation |
+| `AGENTSERVER_WORKSPACE_TOKEN` | workspace lifetime (rotatable) | workspace | Env var on jupyter container | Kernel → gateway WS Bearer auth |
+| `AGENTSERVER_USER_ID` | per-kernel | not auth, attribution only | Env var injected per-kernel | SDK includes in `_meta.user_id` for log attribution |
+
+**Key simplification:** `AGENTSERVER_USER_ID` is **not used for auth**. Gateway already trusts the workspace token (which proves the kernel was spawned by agentserver for that workspace). User ID is metadata only. This avoids per-call signing.
+
+## Network topology
+
+| Hop | URL |
+|---|---|
+| Browser → agentserver web | existing `https://agentserver/...` |
+| Browser ↔ jupyter (iframe) | `https://agentserver/api/notebooks/{ws}/...` (reverse proxy) |
+| agentserver web → notebook supervisor | in-process (Go interface call) |
+| notebook supervisor → k8s | k8s API (apps/v1, core/v1) |
+| jupyter container service | `notebook-{ws}.<ns>.svc.cluster.local:8888` |
+| jupyter kernel SDK → gateway | `ws://codex-app-gateway.<ns>.svc.cluster.local:8086/notebook/ws` |
+| gateway → codex app-server | existing (codex stdio) |
+| gateway → agentserver db (oplog) | existing PG connection pool |
+
+## Failure modes & mitigations
+
+| Failure | Mitigation |
+|---|---|
+| Notebook container slow to start | 60s timeout in `EnsureRunning`; web UI shows progress; user can retry |
+| Gateway oplog DB write slow | Bounded channel, fire-and-forget; never blocks tool call; metric on drop |
+| Gateway oplog DB down | Same; system continues serving tool calls; alerting on metric |
+| Huge `write_file` payload (e.g. 1 GB binary) | Interceptor inspects frame header only; over threshold logs size+sha256, not bytes |
+| Shell loop spams oplog | App-layer sampling toggle (off in v1); DB partitioned by month |
+| User session expires during long cell | JWT refresh while iframe is open; in-cell ws connection uses `AGENTSERVER_WORKSPACE_TOKEN` (long-lived), so cell completes |
+| Workspace volume PV full | Standard k8s quota; agentserver shows warning on workspace status |
+| Custom tool with unknown schema | `env.call(tool, args)` works regardless; SDK doesn't validate schema (env-mcp does) |
+| Two users edit same `.ipynb` | Conflict on save (last writer wins for v1); RTC deferred to v1.5 |
+| Idle reaper kills container while user inactive | PV persists; next `EnsureRunning` brings it back; kernel state is lost (expected) |
+
+## Out-of-scope items intentionally deferred
+
+1. **State engine / IaC layer** — see "Why no Pulumi" appendix below.
+2. **`@ctx.task` / `@ctx.parallel_map` / `@ctx.retry` decorators** — pure async only in v1.
+3. **LLM call logging** — codex thread history already has it; unify v1.5.
+4. **Real-time collaborative editing** — Jupyter RTC + Y.js.
+5. **External SDK distribution** (PyPI / mirror) — version-pinned in image.
+6. **Static-analysis `.pyi` stubs for dynamic tools** — runtime help only in v1.
+7. **Per-user container isolation** — per-workspace shared by design.
+8. **Notebook templates / starter examples** — separate spec.
+9. **Replay button on operations panel** — list/read only in v1.
+
+## Why no Pulumi-style state engine (decision record)
+
+State engine surface (state storage + diff + apply + per-resource providers + lock + drift + replace semantics + multi-stack + secrets) is **5-8 person-weeks for an MVP, 3-6 months for production-ready**. Marginal value over imperative SDK in this domain is limited because:
+
+1. env-mcp surface is small (file, dir, process, shell). State machinery cost is the same regardless of resource count.
+2. Executors are often ephemeral; drift detection's value scales with infra longevity.
+3. `env.shell("./install.sh")` is opaque to diff; the main IaC value-add (diff preview) doesn't apply to most operations.
+4. Most env-mcp tools are already idempotent at the tool level (`write_file`, `apply_patch`); the safety case for re-runs is weaker.
+5. Audit/reproducibility — the other big IaC story — is already covered by the operation log at ~10% of state-engine cost.
+
+Door left open: SDK methods are atomic with clear inputs/outputs. A future state-engine layer can wrap them as resources without restructuring.
+
+## Implementation phases
+
+**Phase 0 — backend prep**
+- env-mcp per-env capability reporting (separate spec)
+- New `operations` table migration
+- Gateway `/notebook/ws` route + Interceptor skeleton (no DB write yet, just logs to stderr to validate parsing)
+
+**Phase 1 — SDK + jupyter image**
+- `sdk/python/` with `Ctx`, `Env`, `Process`, types, `_repr_html_` for jupyter
+- `Dockerfile.notebook` + ipython startup
+- Local docker-compose smoke test: spin jupyter against a stub gateway, validate `await ctx.envs()` round-trip
+
+**Phase 2 — notebook supervisor + proxy**
+- `internal/notebooksupervisor/` (k8s spawner, idle reap)
+- Jupyter proxy handler in agentserver web
+- JWT minting + jupyter IdentityProvider + KernelProvisioner
+
+**Phase 3 — Web UI**
+- `<NotebooksPanel />` iframe + session lifecycle
+- `<OperationsPanel />` with filters
+
+**Phase 4 — Operation log write path**
+- Wire Interceptor → agentserver DB
+- `operations/list` RPC + SDK `ctx.history(...)`
+- Payload truncation + bounded channel + metrics
+
+**Phase 5 — Hardening & release**
+- Token refresh edge cases
+- Idle reap thresholds tuning
+- Resource quota documentation
+- e2e: real user opens panel, runs notebook against real env-mcp + HPC executor
+
+## Open questions
+
+1. **Storage class for workspace PV** — RWO or RWX? Multiple users in same workspace open jupyter concurrently → RWX needed unless we accept "one notebook editor at a time per workspace".
+2. **Per-workspace cost accounting** — notebook container is non-trivial cost; should this surface in workspace billing/quota UI?
+3. **What happens to running cells when idle reaper fires** — cells executing right when reap criteria flips. Need a graceful shutdown signal that lets running ops finish (or aborts them cleanly) before container kill.
+4. **Token rotation for `AGENTSERVER_WORKSPACE_TOKEN`** — currently "rotatable" but no concrete rotation flow specified. Likely needs a kernel restart to pick up new token; deferred.
+5. **Schema validation in SDK** — should `env.submit_task(...)` validate kwargs against `tools/list` schema client-side, or always round-trip to env-mcp for validation? v1 is round-trip (simpler); v1.5 could add client validation.
+
+## Success criteria
+
+A developer can:
+1. Open the Notebooks panel in the web UI within 10 seconds of clicking
+2. Run `await ctx.envs()` and see their workspace's connected envs as Python objects
+3. Run `await alpha.shell("uname -a")` and get a `ShellResult` rendered as a Jupyter cell output
+4. Run `await hpc.submit_task(script="...")` without the SDK having been compiled with knowledge of HPC
+5. Open the Operations panel and see every call from step 3 and 4 logged, attributable to them, with arguments and timing
+6. Save the notebook; close the panel; reopen tomorrow; reload the notebook; pick up where they left off (kernel state likely lost, file state preserved)

--- a/internal/codexappgateway/config.go
+++ b/internal/codexappgateway/config.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -65,6 +66,13 @@ type ServeConfig struct {
 	// list environments, which is fine for tests that don't exercise
 	// list_environments).
 	ListenAddr string
+
+	// OperationLog endpoint + auth. When OperationLogURL is empty, the
+	// /notebook/ws Interceptor is constructed but oplog Submit is a no-op
+	// (Client is nil and the Interceptor guards check nil).
+	OperationLogURL    string
+	OperationLogSecret string // X-Internal-Secret header value
+	OperationLogChan   int    // bounded channel capacity, default 1024
 }
 
 func LoadServeConfigFromEnv() (ServeConfig, error) {
@@ -108,6 +116,16 @@ func LoadServeConfigFromEnv() (ServeConfig, error) {
 	}
 	cfg.AgentserverInternalURL = os.Getenv("CXG_AGENTSERVER_INTERNAL_URL")
 	cfg.AgentserverInternalSecret = os.Getenv("CXG_AGENTSERVER_INTERNAL_SECRET")
+	cfg.OperationLogURL = os.Getenv("CXG_OPLOG_URL")
+	cfg.OperationLogSecret = os.Getenv("CXG_OPLOG_SECRET")
+	cfg.OperationLogChan = 1024
+	if v := os.Getenv("CXG_OPLOG_CHAN"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n <= 0 {
+			return cfg, fmt.Errorf("parse CXG_OPLOG_CHAN: %q", v)
+		}
+		cfg.OperationLogChan = n
+	}
 	if cfg.S3.Endpoint == "" {
 		return cfg, fmt.Errorf("CXG_S3_ENDPOINT is required")
 	}

--- a/internal/codexappgateway/oplog/client.go
+++ b/internal/codexappgateway/oplog/client.go
@@ -1,0 +1,171 @@
+package oplog
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"sync/atomic"
+	"time"
+)
+
+// Operation is what we POST to agentserver /internal/operations.
+// Field shapes match internal/server/operations.go's request struct.
+type Operation struct {
+	ID          string  `json:"id"`
+	WorkspaceID string  `json:"workspace_id"`
+	UserID      *string `json:"user_id,omitempty"`
+	Source      string  `json:"source"`
+	ThreadID    *string `json:"thread_id,omitempty"`
+	RequestID   *string `json:"request_id,omitempty"`
+
+	EnvID         string          `json:"env_id"`
+	Tool          string          `json:"tool"`
+	Arguments     json.RawMessage `json:"arguments,omitempty"`
+	ArgumentsMeta json.RawMessage `json:"arguments_meta,omitempty"`
+
+	IsError       bool            `json:"is_error"`
+	ResultSummary *string         `json:"result_summary,omitempty"`
+	ResultMeta    json.RawMessage `json:"result_meta,omitempty"`
+
+	StartedAt   time.Time `json:"started_at"`
+	CompletedAt time.Time `json:"completed_at"`
+	DurationMs  int32     `json:"duration_ms"`
+}
+
+// Client posts Operations to agentserver. Submit is non-blocking; one
+// background goroutine drains a bounded channel and POSTs each one.
+type Client struct {
+	url     string
+	secret  string
+	ch      chan Operation
+	hc      *http.Client
+	logger  *slog.Logger
+	dropped uint64
+	cancel  context.CancelFunc
+	done    chan struct{}
+}
+
+// NewClient starts the background drainer immediately. Capacity bounds
+// how many Operations can queue before Submit starts dropping.
+func NewClient(url, secret string, capacity int) *Client {
+	if capacity <= 0 {
+		capacity = 1024
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &Client{
+		url:    url,
+		secret: secret,
+		ch:     make(chan Operation, capacity),
+		hc:     &http.Client{Timeout: 5 * time.Second},
+		logger: slog.Default().With("component", "oplog"),
+		cancel: cancel,
+		done:   make(chan struct{}),
+	}
+	go c.drain(ctx)
+	return c
+}
+
+// Submit enqueues op. Never blocks. Drops on full channel and bumps the
+// `dropped` counter, which a metrics exporter can read via Dropped().
+func (c *Client) Submit(op Operation) {
+	select {
+	case c.ch <- op:
+	default:
+		atomic.AddUint64(&c.dropped, 1)
+	}
+}
+
+// Dropped is the cumulative number of Submit calls that hit a full channel.
+func (c *Client) Dropped() uint64 { return atomic.LoadUint64(&c.dropped) }
+
+// Close stops the drainer. Already-queued ops are abandoned.
+func (c *Client) Close() {
+	c.cancel()
+	<-c.done
+}
+
+func (c *Client) drain(ctx context.Context) {
+	defer close(c.done)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case op := <-c.ch:
+			c.post(ctx, op)
+		}
+	}
+}
+
+func (c *Client) post(ctx context.Context, op Operation) {
+	buf, err := json.Marshal(op)
+	if err != nil {
+		c.logger.Warn("oplog: marshal failed", "id", op.ID, "err", err)
+		return
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.url, bytes.NewReader(buf))
+	if err != nil {
+		c.logger.Warn("oplog: build request failed", "err", err)
+		return
+	}
+	req.Header.Set("X-Internal-Secret", c.secret)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		c.logger.Warn("oplog: POST failed", "err", err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 300 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		c.logger.Warn("oplog: agentserver non-2xx",
+			"status", resp.StatusCode, "body", string(body))
+	}
+}
+
+// ListClient is the synchronous read-side: used by the gateway's
+// operations/list RPC interceptor.
+type ListClient struct {
+	url    string
+	secret string
+	hc     *http.Client
+}
+
+func NewListClient(url, secret string) *ListClient {
+	return &ListClient{
+		url: url, secret: secret,
+		hc: &http.Client{Timeout: 10 * time.Second},
+	}
+}
+
+// List forwards filter params to agentserver and returns the raw JSON body.
+func (c *ListClient) List(ctx context.Context, params map[string]string) (json.RawMessage, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.url, nil)
+	if err != nil {
+		return nil, err
+	}
+	q := req.URL.Query()
+	for k, v := range params {
+		if v != "" {
+			q.Set(k, v)
+		}
+	}
+	req.URL.RawQuery = q.Encode()
+	req.Header.Set("X-Internal-Secret", c.secret)
+	resp, err := c.hc.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("operations list: %d %s", resp.StatusCode, string(body))
+	}
+	return body, nil
+}

--- a/internal/codexappgateway/oplog/client_test.go
+++ b/internal/codexappgateway/oplog/client_test.go
@@ -1,0 +1,169 @@
+package oplog
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestClient_Submit_FireAndForgetPOST(t *testing.T) {
+	var (
+		mu      sync.Mutex
+		bodies  [][]byte
+		gotAuth string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("X-Internal-Secret")
+		buf := make([]byte, r.ContentLength)
+		_, _ = r.Body.Read(buf)
+		mu.Lock()
+		bodies = append(bodies, buf)
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL+"/internal/operations", "secret-x", 16)
+	defer c.Close()
+
+	op := Operation{
+		ID: "op-1", WorkspaceID: "ws", Source: "sdk",
+		EnvID: "alpha", Tool: "shell", IsError: false,
+		StartedAt: time.Now().UTC(), CompletedAt: time.Now().UTC(),
+		DurationMs: 1,
+	}
+	c.Submit(op)
+	c.Submit(op)
+
+	if !waitFor(2*time.Second, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(bodies) == 2
+	}) {
+		mu.Lock()
+		n := len(bodies)
+		mu.Unlock()
+		t.Fatalf("flushed %d, want 2", n)
+	}
+	if gotAuth != "secret-x" {
+		t.Fatalf("X-Internal-Secret = %q, want secret-x", gotAuth)
+	}
+}
+
+func TestClient_Submit_BoundedDropsOnFull(t *testing.T) {
+	block := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-block
+	}))
+	defer srv.Close()
+	defer close(block)
+
+	c := NewClient(srv.URL+"/", "s", 2)
+	defer c.Close()
+
+	op := Operation{
+		ID: "op", WorkspaceID: "ws", Source: "sdk",
+		EnvID: "a", Tool: "shell",
+		StartedAt: time.Now().UTC(), CompletedAt: time.Now().UTC(),
+	}
+	done := make(chan struct{})
+	go func() {
+		for i := 0; i < 50; i++ {
+			c.Submit(op)
+		}
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("Submit blocked")
+	}
+	if c.Dropped() == 0 {
+		t.Fatalf("expected drops, got %d", c.Dropped())
+	}
+}
+
+func TestClient_Submit_DoesNotBlockOnServerError(t *testing.T) {
+	hits := int64(0)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&hits, 1)
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL+"/", "s", 16)
+	defer c.Close()
+
+	op := Operation{
+		ID: "x", WorkspaceID: "ws", Source: "sdk",
+		EnvID: "a", Tool: "shell",
+		StartedAt: time.Now().UTC(), CompletedAt: time.Now().UTC(),
+	}
+	c.Submit(op)
+	if !waitFor(time.Second, func() bool { return atomic.LoadInt64(&hits) >= 1 }) {
+		t.Fatal("server never received the post")
+	}
+	c.Submit(op)
+	if !waitFor(time.Second, func() bool { return atomic.LoadInt64(&hits) >= 2 }) {
+		t.Fatal("client stopped sending after server error")
+	}
+}
+
+func TestOperation_MarshalJSON(t *testing.T) {
+	o := Operation{
+		ID: "x", WorkspaceID: "w", Source: "sdk",
+		EnvID: "a", Tool: "shell", IsError: false,
+		Arguments:   json.RawMessage(`{"a":1}`),
+		StartedAt:   time.Unix(1700000000, 0).UTC(),
+		CompletedAt: time.Unix(1700000001, 0).UTC(),
+		DurationMs:  5,
+	}
+	b, err := json.Marshal(o)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	s := string(b)
+	if !strings.Contains(s, `"workspace_id":"w"`) || !strings.Contains(s, `"arguments":{"a":1}`) {
+		t.Fatalf("body = %s", b)
+	}
+}
+
+func TestListClient_ForwardsParamsAndReturnsBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Internal-Secret") != "s" {
+			t.Fatalf("auth")
+		}
+		q := r.URL.Query()
+		if q.Get("workspace_id") != "ws" || q.Get("tool") != "shell" || q.Get("limit") != "10" {
+			t.Fatalf("query: %v", q)
+		}
+		_, _ = w.Write([]byte(`{"operations":[{"id":"op_1"}]}`))
+	}))
+	defer srv.Close()
+
+	lc := NewListClient(srv.URL+"/", "s")
+	body, err := lc.List(t.Context(),
+		map[string]string{"workspace_id": "ws", "tool": "shell", "limit": "10"})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if !strings.Contains(string(body), `"op_1"`) {
+		t.Fatalf("body = %s", body)
+	}
+}
+
+func waitFor(timeout time.Duration, cond func() bool) bool {
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return cond()
+}

--- a/internal/codexappgateway/oplog/doc.go
+++ b/internal/codexappgateway/oplog/doc.go
@@ -1,0 +1,4 @@
+// Package oplog publishes per-call operation records from codex-app-gateway
+// to agentserver's /internal/operations POST endpoint. Submit is async and
+// fire-and-forget; tool calls never block on log delivery.
+package oplog

--- a/internal/codexappgateway/oplog/interceptor.go
+++ b/internal/codexappgateway/oplog/interceptor.go
@@ -1,0 +1,215 @@
+package oplog
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	defaultArgsMaxBytes   = 64 * 1024
+	defaultResultMaxBytes = 4 * 1024
+)
+
+// Submitter is the subset of Client that the Interceptor needs. Lets
+// tests pass a capture stub.
+type Submitter interface {
+	Submit(Operation)
+}
+
+// Config tunes the Interceptor at construction.
+type Config struct {
+	Source         string // "sdk" | "tui"
+	WorkspaceID    string // pinned from the ws Identity
+	ArgsMaxBytes   int    // 0 -> 64 KiB
+	ResultMaxBytes int    // 0 -> 4 KiB
+}
+
+// Interceptor parses JSON-RPC frames as they cross the ws bridge. On a
+// matched request+response for mcpServer/tool/call, it emits one
+// Operation to the Submitter.
+type Interceptor struct {
+	sub Submitter
+	cfg Config
+
+	mu      sync.Mutex
+	pending map[any]pendingReq
+}
+
+type pendingReq struct {
+	startedAt time.Time
+	env       string
+	tool      string
+	threadID  string
+	userID    string
+	args      json.RawMessage
+	argsSize  int
+}
+
+func NewInterceptor(s Submitter, cfg Config) *Interceptor {
+	if cfg.ArgsMaxBytes <= 0 {
+		cfg.ArgsMaxBytes = defaultArgsMaxBytes
+	}
+	if cfg.ResultMaxBytes <= 0 {
+		cfg.ResultMaxBytes = defaultResultMaxBytes
+	}
+	return &Interceptor{sub: s, cfg: cfg, pending: map[any]pendingReq{}}
+}
+
+// OnClientFrame is called on every client->server frame BEFORE it's forwarded.
+// Never blocks. Errors are silent — parsing failures are not Interceptor's
+// problem; the underlying pump still forwards the bytes.
+func (i *Interceptor) OnClientFrame(frame []byte) {
+	var msg struct {
+		ID     any             `json:"id"`
+		Method string          `json:"method"`
+		Params json.RawMessage `json:"params"`
+	}
+	if err := json.Unmarshal(frame, &msg); err != nil {
+		return
+	}
+	if msg.ID == nil || msg.Method != "mcpServer/tool/call" {
+		return
+	}
+	var p struct {
+		ThreadID  string          `json:"thread_id"`
+		Server    string          `json:"server"`
+		Tool      string          `json:"tool"`
+		Arguments json.RawMessage `json:"arguments"`
+		Meta      struct {
+			UserID string `json:"agentserver_user_id"`
+		} `json:"_meta"`
+	}
+	if err := json.Unmarshal(msg.Params, &p); err != nil {
+		return
+	}
+	var envID string
+	if len(p.Arguments) > 0 {
+		var args struct {
+			EnvironmentID string `json:"environment_id"`
+		}
+		_ = json.Unmarshal(p.Arguments, &args)
+		envID = args.EnvironmentID
+	}
+
+	i.mu.Lock()
+	i.pending[msg.ID] = pendingReq{
+		startedAt: time.Now().UTC(),
+		env:       envID,
+		tool:      p.Tool,
+		threadID:  p.ThreadID,
+		userID:    p.Meta.UserID,
+		args:      p.Arguments,
+		argsSize:  len(p.Arguments),
+	}
+	i.mu.Unlock()
+}
+
+// OnServerFrame is called on every server->client frame. If it pairs with
+// a pending request, emits an Operation.
+func (i *Interceptor) OnServerFrame(frame []byte) {
+	var msg struct {
+		ID     any             `json:"id"`
+		Result json.RawMessage `json:"result"`
+		Error  json.RawMessage `json:"error"`
+	}
+	if err := json.Unmarshal(frame, &msg); err != nil {
+		return
+	}
+	if msg.ID == nil {
+		return
+	}
+	i.mu.Lock()
+	pr, ok := i.pending[msg.ID]
+	if ok {
+		delete(i.pending, msg.ID)
+	}
+	i.mu.Unlock()
+	if !ok {
+		return
+	}
+
+	op := Operation{
+		ID:          uuid.NewString(),
+		WorkspaceID: i.cfg.WorkspaceID,
+		Source:      i.cfg.Source,
+		EnvID:       pr.env,
+		Tool:        pr.tool,
+		StartedAt:   pr.startedAt,
+		CompletedAt: time.Now().UTC(),
+	}
+	if pr.threadID != "" {
+		t := pr.threadID
+		op.ThreadID = &t
+	}
+	if pr.userID != "" {
+		u := pr.userID
+		op.UserID = &u
+	}
+	op.DurationMs = int32(op.CompletedAt.Sub(op.StartedAt) / time.Millisecond)
+
+	// Arguments — truncate if oversized
+	if pr.argsSize > i.cfg.ArgsMaxBytes {
+		sum := sha256.Sum256(pr.args)
+		op.ArgumentsMeta = mustJSON(map[string]any{
+			"truncated":  true,
+			"size_bytes": pr.argsSize,
+			"sha256":     hex.EncodeToString(sum[:]),
+		})
+	} else {
+		op.Arguments = pr.args
+	}
+
+	// Result — pull text content as result_summary; record error flag
+	if len(msg.Error) > 0 {
+		op.IsError = true
+		var er struct {
+			Message string `json:"message"`
+		}
+		_ = json.Unmarshal(msg.Error, &er)
+		s := er.Message
+		op.ResultSummary = &s
+	} else if len(msg.Result) > 0 {
+		var r struct {
+			Content []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+			IsError bool `json:"isError"`
+		}
+		_ = json.Unmarshal(msg.Result, &r)
+		op.IsError = r.IsError
+		var b []byte
+		for _, c := range r.Content {
+			if c.Type == "text" {
+				b = append(b, c.Text...)
+			}
+		}
+		total := len(b)
+		if total > i.cfg.ResultMaxBytes {
+			truncated := string(b[:i.cfg.ResultMaxBytes])
+			op.ResultSummary = &truncated
+			op.ResultMeta = mustJSON(map[string]any{
+				"truncated":   true,
+				"total_bytes": total,
+			})
+		} else if total > 0 {
+			s := string(b)
+			op.ResultSummary = &s
+		}
+	}
+
+	i.sub.Submit(op)
+}
+
+func mustJSON(v any) json.RawMessage {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil
+	}
+	return b
+}

--- a/internal/codexappgateway/oplog/interceptor_test.go
+++ b/internal/codexappgateway/oplog/interceptor_test.go
@@ -1,0 +1,181 @@
+package oplog
+
+import (
+	"encoding/json"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+type captureClient struct {
+	mu  sync.Mutex
+	ops []Operation
+}
+
+func (c *captureClient) Submit(op Operation) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.ops = append(c.ops, op)
+}
+func (c *captureClient) Dropped() uint64 { return 0 }
+
+func (c *captureClient) snapshot() []Operation {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]Operation, len(c.ops))
+	copy(out, c.ops)
+	return out
+}
+
+func TestInterceptor_ParesRequestAndResponse(t *testing.T) {
+	cc := &captureClient{}
+	i := NewInterceptor(cc, Config{Source: "sdk", WorkspaceID: "ws-1"})
+
+	req := []byte(`{"jsonrpc":"2.0","id":7,"method":"mcpServer/tool/call","params":{
+		"thread_id":"th-1","server":"env_mcp","tool":"shell",
+		"arguments":{"environment_id":"alpha","command":"ls"},
+		"_meta":{"agentserver_user_id":"u-1"}}}`)
+	resp := []byte(`{"jsonrpc":"2.0","id":7,"result":{
+		"content":[{"type":"text","text":"hi"}],"isError":false}}`)
+
+	i.OnClientFrame(req)
+	i.OnServerFrame(resp)
+
+	ops := cc.snapshot()
+	if len(ops) != 1 {
+		t.Fatalf("ops = %d", len(ops))
+	}
+	op := ops[0]
+	if op.WorkspaceID != "ws-1" || op.Source != "sdk" ||
+		op.EnvID != "alpha" || op.Tool != "shell" || op.IsError {
+		t.Fatalf("op = %+v", op)
+	}
+	if op.UserID == nil || *op.UserID != "u-1" {
+		t.Fatalf("user_id = %v", op.UserID)
+	}
+	if op.ThreadID == nil || *op.ThreadID != "th-1" {
+		t.Fatalf("thread_id = %v", op.ThreadID)
+	}
+	if op.ResultSummary == nil || *op.ResultSummary != "hi" {
+		t.Fatalf("result_summary = %v", op.ResultSummary)
+	}
+}
+
+func TestInterceptor_IgnoresIrrelevantFrames(t *testing.T) {
+	cc := &captureClient{}
+	i := NewInterceptor(cc, Config{Source: "sdk", WorkspaceID: "ws-1"})
+
+	i.OnClientFrame([]byte(`{"method":"initialized"}`))
+	i.OnClientFrame([]byte(`{"jsonrpc":"2.0","id":1,"method":"thread/start","params":{}}`))
+	i.OnServerFrame([]byte(`{"jsonrpc":"2.0","id":1,"result":{"thread_id":"x"}}`))
+	i.OnServerFrame([]byte(`not json`))
+
+	if len(cc.snapshot()) != 0 {
+		t.Fatalf("logged unrelated frames: %+v", cc.snapshot())
+	}
+}
+
+func TestInterceptor_RecordsIsError(t *testing.T) {
+	cc := &captureClient{}
+	i := NewInterceptor(cc, Config{Source: "sdk", WorkspaceID: "ws"})
+	i.OnClientFrame([]byte(`{"jsonrpc":"2.0","id":3,"method":"mcpServer/tool/call","params":{
+		"thread_id":"t","server":"env_mcp","tool":"shell",
+		"arguments":{"environment_id":"a","command":"bad"}}}`))
+	i.OnServerFrame([]byte(`{"jsonrpc":"2.0","id":3,"result":{
+		"content":[{"type":"text","text":"oops"}],"isError":true}}`))
+
+	ops := cc.snapshot()
+	if len(ops) != 1 || !ops[0].IsError {
+		t.Fatalf("ops = %+v", ops)
+	}
+}
+
+func TestInterceptor_TruncatesLargeArguments(t *testing.T) {
+	cc := &captureClient{}
+	i := NewInterceptor(cc, Config{Source: "sdk", WorkspaceID: "ws", ArgsMaxBytes: 50})
+
+	big := make([]byte, 200)
+	for x := range big {
+		big[x] = 'a'
+	}
+	args, _ := json.Marshal(map[string]any{"data": string(big), "environment_id": "a"})
+	frame := append([]byte(`{"jsonrpc":"2.0","id":11,"method":"mcpServer/tool/call","params":{
+		"server":"env_mcp","tool":"write_file","arguments":`), args...)
+	frame = append(frame, '}', '}')
+	i.OnClientFrame(frame)
+	i.OnServerFrame([]byte(`{"jsonrpc":"2.0","id":11,"result":{"content":[],"isError":false}}`))
+
+	ops := cc.snapshot()
+	if len(ops) != 1 {
+		t.Fatalf("ops = %d", len(ops))
+	}
+	op := ops[0]
+	if op.Arguments != nil {
+		t.Fatal("arguments should be nil when truncated")
+	}
+	if op.ArgumentsMeta == nil {
+		t.Fatal("arguments_meta missing")
+	}
+	var m map[string]any
+	_ = json.Unmarshal(op.ArgumentsMeta, &m)
+	if m["truncated"] != true {
+		t.Fatalf("arguments_meta = %v", m)
+	}
+}
+
+func TestInterceptor_TruncatesLargeTextResult(t *testing.T) {
+	cc := &captureClient{}
+	i := NewInterceptor(cc, Config{Source: "sdk", WorkspaceID: "ws", ResultMaxBytes: 10})
+
+	long := make([]byte, 100)
+	for x := range long {
+		long[x] = 'z'
+	}
+	i.OnClientFrame([]byte(`{"jsonrpc":"2.0","id":4,"method":"mcpServer/tool/call","params":{
+		"server":"env_mcp","tool":"read_file","arguments":{"environment_id":"a","path":"/x"}}}`))
+	resp, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0", "id": 4,
+		"result": map[string]any{
+			"content": []map[string]any{{"type": "text", "text": string(long)}},
+			"isError": false,
+		},
+	})
+	i.OnServerFrame(resp)
+
+	op := cc.snapshot()[0]
+	if op.ResultSummary == nil || len(*op.ResultSummary) > 10 {
+		t.Fatalf("result_summary = %v", op.ResultSummary)
+	}
+	if op.ResultMeta == nil {
+		t.Fatal("result_meta missing")
+	}
+}
+
+func TestInterceptor_ConcurrentPairs(t *testing.T) {
+	cc := &captureClient{}
+	i := NewInterceptor(cc, Config{Source: "sdk", WorkspaceID: "ws"})
+
+	var wg sync.WaitGroup
+	var sent int64
+	for n := 0; n < 50; n++ {
+		wg.Add(1)
+		id := n + 1
+		go func() {
+			defer wg.Done()
+			req := []byte(`{"jsonrpc":"2.0","id":` + strconv.Itoa(id) + `,"method":"mcpServer/tool/call","params":{
+				"server":"env_mcp","tool":"shell","arguments":{"environment_id":"a","command":"x"}}}`)
+			resp := []byte(`{"jsonrpc":"2.0","id":` + strconv.Itoa(id) + `,"result":{"content":[],"isError":false}}`)
+			i.OnClientFrame(req)
+			i.OnServerFrame(resp)
+			atomic.AddInt64(&sent, 1)
+		}()
+	}
+	wg.Wait()
+	if !waitFor(2*time.Second, func() bool {
+		return len(cc.snapshot()) == 50
+	}) {
+		t.Fatalf("ops = %d, want 50", len(cc.snapshot()))
+	}
+}

--- a/internal/codexappgateway/oplog/operations_list.go
+++ b/internal/codexappgateway/oplog/operations_list.go
@@ -1,0 +1,82 @@
+package oplog
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// TryHandleOperationsList inspects a client→server frame. If it's an
+// `operations/list` JSON-RPC request, it forwards the filters to
+// agentserver via the ListClient and returns a complete JSON-RPC response
+// frame to send back to the client (ok=true). For any other frame,
+// returns (nil, false) — caller forwards the frame normally.
+//
+// Designed to be called from the gateway's outbound proxy path so the
+// request never reaches the codex app-server (which has no operations/list
+// method).
+func TryHandleOperationsList(
+	ctx context.Context,
+	lc *ListClient,
+	workspaceID string,
+	frame []byte,
+) ([]byte, bool) {
+	var msg struct {
+		ID     any             `json:"id"`
+		Method string          `json:"method"`
+		Params json.RawMessage `json:"params"`
+	}
+	if err := json.Unmarshal(frame, &msg); err != nil {
+		return nil, false
+	}
+	if msg.Method != "operations/list" || msg.ID == nil {
+		return nil, false
+	}
+
+	params := map[string]string{"workspace_id": workspaceID}
+	var p struct {
+		Limit   *int    `json:"limit"`
+		EnvID   *string `json:"env_id"`
+		Tool    *string `json:"tool"`
+		Source  *string `json:"source"`
+		IsError *bool   `json:"is_error"`
+		Since   *string `json:"since"`
+		ID      *string `json:"id"`
+	}
+	_ = json.Unmarshal(msg.Params, &p)
+	if p.Limit != nil {
+		params["limit"] = fmt.Sprintf("%d", *p.Limit)
+	}
+	if p.EnvID != nil {
+		params["env_id"] = *p.EnvID
+	}
+	if p.Tool != nil {
+		params["tool"] = *p.Tool
+	}
+	if p.Source != nil {
+		params["source"] = *p.Source
+	}
+	if p.IsError != nil {
+		params["is_error"] = fmt.Sprintf("%t", *p.IsError)
+	}
+	if p.Since != nil {
+		params["since"] = *p.Since
+	}
+	if p.ID != nil {
+		params["id"] = *p.ID
+	}
+
+	body, err := lc.List(ctx, params)
+	if err != nil {
+		errResp, _ := json.Marshal(map[string]any{
+			"jsonrpc": "2.0", "id": msg.ID,
+			"error": map[string]any{"code": -32603, "message": err.Error()},
+		})
+		return errResp, true
+	}
+	resp, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0", "id": msg.ID,
+		"result": json.RawMessage(body),
+	})
+	return resp, true
+}

--- a/internal/codexappgateway/oplog/operations_list_test.go
+++ b/internal/codexappgateway/oplog/operations_list_test.go
@@ -1,0 +1,119 @@
+package oplog
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestHandleOperationsList_ForwardsAndReturns(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		if q.Get("workspace_id") != "ws-1" {
+			t.Fatalf("ws=%q", q.Get("workspace_id"))
+		}
+		if q.Get("limit") != "10" {
+			t.Fatalf("limit=%q", q.Get("limit"))
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"operations": []map[string]any{
+				{"id": "op_1", "env_id": "a", "tool": "shell", "is_error": false},
+			},
+		})
+	}))
+	defer srv.Close()
+
+	lc := NewListClient(srv.URL+"/", "s")
+	frame, ok := TryHandleOperationsList(context.Background(), lc, "ws-1",
+		[]byte(`{"jsonrpc":"2.0","id":42,"method":"operations/list","params":{"limit":10}}`))
+	if !ok {
+		t.Fatal("not handled")
+	}
+	var resp struct {
+		ID     int             `json:"id"`
+		Result json.RawMessage `json:"result"`
+	}
+	if err := json.Unmarshal(frame, &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ID != 42 {
+		t.Fatalf("id=%d", resp.ID)
+	}
+	if !strings.Contains(string(resp.Result), `"op_1"`) {
+		t.Fatalf("result=%s", resp.Result)
+	}
+}
+
+func TestTryHandleOperationsList_OtherMethodsIgnored(t *testing.T) {
+	frame, ok := TryHandleOperationsList(context.Background(), nil, "ws",
+		[]byte(`{"jsonrpc":"2.0","id":1,"method":"mcpServer/tool/call"}`))
+	if ok || frame != nil {
+		t.Fatalf("should not handle")
+	}
+}
+
+func TestTryHandleOperationsList_NotificationIgnored(t *testing.T) {
+	frame, ok := TryHandleOperationsList(context.Background(), nil, "ws",
+		[]byte(`{"jsonrpc":"2.0","method":"operations/list"}`))
+	if ok || frame != nil {
+		t.Fatalf("notifications (no id) should not be handled")
+	}
+}
+
+func TestTryHandleOperationsList_ServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	lc := NewListClient(srv.URL+"/", "s")
+
+	frame, ok := TryHandleOperationsList(context.Background(), lc, "ws",
+		[]byte(`{"jsonrpc":"2.0","id":7,"method":"operations/list","params":{}}`))
+	if !ok {
+		t.Fatal("should handle, but produce error response")
+	}
+	var resp struct {
+		ID    int `json:"id"`
+		Error struct {
+			Code    int    `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(frame, &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ID != 7 || resp.Error.Code == 0 {
+		t.Fatalf("resp = %+v", resp)
+	}
+}
+
+func TestTryHandleOperationsList_ForwardsAllFilterParams(t *testing.T) {
+	var got url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		got = r.URL.Query()
+		_, _ = w.Write([]byte(`{"operations":[]}`))
+	}))
+	defer srv.Close()
+	lc := NewListClient(srv.URL+"/", "s")
+
+	body := `{"jsonrpc":"2.0","id":1,"method":"operations/list","params":{
+		"limit":50,"env_id":"alpha","tool":"shell","source":"sdk",
+		"is_error":true,"since":"2026-01-01T00:00:00Z","id":"op_99"}}`
+	_, ok := TryHandleOperationsList(context.Background(), lc, "ws-A", []byte(body))
+	if !ok {
+		t.Fatal("not handled")
+	}
+	for k, want := range map[string]string{
+		"workspace_id": "ws-A", "limit": "50",
+		"env_id": "alpha", "tool": "shell", "source": "sdk",
+		"is_error": "true", "since": "2026-01-01T00:00:00Z", "id": "op_99",
+	} {
+		if v := got.Get(k); v != want {
+			t.Errorf("%s=%q want %q", k, v, want)
+		}
+	}
+}

--- a/internal/codexappgateway/server.go
+++ b/internal/codexappgateway/server.go
@@ -354,7 +354,9 @@ func (s *Server) handleNotebookWS(w http.ResponseWriter, r *http.Request) {
 			// 1) operations/list — handle in gateway, never forward.
 			if s.oplogList != nil {
 				if resp, handled := oplog.TryHandleOperationsList(ctx, s.oplogList, id.WorkspaceID, frame); handled {
-					_ = userWS.Write(ctx, websocket.MessageText, resp)
+					if werr := userWS.Write(ctx, websocket.MessageText, resp); werr != nil {
+						s.logger.Warn("notebook oplog list write", "err", werr, "workspace_id", id.WorkspaceID)
+					}
 					return wsbridge.DropFrame
 				}
 			}

--- a/internal/codexappgateway/server.go
+++ b/internal/codexappgateway/server.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/agentserver/agentserver/internal/codexappgateway/auth"
 	"github.com/agentserver/agentserver/internal/codexappgateway/codexhome"
+	"github.com/agentserver/agentserver/internal/codexappgateway/oplog"
 	"github.com/agentserver/agentserver/internal/codexappgateway/supervisor"
 	"github.com/agentserver/agentserver/internal/codexexecgateway/execmodel"
 	"github.com/agentserver/agentserver/internal/shortid"
@@ -41,6 +42,11 @@ type Server struct {
 	buildConfig func(ctx context.Context, workspaceID, loopbackToken string) (supervisor.SpawnConfig, error)
 
 	execClient connectedClient // exposed for the loopback /internal/connected handler
+
+	// oplog clients. nil when OperationLogURL/Secret are empty; the
+	// /notebook/ws handler degrades to a transparent proxy in that case.
+	oplogClient *oplog.Client
+	oplogList   *oplog.ListClient
 }
 
 // workspaceTokenFetcher is the subset of *WorkspaceTokenClient buildConfig
@@ -89,6 +95,10 @@ func NewServer(cfg ServeConfig, codexBin, selfBin string, logger *slog.Logger) (
 		execClient: execClient,
 	}
 	s.buildConfig = makeBuildConfig(cfg, execClient, wsTokenClient, selfBin, logger)
+	if cfg.OperationLogURL != "" && cfg.OperationLogSecret != "" {
+		s.oplogClient = oplog.NewClient(cfg.OperationLogURL, cfg.OperationLogSecret, cfg.OperationLogChan)
+		s.oplogList = oplog.NewListClient(cfg.OperationLogURL, cfg.OperationLogSecret)
+	}
 	return s, nil
 }
 
@@ -197,9 +207,15 @@ func (s *Server) Run(ctx context.Context, listenAddr string) error {
 		defer cancel()
 		_ = httpSrv.Shutdown(shutdownCtx)
 		s.sup.ShutdownAll(shutdownCtx)
+		if s.oplogClient != nil {
+			s.oplogClient.Close()
+		}
 		return nil
 	case err := <-errCh:
 		s.sup.ShutdownAll(context.Background())
+		if s.oplogClient != nil {
+			s.oplogClient.Close()
+		}
 		if errors.Is(err, http.ErrServerClosed) {
 			return nil
 		}
@@ -220,6 +236,7 @@ func (s *Server) Routes() http.Handler {
 	r.Get("/healthz", func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(200) })
 	r.Get("/", s.handleCodexAppWS)
 	r.Get("/codex-app/ws", s.handleCodexAppWS)
+	r.Get("/notebook/ws", s.handleNotebookWS)
 	r.Get("/internal/connected", s.handleInternalConnected)
 	return r
 }
@@ -276,3 +293,89 @@ func (s *Server) handleCodexAppWS(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// handleNotebookWS is the SDK-facing variant of handleCodexAppWS. It uses
+// wsbridge.RunProxyWithInterceptor to (1) intercept operations/list RPCs
+// and serve them from agentserver's oplog (codex has no such method), and
+// (2) observe tool/call frames to emit Operation records. WorkspaceID is
+// pinned from the verified Identity, never trusted from frame payload.
+func (s *Server) handleNotebookWS(w http.ResponseWriter, r *http.Request) {
+	tok, ok := auth.ExtractBearer(r)
+	if !ok {
+		http.Error(w, "missing Bearer", http.StatusUnauthorized)
+		return
+	}
+	id, err := s.auth.Verify(r.Context(), tok)
+	if err != nil {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	userWS, err := websocket.Accept(w, r, nil)
+	if err != nil {
+		s.logger.Warn("notebook ws accept", "err", err)
+		return
+	}
+	userWS.SetReadLimit(maxWSFrameBytes)
+	defer userWS.Close(websocket.StatusNormalClosure, "client closing")
+
+	ctx := r.Context()
+	key := supervisor.Key{WorkspaceID: id.WorkspaceID}
+	handle, err := s.sup.EnsureSubprocess(ctx, key, func(loopbackToken string) (supervisor.SpawnConfig, error) {
+		return s.buildConfig(ctx, id.WorkspaceID, loopbackToken)
+	})
+	if err != nil {
+		s.logger.Error("ensure subprocess", "err", err, "key", key)
+		_ = userWS.Close(websocket.StatusInternalError, "subprocess unavailable")
+		return
+	}
+
+	childWS, _, err := websocket.Dial(ctx, handle.WSURL, &websocket.DialOptions{
+		CompressionMode: websocket.CompressionDisabled,
+	})
+	if err != nil {
+		s.logger.Error("dial child", "err", err, "url", handle.WSURL)
+		_ = userWS.Close(websocket.StatusInternalError, "subprocess dial failed")
+		return
+	}
+	childWS.SetReadLimit(maxWSFrameBytes)
+	defer childWS.Close(websocket.StatusNormalClosure, "gateway closing")
+
+	// Per-connection Interceptor — workspaceID pinned from the verified
+	// Identity, not from any client-supplied tag. nil when oplog disabled.
+	var perConn *oplog.Interceptor
+	if s.oplogClient != nil {
+		perConn = oplog.NewInterceptor(s.oplogClient, oplog.Config{
+			Source: "sdk", WorkspaceID: id.WorkspaceID,
+		})
+	}
+
+	intc := wsbridge.Interceptor{
+		OnClientFrame: func(frame []byte) []byte {
+			// 1) operations/list — handle in gateway, never forward.
+			if s.oplogList != nil {
+				if resp, handled := oplog.TryHandleOperationsList(ctx, s.oplogList, id.WorkspaceID, frame); handled {
+					_ = userWS.Write(ctx, websocket.MessageText, resp)
+					return wsbridge.DropFrame
+				}
+			}
+			// 2) observe for oplog write side.
+			if perConn != nil {
+				perConn.OnClientFrame(frame)
+			}
+			return nil
+		},
+		OnServerFrame: func(frame []byte) []byte {
+			if perConn != nil {
+				perConn.OnServerFrame(frame)
+			}
+			return nil
+		},
+	}
+
+	s.sup.Touch(key)
+	if err := wsbridge.RunProxyWithInterceptor(ctx, userWS, childWS, intc, func() {
+		s.sup.Touch(key)
+	}); err != nil {
+		s.logger.Info("notebook proxy ended", "err", err, "key", key)
+	}
+}

--- a/internal/codexappgateway/server_test.go
+++ b/internal/codexappgateway/server_test.go
@@ -4,16 +4,20 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/agentserver/agentserver/internal/codexappgateway/auth"
 	"github.com/agentserver/agentserver/internal/codexappgateway/codexhome"
+	"github.com/agentserver/agentserver/internal/codexappgateway/oplog"
 	"github.com/agentserver/agentserver/internal/codexappgateway/supervisor"
+	"github.com/agentserver/agentserver/internal/wsbridge"
 
 	"nhooyr.io/websocket"
 )
@@ -52,6 +56,245 @@ func TestServer_WSEndpoint_HappyPath_ProxiesToFakeChild(t *testing.T) {
 	// without immediate error (proxy is alive).
 	if err := c.Write(ctx, websocket.MessageText, []byte(`{"id":1,"method":"ping"}`)); err != nil {
 		t.Fatalf("write: %v", err)
+	}
+}
+
+func TestServer_NotebookWS_AuthRequired(t *testing.T) {
+	srv := makeTestServer(t)
+	defer srv.Close()
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http") + "/notebook/ws"
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	_, resp, err := websocket.Dial(ctx, wsURL, nil)
+	if err == nil {
+		t.Fatal("expected dial to fail without Bearer")
+	}
+	if resp == nil || resp.StatusCode != http.StatusUnauthorized {
+		t.Errorf("status = %v", resp)
+	}
+}
+
+// TestServer_NotebookWS_OplogReceivesToolCall exercises the /notebook/ws
+// route end-to-end against a stub child ws that echoes a tool/call result.
+// Verifies the gateway's Interceptor POSTs an Operation to the oplog HTTP
+// endpoint pinned to the verified workspace.
+func TestServer_NotebookWS_OplogReceivesToolCall(t *testing.T) {
+	// Fake child ws — echoes a result frame whenever it receives a request.
+	childMux := http.NewServeMux()
+	childMux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer c.Close(websocket.StatusNormalClosure, "")
+		ctx := r.Context()
+		for {
+			_, data, err := c.Read(ctx)
+			if err != nil {
+				return
+			}
+			var msg struct {
+				ID     any    `json:"id"`
+				Method string `json:"method"`
+			}
+			if err := json.Unmarshal(data, &msg); err != nil {
+				continue
+			}
+			if msg.ID == nil {
+				continue
+			}
+			resp, _ := json.Marshal(map[string]any{
+				"jsonrpc": "2.0", "id": msg.ID,
+				"result": map[string]any{
+					"content": []map[string]any{{"type": "text", "text": "ok"}},
+					"isError": false,
+				},
+			})
+			_ = c.Write(ctx, websocket.MessageText, resp)
+		}
+	})
+	childSrv := httptest.NewServer(childMux)
+	defer childSrv.Close()
+	childWSURL := "ws" + strings.TrimPrefix(childSrv.URL, "http")
+
+	// Fake agentserver: token verify only.
+	asSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/internal/codex/tokens/verify" {
+			http.Error(w, "404", 404)
+			return
+		}
+		var body struct{ Token string }
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		if !strings.HasPrefix(body.Token, "ast_") {
+			http.Error(w, `{"error":"invalid_token"}`, http.StatusUnauthorized)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"user_id": "u_test", "workspace_id": "ws_test",
+		})
+	}))
+	defer asSrv.Close()
+
+	// Fake oplog endpoint: capture POSTs.
+	var (
+		mu       sync.Mutex
+		captured []oplog.Operation
+		gotCh    = make(chan struct{}, 8)
+	)
+	opSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method", 405)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var op oplog.Operation
+		if err := json.Unmarshal(body, &op); err != nil {
+			http.Error(w, err.Error(), 400)
+			return
+		}
+		mu.Lock()
+		captured = append(captured, op)
+		mu.Unlock()
+		w.WriteHeader(200)
+		select {
+		case gotCh <- struct{}{}:
+		default:
+		}
+	}))
+	defer opSrv.Close()
+
+	// Server with a stub supervisor: EnsureSubprocess is bypassed by giving
+	// the supervisor a fake handle directly via a fakeSupervisor — but the
+	// real Supervisor type doesn't allow that injection here. Instead we
+	// route around it by spinning up a real supervisor that points at the
+	// fake codex binary (which prints ws://addr and serves /readyz). The
+	// child it spawns won't be the same as childSrv. To exercise the proxy
+	// against childSrv, we need a way to override the WSURL returned by the
+	// supervisor. The simplest path: write a thin handler-level integration
+	// using EnsureSubprocess on the real supervisor.
+	//
+	// Simpler approach: hand-construct a *Server with a fake supervisor by
+	// replacing the buildConfig and reusing the real fake-codex child. The
+	// fake child will accept ws but not produce tool/call replies. That
+	// defeats this test's goal.
+	//
+	// Instead: bypass Server.handleNotebookWS's supervisor by wiring up an
+	// alternate route that uses the same logic but dials childSrv directly.
+	// Done below via a minimal Server-like router exclusively for this test.
+
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	s := &Server{
+		cfg:    ServeConfig{},
+		auth:   auth.NewRemoteVerifier(asSrv.URL, "ignored"),
+		logger: logger,
+	}
+	s.oplogClient = oplog.NewClient(opSrv.URL, "secret", 16)
+	s.oplogList = oplog.NewListClient(opSrv.URL, "secret")
+	t.Cleanup(func() { s.oplogClient.Close() })
+
+	// Minimal handler that mirrors handleNotebookWS but dials childSrv
+	// directly (no supervisor). Keeps the interceptor wiring under test.
+	handler := func(w http.ResponseWriter, r *http.Request) {
+		tok, ok := auth.ExtractBearer(r)
+		if !ok {
+			http.Error(w, "missing Bearer", 401)
+			return
+		}
+		id, err := s.auth.Verify(r.Context(), tok)
+		if err != nil {
+			http.Error(w, "unauthorized", 401)
+			return
+		}
+		userWS, err := websocket.Accept(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer userWS.Close(websocket.StatusNormalClosure, "")
+		userWS.SetReadLimit(maxWSFrameBytes)
+		ctx := r.Context()
+		cWS, _, err := websocket.Dial(ctx, childWSURL, nil)
+		if err != nil {
+			t.Errorf("dial child: %v", err)
+			return
+		}
+		defer cWS.Close(websocket.StatusNormalClosure, "")
+		cWS.SetReadLimit(maxWSFrameBytes)
+
+		perConn := oplog.NewInterceptor(s.oplogClient, oplog.Config{
+			Source: "sdk", WorkspaceID: id.WorkspaceID,
+		})
+		intc := wsbridge.Interceptor{
+			OnClientFrame: func(frame []byte) []byte {
+				if s.oplogList != nil {
+					if resp, handled := oplog.TryHandleOperationsList(ctx, s.oplogList, id.WorkspaceID, frame); handled {
+						_ = userWS.Write(ctx, websocket.MessageText, resp)
+						return wsbridge.DropFrame
+					}
+				}
+				perConn.OnClientFrame(frame)
+				return nil
+			},
+			OnServerFrame: func(frame []byte) []byte {
+				perConn.OnServerFrame(frame)
+				return nil
+			},
+		}
+		_ = wsbridge.RunProxyWithInterceptor(ctx, userWS, cWS, intc, nil)
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/notebook/ws", handler)
+	gw := httptest.NewServer(mux)
+	defer gw.Close()
+
+	// Client dial + tool/call frame.
+	wsURL := "ws" + strings.TrimPrefix(gw.URL, "http") + "/notebook/ws"
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	c, _, err := websocket.Dial(ctx, wsURL, &websocket.DialOptions{
+		HTTPHeader: http.Header{"Authorization": []string{"Bearer ast_token"}},
+	})
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close(websocket.StatusNormalClosure, "")
+
+	req := `{"jsonrpc":"2.0","id":42,"method":"mcpServer/tool/call","params":{"thread_id":"t1","server":"exe_abc","tool":"shell","arguments":{"environment_id":"env_x","cmd":"echo hi"}}}`
+	if err := c.Write(ctx, websocket.MessageText, []byte(req)); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	// Read the response (echoed by fake child)
+	if _, _, err := c.Read(ctx); err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+
+	// Wait for oplog POST
+	select {
+	case <-gotCh:
+	case <-time.After(3 * time.Second):
+		t.Fatal("oplog endpoint never received a POST")
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(captured) != 1 {
+		t.Fatalf("captured = %d, want 1", len(captured))
+	}
+	op := captured[0]
+	if op.WorkspaceID != "ws_test" {
+		t.Errorf("WorkspaceID = %q, want ws_test", op.WorkspaceID)
+	}
+	if op.Source != "sdk" {
+		t.Errorf("Source = %q, want sdk", op.Source)
+	}
+	if op.Tool != "shell" {
+		t.Errorf("Tool = %q, want shell", op.Tool)
+	}
+	if op.EnvID != "env_x" {
+		t.Errorf("EnvID = %q, want env_x", op.EnvID)
+	}
+	if op.IsError {
+		t.Errorf("IsError = true, want false")
 	}
 }
 

--- a/internal/db/migrations/023_operations.sql
+++ b/internal/db/migrations/023_operations.sql
@@ -1,0 +1,36 @@
+-- v1 operation log. Written by codex-app-gateway via POST /internal/operations
+-- whenever an mcpServer/tool/call request/response pair completes.
+--
+-- Columns marked v1.5 are populated only when env-mcp itself emits the record
+-- (LLM-initiated calls) or when the IPython kernel attribution metadata is
+-- wired up. v1 leaves them NULL.
+
+CREATE TABLE operations (
+  id              UUID PRIMARY KEY,
+  workspace_id    TEXT NOT NULL,
+  user_id         TEXT,
+  source          TEXT NOT NULL,
+  thread_id       TEXT,
+  request_id      TEXT,
+
+  env_id          TEXT NOT NULL,
+  tool            TEXT NOT NULL,
+  arguments       JSONB,
+  arguments_meta  JSONB,
+
+  is_error        BOOLEAN NOT NULL,
+  result_summary  TEXT,
+  result_meta     JSONB,
+
+  started_at      TIMESTAMPTZ NOT NULL,
+  completed_at    TIMESTAMPTZ NOT NULL,
+  duration_ms     INTEGER NOT NULL,
+
+  -- v1.5
+  notebook_path   TEXT,
+  cell_id         TEXT
+);
+
+CREATE INDEX ops_ws_time   ON operations (workspace_id, started_at DESC);
+CREATE INDEX ops_ws_env    ON operations (workspace_id, env_id, started_at DESC);
+CREATE INDEX ops_ws_source ON operations (workspace_id, source, started_at DESC);

--- a/internal/db/operations.go
+++ b/internal/db/operations.go
@@ -1,0 +1,169 @@
+package db
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Operation is one row of the operations table — a single completed
+// mcpServer/tool/call observed by codex-app-gateway.
+type Operation struct {
+	ID          string
+	WorkspaceID string
+	UserID      *string
+	Source      string // "sdk" | "tui" | (v1.5) "llm"
+	ThreadID    *string
+	RequestID   *string
+
+	EnvID         string
+	Tool          string
+	Arguments     json.RawMessage // nil if truncated
+	ArgumentsMeta json.RawMessage // {"truncated":true,"size_bytes":N,"sha256":"..."} if so
+
+	IsError       bool
+	ResultSummary *string
+	ResultMeta    json.RawMessage
+
+	StartedAt   time.Time
+	CompletedAt time.Time
+	DurationMs  int32
+
+	NotebookPath *string // v1.5
+	CellID       *string // v1.5
+}
+
+// OperationFilter is the optional filter set for ListOperations.
+type OperationFilter struct {
+	WorkspaceID string // REQUIRED — server-side enforced
+	EnvID       string // optional
+	Tool        string // optional
+	Source      string // optional
+	IsError     *bool  // optional
+	Since       *time.Time
+	ID          string // optional: exact match (returns 0 or 1 rows)
+	Limit       int    // default 100, max 1000
+}
+
+func (db *DB) InsertOperation(o Operation) error {
+	const q = `
+INSERT INTO operations (
+  id, workspace_id, user_id, source, thread_id, request_id,
+  env_id, tool, arguments, arguments_meta,
+  is_error, result_summary, result_meta,
+  started_at, completed_at, duration_ms,
+  notebook_path, cell_id
+) VALUES (
+  $1,$2,$3,$4,$5,$6, $7,$8,$9,$10, $11,$12,$13, $14,$15,$16, $17,$18
+)`
+	_, err := db.Exec(q,
+		o.ID, o.WorkspaceID, o.UserID, o.Source, o.ThreadID, o.RequestID,
+		o.EnvID, o.Tool, nullableJSON(o.Arguments), nullableJSON(o.ArgumentsMeta),
+		o.IsError, o.ResultSummary, nullableJSON(o.ResultMeta),
+		o.StartedAt, o.CompletedAt, o.DurationMs,
+		o.NotebookPath, o.CellID,
+	)
+	return err
+}
+
+func nullableJSON(b json.RawMessage) any {
+	if len(b) == 0 {
+		return nil
+	}
+	return []byte(b)
+}
+
+const defaultListLimit = 100
+const maxListLimit = 1000
+
+func (db *DB) ListOperations(f OperationFilter) ([]Operation, error) {
+	if f.WorkspaceID == "" {
+		return nil, fmt.Errorf("ListOperations: WorkspaceID required")
+	}
+	if f.Limit <= 0 {
+		f.Limit = defaultListLimit
+	}
+	if f.Limit > maxListLimit {
+		f.Limit = maxListLimit
+	}
+
+	var (
+		args  []any
+		where []string
+	)
+	pushArg := func(v any) string {
+		args = append(args, v)
+		return fmt.Sprintf("$%d", len(args))
+	}
+	where = append(where, "workspace_id = "+pushArg(f.WorkspaceID))
+	if f.ID != "" {
+		where = append(where, "id = "+pushArg(f.ID))
+	}
+	if f.EnvID != "" {
+		where = append(where, "env_id = "+pushArg(f.EnvID))
+	}
+	if f.Tool != "" {
+		where = append(where, "tool = "+pushArg(f.Tool))
+	}
+	if f.Source != "" {
+		where = append(where, "source = "+pushArg(f.Source))
+	}
+	if f.IsError != nil {
+		where = append(where, "is_error = "+pushArg(*f.IsError))
+	}
+	if f.Since != nil {
+		where = append(where, "started_at >= "+pushArg(*f.Since))
+	}
+	limit := pushArg(f.Limit)
+
+	q := `SELECT id, workspace_id, user_id, source, thread_id, request_id,
+		env_id, tool, arguments, arguments_meta,
+		is_error, result_summary, result_meta,
+		started_at, completed_at, duration_ms,
+		notebook_path, cell_id
+		FROM operations WHERE ` + strings.Join(where, " AND ") +
+		" ORDER BY started_at DESC LIMIT " + limit
+	rows, err := db.Query(q, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Operation
+	for rows.Next() {
+		var o Operation
+		var argsCol, argsMeta, resMeta sql.NullString
+		err := rows.Scan(
+			&o.ID, &o.WorkspaceID, &o.UserID, &o.Source, &o.ThreadID, &o.RequestID,
+			&o.EnvID, &o.Tool, &argsCol, &argsMeta,
+			&o.IsError, &o.ResultSummary, &resMeta,
+			&o.StartedAt, &o.CompletedAt, &o.DurationMs,
+			&o.NotebookPath, &o.CellID,
+		)
+		if err != nil {
+			return nil, err
+		}
+		if argsCol.Valid {
+			o.Arguments = json.RawMessage(argsCol.String)
+		}
+		if argsMeta.Valid {
+			o.ArgumentsMeta = json.RawMessage(argsMeta.String)
+		}
+		if resMeta.Valid {
+			o.ResultMeta = json.RawMessage(resMeta.String)
+		}
+		out = append(out, o)
+	}
+	return out, rows.Err()
+}
+
+// PruneOperationsOlderThan deletes operations whose started_at is strictly
+// before cutoff. Returns the number of rows deleted.
+func (db *DB) PruneOperationsOlderThan(cutoff time.Time) (int64, error) {
+	res, err := db.Exec("DELETE FROM operations WHERE started_at < $1", cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}

--- a/internal/db/operations_test.go
+++ b/internal/db/operations_test.go
@@ -1,0 +1,106 @@
+package db
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+func TestOperationsInsertAndList(t *testing.T) {
+	d := newTestDB(t)
+	t.Cleanup(func() { d.Exec(`DELETE FROM operations WHERE workspace_id = $1`, "ws-1-"+t.Name()) })
+
+	ws := "ws-1-" + t.Name()
+	op := Operation{
+		ID:            uuid.NewString(),
+		WorkspaceID:   ws,
+		UserID:        opPtr("u-1"),
+		Source:        "sdk",
+		ThreadID:      opPtr("th-1"),
+		RequestID:     opPtr("rpc-1"),
+		EnvID:         "alpha",
+		Tool:          "shell",
+		Arguments:     json.RawMessage(`{"command":"ls"}`),
+		IsError:       false,
+		ResultSummary: opPtr("ok"),
+		StartedAt:     time.Now().UTC().Truncate(time.Microsecond),
+		CompletedAt:   time.Now().UTC().Truncate(time.Microsecond),
+		DurationMs:    7,
+	}
+	if err := d.InsertOperation(op); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	rows, err := d.ListOperations(OperationFilter{WorkspaceID: ws, Limit: 10})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	got := rows[0]
+	if got.ID != op.ID || got.EnvID != "alpha" || got.Tool != "shell" {
+		t.Fatalf("got = %+v", got)
+	}
+}
+
+func TestOperationsFilterByEnv(t *testing.T) {
+	d := newTestDB(t)
+	ws := "ws-1-" + t.Name()
+	t.Cleanup(func() { d.Exec(`DELETE FROM operations WHERE workspace_id = $1`, ws) })
+
+	must := func(env string) {
+		err := d.InsertOperation(Operation{
+			ID: uuid.NewString(), WorkspaceID: ws, Source: "sdk",
+			EnvID: env, Tool: "shell", IsError: false,
+			Arguments: json.RawMessage(`{}`),
+			StartedAt: time.Now().UTC(), CompletedAt: time.Now().UTC(),
+			DurationMs: 1,
+		})
+		if err != nil {
+			t.Fatalf("insert(%s): %v", env, err)
+		}
+	}
+	must("alpha")
+	must("alpha")
+	must("beta")
+
+	rows, err := d.ListOperations(OperationFilter{WorkspaceID: ws, EnvID: "alpha", Limit: 10})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("alpha rows = %d, want 2", len(rows))
+	}
+}
+
+func TestOperationsPruneOlderThan(t *testing.T) {
+	d := newTestDB(t)
+	ws := "ws-prune-" + t.Name()
+	t.Cleanup(func() { d.Exec(`DELETE FROM operations WHERE workspace_id = $1`, ws) })
+
+	oldT := time.Now().UTC().Add(-100 * 24 * time.Hour)
+	newT := time.Now().UTC()
+	for _, st := range []time.Time{oldT, newT} {
+		err := d.InsertOperation(Operation{
+			ID: uuid.NewString(), WorkspaceID: ws, Source: "sdk",
+			EnvID: "a", Tool: "shell", IsError: false,
+			Arguments: json.RawMessage(`{}`),
+			StartedAt: st, CompletedAt: st, DurationMs: 1,
+		})
+		if err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+	n, err := d.PruneOperationsOlderThan(time.Now().Add(-90 * 24 * time.Hour))
+	if err != nil {
+		t.Fatalf("prune: %v", err)
+	}
+	if n < 1 {
+		t.Fatalf("pruned = %d, want >= 1", n)
+	}
+}
+
+func opPtr[T any](v T) *T { return &v }

--- a/internal/server/operations.go
+++ b/internal/server/operations.go
@@ -1,0 +1,168 @@
+package server
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/agentserver/agentserver/internal/db"
+)
+
+// postInternalOperations is POST /internal/operations.
+// Body is a JSON object matching the agentserver "operation record" shape.
+// Auth: X-Internal-Secret matching INTERNAL_API_SECRET (enforced by caller in
+// server.go), same pattern as the other /internal/* endpoints.
+//
+// Fire-and-forget from the gateway: returns 204 on insert success. Validation
+// errors return 400; DB errors return 500.
+func (s *Server) postInternalOperations(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		ID            string          `json:"id"`
+		WorkspaceID   string          `json:"workspace_id"`
+		UserID        *string         `json:"user_id,omitempty"`
+		Source        string          `json:"source"`
+		ThreadID      *string         `json:"thread_id,omitempty"`
+		RequestID     *string         `json:"request_id,omitempty"`
+		EnvID         string          `json:"env_id"`
+		Tool          string          `json:"tool"`
+		Arguments     json.RawMessage `json:"arguments,omitempty"`
+		ArgumentsMeta json.RawMessage `json:"arguments_meta,omitempty"`
+		IsError       bool            `json:"is_error"`
+		ResultSummary *string         `json:"result_summary,omitempty"`
+		ResultMeta    json.RawMessage `json:"result_meta,omitempty"`
+		StartedAt     time.Time       `json:"started_at"`
+		CompletedAt   time.Time       `json:"completed_at"`
+		DurationMs    int32           `json:"duration_ms"`
+		NotebookPath  *string         `json:"notebook_path,omitempty"`
+		CellID        *string         `json:"cell_id,omitempty"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+		http.Error(w, "invalid json: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	if body.ID == "" || body.WorkspaceID == "" || body.Source == "" ||
+		body.EnvID == "" || body.Tool == "" {
+		http.Error(w, "missing required fields (id, workspace_id, source, env_id, tool)",
+			http.StatusBadRequest)
+		return
+	}
+	op := db.Operation{
+		ID:            body.ID,
+		WorkspaceID:   body.WorkspaceID,
+		UserID:        body.UserID,
+		Source:        body.Source,
+		ThreadID:      body.ThreadID,
+		RequestID:     body.RequestID,
+		EnvID:         body.EnvID,
+		Tool:          body.Tool,
+		Arguments:     body.Arguments,
+		ArgumentsMeta: body.ArgumentsMeta,
+		IsError:       body.IsError,
+		ResultSummary: body.ResultSummary,
+		ResultMeta:    body.ResultMeta,
+		StartedAt:     body.StartedAt,
+		CompletedAt:   body.CompletedAt,
+		DurationMs:    body.DurationMs,
+		NotebookPath:  body.NotebookPath,
+		CellID:        body.CellID,
+	}
+	if err := s.DB.InsertOperation(op); err != nil {
+		log.Printf("postInternalOperations: insert id=%s ws=%s: %v",
+			op.ID, op.WorkspaceID, err)
+		http.Error(w, "insert failed", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// getInternalOperations is GET /internal/operations.
+// Query params: workspace_id (REQUIRED), env_id, tool, source, is_error,
+// since (RFC3339), id, limit.
+func (s *Server) getInternalOperations(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	wsID := q.Get("workspace_id")
+	if wsID == "" {
+		http.Error(w, "workspace_id required", http.StatusBadRequest)
+		return
+	}
+	f := db.OperationFilter{
+		WorkspaceID: wsID,
+		EnvID:       q.Get("env_id"),
+		Tool:        q.Get("tool"),
+		Source:      q.Get("source"),
+		ID:          q.Get("id"),
+	}
+	if v := q.Get("is_error"); v != "" {
+		b := v == "true" || v == "1"
+		f.IsError = &b
+	}
+	if v := q.Get("since"); v != "" {
+		t, err := time.Parse(time.RFC3339Nano, v)
+		if err != nil {
+			http.Error(w, "since: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		f.Since = &t
+	}
+	if v := q.Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 0 {
+			http.Error(w, "limit: invalid", http.StatusBadRequest)
+			return
+		}
+		f.Limit = n
+	}
+	rows, err := s.DB.ListOperations(f)
+	if err != nil {
+		log.Printf("getInternalOperations: list ws=%s: %v", wsID, err)
+		http.Error(w, "list failed", http.StatusInternalServerError)
+		return
+	}
+	type respRow struct {
+		ID            string          `json:"id"`
+		WorkspaceID   string          `json:"workspace_id"`
+		UserID        *string         `json:"user_id,omitempty"`
+		Source        string          `json:"source"`
+		ThreadID      *string         `json:"thread_id,omitempty"`
+		RequestID     *string         `json:"request_id,omitempty"`
+		EnvID         string          `json:"env_id"`
+		Tool          string          `json:"tool"`
+		Arguments     json.RawMessage `json:"arguments,omitempty"`
+		ArgumentsMeta json.RawMessage `json:"arguments_meta,omitempty"`
+		IsError       bool            `json:"is_error"`
+		ResultSummary *string         `json:"result_summary,omitempty"`
+		ResultMeta    json.RawMessage `json:"result_meta,omitempty"`
+		StartedAt     time.Time       `json:"started_at"`
+		CompletedAt   time.Time       `json:"completed_at"`
+		DurationMs    int32           `json:"duration_ms"`
+		NotebookPath  *string         `json:"notebook_path,omitempty"`
+		CellID        *string         `json:"cell_id,omitempty"`
+	}
+	out := make([]respRow, 0, len(rows))
+	for _, o := range rows {
+		out = append(out, respRow{
+			ID:            o.ID,
+			WorkspaceID:   o.WorkspaceID,
+			UserID:        o.UserID,
+			Source:        o.Source,
+			ThreadID:      o.ThreadID,
+			RequestID:     o.RequestID,
+			EnvID:         o.EnvID,
+			Tool:          o.Tool,
+			Arguments:     o.Arguments,
+			ArgumentsMeta: o.ArgumentsMeta,
+			IsError:       o.IsError,
+			ResultSummary: o.ResultSummary,
+			ResultMeta:    o.ResultMeta,
+			StartedAt:     o.StartedAt,
+			CompletedAt:   o.CompletedAt,
+			DurationMs:    o.DurationMs,
+			NotebookPath:  o.NotebookPath,
+			CellID:        o.CellID,
+		})
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{"operations": out})
+}

--- a/internal/server/operations_retention.go
+++ b/internal/server/operations_retention.go
@@ -1,0 +1,52 @@
+package server
+
+import (
+	"context"
+	"log"
+	"time"
+)
+
+// runRetentionOnce deletes operations older than ttl. Exposed for tests
+// and for an admin "prune now" code path if needed later.
+func (s *Server) runRetentionOnce(ttl time.Duration) (int64, error) {
+	cutoff := time.Now().Add(-ttl)
+	return s.DB.PruneOperationsOlderThan(cutoff)
+}
+
+// StartRetentionLoop is the exported entry point for the server's main
+// lifecycle to launch the retention loop in a goroutine.
+func (s *Server) StartRetentionLoop(ctx context.Context, ttl time.Duration, every time.Duration) {
+	s.startRetentionLoop(ctx, ttl, every)
+}
+
+// startRetentionLoop ticks every `every` and prunes operations older
+// than ttl. Returns when ctx is cancelled. Errors are logged, not
+// propagated — a transient PG failure shouldn't kill the loop.
+//
+// ttl <= 0 disables the loop (returns immediately).
+func (s *Server) startRetentionLoop(ctx context.Context, ttl time.Duration, every time.Duration) {
+	if ttl <= 0 {
+		return
+	}
+	if every <= 0 {
+		every = time.Hour
+	}
+	log.Printf("operations retention loop: ttl=%s interval=%s", ttl, every)
+	t := time.NewTicker(every)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			n, err := s.runRetentionOnce(ttl)
+			if err != nil {
+				log.Printf("operations retention: prune failed: %v", err)
+				continue
+			}
+			if n > 0 {
+				log.Printf("operations retention: pruned %d rows older than %s", n, ttl)
+			}
+		}
+	}
+}

--- a/internal/server/operations_retention_test.go
+++ b/internal/server/operations_retention_test.go
@@ -1,0 +1,91 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/agentserver/agentserver/internal/db"
+)
+
+func TestStartRetention_DeletesOldRows(t *testing.T) {
+	s, cleanup := newTestServerTUI(t, "")
+	defer cleanup()
+
+	// Seed: 1 old + 1 new
+	ws := "ws-retention-" + t.Name()
+	old := time.Now().UTC().Add(-100 * 24 * time.Hour)
+	now := time.Now().UTC()
+	for _, ts := range []time.Time{old, now} {
+		err := s.DB.InsertOperation(db.Operation{
+			ID: uuid.NewString(), WorkspaceID: ws, Source: "sdk",
+			EnvID: "a", Tool: "shell", IsError: false,
+			Arguments: json.RawMessage(`{}`),
+			StartedAt: ts, CompletedAt: ts, DurationMs: 1,
+		})
+		if err != nil {
+			t.Fatalf("seed: %v", err)
+		}
+	}
+	t.Cleanup(func() {
+		_, _ = s.DB.Exec("DELETE FROM operations WHERE workspace_id = $1", ws)
+	})
+
+	n, err := s.runRetentionOnce(90 * 24 * time.Hour)
+	if err != nil {
+		t.Fatalf("retention: %v", err)
+	}
+	if n < 1 {
+		t.Fatalf("deleted = %d, want >= 1", n)
+	}
+
+	// Newer row survives
+	rows, err := s.DB.ListOperations(db.OperationFilter{WorkspaceID: ws, Limit: 10})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("remaining = %d, want 1", len(rows))
+	}
+}
+
+func TestStartRetention_TickerStops(t *testing.T) {
+	s, cleanup := newTestServerTUI(t, "")
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		s.startRetentionLoop(ctx, 90*24*time.Hour, 50*time.Millisecond)
+		close(done)
+	}()
+	time.Sleep(150 * time.Millisecond)
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("retention loop did not exit after ctx cancel")
+	}
+}
+
+func TestStartRetention_ZeroTTLDisables(t *testing.T) {
+	s, cleanup := newTestServerTUI(t, "")
+	defer cleanup()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// With ttl=0 the loop returns immediately
+	done := make(chan struct{})
+	go func() {
+		s.startRetentionLoop(ctx, 0, 50*time.Millisecond)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("zero TTL should disable the loop and return immediately")
+	}
+}

--- a/internal/server/operations_test.go
+++ b/internal/server/operations_test.go
@@ -1,0 +1,174 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/google/uuid"
+
+	"github.com/agentserver/agentserver/internal/db"
+)
+
+// operationsRouter wires the /internal/operations routes with the same
+// X-Internal-Secret check used in production (server.go), so tests cover
+// both the auth gate and the handler bodies.
+func operationsRouter(s *Server) *chi.Mux {
+	r := chi.NewRouter()
+	r.Post("/internal/operations", func(w http.ResponseWriter, req *http.Request) {
+		secret := os.Getenv("INTERNAL_API_SECRET")
+		if secret != "" {
+			if req.Header.Get("X-Internal-Secret") != secret {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+		}
+		s.postInternalOperations(w, req)
+	})
+	r.Get("/internal/operations", func(w http.ResponseWriter, req *http.Request) {
+		secret := os.Getenv("INTERNAL_API_SECRET")
+		if secret != "" {
+			if req.Header.Get("X-Internal-Secret") != secret {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+		}
+		s.getInternalOperations(w, req)
+	})
+	return r
+}
+
+func TestPostInternalOperations_Unauthorized(t *testing.T) {
+	os.Setenv("INTERNAL_API_SECRET", "opsecret")
+	defer os.Unsetenv("INTERNAL_API_SECRET")
+
+	s := &Server{}
+	req := httptest.NewRequest(http.MethodPost, "/internal/operations",
+		bytes.NewReader([]byte(`{}`)))
+	// no X-Internal-Secret header
+	rr := httptest.NewRecorder()
+	operationsRouter(s).ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status %d, want 401", rr.Code)
+	}
+}
+
+func TestGetInternalOperations_RequiresWorkspaceID(t *testing.T) {
+	// No INTERNAL_API_SECRET set, so auth is bypassed; handler must still
+	// reject missing workspace_id with 400.
+	s := &Server{}
+	req := httptest.NewRequest(http.MethodGet, "/internal/operations", nil)
+	rr := httptest.NewRecorder()
+	operationsRouter(s).ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status %d, want 400", rr.Code)
+	}
+}
+
+func TestPostInternalOperations_WritesRow(t *testing.T) {
+	s, cleanup := newTestServerTUI(t, "")
+	defer cleanup()
+
+	id := uuid.NewString()
+	ws := "ws_post_" + t.Name()
+	now := time.Now().UTC()
+	body := map[string]any{
+		"id":             id,
+		"workspace_id":   ws,
+		"source":         "sdk",
+		"env_id":         "alpha",
+		"tool":           "shell",
+		"arguments":      map[string]any{"command": "ls"},
+		"is_error":       false,
+		"result_summary": "ok",
+		"started_at":     now.Format(time.RFC3339Nano),
+		"completed_at":   now.Add(8 * time.Millisecond).Format(time.RFC3339Nano),
+		"duration_ms":    8,
+	}
+	t.Cleanup(func() {
+		s.DB.Exec(`DELETE FROM operations WHERE workspace_id=$1`, ws)
+	})
+
+	buf, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/internal/operations",
+		bytes.NewReader(buf))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	operationsRouter(s).ServeHTTP(rr, req)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	// Verify the row landed by listing it back.
+	rows, err := s.DB.ListOperations(db.OperationFilter{WorkspaceID: ws})
+	if err != nil {
+		t.Fatalf("ListOperations: %v", err)
+	}
+	if len(rows) != 1 || rows[0].ID != id {
+		t.Fatalf("rows = %+v, want 1 with id=%s", rows, id)
+	}
+}
+
+func TestGetInternalOperations_FiltersByWorkspaceAndTool(t *testing.T) {
+	s, cleanup := newTestServerTUI(t, "")
+	defer cleanup()
+
+	ws := "ws_get_a_" + t.Name()
+	other := "ws_get_b_" + t.Name()
+	t.Cleanup(func() {
+		s.DB.Exec(`DELETE FROM operations WHERE workspace_id IN ($1,$2)`, ws, other)
+	})
+
+	post := func(wsID, env, tool string) {
+		now := time.Now().UTC()
+		body := map[string]any{
+			"id":           uuid.NewString(),
+			"workspace_id": wsID,
+			"source":       "sdk",
+			"env_id":       env,
+			"tool":         tool,
+			"arguments":    map[string]any{},
+			"is_error":     false,
+			"started_at":   now.Format(time.RFC3339Nano),
+			"completed_at": now.Format(time.RFC3339Nano),
+			"duration_ms":  1,
+		}
+		buf, _ := json.Marshal(body)
+		req := httptest.NewRequest(http.MethodPost, "/internal/operations",
+			bytes.NewReader(buf))
+		req.Header.Set("Content-Type", "application/json")
+		rr := httptest.NewRecorder()
+		operationsRouter(s).ServeHTTP(rr, req)
+		if rr.Code != http.StatusNoContent {
+			t.Fatalf("post: %d %s", rr.Code, rr.Body.String())
+		}
+	}
+	post(ws, "alpha", "shell")
+	post(ws, "alpha", "read_file")
+	post(other, "alpha", "shell")
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/internal/operations?workspace_id="+ws+"&tool=shell&limit=50", nil)
+	rr := httptest.NewRecorder()
+	operationsRouter(s).ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("get: %d %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		Operations []map[string]any `json:"operations"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(resp.Operations) != 1 {
+		t.Fatalf("rows = %d, want 1; body=%s", len(resp.Operations), rr.Body.String())
+	}
+	if resp.Operations[0]["workspace_id"] != ws || resp.Operations[0]["tool"] != "shell" {
+		t.Fatalf("row = %+v", resp.Operations[0])
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -86,6 +86,11 @@ type Server struct {
 	ExecutorsClient            *ExecutorsClient
 	CodexExecGatewayPublicHost string // e.g. "codex-exec.example.com" — used to compose connect commands
 
+	// OperationsRetention is the TTL for rows in the operations table.
+	// 0 disables the background retention loop. Configurable via
+	// AGENTSERVER_OPERATIONS_RETENTION_DAYS (default 90).
+	OperationsRetention time.Duration
+
 	// In-memory pending device code flows (OIDC credential creation).
 	deviceFlows   map[string]*pendingDeviceFlow
 	deviceFlowsMu sync.Mutex

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -210,6 +210,29 @@ func (s *Server) Router() http.Handler {
 	// Internal callback from cc-broker when a turn finishes (T19).
 	r.Post("/internal/sessions/{sid}/turn-finished", s.handleTurnFinished)
 
+	// Internal operation-log endpoints — POST from gateways (fire-and-forget),
+	// GET for SDK retrieval. Auth: X-Internal-Secret matching INTERNAL_API_SECRET.
+	r.Post("/internal/operations", func(w http.ResponseWriter, r *http.Request) {
+		secret := os.Getenv("INTERNAL_API_SECRET")
+		if secret != "" {
+			if r.Header.Get("X-Internal-Secret") != secret {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+		}
+		s.postInternalOperations(w, r)
+	})
+	r.Get("/internal/operations", func(w http.ResponseWriter, r *http.Request) {
+		secret := os.Getenv("INTERNAL_API_SECRET")
+		if secret != "" {
+			if r.Header.Get("X-Internal-Secret") != secret {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+		}
+		s.getInternalOperations(w, r)
+	})
+
 	// IM bridge routes: proxy to standalone imbridge service when configured.
 	if s.IMBridgeURL != "" {
 		imbridgeProxy := newReverseProxy(s.IMBridgeURL)

--- a/internal/wsbridge/wsbridge.go
+++ b/internal/wsbridge/wsbridge.go
@@ -5,6 +5,7 @@
 package wsbridge
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -79,6 +80,80 @@ func KeepAlive(ctx context.Context, conn *websocket.Conn, interval time.Duration
 // Returns nil when src closes cleanly; otherwise the underlying error.
 func PumpFrames(ctx context.Context, src, dst *websocket.Conn) error {
 	return pump(ctx, src, dst, nil)
+}
+
+// DropFrame is returned by an Interceptor callback to indicate the frame
+// should NOT be forwarded downstream. Distinct from returning nil
+// (forward unchanged) and from returning a rewritten slice (forward
+// replacement).
+var DropFrame = []byte("__wsbridge_drop_frame__")
+
+// Interceptor lets a caller observe and optionally rewrite frames as
+// they cross the bridge. Both callbacks may be nil. Returning a non-nil
+// slice replaces the frame written downstream; returning nil forwards
+// the original frame untouched. Return DropFrame to swallow the frame
+// entirely. Callbacks MUST NOT block.
+type Interceptor struct {
+	OnClientFrame func(frame []byte) []byte // a → b direction
+	OnServerFrame func(frame []byte) []byte // b → a direction
+}
+
+// RunProxyWithInterceptor is like RunProxy but lets the caller observe
+// and rewrite frames per direction. `onFrame` is invoked on every
+// successfully forwarded frame (pass nil to skip).
+func RunProxyWithInterceptor(ctx context.Context, a, b *websocket.Conn, intc Interceptor, onFrame func()) error {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	errCh := make(chan error, 2)
+	go func() { errCh <- pumpWithIntercept(ctx, a, b, intc.OnClientFrame, onFrame) }()
+	go func() { errCh <- pumpWithIntercept(ctx, b, a, intc.OnServerFrame, onFrame) }()
+	go keepAlive(ctx, a)
+	err := <-errCh
+	cancel()
+	<-errCh
+	if errors.Is(err, context.Canceled) {
+		return nil
+	}
+	return err
+}
+
+func pumpWithIntercept(
+	ctx context.Context,
+	src, dst *websocket.Conn,
+	onFrameBytes func([]byte) []byte,
+	onTick func(),
+) error {
+	for {
+		mt, data, err := src.Read(ctx)
+		if err != nil {
+			closeErr := websocket.CloseStatus(err)
+			if closeErr == websocket.StatusNormalClosure || closeErr == websocket.StatusGoingAway {
+				return nil
+			}
+			if errors.Is(err, io.EOF) || errors.Is(err, context.Canceled) {
+				return nil
+			}
+			return err
+		}
+		out := data
+		if onFrameBytes != nil {
+			if rewritten := onFrameBytes(data); rewritten != nil {
+				if bytes.Equal(rewritten, DropFrame) {
+					if onTick != nil {
+						onTick()
+					}
+					continue
+				}
+				out = rewritten
+			}
+		}
+		if onTick != nil {
+			onTick()
+		}
+		if err := dst.Write(ctx, mt, out); err != nil {
+			return err
+		}
+	}
 }
 
 func pump(ctx context.Context, src, dst *websocket.Conn, onFrame func()) error {

--- a/internal/wsbridge/wsbridge_test.go
+++ b/internal/wsbridge/wsbridge_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -183,4 +184,219 @@ func TestPumpFrames_PreservesTextAndBinary(t *testing.T) {
 
 	cliA.Close(websocket.StatusNormalClosure, "")
 	cliB.Close(websocket.StatusNormalClosure, "")
+}
+
+// newWSPair returns two server-side websocket conns. They are the
+// "bridge ends" the tests pass to RunProxyWithInterceptor. The
+// corresponding client-side dial conns are stashed and the
+// writeText/readText helpers route through them automatically by
+// looking up the pair in pairRegistry.
+//
+// Why two ends rather than one conn-pair: RunProxyWithInterceptor
+// reads from `a`, writes to `b`, and vice versa. To exercise that, the
+// test must inject a frame into `a` from the "other side" (so the
+// pump's Read on `a` returns it) and observe a forwarded frame out the
+// other side of `b`. That requires four endpoints: a-server (bridge),
+// a-client (test), b-server (bridge), b-client (test).
+func newWSPair(t *testing.T) (*websocket.Conn, *websocket.Conn) {
+	t.Helper()
+	srvCh := func() (*httptest.Server, chan *websocket.Conn) {
+		ch := make(chan *websocket.Conn, 1)
+		hs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ws, err := websocket.Accept(w, r, nil)
+			if err != nil {
+				return
+			}
+			ch <- ws
+			<-r.Context().Done()
+		}))
+		return hs, ch
+	}
+	hsA, chA := srvCh()
+	t.Cleanup(hsA.Close)
+	hsB, chB := srvCh()
+	t.Cleanup(hsB.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	cliA, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(hsA.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial A: %v", err)
+	}
+	cliB, _, err := websocket.Dial(ctx, "ws"+strings.TrimPrefix(hsB.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial B: %v", err)
+	}
+	srvA := <-chA
+	srvB := <-chB
+	t.Cleanup(func() {
+		cliA.Close(websocket.StatusNormalClosure, "")
+		cliB.Close(websocket.StatusNormalClosure, "")
+	})
+	// Register the client-side counterparts so writeText/readText can
+	// find them when given the server-side conns.
+	pairRegistry.Lock()
+	if pairRegistry.m == nil {
+		pairRegistry.m = map[*websocket.Conn]*websocket.Conn{}
+	}
+	pairRegistry.m[srvA] = cliA
+	pairRegistry.m[srvB] = cliB
+	pairRegistry.Unlock()
+	t.Cleanup(func() {
+		pairRegistry.Lock()
+		delete(pairRegistry.m, srvA)
+		delete(pairRegistry.m, srvB)
+		pairRegistry.Unlock()
+	})
+	return srvA, srvB
+}
+
+// pairRegistry maps a bridge-side conn to its client-side counterpart
+// so writeText/readText can route a "write on a" → "actually write on
+// the client end of a so the bridge reads it" without changing the
+// test surface.
+var pairRegistry = struct {
+	sync.Mutex
+	m map[*websocket.Conn]*websocket.Conn
+}{}
+
+func pairOf(c *websocket.Conn) *websocket.Conn {
+	pairRegistry.Lock()
+	defer pairRegistry.Unlock()
+	if peer, ok := pairRegistry.m[c]; ok {
+		return peer
+	}
+	return c
+}
+
+// writeText writes a text frame "to c" — but actually writes on c's
+// client-side peer so the bridge reading from c receives it.
+func writeText(c *websocket.Conn, s string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	return pairOf(c).Write(ctx, websocket.MessageText, []byte(s))
+}
+
+// readText reads a text frame "from c" — but actually reads on c's
+// client-side peer so it observes what the bridge wrote to c.
+func readText(t *testing.T, c *websocket.Conn) string {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	mt, data, err := pairOf(c).Read(ctx)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if mt != websocket.MessageText {
+		t.Fatalf("expected text frame, got %v", mt)
+	}
+	return string(data)
+}
+
+func TestRunProxyWithInterceptor_CallbacksAndRewrite(t *testing.T) {
+	a, b := newWSPair(t)
+	defer a.Close(websocket.StatusNormalClosure, "")
+	defer b.Close(websocket.StatusNormalClosure, "")
+
+	var (
+		ctc, stc [][]byte
+		mu       sync.Mutex
+	)
+	intc := wsbridge.Interceptor{
+		OnClientFrame: func(frame []byte) []byte {
+			mu.Lock()
+			defer mu.Unlock()
+			ctc = append(ctc, append([]byte(nil), frame...))
+			return nil
+		},
+		OnServerFrame: func(frame []byte) []byte {
+			mu.Lock()
+			defer mu.Unlock()
+			stc = append(stc, append([]byte(nil), frame...))
+			if string(frame) == "swap-me" {
+				return []byte(`{"intercepted":true}`)
+			}
+			return nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go wsbridge.RunProxyWithInterceptor(ctx, a, b, intc, nil)
+
+	if err := writeText(a, "hello-server"); err != nil {
+		t.Fatal(err)
+	}
+	if got := readText(t, b); got != "hello-server" {
+		t.Fatalf("server got %q", got)
+	}
+
+	if err := writeText(b, "swap-me"); err != nil {
+		t.Fatal(err)
+	}
+	if got := readText(t, a); got != `{"intercepted":true}` {
+		t.Fatalf("client got %q", got)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(ctc) != 1 || string(ctc[0]) != "hello-server" {
+		t.Fatalf("ctc=%q", ctc)
+	}
+	if len(stc) != 1 || string(stc[0]) != "swap-me" {
+		t.Fatalf("stc=%q", stc)
+	}
+}
+
+func TestRunProxyWithInterceptor_DropFrameSwallows(t *testing.T) {
+	a, b := newWSPair(t)
+	defer a.Close(websocket.StatusNormalClosure, "")
+	defer b.Close(websocket.StatusNormalClosure, "")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go wsbridge.RunProxyWithInterceptor(ctx, a, b, wsbridge.Interceptor{
+		OnClientFrame: func(frame []byte) []byte {
+			if string(frame) == "drop-me" {
+				return wsbridge.DropFrame
+			}
+			return nil
+		},
+	}, nil)
+
+	if err := writeText(a, "drop-me"); err != nil {
+		t.Fatal(err)
+	}
+	// b must not receive the dropped frame within a window. Read on b's
+	// client-side peer; the bridge's write-out of b is what we'd see.
+	bctx, bcancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+	defer bcancel()
+	_, _, err := pairOf(b).Read(bctx)
+	if err == nil {
+		t.Fatal("b should not have received the dropped frame")
+	}
+}
+
+func TestRunProxyWithInterceptor_NilCallbacksForwardUnchanged(t *testing.T) {
+	a, b := newWSPair(t)
+	defer a.Close(websocket.StatusNormalClosure, "")
+	defer b.Close(websocket.StatusNormalClosure, "")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	// All-nil interceptor — should behave exactly like RunProxy
+	go wsbridge.RunProxyWithInterceptor(ctx, a, b, wsbridge.Interceptor{}, nil)
+
+	if err := writeText(a, "ping"); err != nil {
+		t.Fatal(err)
+	}
+	if got := readText(t, b); got != "ping" {
+		t.Fatalf("got %q", got)
+	}
+	if err := writeText(b, "pong"); err != nil {
+		t.Fatal(err)
+	}
+	if got := readText(t, a); got != "pong" {
+		t.Fatalf("got %q", got)
+	}
 }

--- a/notebook/README.md
+++ b/notebook/README.md
@@ -1,0 +1,65 @@
+# Notebook image (Plan 1)
+
+`Dockerfile.notebook` at repo root builds a self-contained jupyter image
+with `agentserver_sdk` pre-installed. `ctx` is auto-injected into every
+kernel via `ipython_startup/00-ctx.py`.
+
+## Build
+
+```bash
+docker build -f Dockerfile.notebook -t agentserver-notebook:dev .
+```
+
+## Run (against a stub gateway)
+
+See `docker-compose.smoke.yml`:
+
+```bash
+docker compose -f notebook/docker-compose.smoke.yml up --build
+```
+
+Then open <http://localhost:8888/lab>. In a new notebook:
+
+```python
+envs = await ctx.envs()
+envs   # rendered as table thanks to _repr_html_
+```
+
+## Env vars consumed by `ctx = Ctx.from_env()`
+
+| var | default | purpose |
+|---|---|---|
+| `AGENTSERVER_GATEWAY_URL` | `ws://localhost:8086/notebook/ws` | WS endpoint |
+| `AGENTSERVER_WORKSPACE_TOKEN` | (empty) | Bearer for gateway |
+| `AGENTSERVER_WORKSPACE_ID` | (empty) | workspace key |
+| `AGENTSERVER_USER_ID` | (empty) | attribution only |
+
+## Smoke walkthrough (4 cells)
+
+Once `docker compose -f notebook/docker-compose.smoke.yml up --build` is
+running and you've opened <http://localhost:8888/lab>:
+
+```python
+# Cell 1 — list envs
+envs = await ctx.envs()
+envs
+
+# Cell 2 — typed shell
+alpha = await ctx.env("alpha")
+await alpha.shell("hi")
+
+# Cell 3 — dynamic dispatch (custom HPC tool)
+hpc = await ctx.env("hpc")
+await hpc.submit_task(script="x")
+
+# Cell 4 — operations history
+await ctx.history(limit=5)
+# stub returns 2 fake records; real backend returns rows from the
+# operations table written by every previous SDK call (Plan 2).
+```
+
+Tear down:
+
+```bash
+docker compose -f notebook/docker-compose.smoke.yml down -v
+```

--- a/notebook/stub_gateway_runner.py
+++ b/notebook/stub_gateway_runner.py
@@ -1,0 +1,99 @@
+"""Run the test stub gateway as a long-lived process for local smoke.
+
+Listens on 0.0.0.0:8086. Responds to:
+  - initialize / initialized (no-op)
+  - thread/start -> fake thread id
+  - envs/list -> two fake envs
+  - env/capabilities -> tools per env
+  - mcpServer/tool/call -> for `shell`, returns the command back as stdout
+  - operations/list -> 2 synthetic records (smoke walkthrough Cell 4)
+"""
+from __future__ import annotations
+
+import asyncio
+import datetime
+import json
+import os
+import sys
+import uuid
+
+import websockets
+
+# The compose file mounts sdk/python/tests/stub_gateway.py next to this
+# runner at /app, so /app is on sys.path already (cwd). Keep the explicit
+# insert so the script also works when invoked from elsewhere.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from stub_gateway import StubGateway  # noqa: E402
+
+
+async def main() -> None:
+    g = StubGateway()
+
+    g.on("envs/list", lambda p: {"envs": [
+        {"name": "alpha", "type": "shell"},
+        {"name": "hpc",   "type": "hpc"},
+    ]})
+
+    def caps(p):
+        env_id = p["env_id"]
+        if env_id == "alpha":
+            return {"tools": [
+                {"name": "shell",     "description": "run sh", "inputSchema": {}},
+                {"name": "read_file", "description": "read",   "inputSchema": {}},
+            ]}
+        return {"tools": [
+            {"name": "shell",       "description": "run sh",     "inputSchema": {}},
+            {"name": "submit_task", "description": "submit HPC", "inputSchema": {}},
+        ]}
+    g.on("env/capabilities", caps)
+
+    def tool_call(p):
+        if p["tool"] == "shell":
+            cmd = p["arguments"]["command"]
+            return {
+                "content": [{"type": "text", "text": cmd}],
+                "structuredContent": {"stdout": f"stub ran: {cmd}", "stderr": "", "exit_code": 0},
+                "isError": False,
+            }
+        return {"content": [{"type": "text", "text": f"stub: {p['tool']}"}], "isError": False}
+    g.on("mcpServer/tool/call", tool_call)
+
+    def operations_list(p):
+        now = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        return {"operations": [
+            {"id": str(uuid.uuid4()), "env_id": "alpha", "tool": "shell",
+             "is_error": False, "started_at": now, "duration_ms": 7,
+             "source": "sdk", "user_id": "smoke-user"},
+            {"id": str(uuid.uuid4()), "env_id": "hpc", "tool": "submit_task",
+             "is_error": False, "started_at": now, "duration_ms": 320,
+             "source": "sdk", "user_id": "smoke-user"},
+        ]}
+    g.on("operations/list", operations_list)
+
+    async def handle(ws):
+        async for raw in ws:
+            msg = json.loads(raw)
+            g.received.append(msg)
+            mid = msg.get("id")
+            method = msg.get("method")
+            if mid is None:
+                continue
+            h = g._handlers.get(method)
+            if h is None:
+                resp = {"jsonrpc": "2.0", "id": mid,
+                        "error": {"code": -32601, "message": f"Method not found: {method}"}}
+            else:
+                out = h(msg.get("params", {}) or {})
+                if isinstance(out, dict) and "error" in out and "code" in out["error"]:
+                    resp = {"jsonrpc": "2.0", "id": mid, "error": out["error"]}
+                else:
+                    resp = {"jsonrpc": "2.0", "id": mid, "result": out}
+            await ws.send(json.dumps(resp))
+
+    server = await websockets.serve(handle, "0.0.0.0", 8086)
+    print("stub-gateway listening on ws://0.0.0.0:8086", flush=True)
+    await server.wait_closed()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

Plan 2 of the Python env SDK design ([spec § 7](docs/superpowers/specs/2026-05-18-python-env-sdk-design.md) / [plan](docs/superpowers/plans/2026-05-18-operation-log.md)). Adds append-only operation log for every \`mcpServer/tool/call\` going through \`codex-app-gateway\`.

End-to-end flow:
- Every SDK / TUI call → gateway intercepts → fire-and-forget POST to agentserver \`/internal/operations\` → PG row
- \`await ctx.history(...)\` from SDK → \`operations/list\` JSON-RPC → gateway intercepts → agentserver \`GET /internal/operations\` → response routed back over WS without ever reaching codex
- Hourly retention loop on agentserver prunes rows older than configurable TTL (default 90d)

## What's in scope

- **`operations` PG table** + DB layer (migration 023, Insert/List/Prune)
- **agentserver `/internal/operations` POST + GET** behind \`X-Internal-Secret\` (existing repo convention; spec said "Bearer" but actual pattern is header-based)
- **Hourly retention loop** in agentserver (\`AGENTSERVER_OPERATIONS_RETENTION_DAYS\`, default 90, 0 disables)
- **\`oplog\` package** in codex-app-gateway:
  - async \`Client\` with bounded channel (default 1024), drop+metric on overflow
  - \`Interceptor\` parsing JSON-RPC frames, pending-map pairs request+response, payload truncation (64KiB args / 4KiB result with sha256+size meta)
  - \`TryHandleOperationsList\` intercepts SDK \`operations/list\` requests
- **\`wsbridge.RunProxyWithInterceptor\`** new variant + \`DropFrame\` sentinel
- **Gateway \`/notebook/ws\`** new route (source=\"sdk\") next to existing \`/codex-app/ws\` (untouched, source=\"tui\")
- **Helm wiring**: \`operations.{enabled,retentionDays,channelCapacity}\` values + \`CXG_OPLOG_{URL,SECRET,CHAN}\` env vars on the gateway + retention env on agentserver
- **\`notebook/\` smoke stub** updated to return 2 synthetic operations so \`ctx.history()\` shows non-empty in the walkthrough

## What's NOT in scope

- Web UI \`<OperationsPanel />\` (Plan 3)
- LLM-initiated tool call logging (v1.5 — env-mcp emits records via same endpoint)
- Cell/notebook attribution (\`notebook_path\`, \`cell_id\` schema columns landed, kept NULL for v1)
- Per-workspace retention overrides (global default for now)

## Branch coupling note

\`notebook/stub_gateway_runner.py\` and \`notebook/README.md\` are created as NEW files on this branch because Plan 1 (#83) hasn't merged yet. When both merge sequentially, the second merger needs to resolve the trivial conflict on those two files (take the Plan 2 version — it's strictly additive on top of Plan 1).

## Findings caught by review loops

1. **\`operations/list\` synthetic response was swallowing Write errors** (caught in final review) → fixed with explicit \`s.logger.Warn\` so production failures are observable
2. **Auth pattern was \`X-Internal-Secret\` not Bearer** (caught in P2.2 spec review) → plan adjusted, propagated to P2.4 + P2.9
3. **\`newWSPair\` test helper needed 4 endpoints not 2** (caught in P2.7 implementer) → \`pairRegistry\` helper routes write/read through client-side peers

## Test plan

- [x] \`go test ./internal/db ./internal/server ./internal/wsbridge ./internal/codexappgateway/... ./cmd/codex-app-gateway -count=1\` — all 10 packages pass
- [x] \`go vet ./...\` clean
- [x] \`helm lint deploy/helm/agentserver\` — 1 chart linted, 0 failed
- [x] \`helm template deploy/helm/agentserver | grep -B1 -A2 'CXG_OPLOG\|AGENTSERVER_OPERATIONS'\` — renders expected env vars
- [ ] **DB integration tests**: gated on \`TEST_DATABASE_URL\` (skip-clean locally; CI must set it to exercise insert/list/prune end-to-end)
- [ ] **End-to-end against real env-mcp**: Plan 3 follow-up
- [ ] **Web UI Operations panel**: Plan 3 follow-up

## Known follow-ups (non-blocking)

- \`DropFrame\` byte-sentinel is brittle; refactor to typed \`(out []byte, drop bool)\` return if a second Interceptor caller appears
- \`Interceptor.pending\` map has no upper bound (per-ws lifetime caps it in practice); add a TTL sweep if seen growing
- Retention loop's first prune is delayed by interval (1h); could add an immediate run on boot
- POST \`/internal/operations\` has no \`http.MaxBytesReader\` — bounded by gateway being only caller behind internal secret, but defense-in-depth would be a one-liner

🤖 Generated with [Claude Code](https://claude.com/claude-code)