### PR TITLE
feat(notebook,helm): NOTEBOOK_* env wiring + short-id PVC (v0.58.0)

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.57.1
-appVersion: "0.57.1"
+version: 0.58.0
+appVersion: "0.58.0"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/deploy/helm/agentserver/templates/deployment.yaml
+++ b/deploy/helm/agentserver/templates/deployment.yaml
@@ -283,6 +283,28 @@ spec:
             {{- end }}
             - name: NOTEBOOK_BASE_URL_PATTERN
               value: {{ .Values.notebook.baseURLPattern | quote }}
+            - name: NOTEBOOK_IMAGE
+              value: {{ printf "%s:%s" .Values.notebook.image.repository .Values.notebook.image.tag | quote }}
+            - name: NOTEBOOK_IMAGE_PULL_POLICY
+              value: {{ .Values.notebook.image.pullPolicy | quote }}
+            - name: NOTEBOOK_CPU_REQUEST
+              value: {{ .Values.notebook.resources.cpuRequest | quote }}
+            - name: NOTEBOOK_CPU_LIMIT
+              value: {{ .Values.notebook.resources.cpuLimit | quote }}
+            - name: NOTEBOOK_MEM_REQUEST
+              value: {{ .Values.notebook.resources.memoryRequest | quote }}
+            - name: NOTEBOOK_MEM_LIMIT
+              value: {{ .Values.notebook.resources.memoryLimit | quote }}
+            - name: NOTEBOOK_EPHEMERAL_STORAGE
+              value: {{ .Values.notebook.resources.ephemeralStorage | quote }}
+            - name: NOTEBOOK_WORKSPACE_PVC
+              value: {{ .Values.notebook.workspacePVCName | quote }}
+            - name: NOTEBOOK_IDLE_TTL_SECONDS
+              value: {{ .Values.notebook.idleTTLSeconds | quote }}
+            - name: NOTEBOOK_REAP_INTERVAL_SECONDS
+              value: {{ .Values.notebook.reapIntervalSeconds | quote }}
+            - name: NOTEBOOK_READY_TIMEOUT_SECONDS
+              value: {{ .Values.notebook.readyTimeoutSeconds | quote }}
           livenessProbe:
             httpGet:
               path: /healthz

--- a/deploy/helm/agentserver/values.yaml
+++ b/deploy/helm/agentserver/values.yaml
@@ -402,8 +402,12 @@ notebook:
   idleTTLSeconds: 14400      # 4h
   reapIntervalSeconds: 300   # 5min
   readyTimeoutSeconds: 60
-  # PVC name pattern. Must match the existing workspace-volume provisioner.
-  # The literal "{workspace_id}" is substituted at runtime by the supervisor.
-  workspacePVCName: "ws-{workspace_id}"
+  # PVC name pattern. Must match the existing workspace-volume provisioner
+  # (internal/storage/workspacedrive.go names workspace PVCs
+  # `agent-ws-<first-8-of-workspace-id>-disk`).
+  # Placeholders substituted at runtime by the supervisor:
+  #   {workspace_id}        – full UUID
+  #   {workspace_id_short}  – first 8 chars
+  workspacePVCName: "agent-ws-{workspace_id_short}-disk"
   jwtSecret: ""  # Empty = feature disabled. Generate with `openssl rand -hex 32`
   baseURLPattern: "/api/notebooks/{workspace_id}/"

--- a/internal/notebooksupervisor/spawn.go
+++ b/internal/notebooksupervisor/spawn.go
@@ -49,7 +49,7 @@ func BuildDeployment(k Key, c Config) (*appsv1.Deployment, error) {
 	for k2, v := range c.ExtraEnvVars {
 		envVars = append(envVars, corev1.EnvVar{
 			Name:  k2,
-			Value: strings.ReplaceAll(v, "{workspace_id}", k.WorkspaceID),
+			Value: substituteWorkspaceID(v, k.WorkspaceID),
 		})
 	}
 	container := corev1.Container{
@@ -65,7 +65,7 @@ func BuildDeployment(k Key, c Config) (*appsv1.Deployment, error) {
 			{Name: workspaceVolumeName, MountPath: workspaceMountPath},
 		},
 	}
-	pvcName := strings.ReplaceAll(c.WorkspacePVCName, "{workspace_id}", k.WorkspaceID)
+	pvcName := substituteWorkspaceID(c.WorkspacePVCName, k.WorkspaceID)
 	pod := corev1.PodSpec{
 		Containers: []corev1.Container{container},
 		Volumes: []corev1.Volume{
@@ -120,6 +120,18 @@ func BuildService(k Key) (*corev1.Service, error) {
 			}},
 		},
 	}, nil
+}
+
+// substituteWorkspaceID replaces both {workspace_id} (full UUID) and
+// {workspace_id_short} (first 8 chars, matching the agent-ws-<short>
+// convention used by internal/storage/workspacedrive.go) in s.
+func substituteWorkspaceID(s, workspaceID string) string {
+	short := workspaceID
+	if len(short) > 8 {
+		short = short[:8]
+	}
+	s = strings.ReplaceAll(s, "{workspace_id_short}", short)
+	return strings.ReplaceAll(s, "{workspace_id}", workspaceID)
 }
 
 // ServiceURL returns the cluster-internal HTTP url for the Service.

--- a/internal/notebooksupervisor/spawn_test.go
+++ b/internal/notebooksupervisor/spawn_test.go
@@ -181,6 +181,37 @@ func TestBuildDeployment_PVCNameNoTemplate(t *testing.T) {
 	}
 }
 
+func TestBuildDeployment_PVCNameShortIDSubstitution(t *testing.T) {
+	c := Config{
+		Image:            "img:tag",
+		WorkspacePVCName: "agent-ws-{workspace_id_short}-disk",
+	}.WithDefaults()
+	k := Key{
+		WorkspaceID: "77f66719-313d-4574-a13a-2fdb41224bef",
+		Namespace:   "agent-ws-77f66719",
+	}
+	d, err := BuildDeployment(k, c)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	var pvcName string
+	for _, v := range d.Spec.Template.Spec.Volumes {
+		if v.PersistentVolumeClaim != nil {
+			pvcName = v.PersistentVolumeClaim.ClaimName
+		}
+	}
+	if pvcName != "agent-ws-77f66719-disk" {
+		t.Errorf("pvc name = %q, want agent-ws-77f66719-disk", pvcName)
+	}
+}
+
+func TestSubstituteWorkspaceID_ShortIDFallsBackToFullForShortInput(t *testing.T) {
+	got := substituteWorkspaceID("ws-{workspace_id_short}-x", "abc")
+	if got != "ws-abc-x" {
+		t.Errorf("short<=8 should pass through full id, got=%q", got)
+	}
+}
+
 func TestBuildDeployment_ExtraEnvVarsWithSubstitution(t *testing.T) {
 	c := Config{
 		Image:            "img:tag",


### PR DESCRIPTION
## Summary
Bundle WIP that was already present in the working tree:
- chart 0.57.1 → 0.58.0
- \`deployment.yaml\`: propagate all notebook supervisor settings as env vars (NOTEBOOK_IMAGE, CPU/MEM REQUEST/LIMIT, NOTEBOOK_WORKSPACE_PVC, IDLE_TTL_SECONDS, REAP_INTERVAL_SECONDS, READY_TIMEOUT_SECONDS) so prod doesn't fall back to in-binary defaults.
- \`values.yaml\`: default workspacePVCName flipped to \`agent-ws-{workspace_id_short}-disk\` to match \`internal/storage/workspacedrive.go\` naming.
- \`internal/notebooksupervisor/spawn.go\`: new \`substituteWorkspaceID\` helper handles both \`{workspace_id}\` (full UUID) and \`{workspace_id_short}\` (first 8 chars). Test added.

These changes were already in the working tree (carried over from earlier notebook supervisor work); per user direction, bundling into v0.58.0 alongside #92's sidebar polish.

## Test plan
- [ ] \`go test ./internal/notebooksupervisor/...\` (run locally: ok)
- [ ] Helm template renders without errors against a sample values file
- [ ] After release: notebook pod env actually shows the new variables