### PR TITLE
chore(server): GET /api/workspaces/{id}/operations follow-up

### DIFF
--- a/internal/server/operations.go
+++ b/internal/server/operations.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/go-chi/chi/v5"
+
 	"github.com/agentserver/agentserver/internal/db"
 )
 
@@ -165,4 +167,25 @@ func (s *Server) getInternalOperations(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(map[string]any{"operations": out})
+}
+
+// getWorkspaceOperations is GET /api/workspaces/{id}/operations.
+// User-session authed via the existing chi protected group; workspace
+// membership enforced. Filter query params are the same as
+// getInternalOperations; workspace_id is forced from the URL so a
+// caller can't query a workspace they're not a member of.
+func (s *Server) getWorkspaceOperations(w http.ResponseWriter, r *http.Request) {
+	wsID := chi.URLParam(r, "id")
+	if wsID == "" {
+		http.Error(w, "workspace id required", http.StatusBadRequest)
+		return
+	}
+	if _, ok := s.requireWorkspaceMember(w, r, wsID); !ok {
+		return // requireWorkspaceMember has already written the response
+	}
+	// Force workspace_id from the URL; ignore any user-supplied query value.
+	q := r.URL.Query()
+	q.Set("workspace_id", wsID)
+	r.URL.RawQuery = q.Encode()
+	s.getInternalOperations(w, r)
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -369,6 +369,9 @@ func (s *Server) Router() http.Handler {
 		r.Put("/api/workspaces/{id}/members/{userId}", s.handleUpdateMemberRole)
 		r.Delete("/api/workspaces/{id}/members/{userId}", s.handleRemoveMember)
 
+		// Workspace operations log (read-only, member-gated, wraps /internal/operations)
+		r.Get("/api/workspaces/{id}/operations", s.getWorkspaceOperations)
+
 		// Workspace LLM quota (read-only for members)
 		r.Get("/api/workspaces/{id}/llm-quota", s.handleGetWorkspaceLLMQuota)
 


### PR DESCRIPTION
Follow-up flagged in #88 (Plan 3c): the OperationsPanel React component calls \`GET /api/workspaces/{id}/operations\` but the endpoint didn't exist (only the internal-secret \`/internal/operations\` from #84).

This adds a thin user-facing wrapper:

- \`internal/server/operations.go\` — new \`getWorkspaceOperations\` handler that runs \`s.requireWorkspaceMember\` (existing helper), forces \`workspace_id\` from the URL path (prevents cross-workspace reads via query param manipulation), then delegates to \`getInternalOperations\`
- \`internal/server/server.go\` — register the route inside the existing protected group, next to the workspace member routes

26 lines added.

## Test plan

- [x] \`go vet ./... && go build ./... && go test ./internal/server\` clean
- [ ] Manual: create a workspace, add an operation via the gateway oplog, hit \`GET /api/workspaces/{ws}/operations\`, expect 200 + JSON list
- [ ] Manual: hit the same URL as a non-member, expect 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)