### PR TITLE
fix(web): polish workspace sidebar and panel theming

### DIFF
--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>agentserver</title>
-    <script type="module" crossorigin src="/assets/index-Cg3c2qPy.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-v9ILyisA.css">
+    <script type="module" crossorigin src="/assets/index-Cmy6xxPy.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-BOShkDKZ.css">
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -20,7 +20,6 @@ import { OAuthLogin, PENDING_LOGIN_CHALLENGE_KEY } from './components/OAuthLogin
 const PENDING_CONSENT_CHALLENGE_KEY = 'agentserver_pending_consent_challenge'
 const PENDING_DEVICE_PARAMS_KEY = 'agentserver_pending_device_params'
 import { TopBar } from './components/TopBar'
-import { SandboxList } from './components/SandboxList'
 import { SandboxDetail } from './components/SandboxDetail'
 import { ManageWorkspaces } from './components/ManageWorkspaces'
 import { AdminPanel } from './components/AdminPanel'
@@ -38,10 +37,12 @@ function WorkspaceDetailRoute({
   workspaces,
   onRename,
   initialTab,
+  sandboxOverride,
 }: {
   workspaces: Workspace[]
   onRename?: (id: string, name: string) => void
   initialTab?: WorkspaceTab
+  sandboxOverride?: React.ReactNode
 }) {
   const { workspaceId } = useParams<{ workspaceId: string }>()
   const workspace = workspaces.find((w) => w.id === workspaceId)
@@ -49,7 +50,12 @@ function WorkspaceDetailRoute({
     return <Navigate to="/" replace />
   }
   return (
-    <WorkspaceDetail workspace={workspace} onRename={onRename} initialTab={initialTab} />
+    <WorkspaceDetail
+      workspace={workspace}
+      onRename={onRename}
+      initialTab={initialTab}
+      sandboxOverride={sandboxOverride}
+    />
   )
 }
 
@@ -117,7 +123,6 @@ export default function App() {
   const [workspaces, setWorkspaces] = useState<Workspace[]>([])
   const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null)
   const [sandboxes, setSandboxes] = useState<Sandbox[]>([])
-  const [creating, setCreating] = useState(false)
 
   const refreshSandboxes = useCallback(async () => {
     if (!selectedWorkspaceId) return
@@ -275,26 +280,6 @@ export default function App() {
     )
   }
 
-  const sandboxList = (
-    <SandboxList
-      selectedWorkspaceId={selectedWorkspaceId}
-      sandboxes={sandboxes}
-      setSandboxes={setSandboxes}
-      onRefreshSandboxes={refreshSandboxes}
-      creating={creating}
-      setCreating={setCreating}
-    />
-  )
-
-  const sandboxLayout = (content: React.ReactNode) => (
-    <div className="flex flex-1 min-h-0">
-      {sandboxList}
-      <div className="flex flex-1 flex-col bg-[var(--background)]">
-        {content}
-      </div>
-    </div>
-  )
-
   return (
     <div className="flex flex-col h-screen">
       <TopBar
@@ -317,15 +302,22 @@ export default function App() {
         } />
         <Route
           path="/w/:workspaceId/sandboxes/:sandboxId"
-          element={sandboxLayout(
-            <SandboxDetailRoute
-              sandboxes={sandboxes}
-              onPause={handlePause}
-              onResume={handleResume}
-              onDelete={handleDelete}
-              onRename={handleRenameSandbox}
+          element={
+            <WorkspaceDetailRoute
+              workspaces={workspaces}
+              onRename={handleRenameWorkspace}
+              initialTab="sandbox"
+              sandboxOverride={
+                <SandboxDetailRoute
+                  sandboxes={sandboxes}
+                  onPause={handlePause}
+                  onResume={handleResume}
+                  onDelete={handleDelete}
+                  onRename={handleRenameSandbox}
+                />
+              }
             />
-          )}
+          }
         />
         <Route
           path="/workspaces"

--- a/web/src/components/NotebooksPanel.tsx
+++ b/web/src/components/NotebooksPanel.tsx
@@ -58,8 +58,8 @@ export default function NotebooksPanel({ workspaceId }: Props) {
 
   if (loading && !session) {
     return (
-      <div className="flex items-center justify-center h-96 text-gray-500">
-        <Loader2 className="w-5 h-5 mr-2 animate-spin" />
+      <div className="flex h-96 items-center justify-center text-sm text-[var(--muted-foreground)]">
+        <Loader2 size={16} className="mr-2 animate-spin" />
         Starting notebook environment…
       </div>
     )
@@ -67,11 +67,11 @@ export default function NotebooksPanel({ workspaceId }: Props) {
 
   if (error) {
     return (
-      <div className="flex items-start gap-3 p-4 border border-red-300 bg-red-50 rounded">
-        <AlertCircle className="w-5 h-5 text-red-600 mt-0.5 shrink-0" />
+      <div className="flex items-start gap-3 rounded-lg border border-red-500/30 bg-red-500/10 p-4">
+        <AlertCircle size={18} className="mt-0.5 shrink-0 text-red-400" />
         <div>
-          <div className="font-medium text-red-900">Could not start notebook</div>
-          <div className="text-sm text-red-800 mt-1 whitespace-pre-wrap">{error}</div>
+          <div className="text-sm font-medium text-[var(--foreground)]">Could not start notebook</div>
+          <div className="mt-1 whitespace-pre-wrap text-xs text-red-400">{error}</div>
         </div>
       </div>
     )
@@ -82,12 +82,12 @@ export default function NotebooksPanel({ workspaceId }: Props) {
   const iframeSrc = `${session.url}?token=${encodeURIComponent(session.token)}`
 
   return (
-    <div className="h-[80vh] w-full">
+    <div className="h-[80vh] w-full overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--card)]">
       <iframe
         key={session.token}
         src={iframeSrc}
         sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
-        className="w-full h-full border rounded"
+        className="h-full w-full"
         title="Notebook"
       />
     </div>

--- a/web/src/components/OperationsPanel.tsx
+++ b/web/src/components/OperationsPanel.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
-import { RefreshCw, AlertCircle } from 'lucide-react'
+import { RefreshCw, AlertCircle, X } from 'lucide-react'
 import {
   listOperations,
   type Operation,
@@ -46,7 +46,7 @@ export default function OperationsPanel({ workspaceId }: Props) {
   return (
     <div className="flex flex-col gap-3">
       {/* Filter bar */}
-      <div className="flex flex-wrap items-end gap-3 p-3 border rounded bg-gray-50">
+      <div className="flex flex-wrap items-end gap-3 rounded-lg border border-[var(--border)] bg-[var(--card)] p-3">
         <FilterInput
           label="env"
           value={filters.env_id ?? ''}
@@ -57,10 +57,10 @@ export default function OperationsPanel({ workspaceId }: Props) {
           value={filters.tool ?? ''}
           onChange={(v) => setFilters((f) => ({ ...f, tool: v || undefined }))}
         />
-        <div className="flex flex-col">
-          <label className="text-xs text-gray-600">source</label>
+        <div className="flex flex-col gap-1">
+          <label className="text-xs text-[var(--muted-foreground)]">source</label>
           <select
-            className="border rounded px-2 py-1 text-sm"
+            className="rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm text-[var(--foreground)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]"
             value={filters.source ?? ''}
             onChange={(e) =>
               setFilters((f) => ({
@@ -76,7 +76,7 @@ export default function OperationsPanel({ workspaceId }: Props) {
             ))}
           </select>
         </div>
-        <label className="flex items-center gap-1 text-sm">
+        <label className="flex items-center gap-1.5 text-sm text-[var(--foreground)]">
           <input
             type="checkbox"
             checked={filters.is_error === true}
@@ -89,7 +89,7 @@ export default function OperationsPanel({ workspaceId }: Props) {
           />
           errors only
         </label>
-        <label className="flex items-center gap-1 text-sm">
+        <label className="flex items-center gap-1.5 text-sm text-[var(--foreground)]">
           <input
             type="checkbox"
             checked={autoRefresh}
@@ -99,38 +99,38 @@ export default function OperationsPanel({ workspaceId }: Props) {
         </label>
         <button
           onClick={() => void refresh()}
-          className="flex items-center gap-1 px-3 py-1 text-sm bg-blue-600 text-white rounded hover:bg-blue-700"
+          className="inline-flex items-center gap-1.5 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-1 text-xs font-medium text-[var(--foreground)] hover:bg-[var(--secondary)] transition-colors"
         >
-          <RefreshCw className={`w-3 h-3 ${loading ? 'animate-spin' : ''}`} />
+          <RefreshCw size={12} className={loading ? 'animate-spin' : ''} />
           Refresh
         </button>
       </div>
 
       {error && (
-        <div className="flex items-start gap-2 p-3 border border-red-300 bg-red-50 rounded">
-          <AlertCircle className="w-4 h-4 text-red-600 mt-0.5 shrink-0" />
-          <div className="text-sm text-red-800 whitespace-pre-wrap">{error}</div>
+        <div className="flex items-start gap-2 rounded-lg border border-red-500/30 bg-red-500/10 p-3">
+          <AlertCircle size={16} className="mt-0.5 shrink-0 text-red-400" />
+          <div className="whitespace-pre-wrap text-sm text-red-400">{error}</div>
         </div>
       )}
 
       {/* Table */}
-      <div className="overflow-x-auto border rounded">
+      <div className="overflow-x-auto rounded-lg border border-[var(--border)] bg-[var(--card)]">
         <table className="w-full text-sm">
-          <thead className="bg-gray-100 text-gray-700">
+          <thead className="bg-[var(--muted)] text-[var(--muted-foreground)]">
             <tr>
-              <th className="px-3 py-2 text-left">started</th>
-              <th className="px-3 py-2 text-left">env</th>
-              <th className="px-3 py-2 text-left">tool</th>
-              <th className="px-3 py-2 text-left">source</th>
-              <th className="px-3 py-2 text-left">user</th>
-              <th className="px-3 py-2 text-right">dur (ms)</th>
-              <th className="px-3 py-2 text-left">status</th>
+              <th className="px-3 py-2 text-left font-medium">started</th>
+              <th className="px-3 py-2 text-left font-medium">env</th>
+              <th className="px-3 py-2 text-left font-medium">tool</th>
+              <th className="px-3 py-2 text-left font-medium">source</th>
+              <th className="px-3 py-2 text-left font-medium">user</th>
+              <th className="px-3 py-2 text-right font-medium">dur (ms)</th>
+              <th className="px-3 py-2 text-left font-medium">status</th>
             </tr>
           </thead>
           <tbody>
             {ops.length === 0 && !loading ? (
               <tr>
-                <td colSpan={7} className="px-3 py-6 text-center text-gray-500">
+                <td colSpan={7} className="px-3 py-6 text-center text-sm text-[var(--muted-foreground)]">
                   No operations match these filters.
                 </td>
               </tr>
@@ -139,23 +139,23 @@ export default function OperationsPanel({ workspaceId }: Props) {
                 <tr
                   key={op.id}
                   onClick={() => setSelected(op)}
-                  className="border-t cursor-pointer hover:bg-gray-50"
+                  className="cursor-pointer border-t border-[var(--border)] hover:bg-[var(--secondary)]/50"
                 >
-                  <td className="px-3 py-1 font-mono text-xs">
+                  <td className="px-3 py-1.5 font-mono text-xs text-[var(--foreground)]">
                     {new Date(op.started_at).toLocaleString()}
                   </td>
-                  <td className="px-3 py-1 font-mono">{op.env_id}</td>
-                  <td className="px-3 py-1 font-mono">{op.tool}</td>
-                  <td className="px-3 py-1">{op.source}</td>
-                  <td className="px-3 py-1 font-mono text-xs text-gray-600">
+                  <td className="px-3 py-1.5 font-mono text-xs text-[var(--foreground)]">{op.env_id}</td>
+                  <td className="px-3 py-1.5 font-mono text-xs text-[var(--foreground)]">{op.tool}</td>
+                  <td className="px-3 py-1.5 text-xs text-[var(--foreground)]">{op.source}</td>
+                  <td className="px-3 py-1.5 font-mono text-xs text-[var(--muted-foreground)]">
                     {op.user_id ?? '—'}
                   </td>
-                  <td className="px-3 py-1 text-right tabular-nums">{op.duration_ms}</td>
-                  <td className="px-3 py-1">
+                  <td className="px-3 py-1.5 text-right tabular-nums text-xs text-[var(--foreground)]">{op.duration_ms}</td>
+                  <td className="px-3 py-1.5 text-xs">
                     {op.is_error ? (
-                      <span className="text-red-600 font-medium">error</span>
+                      <span className="font-medium text-red-400">error</span>
                     ) : (
-                      <span className="text-green-700">ok</span>
+                      <span className="text-green-400">ok</span>
                     )}
                   </td>
                 </tr>
@@ -183,13 +183,13 @@ function FilterInput({
   onChange: (v: string) => void
 }) {
   return (
-    <div className="flex flex-col">
-      <label className="text-xs text-gray-600">{label}</label>
+    <div className="flex flex-col gap-1">
+      <label className="text-xs text-[var(--muted-foreground)]">{label}</label>
       <input
         type="text"
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        className="border rounded px-2 py-1 text-sm w-32"
+        className="w-32 rounded-md border border-[var(--border)] bg-[var(--background)] px-2 py-1 text-sm text-[var(--foreground)] placeholder:text-[var(--muted-foreground)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)]"
       />
     </div>
   )
@@ -204,23 +204,23 @@ function OperationDetailModal({
 }) {
   return (
     <div
-      className="fixed inset-0 bg-black/40 flex items-center justify-center z-50 p-4"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
       onClick={onClose}
     >
       <div
-        className="bg-white rounded-lg shadow-xl max-w-3xl w-full max-h-[80vh] overflow-auto"
+        className="max-h-[80vh] w-full max-w-3xl overflow-auto rounded-lg border border-[var(--border)] bg-[var(--card)] shadow-xl"
         onClick={(e) => e.stopPropagation()}
       >
-        <div className="px-4 py-3 border-b flex items-center justify-between">
-          <div className="font-mono text-sm">{op.id}</div>
+        <div className="flex items-center justify-between border-b border-[var(--border)] px-4 py-3">
+          <div className="font-mono text-sm text-[var(--foreground)]">{op.id}</div>
           <button
             onClick={onClose}
-            className="text-gray-500 hover:text-gray-900"
+            className="text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
           >
-            ✕
+            <X size={16} />
           </button>
         </div>
-        <div className="p-4 space-y-3 text-sm">
+        <div className="space-y-3 p-4 text-sm">
           <Row label="started_at" value={op.started_at} />
           <Row label="duration_ms" value={String(op.duration_ms)} />
           <Row label="env" value={op.env_id} />
@@ -230,32 +230,32 @@ function OperationDetailModal({
           <Row
             label="is_error"
             value={op.is_error ? 'true' : 'false'}
-            valueClass={op.is_error ? 'text-red-600 font-medium' : ''}
+            valueClass={op.is_error ? 'text-red-400 font-medium' : ''}
           />
           {op.arguments !== undefined && op.arguments !== null && (
             <div>
-              <div className="text-xs text-gray-600 mb-1">arguments</div>
-              <pre className="bg-gray-50 border rounded p-2 overflow-auto max-h-64 text-xs">
+              <div className="mb-1 text-xs text-[var(--muted-foreground)]">arguments</div>
+              <pre className="max-h-64 overflow-auto rounded-md border border-[var(--border)] bg-[var(--background)] p-2 text-xs text-[var(--foreground)]">
                 {JSON.stringify(op.arguments, null, 2)}
               </pre>
             </div>
           )}
           {op.arguments_meta && (
-            <div className="text-xs text-gray-600">
+            <div className="text-xs text-[var(--muted-foreground)]">
               arguments truncated: {op.arguments_meta.size_bytes} bytes, sha256{' '}
-              <code>{op.arguments_meta.sha256.slice(0, 12)}…</code>
+              <code className="text-[var(--foreground)]">{op.arguments_meta.sha256.slice(0, 12)}…</code>
             </div>
           )}
           {op.result_summary && (
             <div>
-              <div className="text-xs text-gray-600 mb-1">result_summary</div>
-              <pre className="bg-gray-50 border rounded p-2 overflow-auto max-h-64 text-xs whitespace-pre-wrap">
+              <div className="mb-1 text-xs text-[var(--muted-foreground)]">result_summary</div>
+              <pre className="max-h-64 overflow-auto whitespace-pre-wrap rounded-md border border-[var(--border)] bg-[var(--background)] p-2 text-xs text-[var(--foreground)]">
                 {op.result_summary}
               </pre>
             </div>
           )}
           {op.result_meta && (
-            <div className="text-xs text-gray-600">
+            <div className="text-xs text-[var(--muted-foreground)]">
               result truncated: total {op.result_meta.total_bytes} bytes
             </div>
           )}
@@ -276,8 +276,8 @@ function Row({
 }) {
   return (
     <div className="flex gap-3">
-      <div className="text-xs text-gray-600 w-24 shrink-0">{label}</div>
-      <div className={`flex-1 font-mono ${valueClass}`}>{value}</div>
+      <div className="w-24 shrink-0 text-xs text-[var(--muted-foreground)]">{label}</div>
+      <div className={`flex-1 font-mono text-[var(--foreground)] ${valueClass}`}>{value}</div>
     </div>
   )
 }

--- a/web/src/components/SandboxList.tsx
+++ b/web/src/components/SandboxList.tsx
@@ -18,6 +18,7 @@ interface SandboxListProps {
   onRefreshSandboxes: () => void
   creating: boolean
   setCreating: (v: boolean) => void
+  variant?: 'rail' | 'flat'
 }
 
 function StatusDot({ status }: { status: string }) {
@@ -44,7 +45,9 @@ export function SandboxList({
   onRefreshSandboxes,
   creating,
   setCreating,
+  variant = 'rail',
 }: SandboxListProps) {
+  const isFlat = variant === 'flat'
   const navigate = useNavigate()
   const location = useLocation()
   const sandboxMatch = location.pathname.match(/\/sandboxes\/(.+)$/)
@@ -156,7 +159,11 @@ export function SandboxList({
   }
 
   return (
-    <div className="flex h-full w-60 flex-col border-r border-[var(--border)] bg-[var(--muted)]">
+    <div className={
+      isFlat
+        ? 'flex h-full w-full flex-col rounded-lg border border-[var(--border)] bg-[var(--card)] overflow-hidden'
+        : 'flex h-full w-60 flex-col border-r border-[var(--border)] bg-[var(--muted)]'
+    }>
       {/* Sandbox header */}
       <div className="flex items-center justify-between border-b border-[var(--border)] p-3">
         <div className="flex items-center gap-1.5">
@@ -226,7 +233,7 @@ export function SandboxList({
                   code
                 </span>
               )}
-              <div className="hidden gap-0.5 group-hover:flex">
+              <div className={isFlat ? 'flex gap-0.5' : 'hidden gap-0.5 group-hover:flex'}>
                 {!sbx.is_local && sbx.status === 'running' && (
                   <button
                     onClick={(e) => handlePause(sbx.id, e)}

--- a/web/src/components/WorkspaceDetail.tsx
+++ b/web/src/components/WorkspaceDetail.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
+import { useNavigate, useLocation } from 'react-router-dom'
 import {
   Clock,
   Users,
@@ -18,6 +19,7 @@ import {
   Globe,
   Server,
   Brain,
+  Activity,
 } from 'lucide-react'
 import {
   listMembers,
@@ -74,6 +76,7 @@ export type Tab =
   | 'llm'
   | 'im'
   | 'traces'
+  | 'operations'
   | 'credentials'
   | 'members'
   | 'settings'
@@ -82,10 +85,20 @@ interface WorkspaceDetailProps {
   workspace: Workspace
   onRename?: (id: string, name: string) => void
   initialTab?: Tab
+  sandboxOverride?: React.ReactNode
 }
 
-export function WorkspaceDetail({ workspace, onRename, initialTab }: WorkspaceDetailProps) {
+export function WorkspaceDetail({ workspace, onRename, initialTab, sandboxOverride }: WorkspaceDetailProps) {
   const [tab, setTab] = useState<Tab>(initialTab ?? 'sandbox')
+  const navigate = useNavigate()
+  const location = useLocation()
+  const selectTab = (next: Tab) => {
+    setTab(next)
+    // If we're on a sub-route like /sandboxes/:id, return to the workspace root so the URL matches the visible tab.
+    if (location.pathname !== `/w/${workspace.id}`) {
+      navigate(`/w/${workspace.id}`)
+    }
+  }
   const [members, setMembers] = useState<WorkspaceMember[]>([])
   const [sbxQuota, setSbxQuota] = useState<{ current: number; max: number } | null>(null)
   const [defaults, setDefaults] = useState<WorkspaceSandboxDefaults | null>(null)
@@ -93,8 +106,6 @@ export function WorkspaceDetail({ workspace, onRename, initialTab }: WorkspaceDe
   const [traces, setTraces] = useState<TraceItem[]>([])
   const [tracesTotal, setTracesTotal] = useState(0)
   const [tracesPage, setTracesPage] = useState(0)
-  const [editing, setEditing] = useState(false)
-  const [editName, setEditName] = useState(workspace.name)
 
   useEffect(() => {
     setTab(initialTab ?? 'sandbox')
@@ -130,65 +141,21 @@ export function WorkspaceDetail({ workspace, onRename, initialTab }: WorkspaceDe
   const fetchDetail = useCallback((traceId: string) => getWorkspaceTraceDetail(workspace.id, traceId), [workspace.id])
 
   const sidebarItems: { key: Tab; label: string; icon: React.ReactNode; badge?: number }[] = [
-    { key: 'overview', label: 'Overview', icon: <LayoutDashboard size={15} /> },
-    { key: 'browser', label: 'Browser 管理', icon: <Globe size={15} /> },
-    { key: 'executor', label: 'Executor 管理', icon: <Server size={15} /> },
-    { key: 'sandbox', label: 'Sandbox 管理', icon: <Box size={15} /> },
-    { key: 'llm', label: 'LLM 管理', icon: <Brain size={15} /> },
-    { key: 'im', label: 'IM 管理', icon: <Bot size={15} /> },
-    { key: 'traces', label: 'Traces 管理', icon: <MessageSquare size={15} />, badge: tracesTotal > 0 ? tracesTotal : undefined },
-    { key: 'credentials', label: 'Credential 管理', icon: <Key size={15} /> },
-    { key: 'members', label: 'Member 管理', icon: <Users size={15} />, badge: members.length > 0 ? members.length : undefined },
-    { key: 'settings', label: 'Settings', icon: <Settings size={15} /> },
+    { key: 'overview', label: 'Overview', icon: <LayoutDashboard size={16} /> },
+    { key: 'browser', label: 'Browser', icon: <Globe size={16} /> },
+    { key: 'executor', label: 'Executor', icon: <Server size={16} /> },
+    { key: 'sandbox', label: 'Sandbox', icon: <Box size={16} /> },
+    { key: 'llm', label: 'LLM', icon: <Brain size={16} /> },
+    { key: 'im', label: 'IM', icon: <Bot size={16} /> },
+    { key: 'traces', label: 'Traces', icon: <MessageSquare size={16} />, badge: tracesTotal > 0 ? tracesTotal : undefined },
+    { key: 'operations', label: 'Operations', icon: <Activity size={16} /> },
+    { key: 'credentials', label: 'Credentials', icon: <Key size={16} /> },
+    { key: 'members', label: 'Members', icon: <Users size={16} />, badge: members.length > 0 ? members.length : undefined },
+    { key: 'settings', label: 'Settings', icon: <Settings size={16} /> },
   ]
 
   return (
     <div className="flex h-full w-full flex-col">
-      {/* Header */}
-      <div className="shrink-0 border-b border-[var(--border)] bg-[var(--card)] px-6 py-4">
-        <div className="flex items-start justify-between gap-4">
-          <div className="min-w-0 flex-1">
-            <div className="flex items-center gap-2">
-              {editing ? (
-                <input
-                  autoFocus
-                  className="text-lg font-semibold text-[var(--foreground)] bg-transparent border-b border-[var(--border)] outline-none"
-                  value={editName}
-                  onChange={(e) => setEditName(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter') {
-                      const trimmed = editName.trim()
-                      if (trimmed && trimmed !== workspace.name) {
-                        renameWorkspace(workspace.id, trimmed).then(() => onRename?.(workspace.id, trimmed)).catch(() => {})
-                      }
-                      setEditing(false)
-                    } else if (e.key === 'Escape') {
-                      setEditName(workspace.name)
-                      setEditing(false)
-                    }
-                  }}
-                  onBlur={() => {
-                    const trimmed = editName.trim()
-                    if (trimmed && trimmed !== workspace.name) {
-                      renameWorkspace(workspace.id, trimmed).then(() => onRename?.(workspace.id, trimmed)).catch(() => {})
-                    }
-                    setEditing(false)
-                  }}
-                />
-              ) : (
-                <>
-                  <h1 className="text-lg font-semibold text-[var(--foreground)] truncate">{workspace.name}</h1>
-                  <button onClick={() => { setEditName(workspace.name); setEditing(true) }} className="text-[var(--muted-foreground)] hover:text-[var(--foreground)]">
-                    <Pencil size={14} />
-                  </button>
-                </>
-              )}
-            </div>
-            <div className="mt-1 text-xs text-[var(--muted-foreground)]">Workspace</div>
-          </div>
-        </div>
-      </div>
-
       {/* Body: sidebar + content */}
       <div className="flex min-h-0 flex-1">
         {/* Sidebar */}
@@ -197,8 +164,8 @@ export function WorkspaceDetail({ workspace, onRename, initialTab }: WorkspaceDe
             {sidebarItems.map((t) => (
               <button
                 key={t.key}
-                onClick={() => setTab(t.key)}
-                className={`inline-flex w-full items-center gap-2 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+                onClick={() => selectTab(t.key)}
+                className={`inline-flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors ${
                   tab === t.key
                     ? 'bg-[var(--secondary)] text-[var(--foreground)]'
                     : 'text-[var(--muted-foreground)] hover:text-[var(--foreground)] hover:bg-[var(--secondary)]/50'
@@ -224,6 +191,7 @@ export function WorkspaceDetail({ workspace, onRename, initialTab }: WorkspaceDe
               sbxQuota={sbxQuota}
               defaults={defaults}
               llmQuota={llmQuota}
+              onRename={onRename}
             />
           )}
           {tab === 'browser' && (
@@ -233,7 +201,7 @@ export function WorkspaceDetail({ workspace, onRename, initialTab }: WorkspaceDe
             <RemoteExecutorsPanel workspaceId={workspace.id} />
           )}
           {tab === 'sandbox' && (
-            <SandboxPanel workspaceId={workspace.id} />
+            sandboxOverride ?? <SandboxPanel workspaceId={workspace.id} />
           )}
           {tab === 'llm' && (
             <LLMTab workspaceId={workspace.id} />
@@ -242,18 +210,18 @@ export function WorkspaceDetail({ workspace, onRename, initialTab }: WorkspaceDe
             <IMTab workspaceId={workspace.id} />
           )}
           {tab === 'traces' && (
-            <div className="flex flex-col gap-6">
-              <TracesTab
-                traces={traces}
-                tracesTotal={tracesTotal}
-                tracesPage={tracesPage}
-                totalPages={totalPages}
-                onPageChange={setTracesPage}
-                fetchDetail={fetchDetail}
-                showSandboxId
-              />
-              <OperationsPanel workspaceId={workspace.id} />
-            </div>
+            <TracesTab
+              traces={traces}
+              tracesTotal={tracesTotal}
+              tracesPage={tracesPage}
+              totalPages={totalPages}
+              onPageChange={setTracesPage}
+              fetchDetail={fetchDetail}
+              showSandboxId
+            />
+          )}
+          {tab === 'operations' && (
+            <OperationsPanel workspaceId={workspace.id} />
           )}
           {tab === 'credentials' && (
             <CredentialsTab workspaceId={workspace.id} />
@@ -274,15 +242,49 @@ export function WorkspaceDetail({ workspace, onRename, initialTab }: WorkspaceDe
   )
 }
 
-function OverviewTab({ workspace, sbxQuota, defaults, llmQuota }: {
+function OverviewTab({ workspace, sbxQuota, defaults, llmQuota, onRename }: {
   workspace: Workspace
   sbxQuota: { current: number; max: number } | null
   defaults: WorkspaceSandboxDefaults | null
   llmQuota: WorkspaceLLMQuota | null
+  onRename?: (id: string, name: string) => void
 }) {
   const effectiveMaxRpd = llmQuota?.workspace_quota?.max_rpd ?? llmQuota?.default_max_rpd ?? null
+  const [editing, setEditing] = useState(false)
+  const [editName, setEditName] = useState(workspace.name)
+  const commit = () => {
+    const trimmed = editName.trim()
+    if (trimmed && trimmed !== workspace.name) {
+      renameWorkspace(workspace.id, trimmed).then(() => onRename?.(workspace.id, trimmed)).catch(() => {})
+    }
+    setEditing(false)
+  }
   return (
     <div className="flex flex-col gap-6 max-w-3xl">
+      {/* Name + rename */}
+      <div className="flex items-center gap-2">
+        {editing ? (
+          <input
+            autoFocus
+            className="text-xl font-semibold text-[var(--foreground)] bg-transparent border-b border-[var(--border)] outline-none"
+            value={editName}
+            onChange={(e) => setEditName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') commit()
+              else if (e.key === 'Escape') { setEditName(workspace.name); setEditing(false) }
+            }}
+            onBlur={commit}
+          />
+        ) : (
+          <>
+            <h1 className="text-xl font-semibold text-[var(--foreground)] truncate">{workspace.name}</h1>
+            <button onClick={() => { setEditName(workspace.name); setEditing(true) }} className="text-[var(--muted-foreground)] hover:text-[var(--foreground)]" title="Rename workspace">
+              <Pencil size={14} />
+            </button>
+          </>
+        )}
+      </div>
+
       {/* Info cards */}
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
         <InfoCard icon={<Clock size={14} />} label="Created" value={new Date(workspace.created_at).toLocaleString()} />
@@ -337,16 +339,15 @@ function SandboxPanel({ workspaceId }: { workspaceId: string }) {
   }, [workspaceId])
   useEffect(() => { refresh() }, [refresh])
   return (
-    <div className="-m-6 flex h-[calc(100%+3rem)]">
-      <SandboxList
-        selectedWorkspaceId={workspaceId}
-        sandboxes={sandboxes}
-        setSandboxes={setSandboxes}
-        onRefreshSandboxes={refresh}
-        creating={creating}
-        setCreating={setCreating}
-      />
-    </div>
+    <SandboxList
+      selectedWorkspaceId={workspaceId}
+      sandboxes={sandboxes}
+      setSandboxes={setSandboxes}
+      onRefreshSandboxes={refresh}
+      creating={creating}
+      setCreating={setCreating}
+      variant="flat"
+    />
   )
 }
 
@@ -957,7 +958,7 @@ function SettingsTab({ workspace }: { workspace: Workspace }) {
         </div>
       </div>
       <p className="mt-3 text-xs text-[var(--muted-foreground)]">
-        To rename this workspace, use the pencil icon next to the name in the header.
+        To rename this workspace, use the pencil icon next to the name in the Overview tab.
       </p>
     </div>
   )


### PR DESCRIPTION
## Summary
Six UI fixes on top of #91:
- Sidebar labels switched to English; font bumped (text-xs → text-sm, icons 15 → 16); padding bumped (py-1.5 → py-2).
- Operations is now its own sidebar item (Activity icon), no longer bundled inside the Traces panel.
- Removed the top header strip with the pencil rename. The workspace name + rename pencil now live inside the Overview tab.
- NotebooksPanel + OperationsPanel re-themed from raw tailwind colors (\`text-gray-*\`, \`bg-red-50\`, \`border-red-300\`, \`bg-gray-50\`) to the app's CSS variables (\`--card\`, \`--border\`, \`--foreground\`, \`--muted-foreground\`, \`--secondary\`).
- Sandbox panel: \`SandboxList\` gained a \`variant=\"flat\"\` mode so it can be embedded inside the workspace content area without its 240 px rail chrome.
- \`/w/:wsId/sandboxes/:sbxId\` now mounts \`WorkspaceDetail\` with the sandbox detail injected via \`sandboxOverride\`, so the workspace sidebar persists on the detail page. Clicking another sidebar item navigates back to \`/w/:wsId\` so the URL matches the visible tab.

## Test plan
- [ ] Sidebar shows English labels: Overview, Browser, Executor, Sandbox, LLM, IM, Traces, Operations, Credentials, Members, Settings.
- [ ] Overview tab shows workspace name with pencil; renaming works.
- [ ] Browser tab (Codex Remote Access + Notebooks) looks consistent with the rest of the app — no more red-50 / gray-50 panels.
- [ ] Sandbox tab shows the list directly (no left rail).
- [ ] Clicking a sandbox row opens the detail page with the workspace sidebar still visible.
- [ ] From the sandbox detail page, clicking Operations (or any other tab) returns to /w/:wsId with that tab active.
- [ ] Operations tab shows the operations panel only; Traces tab shows traces only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)