### PR TITLE
chore(helm,ci): bump chart to 0.57.0 + build-notebook job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -469,9 +469,44 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  build-notebook:
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v6
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/agentserver/agentserver-notebook
+          tags: |
+            type=sha,prefix=
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile.notebook
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   publish-helm:
     runs-on: ubuntu-latest
-    needs: [build-server, build-opencode, build-llmproxy, build-imbridge, build-cc-broker, build-executor-registry, build-credentialproxy, build-sandboxproxy, build-nanoclaw, build-claudecode, build-codex-app-gateway, build-codex-exec-gateway]
+    needs: [build-server, build-opencode, build-llmproxy, build-imbridge, build-cc-broker, build-executor-registry, build-credentialproxy, build-sandboxproxy, build-nanoclaw, build-claudecode, build-codex-app-gateway, build-codex-exec-gateway, build-notebook]
     steps:
       - uses: actions/checkout@v6
 
@@ -489,7 +524,7 @@ jobs:
   release:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    needs: [build-server, build-opencode, build-llmproxy, build-imbridge, build-cc-broker, build-executor-registry, build-credentialproxy, build-sandboxproxy, build-nanoclaw, build-claudecode, build-codex-app-gateway, build-codex-exec-gateway]
+    needs: [build-server, build-opencode, build-llmproxy, build-imbridge, build-cc-broker, build-executor-registry, build-credentialproxy, build-sandboxproxy, build-nanoclaw, build-claudecode, build-codex-app-gateway, build-codex-exec-gateway, build-notebook]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.56.0
-appVersion: "0.56.0"
+version: 0.57.0
+appVersion: "0.57.0"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/deploy/helm/agentserver/values.yaml
+++ b/deploy/helm/agentserver/values.yaml
@@ -386,10 +386,10 @@ gateway:
 
 notebook:
   # Image for the per-workspace Jupyter Server. Built by
-  # Dockerfile.notebook (Plan 1).
+  # Dockerfile.notebook (Plan 1) + .github/workflows/build.yml.
   image:
     repository: ghcr.io/agentserver/agentserver-notebook
-    tag: dev
+    tag: latest
     pullPolicy: IfNotPresent
   # Per-workspace resource limits. Apply to the notebook container.
   resources:


### PR DESCRIPTION
Releases the notebook stack landed in #83 / #84 / #85 / #86 / #88 / #89.

## Changes

- \`build-notebook\` CI job builds + pushes \`ghcr.io/agentserver/agentserver-notebook\` to GHCR with the standard tag set (sha, branch, semver, latest-on-default-branch). Mirrors all 11 existing \`build-*\` jobs.
- \`publish-helm\` + \`release\` jobs gated on \`build-notebook\` so the chart never publishes ahead of its required image
- helm Chart \`0.56.0\` → \`0.57.0\` (minor — substantial feature additions: Python SDK, oplog, notebook supervisor + proxy, Web UI panels)
- \`values.notebook.image.tag\` \`dev\` → \`latest\` (matches the rest of the chart; CI will publish \`:latest\` on every default-branch push)

## Test plan

- [x] \`helm lint deploy/helm/agentserver\` clean
- [x] \`build.yml\` YAML syntax valid
- [ ] CI passes on this branch (build-notebook will run for the first time here)
- [ ] After merge: tag \`v0.57.0\` triggers \`release\` (goreleaser) + \`publish-helm\` (chart push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)