### PR TITLE
fix(web): rename Browser → Explorers, pluralize sidebar, Notebook as launch button (v0.58.1)

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.58.0
-appVersion: "0.58.0"
+version: 0.58.1
+appVersion: "0.58.1"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>agentserver</title>
-    <script type="module" crossorigin src="/assets/index-Cmy6xxPy.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-BOShkDKZ.css">
+    <script type="module" crossorigin src="/assets/index-D42rkH9G.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-DEp75Z8f.css">
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/components/NotebooksPanel.tsx
+++ b/web/src/components/NotebooksPanel.tsx
@@ -1,95 +1,58 @@
-import { useEffect, useRef, useState } from 'react'
-import { Loader2, AlertCircle } from 'lucide-react'
-import { createNotebookSession, type NotebookSession } from '../lib/api'
+import { useState } from 'react'
+import { Loader2, AlertCircle, ExternalLink, BookOpen } from 'lucide-react'
+import { createNotebookSession } from '../lib/api'
 
 interface Props {
   workspaceId: string
 }
 
-// Refresh the session this many seconds before the JWT actually expires.
-// 10-min TTL minus 1-min safety = refresh every 9 minutes.
-const REFRESH_BUFFER_SECONDS = 60
-
 export default function NotebooksPanel({ workspaceId }: Props) {
-  const [session, setSession] = useState<NotebookSession | null>(null)
-  const [loading, setLoading] = useState(true)
+  const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const timerRef = useRef<number | null>(null)
 
-  useEffect(() => {
-    let cancelled = false
-
-    const scheduleRefresh = (expiresAt: number) => {
-      if (timerRef.current !== null) {
-        window.clearTimeout(timerRef.current)
-      }
-      const now = Math.floor(Date.now() / 1000)
-      const delayMs = Math.max(1000, (expiresAt - now - REFRESH_BUFFER_SECONDS) * 1000)
-      timerRef.current = window.setTimeout(() => void fetchSession(), delayMs)
+  const launch = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const s = await createNotebookSession(workspaceId)
+      const url = `${s.url}?token=${encodeURIComponent(s.token)}`
+      window.open(url, '_blank', 'noopener,noreferrer')
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setLoading(false)
     }
-
-    const fetchSession = async () => {
-      try {
-        setLoading(true)
-        const s = await createNotebookSession(workspaceId)
-        if (cancelled) return
-        setSession(s)
-        setError(null)
-        scheduleRefresh(s.expires_at)
-      } catch (e) {
-        if (cancelled) return
-        setError(e instanceof Error ? e.message : String(e))
-        setSession(null)
-      } finally {
-        if (!cancelled) setLoading(false)
-      }
-    }
-
-    void fetchSession()
-
-    return () => {
-      cancelled = true
-      if (timerRef.current !== null) {
-        window.clearTimeout(timerRef.current)
-        timerRef.current = null
-      }
-    }
-  }, [workspaceId])
-
-  if (loading && !session) {
-    return (
-      <div className="flex h-96 items-center justify-center text-sm text-[var(--muted-foreground)]">
-        <Loader2 size={16} className="mr-2 animate-spin" />
-        Starting notebook environment…
-      </div>
-    )
   }
-
-  if (error) {
-    return (
-      <div className="flex items-start gap-3 rounded-lg border border-red-500/30 bg-red-500/10 p-4">
-        <AlertCircle size={18} className="mt-0.5 shrink-0 text-red-400" />
-        <div>
-          <div className="text-sm font-medium text-[var(--foreground)]">Could not start notebook</div>
-          <div className="mt-1 whitespace-pre-wrap text-xs text-red-400">{error}</div>
-        </div>
-      </div>
-    )
-  }
-
-  if (!session) return null
-
-  const iframeSrc = `${session.url}?token=${encodeURIComponent(session.token)}`
 
   return (
-    <div className="h-[80vh] w-full overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--card)]">
-      <iframe
-        key={session.token}
-        src={iframeSrc}
-        sandbox="allow-scripts allow-same-origin allow-forms allow-popups"
-        className="h-full w-full"
-        title="Notebook"
-      />
+    <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] p-5">
+      <div className="flex items-start gap-4">
+        <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-md bg-[var(--secondary)] text-[var(--foreground)]">
+          <BookOpen size={18} />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-medium text-[var(--foreground)]">Jupyter Notebook</div>
+          <p className="mt-1 text-xs text-[var(--muted-foreground)]">
+            Launch a per-workspace JupyterLab session in a new tab. Sessions reuse the workspace volume and idle out after inactivity.
+          </p>
+          <div className="mt-3">
+            <button
+              onClick={launch}
+              disabled={loading}
+              className="inline-flex items-center gap-1.5 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-1.5 text-xs font-medium text-[var(--foreground)] hover:bg-[var(--secondary)] disabled:opacity-50 transition-colors"
+            >
+              {loading ? <Loader2 size={12} className="animate-spin" /> : <ExternalLink size={12} />}
+              {loading ? 'Starting…' : 'Open Notebook'}
+            </button>
+          </div>
+          {error && (
+            <div className="mt-3 flex items-start gap-2 rounded-md border border-red-500/30 bg-red-500/10 p-2.5">
+              <AlertCircle size={14} className="mt-0.5 shrink-0 text-red-400" />
+              <div className="whitespace-pre-wrap text-xs text-red-400">{error}</div>
+            </div>
+          )}
+        </div>
+      </div>
     </div>
   )
 }

--- a/web/src/components/WorkspaceDetail.tsx
+++ b/web/src/components/WorkspaceDetail.tsx
@@ -70,7 +70,7 @@ import { SandboxList } from './SandboxList'
 
 export type Tab =
   | 'overview'
-  | 'browser'
+  | 'explorers'
   | 'executor'
   | 'sandbox'
   | 'llm'
@@ -142,9 +142,9 @@ export function WorkspaceDetail({ workspace, onRename, initialTab, sandboxOverri
 
   const sidebarItems: { key: Tab; label: string; icon: React.ReactNode; badge?: number }[] = [
     { key: 'overview', label: 'Overview', icon: <LayoutDashboard size={16} /> },
-    { key: 'browser', label: 'Browser', icon: <Globe size={16} /> },
-    { key: 'executor', label: 'Executor', icon: <Server size={16} /> },
-    { key: 'sandbox', label: 'Sandbox', icon: <Box size={16} /> },
+    { key: 'explorers', label: 'Explorers', icon: <Globe size={16} /> },
+    { key: 'executor', label: 'Executors', icon: <Server size={16} /> },
+    { key: 'sandbox', label: 'Sandboxes', icon: <Box size={16} /> },
     { key: 'llm', label: 'LLM', icon: <Brain size={16} /> },
     { key: 'im', label: 'IM', icon: <Bot size={16} /> },
     { key: 'traces', label: 'Traces', icon: <MessageSquare size={16} />, badge: tracesTotal > 0 ? tracesTotal : undefined },
@@ -194,8 +194,8 @@ export function WorkspaceDetail({ workspace, onRename, initialTab, sandboxOverri
               onRename={onRename}
             />
           )}
-          {tab === 'browser' && (
-            <BrowserPanel workspaceId={workspace.id} />
+          {tab === 'explorers' && (
+            <ExplorersPanel workspaceId={workspace.id} />
           )}
           {tab === 'executor' && (
             <RemoteExecutorsPanel workspaceId={workspace.id} />
@@ -322,7 +322,7 @@ function OverviewTab({ workspace, sbxQuota, defaults, llmQuota, onRename }: {
   )
 }
 
-function BrowserPanel({ workspaceId }: { workspaceId: string }) {
+function ExplorersPanel({ workspaceId }: { workspaceId: string }) {
   return (
     <div className="flex flex-col gap-6">
       <CodexTokensPanel workspaceId={workspaceId} />


### PR DESCRIPTION
## Summary
- Sidebar: Browser → Explorers, Executor → Executors, Sandbox → Sandboxes (already plural: Traces, Operations, Credentials, Members, Settings; LLM/IM stay as acronyms; Overview stays singular).
- Internal tab key \`browser\` → \`explorers\`; \`BrowserPanel\` → \`ExplorersPanel\`.
- NotebooksPanel: drop the embedded iframe; render a card with an "Open Notebook" button that creates a session and opens JupyterLab in a new tab.
- Chart bump 0.58.0 → 0.58.1.

## Test plan
- [ ] Sidebar shows English plural labels.
- [ ] Explorers tab shows Codex Remote Access panel + a Jupyter Notebook launch card (no embedded iframe).
- [ ] Clicking "Open Notebook" opens JupyterLab in a new tab and authenticates via the issued JWT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)