### PR TITLE
fix(weixin): align imbridge with @tencent-weixin/openclaw-weixin@2.4.3

### DIFF
--- a/internal/imbridge/bridge.go
+++ b/internal/imbridge/bridge.go
@@ -52,6 +52,13 @@ type BridgeBinding struct {
 	RoutingMode string // "nanoclaw" (default) or "stateless_cc"
 }
 
+// pollerEntry tracks an active poller so the bridge can both cancel it and
+// invoke its provider's lifecycle hooks (e.g. notifyStop) on shutdown.
+type pollerEntry struct {
+	cancel  context.CancelFunc
+	binding BridgeBinding
+}
+
 // Bridge manages per-binding poll goroutines for all IM providers.
 type Bridge struct {
 	db               BridgeDB
@@ -59,11 +66,11 @@ type Bridge struct {
 	exec             ExecCommander
 	agentserverURL   string
 	providers        map[string]Provider
-	pollers          map[string]context.CancelFunc // key: channelID
-	registeredGroups map[string]string             // key: "sandboxID:chatJID" → cached settings hash
-	channelMention   map[string]bool               // key: channelID → require_mention setting
-	channelRouting   map[string]string             // key: channelID → routing_mode (runtime override of binding)
-	typingSessions   map[string]func()             // key: "channelID:userID" → cancel func
+	pollers          map[string]pollerEntry // key: channelID
+	registeredGroups map[string]string      // key: "sandboxID:chatJID" → cached settings hash
+	channelMention   map[string]bool        // key: channelID → require_mention setting
+	channelRouting   map[string]string      // key: channelID → routing_mode (runtime override of binding)
+	typingSessions   map[string]func()      // key: "channelID:userID" → cancel func
 	mu               sync.Mutex
 }
 
@@ -83,7 +90,7 @@ func NewBridge(db BridgeDB, resolver SandboxResolver, exec ExecCommander, provid
 		exec:             exec,
 		agentserverURL:   agentserverURL,
 		providers:        pm,
-		pollers:          make(map[string]context.CancelFunc),
+		pollers:          make(map[string]pollerEntry),
 		registeredGroups: make(map[string]string),
 		channelMention:   make(map[string]bool),
 		channelRouting:   make(map[string]string),
@@ -107,13 +114,18 @@ func (b *Bridge) GetProvider(name string) Provider {
 
 // StartPoller starts a long-poll goroutine for a channel.
 // If a poller already exists for this channel, it is stopped first.
+//
+// If the provider implements LifecycleProvider, OnPollerStart is invoked
+// best-effort in a separate goroutine; failures are logged but do not
+// block poller startup.
 func (b *Bridge) StartPoller(binding BridgeBinding) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 
 	key := binding.ChannelID
-	if cancel, ok := b.pollers[key]; ok {
-		cancel()
+	prevEntry, replacing := b.pollers[key]
+	if replacing {
+		prevEntry.cancel()
 	}
 
 	// Seed the in-memory routing map so getChannelRoutingMode returns
@@ -122,34 +134,87 @@ func (b *Bridge) StartPoller(binding BridgeBinding) {
 	b.channelRouting[key] = binding.RoutingMode
 
 	ctx, cancel := context.WithCancel(context.Background())
-	b.pollers[key] = cancel
+	b.pollers[key] = pollerEntry{cancel: cancel, binding: binding}
 
+	if replacing {
+		// Same channelID often means same bot account (re-login). Serialize
+		// notifyStop(old) → notifyStart(new) so the upstream server's per-account
+		// online state is not corrupted by reordering. Detached from the bridge
+		// lock; the new pollLoop starts in parallel since it doesn't depend on
+		// notify lifecycle.
+		go func() {
+			invokeOnPollerStop(prevEntry.binding)
+			invokeOnPollerStart(binding)
+		}()
+	} else {
+		go invokeOnPollerStart(binding)
+	}
 	go b.pollLoop(ctx, binding)
 }
 
-// StopPoller stops the polling goroutine for a specific channel.
+// StopPoller stops the polling goroutine for a specific channel and, if the
+// provider implements LifecycleProvider, fires OnPollerStop in a separate
+// goroutine (best-effort, won't block return).
 func (b *Bridge) StopPoller(channelID string) {
 	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	if cancel, ok := b.pollers[channelID]; ok {
-		cancel()
+	entry, ok := b.pollers[channelID]
+	if ok {
+		entry.cancel()
 		delete(b.pollers, channelID)
+	}
+	b.mu.Unlock()
+	if ok {
+		go invokeOnPollerStop(entry.binding)
 	}
 }
 
 // StopAllPollers stops all polling goroutines and typing sessions.
+// LifecycleProvider hooks fire best-effort in goroutines.
 func (b *Bridge) StopAllPollers() {
 	b.mu.Lock()
-	defer b.mu.Unlock()
-
-	for key, cancel := range b.pollers {
-		cancel()
+	entries := make([]pollerEntry, 0, len(b.pollers))
+	for key, entry := range b.pollers {
+		entry.cancel()
+		entries = append(entries, entry)
 		delete(b.pollers, key)
 	}
 	for key, cancel := range b.typingSessions {
 		cancel()
 		delete(b.typingSessions, key)
+	}
+	b.mu.Unlock()
+	for _, e := range entries {
+		go invokeOnPollerStop(e.binding)
+	}
+}
+
+// invokeOnPollerStart fires the optional LifecycleProvider.OnPollerStart hook
+// with a short timeout. Failures are logged and ignored.
+func invokeOnPollerStart(binding BridgeBinding) {
+	lp, ok := binding.Provider.(LifecycleProvider)
+	if !ok {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := lp.OnPollerStart(ctx, &binding.Credentials); err != nil {
+		log.Printf("imbridge: %s OnPollerStart failed (ignored) channel=%s: %v",
+			binding.Provider.Name(), binding.ChannelID, err)
+	}
+}
+
+// invokeOnPollerStop fires the optional LifecycleProvider.OnPollerStop hook
+// with a short timeout. Failures are logged and ignored.
+func invokeOnPollerStop(binding BridgeBinding) {
+	lp, ok := binding.Provider.(LifecycleProvider)
+	if !ok {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if err := lp.OnPollerStop(ctx, &binding.Credentials); err != nil {
+		log.Printf("imbridge: %s OnPollerStop failed (ignored) channel=%s: %v",
+			binding.Provider.Name(), binding.ChannelID, err)
 	}
 }
 

--- a/internal/imbridge/bridge_routing_test.go
+++ b/internal/imbridge/bridge_routing_test.go
@@ -1,7 +1,6 @@
 package imbridge
 
 import (
-	"context"
 	"sync"
 	"testing"
 )
@@ -14,7 +13,7 @@ import (
 func TestForwardMessageChannelRoutingOverridesBinding(t *testing.T) {
 	b := &Bridge{
 		providers:        map[string]Provider{},
-		pollers:          map[string]context.CancelFunc{},
+		pollers:          map[string]pollerEntry{},
 		registeredGroups: map[string]string{},
 		channelMention:   map[string]bool{},
 		channelRouting:   map[string]string{},
@@ -45,7 +44,7 @@ func TestForwardMessageChannelRoutingOverridesBinding(t *testing.T) {
 func TestSetChannelRoutingModeConcurrent(t *testing.T) {
 	b := &Bridge{
 		providers:        map[string]Provider{},
-		pollers:          map[string]context.CancelFunc{},
+		pollers:          map[string]pollerEntry{},
 		registeredGroups: map[string]string{},
 		channelMention:   map[string]bool{},
 		channelRouting:   map[string]string{},

--- a/internal/imbridge/matrix_provider.go
+++ b/internal/imbridge/matrix_provider.go
@@ -145,7 +145,8 @@ func (p *MatrixProvider) Send(ctx context.Context, creds *Credentials, toUserID,
 }
 
 // SendImage implements ImageSendProvider for Matrix.
-func (p *MatrixProvider) SendImage(ctx context.Context, creds *Credentials, toUserID string, imageData []byte, caption string) error {
+// meta is unused (Matrix room ID is encoded in toUserID).
+func (p *MatrixProvider) SendImage(ctx context.Context, creds *Credentials, toUserID string, imageData []byte, caption string, _ map[string]string) error {
 	roomID := strings.TrimSuffix(toUserID, "@matrix")
 
 	if p.CryptoManager != nil {

--- a/internal/imbridge/provider.go
+++ b/internal/imbridge/provider.go
@@ -44,8 +44,9 @@ type TypingProvider interface {
 }
 
 // ImageSendProvider is an optional interface for providers that support sending images.
+// meta carries provider-specific state (e.g., WeChat context_token). May be nil.
 type ImageSendProvider interface {
-	SendImage(ctx context.Context, creds *Credentials, toUserID string, imageData []byte, caption string) error
+	SendImage(ctx context.Context, creds *Credentials, toUserID string, imageData []byte, caption string, meta map[string]string) error
 }
 
 // ConfigurableProvider validates credentials during configure.
@@ -62,6 +63,15 @@ type DisconnectProvider interface {
 // InitializableProvider can be initialized with server-level configuration.
 type InitializableProvider interface {
 	InitProvider(dbURL string) error
+}
+
+// LifecycleProvider lets a provider react when its poller is started or
+// stopped — for example, to notify the upstream server about per-account
+// online state. Implementations should be best-effort and tolerate
+// network errors without affecting the poller's own startup/shutdown.
+type LifecycleProvider interface {
+	OnPollerStart(ctx context.Context, creds *Credentials) error
+	OnPollerStop(ctx context.Context, creds *Credentials) error
 }
 
 // InboundMessage represents a single incoming message from the IM platform.

--- a/internal/imbridge/telegram_provider.go
+++ b/internal/imbridge/telegram_provider.go
@@ -218,7 +218,8 @@ func (p *TelegramProvider) ValidateCredentials(ctx context.Context, baseURL, tok
 }
 
 // SendImage implements ImageSendProvider for Telegram.
-func (p *TelegramProvider) SendImage(ctx context.Context, creds *Credentials, toUserID string, imageData []byte, caption string) error {
+// meta is unused (Telegram has no per-conversation context_token).
+func (p *TelegramProvider) SendImage(ctx context.Context, creds *Credentials, toUserID string, imageData []byte, caption string, _ map[string]string) error {
 	chatID, err := strconv.ParseInt(strings.TrimSuffix(toUserID, "@tg"), 10, 64)
 	if err != nil {
 		return fmt.Errorf("invalid telegram chat ID %q: %w", toUserID, err)

--- a/internal/imbridge/weixin_provider.go
+++ b/internal/imbridge/weixin_provider.go
@@ -32,8 +32,8 @@ func (p *WeixinProvider) Poll(ctx context.Context, creds *Credentials, cursor st
 	// Handle API-level errors
 	if resp.Ret != 0 || resp.ErrCode != 0 {
 		if resp.ErrCode == weixin.SessionExpiredErrCode || resp.Ret == weixin.SessionExpiredErrCode {
-			log.Printf("imbridge: weixin session expired for bot=%s, backing off 5m", creds.BotID)
-			return &PollResult{ShouldBackoff: 5 * time.Minute}, nil
+			log.Printf("imbridge: weixin session expired for bot=%s, backing off 1h", creds.BotID)
+			return &PollResult{ShouldBackoff: 1 * time.Hour}, nil
 		}
 		return nil, fmt.Errorf("ilink API error: ret=%d errcode=%d errmsg=%s", resp.Ret, resp.ErrCode, resp.ErrMsg)
 	}
@@ -210,8 +210,13 @@ func describeWeixinMedia(items []weixin.MessageItem) string {
 
 // SendImage implements ImageSendProvider for WeChat.
 // Uploads the image to CDN and sends it, then sends the caption as a separate text message.
-func (p *WeixinProvider) SendImage(ctx context.Context, creds *Credentials, toUserID string, imageData []byte, caption string) error {
+// Both calls carry the meta["context_token"] so the iLink server can route the
+// outbound back through the originating conversation.
+func (p *WeixinProvider) SendImage(ctx context.Context, creds *Credentials, toUserID string, imageData []byte, caption string, meta map[string]string) error {
 	contextToken := ""
+	if meta != nil {
+		contextToken = meta["context_token"]
+	}
 	if err := weixin.UploadAndSendImage(ctx, creds.BaseURL, "", creds.BotToken, toUserID, imageData, contextToken); err != nil {
 		return err
 	}
@@ -221,6 +226,19 @@ func (p *WeixinProvider) SendImage(ctx context.Context, creds *Credentials, toUs
 	return nil
 }
 
+// OnPollerStart implements LifecycleProvider — notifies the iLink server
+// that this client is starting to long-poll for the given bot, so the
+// server can reconcile per-account online state. Best-effort.
+func (p *WeixinProvider) OnPollerStart(ctx context.Context, creds *Credentials) error {
+	return weixin.NotifyStart(ctx, creds.BaseURL, creds.BotToken)
+}
+
+// OnPollerStop implements LifecycleProvider — notifies the iLink server
+// that this client is going offline. Best-effort.
+func (p *WeixinProvider) OnPollerStop(ctx context.Context, creds *Credentials) error {
+	return weixin.NotifyStop(ctx, creds.BaseURL, creds.BotToken)
+}
+
 // --- QR Login session management (delegates to weixin package) ---
 
 // StartQRLogin initiates a WeChat QR code login flow.
@@ -228,9 +246,17 @@ func (p *WeixinProvider) StartQRLogin(ctx context.Context) (*weixin.Session, err
 	return weixin.StartLogin(ctx, weixin.DefaultAPIBaseURL)
 }
 
-// PollQRLogin polls for the QR code scan status.
-func (p *WeixinProvider) PollQRLogin(ctx context.Context, qrCode string) (*weixin.StatusResult, error) {
-	return weixin.PollLoginStatus(ctx, weixin.DefaultAPIBaseURL, qrCode)
+// PollQRLogin polls for the QR code scan status using the session's
+// CurrentAPIBaseURL (which may differ from DefaultAPIBaseURL after a
+// scaned_but_redirect IDC migration). Callers are responsible for
+// updating session.CurrentAPIBaseURL when the result is
+// scaned_but_redirect, before the next call.
+func (p *WeixinProvider) PollQRLogin(ctx context.Context, session *weixin.Session) (*weixin.StatusResult, error) {
+	baseURL := session.CurrentAPIBaseURL
+	if baseURL == "" {
+		baseURL = weixin.DefaultAPIBaseURL
+	}
+	return weixin.PollLoginStatus(ctx, baseURL, session.QRCode)
 }
 
 // SetSession stores a QR login session for a sandbox.

--- a/internal/imbridgesvc/handlers.go
+++ b/internal/imbridgesvc/handlers.go
@@ -128,7 +128,7 @@ func (s *Server) handleNanoclawIMSend(w http.ResponseWriter, r *http.Request) {
 			http.Error(w, "image sending not supported for provider: "+provider.Name(), http.StatusBadRequest)
 			return
 		}
-		if err := isp.SendImage(r.Context(), creds, userID, mediaData, reqMeta.Text); err != nil {
+		if err := isp.SendImage(r.Context(), creds, userID, mediaData, reqMeta.Text, meta); err != nil {
 			log.Printf("nanoclaw im send image: failed sandbox=%s to=%s: %v", sandboxID, userID, err)
 			http.Error(w, "failed to send image: "+err.Error(), http.StatusBadGateway)
 			return
@@ -288,7 +288,8 @@ func (s *Server) handleImbridgeDirectSendImage(w http.ResponseWriter, r *http.Re
 		BaseURL:   channel.BaseURL,
 	}
 
-	if err := isp.SendImage(r.Context(), creds, req.ToUserID, data, req.Caption); err != nil {
+	meta, _ := s.db.GetAllChannelMeta(channel.ID, req.ToUserID)
+	if err := isp.SendImage(r.Context(), creds, req.ToUserID, data, req.Caption, meta); err != nil {
 		log.Printf("imbridge direct send-image: failed channel=%s provider=%s to=%s: %v",
 			channel.ID, provider.Name(), req.ToUserID, err)
 		http.Error(w, "failed to send image", http.StatusBadGateway)
@@ -364,7 +365,7 @@ func (s *Server) handleIMWeixinQRWait(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result, err := wp.PollQRLogin(r.Context(), session.QRCode)
+	result, err := wp.PollQRLogin(r.Context(), session)
 	if err != nil {
 		log.Printf("weixin qr-wait: poll error: %v", err)
 		http.Error(w, "poll failed", http.StatusBadGateway)
@@ -407,7 +408,45 @@ func (s *Server) handleIMWeixinQRWait(w http.ResponseWriter, r *http.Request) {
 			"qrcode_url": newSession.QRCodeURL,
 		})
 
+	case "scaned_but_redirect":
+		// IDC migration: subsequent polls must target the new host.
+		if result.RedirectHost != "" {
+			session.CurrentAPIBaseURL = "https://" + result.RedirectHost
+			wp.SetSession(id, session)
+			log.Printf("weixin qr-wait: IDC redirect, switching polling host to %s", result.RedirectHost)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"connected": false,
+			"status":    "scaned",
+			"message":   statusMessage("scaned"),
+		})
+
+	case "binded_redirect":
+		wp.TakeSession(id)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"connected":        false,
+			"status":           "binded_redirect",
+			"already_connected": true,
+			"message":          "已连接过此实例，无需重复连接",
+		})
+
+	case "verify_code_blocked":
+		wp.ClearSession(id)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"connected": false,
+			"status":    "verify_code_blocked",
+			"message":   "配对码错误次数过多，请稍后再试",
+		})
+
 	default:
+		// Includes "wait", "scaned", "need_verifycode" (logged-and-waited),
+		// and any unknown future status.
+		if result.Status == "need_verifycode" {
+			log.Printf("weixin qr-wait: need_verifycode received (interactive pair-code not supported yet, sandbox=%s)", id)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"connected": false,
@@ -983,7 +1022,7 @@ func (s *Server) handleWorkspaceWeixinQRWait(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	result, err := wp.PollQRLogin(r.Context(), session.QRCode)
+	result, err := wp.PollQRLogin(r.Context(), session)
 	if err != nil {
 		log.Printf("weixin qr-wait: poll error: %v", err)
 		http.Error(w, "poll failed", http.StatusBadGateway)
@@ -1047,7 +1086,41 @@ func (s *Server) handleWorkspaceWeixinQRWait(w http.ResponseWriter, r *http.Requ
 			"qrcode_url": newSession.QRCodeURL,
 		})
 
+	case "scaned_but_redirect":
+		if result.RedirectHost != "" {
+			session.CurrentAPIBaseURL = "https://" + result.RedirectHost
+			wp.SetSession(wsID, session)
+			log.Printf("weixin qr-wait: IDC redirect, switching polling host to %s", result.RedirectHost)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"connected": false,
+			"status":    "scaned",
+		})
+
+	case "binded_redirect":
+		wp.TakeSession(wsID)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"connected":         false,
+			"status":            "binded_redirect",
+			"already_connected": true,
+			"message":           "已连接过此实例，无需重复连接",
+		})
+
+	case "verify_code_blocked":
+		wp.ClearSession(wsID)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"connected": false,
+			"status":    "verify_code_blocked",
+			"message":   "配对码错误次数过多，请稍后再试",
+		})
+
 	default:
+		if result.Status == "need_verifycode" {
+			log.Printf("weixin qr-wait: need_verifycode received (interactive pair-code not supported yet, workspace=%s)", wsID)
+		}
 		w.Header().Set("Content-Type", "application/json")
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"connected": false,

--- a/internal/weixin/ilink.go
+++ b/internal/weixin/ilink.go
@@ -9,6 +9,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -31,25 +32,77 @@ const (
 	configTimeout        = 10 * time.Second
 	SessionExpiredErrCode = -14
 
+	// iLink app identification headers. The server uses these to
+	// gate features and identify the upstream app. Values match
+	// @tencent-weixin/openclaw-weixin@2.4.3 (ilink_appid="bot",
+	// version 2.4.3 encoded as major<<16|minor<<8|patch = 0x020403).
+	iLinkAppID            = "bot"
+	iLinkAppClientVersion = "132099" // (2<<16)|(4<<8)|3
+
+	// BotAgent sent in every request's base_info. iLink uses this
+	// UA-style string for upstream-app identification.
+	defaultBotAgent = "agentserver"
+
 	// TypingStatus values for SendTyping.
 	TypingStatusTyping = 1
 	TypingStatusCancel = 2
 )
 
-// Session holds the state of an in-progress QR login for a single sandbox.
-type Session struct {
-	QRCode    string    // opaque qrcode string for status polling
-	QRCodeURL string    // image URL for frontend rendering
-	StartedAt time.Time
+// ErrSessionExpired is returned by outbound API helpers when the iLink
+// server reports session-expired (ret/errcode == -14). Callers should
+// treat the bot as needing re-login. Test with errors.Is.
+var ErrSessionExpired = errors.New("weixin: session expired (errcode -14)")
+
+// IsSessionExpired reports whether err (or any wrapped err) is ErrSessionExpired.
+func IsSessionExpired(err error) bool {
+	return errors.Is(err, ErrSessionExpired)
 }
 
-// StatusResult is the parsed response from get_qrcode_status.
+// checkAPIError converts an iLink response envelope into either
+// ErrSessionExpired (when ret/errcode == -14) or a generic error
+// when ret != 0 or errcode != 0. Returns nil on success.
+func checkAPIError(label string, ret, errcode int, errmsg string) error {
+	if ret == SessionExpiredErrCode || errcode == SessionExpiredErrCode {
+		return fmt.Errorf("%s: %w", label, ErrSessionExpired)
+	}
+	if ret != 0 || errcode != 0 {
+		return fmt.Errorf("%s: ret=%d errcode=%d errmsg=%s", label, ret, errcode, errmsg)
+	}
+	return nil
+}
+
+// newBaseInfo returns the base_info envelope attached to every API request.
+func newBaseInfo() BaseInfo {
+	return BaseInfo{ChannelVersion: channelVersion, BotAgent: defaultBotAgent}
+}
+
+// Session holds the state of an in-progress QR login for a single sandbox.
+// CurrentAPIBaseURL tracks the base URL polling should use for the *next*
+// PollLoginStatus call. It starts as the original DefaultAPIBaseURL and may
+// switch mid-flight when the server returns scaned_but_redirect with a new
+// redirect_host (IDC migration).
+type Session struct {
+	QRCode            string    // opaque qrcode string for status polling
+	QRCodeURL         string    // image URL for frontend rendering
+	CurrentAPIBaseURL string    // host to use for next PollLoginStatus
+	StartedAt         time.Time
+}
+
+// StatusResult is the parsed response from get_qrcode_status. The set of
+// statuses matches @tencent-weixin/openclaw-weixin@2.4.3:
+//
+//   wait / scaned / confirmed / expired — original states.
+//   scaned_but_redirect — IDC migration; caller must switch to RedirectHost.
+//   binded_redirect — bot already bound to this instance; no re-login needed.
+//   need_verifycode — server requires a pair-code from the WeChat client.
+//   verify_code_blocked — too many wrong codes; refresh QR and try again.
 type StatusResult struct {
-	Status  string `json:"status"` // "wait", "scaned", "confirmed", "expired"
-	Token   string `json:"bot_token,omitempty"`
-	BotID   string `json:"ilink_bot_id,omitempty"`
-	BaseURL string `json:"baseurl,omitempty"`
-	UserID  string `json:"ilink_user_id,omitempty"`
+	Status       string `json:"status"`
+	Token        string `json:"bot_token,omitempty"`
+	BotID        string `json:"ilink_bot_id,omitempty"`
+	BaseURL      string `json:"baseurl,omitempty"`
+	UserID       string `json:"ilink_user_id,omitempty"`
+	RedirectHost string `json:"redirect_host,omitempty"` // host (no scheme) for scaned_but_redirect
 }
 
 // --- iLink Message API types ---
@@ -57,6 +110,7 @@ type StatusResult struct {
 // BaseInfo is common metadata attached to every iLink API request.
 type BaseInfo struct {
 	ChannelVersion string `json:"channel_version,omitempty"`
+	BotAgent       string `json:"bot_agent,omitempty"`
 }
 
 // MessageItem represents a single content item in a WeixinMessage.
@@ -171,16 +225,25 @@ func purgeExpired() {
 	}
 }
 
+// GetSession returns a copy of the active QR-login session for sandboxID,
+// or nil when none is active or the stored one has expired. The returned
+// pointer is detached from the in-memory map: callers may mutate fields
+// (e.g. CurrentAPIBaseURL on IDC redirect) and persist via SetSession
+// without racing concurrent readers of the same map entry.
 func GetSession(sandboxID string) *Session {
 	mu.Lock()
 	defer mu.Unlock()
 	purgeExpired()
 	s := sessions[sandboxID]
-	if s != nil && time.Since(s.StartedAt) > sessionTTL {
+	if s == nil {
+		return nil
+	}
+	if time.Since(s.StartedAt) > sessionTTL {
 		delete(sessions, sandboxID)
 		return nil
 	}
-	return s
+	cp := *s
+	return &cp
 }
 
 func SetSession(sandboxID string, s *Session) {
@@ -211,6 +274,13 @@ type qrCodeResponse struct {
 }
 
 // StartLogin calls the ilink API to generate a new QR code for WeChat login.
+//
+// Since openclaw-weixin@2.3.1, this is a POST with body
+// {"local_token_list": [...]} so the server can return binded_redirect
+// when the scanning bot is already bound to a known token. We do not
+// currently track previously-issued tokens here, so an empty list is
+// always sent — losing the binded_redirect optimization but matching
+// the current wire protocol.
 func StartLogin(ctx context.Context, apiBaseURL string) (*Session, error) {
 	if apiBaseURL == "" {
 		apiBaseURL = DefaultAPIBaseURL
@@ -224,12 +294,22 @@ func StartLogin(ctx context.Context, apiBaseURL string) (*Session, error) {
 	q.Set("bot_type", defaultBotType)
 	u.RawQuery = q.Encode()
 
+	body, err := json.Marshal(map[string]interface{}{
+		"local_token_list": []string{},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshal get_bot_qrcode body: %w", err)
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, startTimeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, "GET", u.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, "POST", u.String(), bytes.NewReader(body))
 	if err != nil {
 		return nil, err
+	}
+	for k, v := range buildILinkHeaders("") {
+		req.Header[k] = v
 	}
 
 	resp, err := http.DefaultClient.Do(req)
@@ -250,9 +330,10 @@ func StartLogin(ctx context.Context, apiBaseURL string) (*Session, error) {
 	}
 
 	return &Session{
-		QRCode:    qr.QRCode,
-		QRCodeURL: qr.QRCodeImgContent,
-		StartedAt: time.Now(),
+		QRCode:            qr.QRCode,
+		QRCodeURL:         qr.QRCodeImgContent,
+		CurrentAPIBaseURL: apiBaseURL,
+		StartedAt:         time.Now(),
 	}, nil
 }
 
@@ -261,6 +342,10 @@ func buildILinkHeaders(botToken string) http.Header {
 	h := http.Header{}
 	h.Set("Content-Type", "application/json")
 	h.Set("AuthorizationType", "ilink_bot_token")
+	// iLink app identification — required since openclaw-weixin@2.4.2,
+	// where missing/empty values caused production fetch failures.
+	h.Set("iLink-App-Id", iLinkAppID)
+	h.Set("iLink-App-ClientVersion", iLinkAppClientVersion)
 	// X-WECHAT-UIN: random uint32 as decimal string, base64-encoded.
 	// Required by iLink API (matches openclaw-weixin's randomWechatUin).
 	uin := make([]byte, 4)
@@ -287,7 +372,7 @@ func GetUpdates(ctx context.Context, apiBaseURL, botToken, getUpdatesBuf string)
 
 	body := GetUpdatesRequest{
 		GetUpdatesBuf: getUpdatesBuf,
-		BaseInfo:      BaseInfo{ChannelVersion: channelVersion},
+		BaseInfo:      newBaseInfo(),
 	}
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {
@@ -350,7 +435,7 @@ func SendTextMessage(ctx context.Context, apiBaseURL, botToken, toUserID, text, 
 				TextItem: &TextItem{Text: text},
 			}},
 		},
-		BaseInfo: BaseInfo{ChannelVersion: channelVersion},
+		BaseInfo: newBaseInfo(),
 	}
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {
@@ -380,13 +465,14 @@ func SendTextMessage(ctx context.Context, apiBaseURL, botToken, toUserID, text, 
 
 	// Check response body for API-level errors (iLink returns HTTP 200 with ret != 0 on failure).
 	var result struct {
-		Ret    int    `json:"ret"`
-		ErrMsg string `json:"errmsg"`
+		Ret     int    `json:"ret"`
+		ErrCode int    `json:"errcode,omitempty"`
+		ErrMsg  string `json:"errmsg,omitempty"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err == nil && result.Ret != 0 {
-		return fmt.Errorf("ilink sendmessage: ret=%d errmsg=%s", result.Ret, result.ErrMsg)
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil // tolerate empty/unknown body (matches prior behavior)
 	}
-	return nil
+	return checkAPIError("ilink sendmessage", result.Ret, result.ErrCode, result.ErrMsg)
 }
 
 // --- iLink CDN Media Upload ---
@@ -412,7 +498,7 @@ func GetUploadURL(ctx context.Context, apiBaseURL, botToken string, params map[s
 	}
 	u.Path = "/ilink/bot/getuploadurl"
 
-	params["base_info"] = BaseInfo{ChannelVersion: channelVersion}
+	params["base_info"] = newBaseInfo()
 	bodyBytes, err := json.Marshal(params)
 	if err != nil {
 		return nil, fmt.Errorf("marshal getuploadurl: %w", err)
@@ -444,8 +530,8 @@ func GetUploadURL(ctx context.Context, apiBaseURL, botToken string, params map[s
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("ilink getuploadurl: decode: %w", err)
 	}
-	if result.Ret != 0 {
-		return nil, fmt.Errorf("ilink getuploadurl: ret=%d errcode=%d errmsg=%s", result.Ret, result.ErrCode, result.ErrMsg)
+	if err := checkAPIError("ilink getuploadurl", result.Ret, result.ErrCode, result.ErrMsg); err != nil {
+		return nil, err
 	}
 	if result.UploadFullURL == "" && result.UploadParam == "" {
 		return nil, fmt.Errorf("ilink getuploadurl: empty upload_param and upload_full_url")
@@ -528,7 +614,7 @@ func SendImageMessage(ctx context.Context, apiBaseURL, botToken, toUserID string
 				},
 			}},
 		},
-		BaseInfo: BaseInfo{ChannelVersion: channelVersion},
+		BaseInfo: newBaseInfo(),
 	}
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {
@@ -556,13 +642,14 @@ func SendImageMessage(ctx context.Context, apiBaseURL, botToken, toUserID string
 		return fmt.Errorf("ilink sendImageMessage: status %d", resp.StatusCode)
 	}
 	var result struct {
-		Ret    int    `json:"ret"`
-		ErrMsg string `json:"errmsg"`
+		Ret     int    `json:"ret"`
+		ErrCode int    `json:"errcode,omitempty"`
+		ErrMsg  string `json:"errmsg,omitempty"`
 	}
-	if err := json.NewDecoder(resp.Body).Decode(&result); err == nil && result.Ret != 0 {
-		return fmt.Errorf("ilink sendImageMessage: ret=%d errmsg=%s", result.Ret, result.ErrMsg)
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil
 	}
-	return nil
+	return checkAPIError("ilink sendImageMessage", result.Ret, result.ErrCode, result.ErrMsg)
 }
 
 // UploadAndSendImage handles the complete flow: encrypt → CDN upload → send message.
@@ -793,7 +880,8 @@ func isMediaItem(item *MessageItem) bool {
 // GetConfigResponse is the response from ilink/bot/getconfig.
 type GetConfigResponse struct {
 	Ret          int    `json:"ret"`
-	ErrMsg       string `json:"errmsg"`
+	ErrCode      int    `json:"errcode,omitempty"`
+	ErrMsg       string `json:"errmsg,omitempty"`
 	TypingTicket string `json:"typing_ticket"`
 }
 
@@ -811,7 +899,7 @@ func GetConfig(ctx context.Context, apiBaseURL, botToken, userID, contextToken s
 	body := map[string]interface{}{
 		"ilink_user_id": userID,
 		"context_token": contextToken,
-		"base_info":     BaseInfo{ChannelVersion: channelVersion},
+		"base_info":     newBaseInfo(),
 	}
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {
@@ -839,6 +927,9 @@ func GetConfig(ctx context.Context, apiBaseURL, botToken, userID, contextToken s
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("ilink getconfig: decode: %w", err)
 	}
+	if err := checkAPIError("ilink getconfig", result.Ret, result.ErrCode, result.ErrMsg); err != nil {
+		return nil, err
+	}
 	return &result, nil
 }
 
@@ -858,7 +949,7 @@ func SendTyping(ctx context.Context, apiBaseURL, botToken, userID, typingTicket 
 		"ilink_user_id": userID,
 		"typing_ticket": typingTicket,
 		"status":        status,
-		"base_info":     BaseInfo{ChannelVersion: channelVersion},
+		"base_info":     newBaseInfo(),
 	}
 	bodyBytes, err := json.Marshal(body)
 	if err != nil {
@@ -881,7 +972,81 @@ func SendTyping(ctx context.Context, apiBaseURL, botToken, userID, typingTicket 
 		return fmt.Errorf("ilink sendtyping: %w", err)
 	}
 	defer resp.Body.Close()
-	return nil
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("ilink sendtyping: status %d", resp.StatusCode)
+	}
+	var result struct {
+		Ret     int    `json:"ret"`
+		ErrCode int    `json:"errcode,omitempty"`
+		ErrMsg  string `json:"errmsg,omitempty"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil
+	}
+	return checkAPIError("ilink sendtyping", result.Ret, result.ErrCode, result.ErrMsg)
+}
+
+// notifyLifecycle posts to the given lifecycle endpoint (notifystart / notifystop).
+// Returns ErrSessionExpired when the iLink server reports -14. Other non-zero ret/errcode
+// values surface as a generic error. Network/HTTP errors are returned as-is.
+func notifyLifecycle(ctx context.Context, apiBaseURL, botToken, endpoint, label string) error {
+	if apiBaseURL == "" {
+		apiBaseURL = DefaultAPIBaseURL
+	}
+	u, err := url.Parse(apiBaseURL)
+	if err != nil {
+		return fmt.Errorf("invalid apiBaseURL: %w", err)
+	}
+	u.Path = endpoint
+
+	body, err := json.Marshal(map[string]interface{}{
+		"base_info": newBaseInfo(),
+	})
+	if err != nil {
+		return fmt.Errorf("marshal %s body: %w", label, err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, configTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, "POST", u.String(), bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	for k, v := range buildILinkHeaders(botToken) {
+		req.Header[k] = v
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("%s: %w", label, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s: status %d", label, resp.StatusCode)
+	}
+	var result struct {
+		Ret     int    `json:"ret"`
+		ErrCode int    `json:"errcode,omitempty"`
+		ErrMsg  string `json:"errmsg,omitempty"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil
+	}
+	return checkAPIError(label, result.Ret, result.ErrCode, result.ErrMsg)
+}
+
+// NotifyStart tells the iLink server that this channel client is starting
+// to poll for the given bot, so the server can reconcile per-account online
+// state. Best-effort: failures are non-fatal to the poller lifecycle.
+func NotifyStart(ctx context.Context, apiBaseURL, botToken string) error {
+	return notifyLifecycle(ctx, apiBaseURL, botToken, "/ilink/bot/msg/notifystart", "ilink notifystart")
+}
+
+// NotifyStop tells the iLink server that this channel client is shutting down.
+// Best-effort: failures are logged by the caller but do not affect shutdown.
+func NotifyStop(ctx context.Context, apiBaseURL, botToken string) error {
+	return notifyLifecycle(ctx, apiBaseURL, botToken, "/ilink/bot/msg/notifystop", "ilink notifystop")
 }
 
 // PollLoginStatus long-polls the ilink API for QR code scan status.
@@ -906,7 +1071,11 @@ func PollLoginStatus(ctx context.Context, apiBaseURL, qrcode string) (*StatusRes
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("iLink-App-ClientVersion", "1")
+	// QR polling is unauthenticated; pass empty token so buildILinkHeaders
+	// still sets iLink-App-Id / iLink-App-ClientVersion / X-WECHAT-UIN.
+	for k, v := range buildILinkHeaders("") {
+		req.Header[k] = v
+	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/internal/weixin/ilink_test.go
+++ b/internal/weixin/ilink_test.go
@@ -73,4 +73,23 @@ func TestBuildILinkHeaders(t *testing.T) {
 	if h.Get("Content-Type") != "application/json" {
 		t.Errorf("got ct=%q", h.Get("Content-Type"))
 	}
+	if h.Get("iLink-App-Id") != iLinkAppID {
+		t.Errorf("got iLink-App-Id=%q, want %q", h.Get("iLink-App-Id"), iLinkAppID)
+	}
+	if h.Get("iLink-App-ClientVersion") != iLinkAppClientVersion {
+		t.Errorf("got iLink-App-ClientVersion=%q, want %q", h.Get("iLink-App-ClientVersion"), iLinkAppClientVersion)
+	}
+	if h.Get("X-WECHAT-UIN") == "" {
+		t.Error("X-WECHAT-UIN must be present")
+	}
+}
+
+func TestBuildILinkHeadersNoToken(t *testing.T) {
+	h := buildILinkHeaders("")
+	if h.Get("Authorization") != "" {
+		t.Errorf("expected no Authorization when token empty, got %q", h.Get("Authorization"))
+	}
+	if h.Get("iLink-App-Id") != iLinkAppID {
+		t.Errorf("App-Id must be set even without token, got %q", h.Get("iLink-App-Id"))
+	}
 }


### PR DESCRIPTION
## Summary

Bring the Go re-implementation of the WeChat (iLink) channel in `internal/weixin/` and `internal/imbridge/` back into wire-protocol and behavior parity with upstream [`@tencent-weixin/openclaw-weixin@2.4.3`](https://www.npmjs.com/package/@tencent-weixin/openclaw-weixin) (the TS reference implementation). The Go side had been audited against `2.1.1` and drifted across several minor releases — this catches us up.

## What changed

### Protocol / wire fixes
- **Add `iLink-App-Id: "bot"` and `iLink-App-ClientVersion: "132099"` headers on every request** (was missing entirely). Upstream 2.4.2's changelog specifically called out that empty values caused production `fetch failed` errors.
- **Add `bot_agent: "agentserver"` to `base_info`** (upstream 2.3.1 added this for per-app identification on the server).
- **`StartLogin` (QR fetch): GET → POST with `{\"local_token_list\": []}` body** to match the 2.3.1 wire change.
- **Detect `ret == -14` OR `errcode == -14` on all outbound endpoints** (`SendText`, `SendImage`, `GetUploadURL`, `GetConfig`, `SendTyping`) via a new `checkAPIError` helper; surfaced as `ErrSessionExpired` sentinel + `IsSessionExpired()` for callers.
- **`SendTyping` now decodes the response body** instead of silently swallowing `ret != 0`.

### QR-login state machine (3 of 4 new states from upstream 2.3.1)
- `Session` gains `CurrentAPIBaseURL`; `PollQRLogin` uses it (was hard-coded to default), so IDC migration mid-session works.
- Handlers switch on the three new server states:
  - `scaned_but_redirect` — mutate session host and persist
  - `binded_redirect` — clean session, signal `already_connected: true`
  - `verify_code_blocked` — clear session, surface message
- `need_verifycode` is logged-only for now (interactive pair-code flow requires UI work).
- `GetSession` returns a **copy** so handler-side mutation no longer races `purgeExpired`'s read of `StartedAt`.

### Lifecycle hooks (upstream 2.3.1)
- New `LifecycleProvider` interface; `WeixinProvider` implements it by POSTing to `/ilink/bot/msg/notify{start,stop}`.
- `Bridge.StartPoller` / `StopPoller` / `StopAllPollers` invoke the hooks fire-and-forget with 10s timeouts.
- **Same-channel replacement serializes `notifyStop(old) → notifyStart(new)`** so the upstream server's per-account online state is not corrupted by reordering when the same channel re-logs in.
- `b.pollers` becomes `map[string]pollerEntry` to retain the binding for stop-time creds.

### Session-pause alignment
- `WeixinProvider.Poll` backoff on `-14` bumped **5min → 1h**, matching the upstream `SESSION_PAUSE_DURATION_MS`.

### Interface change (mild break)
- `ImageSendProvider.SendImage` now takes `meta map[string]string`.
  - The **WeChat** implementation reads `meta[\"context_token\"]` and threads it through both the CDN upload-send and the caption text (previously hard-coded to `\"\"` — the original bug that started this audit).
  - **Telegram** and **Matrix** accept the parameter and ignore it.
  - Both stateless and sandbox-bound handlers load `meta` from the channel DB before the call.

### Tests
- `TestBuildILinkHeaders` now asserts `iLink-App-Id` / `iLink-App-ClientVersion` / `X-WECHAT-UIN`.
- New `TestBuildILinkHeadersNoToken` checks that the new headers are still set when the token is empty (QR-flow case).
- `bridge_routing_test.go` updated for the new `pollerEntry` map type.

## Out of scope / explicitly deferred

- Voice (type 3) and video (type 5) **inbound media download** — upstream downloads silk-encoded audio (transcodes to wav) and mp4. We still rely on server-side ASR (`voice_item.text`) for voice and emit `\"[User sent a video]\"` placeholder text for video.
- **Outbound** video / file / voice — only image is supported.
- **Interactive `need_verifycode` (pair-code)** flow — requires UI for the user to enter the code; logged-only fallback for now.
- **Dynamic `longpolling_timeout_ms`** — server-suggested per-iteration timeout is decoded but unused; we use fixed 40s.

## Test plan

- [ ] `go build ./...` (passes locally)
- [ ] `go vet ./...` (passes locally)
- [ ] `go test ./internal/weixin/... ./internal/imbridge/... ./internal/imbridgesvc/...` (passes locally)
- [ ] Manually scan a WeChat QR on a deployed staging instance; verify `confirmed` flow still works end-to-end
- [ ] Manually send a text message via the bound bot; verify `notifystart` is observed in iLink logs at poller start
- [ ] Manually trigger an image reply via NanoClaw; verify both the image and caption arrive in WeChat (was previously losing `context_token` — should now route correctly even across multi-account setups)
- [ ] If a `binded_redirect` is plausible to trigger in staging, exercise the handler path and verify `already_connected` is returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)