### PR TITLE
fix(notebook): install SDK + auto-inject ctx (v0.59.4)

### DIFF
--- a/Dockerfile.notebook
+++ b/Dockerfile.notebook
@@ -16,10 +16,9 @@ RUN pip install --no-cache-dir \
       jupyterlab~=4.2 \
       ipykernel~=6.29
 
-# Agentserver-sdk install lands with Plan 1 (feat/python-env-sdk).
-# When that branch is merged, restore:
-#   COPY sdk/python /tmp/sdk
-#   RUN pip install --no-cache-dir /tmp/sdk && rm -rf /tmp/sdk
+# Agentserver Python SDK — exposes Ctx, Env, Process, errors.
+COPY sdk/python /tmp/sdk
+RUN pip install --no-cache-dir /tmp/sdk && rm -rf /tmp/sdk
 
 # Agentserver jupyter extensions (Plan 3b).
 # Registers AgentserverKernelProvisioner via jupyter_client.kernel_provisioners
@@ -29,6 +28,10 @@ RUN pip install --no-cache-dir /tmp/agentserver_jupyter_ext && rm -rf /tmp/agent
 
 # Jupyter config
 COPY notebook/jupyter_server_config.py /etc/jupyter/
+
+# IPython startup hook — auto-injects `ctx` and `asyncio` into every kernel.
+RUN mkdir -p /root/.ipython/profile_default/startup
+COPY notebook/ipython_startup/00-ctx.py /root/.ipython/profile_default/startup/00-ctx.py
 
 # Workspace mount point — host bind or k8s PV later.
 RUN mkdir -p /workspace

--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.59.3
-appVersion: "0.59.3"
+version: 0.59.4
+appVersion: "0.59.4"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
## Summary
The notebook image never installed \`agentserver-sdk\` and never copied \`ipython_startup/00-ctx.py\` into IPython's startup dir, so \`ctx\` was undefined in every kernel.

- \`Dockerfile.notebook\` now copies and pip-installs \`sdk/python\`.
- \`Dockerfile.notebook\` copies \`notebook/ipython_startup/00-ctx.py\` into \`/root/.ipython/profile_default/startup/\` so \`ctx = Ctx.from_env()\` + \`asyncio\` are pre-injected.
- Chart 0.59.3 → 0.59.4.

After this PR, \`await ctx.envs()\` will run, but the SDK still needs \`AGENTSERVER_GATEWAY_URL\` / \`AGENTSERVER_WORKSPACE_ID\` / \`AGENTSERVER_WORKSPACE_TOKEN\` injected into the notebook pod's env via the supervisor for the WS handshake to actually reach the gateway. That's a separate follow-up — see issue / next PR.

## Test plan
- [ ] After deploy, in a fresh notebook cell: \`type(ctx)\` returns the Ctx class.
- [ ] \`await ctx.envs()\` either lists envs (once gateway wiring lands) or raises a clear ConnectionError instead of NameError.

🤖 Generated with [Claude Code](https://claude.com/claude-code)