### PR TITLE
sec(weixin): SSRF allowlist for outbound iLink/CDN URLs

### DIFF
--- a/internal/weixin/ilink.go
+++ b/internal/weixin/ilink.go
@@ -48,6 +48,49 @@ const (
 	TypingStatusCancel = 2
 )
 
+// allowedILinkHostRoots enumerates the DNS roots every iLink API and CDN
+// host must match. Outbound URL construction is gated by parseILinkURL so
+// an attacker-controlled baseURL (from credentials), server-returned
+// redirect_host, fullURL, or upload_full_url cannot redirect requests to
+// arbitrary hosts (SSRF). Upstream uses concrete hosts under
+// ilinkai.weixin.qq.com / novac2c.cdn.weixin.qq.com plus IDC redirects
+// of the form *.weixin.qq.com (China brand) or *.wechat.com (international
+// brand), so a suffix check across both roots covers all legitimate
+// traffic.
+var allowedILinkHostRoots = []string{"weixin.qq.com", "wechat.com"}
+
+// isAllowedILinkHost reports whether host matches one of the allowed
+// roots exactly or is a subdomain of one. Comparison is case-insensitive.
+// Host should already be the bare hostname (no port, no scheme).
+func isAllowedILinkHost(host string) bool {
+	h := strings.ToLower(host)
+	for _, root := range allowedILinkHostRoots {
+		if h == root || strings.HasSuffix(h, "."+root) {
+			return true
+		}
+	}
+	return false
+}
+
+// parseILinkURL parses rawURL and rejects anything that is not an https
+// URL targeting one of the allowed iLink host roots. All outbound HTTP
+// calls in this package must obtain their *url.URL via this helper so a
+// compromised credentials store or a malicious server response cannot
+// pivot the bot to arbitrary internal targets.
+func parseILinkURL(rawURL string) (*url.URL, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid url: %w", err)
+	}
+	if u.Scheme != "https" {
+		return nil, fmt.Errorf("disallowed url scheme %q (must be https)", u.Scheme)
+	}
+	if !isAllowedILinkHost(u.Hostname()) {
+		return nil, fmt.Errorf("disallowed url host %q (must be one of %v or a subdomain)", u.Hostname(), allowedILinkHostRoots)
+	}
+	return u, nil
+}
+
 // ErrSessionExpired is returned by outbound API helpers when the iLink
 // server reports session-expired (ret/errcode == -14). Callers should
 // treat the bot as needing re-login. Test with errors.Is.
@@ -285,7 +328,7 @@ func StartLogin(ctx context.Context, apiBaseURL string) (*Session, error) {
 	if apiBaseURL == "" {
 		apiBaseURL = DefaultAPIBaseURL
 	}
-	u, err := url.Parse(apiBaseURL)
+	u, err := parseILinkURL(apiBaseURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid apiBaseURL: %w", err)
 	}
@@ -364,7 +407,7 @@ func GetUpdates(ctx context.Context, apiBaseURL, botToken, getUpdatesBuf string)
 	if apiBaseURL == "" {
 		apiBaseURL = DefaultAPIBaseURL
 	}
-	u, err := url.Parse(apiBaseURL)
+	u, err := parseILinkURL(apiBaseURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid apiBaseURL: %w", err)
 	}
@@ -416,7 +459,7 @@ func SendTextMessage(ctx context.Context, apiBaseURL, botToken, toUserID, text, 
 	if apiBaseURL == "" {
 		apiBaseURL = DefaultAPIBaseURL
 	}
-	u, err := url.Parse(apiBaseURL)
+	u, err := parseILinkURL(apiBaseURL)
 	if err != nil {
 		return fmt.Errorf("invalid apiBaseURL: %w", err)
 	}
@@ -492,7 +535,7 @@ func GetUploadURL(ctx context.Context, apiBaseURL, botToken string, params map[s
 	if apiBaseURL == "" {
 		apiBaseURL = DefaultAPIBaseURL
 	}
-	u, err := url.Parse(apiBaseURL)
+	u, err := parseILinkURL(apiBaseURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid apiBaseURL: %w", err)
 	}
@@ -542,6 +585,9 @@ func GetUploadURL(ctx context.Context, apiBaseURL, botToken string, params map[s
 // UploadToCDN uploads encrypted file data to the iLink CDN.
 // Returns the download encrypt_query_param from the response header.
 // If uploadFullURL is non-empty, it is used directly as the POST target (takes precedence over uploadParam).
+// The final target URL is gated by parseILinkURL — both uploadFullURL
+// (server-provided) and cdnBaseURL must point at the weixin.qq.com host
+// family or the upload is refused.
 func UploadToCDN(ctx context.Context, cdnBaseURL, uploadParam, filekey string, ciphertext []byte, uploadFullURL string) (string, error) {
 	var cdnURL string
 	if trimmed := strings.TrimSpace(uploadFullURL); trimmed != "" {
@@ -549,6 +595,9 @@ func UploadToCDN(ctx context.Context, cdnBaseURL, uploadParam, filekey string, c
 	} else {
 		cdnURL = fmt.Sprintf("%s/upload?encrypted_query_param=%s&filekey=%s",
 			cdnBaseURL, url.QueryEscape(uploadParam), url.QueryEscape(filekey))
+	}
+	if _, err := parseILinkURL(cdnURL); err != nil {
+		return "", fmt.Errorf("cdn upload: %w", err)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
@@ -583,7 +632,7 @@ func SendImageMessage(ctx context.Context, apiBaseURL, botToken, toUserID string
 	if apiBaseURL == "" {
 		apiBaseURL = DefaultAPIBaseURL
 	}
-	u, err := url.Parse(apiBaseURL)
+	u, err := parseILinkURL(apiBaseURL)
 	if err != nil {
 		return fmt.Errorf("invalid apiBaseURL: %w", err)
 	}
@@ -733,6 +782,8 @@ func AESECBPaddedSize(plaintextSize int) int {
 
 // DownloadFromCDN downloads a file from the iLink CDN.
 // Prefers fullURL (server-provided) over client-side URL construction from encrypt_query_param.
+// The final URL is gated by parseILinkURL so a malicious server response
+// or stale CDN base cannot redirect downloads to arbitrary hosts.
 func DownloadFromCDN(ctx context.Context, cdnBaseURL, encryptQueryParam, fullURL string) ([]byte, error) {
 	var dlURL string
 	if fullURL != "" {
@@ -743,6 +794,9 @@ func DownloadFromCDN(ctx context.Context, cdnBaseURL, encryptQueryParam, fullURL
 		}
 		dlURL = fmt.Sprintf("%s/download?encrypted_query_param=%s",
 			cdnBaseURL, url.QueryEscape(encryptQueryParam))
+	}
+	if _, err := parseILinkURL(dlURL); err != nil {
+		return nil, fmt.Errorf("cdn download: %w", err)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, 60*time.Second)
@@ -890,7 +944,7 @@ func GetConfig(ctx context.Context, apiBaseURL, botToken, userID, contextToken s
 	if apiBaseURL == "" {
 		apiBaseURL = DefaultAPIBaseURL
 	}
-	u, err := url.Parse(apiBaseURL)
+	u, err := parseILinkURL(apiBaseURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid apiBaseURL: %w", err)
 	}
@@ -939,7 +993,7 @@ func SendTyping(ctx context.Context, apiBaseURL, botToken, userID, typingTicket 
 	if apiBaseURL == "" {
 		apiBaseURL = DefaultAPIBaseURL
 	}
-	u, err := url.Parse(apiBaseURL)
+	u, err := parseILinkURL(apiBaseURL)
 	if err != nil {
 		return fmt.Errorf("invalid apiBaseURL: %w", err)
 	}
@@ -993,7 +1047,7 @@ func notifyLifecycle(ctx context.Context, apiBaseURL, botToken, endpoint, label 
 	if apiBaseURL == "" {
 		apiBaseURL = DefaultAPIBaseURL
 	}
-	u, err := url.Parse(apiBaseURL)
+	u, err := parseILinkURL(apiBaseURL)
 	if err != nil {
 		return fmt.Errorf("invalid apiBaseURL: %w", err)
 	}
@@ -1055,7 +1109,7 @@ func PollLoginStatus(ctx context.Context, apiBaseURL, qrcode string) (*StatusRes
 	if apiBaseURL == "" {
 		apiBaseURL = DefaultAPIBaseURL
 	}
-	u, err := url.Parse(apiBaseURL)
+	u, err := parseILinkURL(apiBaseURL)
 	if err != nil {
 		return nil, fmt.Errorf("invalid apiBaseURL: %w", err)
 	}

--- a/internal/weixin/ilink_test.go
+++ b/internal/weixin/ilink_test.go
@@ -93,3 +93,46 @@ func TestBuildILinkHeadersNoToken(t *testing.T) {
 		t.Errorf("App-Id must be set even without token, got %q", h.Get("iLink-App-Id"))
 	}
 }
+
+func TestParseILinkURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		wantErr bool
+	}{
+		// Allowed: weixin.qq.com family.
+		{"default api host", "https://ilinkai.weixin.qq.com", false},
+		{"default cdn host", "https://novac2c.cdn.weixin.qq.com/c2c", false},
+		{"weixin root exact", "https://weixin.qq.com", false},
+		{"weixin deep subdomain", "https://a.b.c.weixin.qq.com/x", false},
+		{"weixin host with port", "https://ilinkai.weixin.qq.com:443/path", false},
+		{"weixin host case-insensitive", "https://ILINKAI.WEIXIN.QQ.COM", false},
+		// Allowed: wechat.com family (international brand).
+		{"wechat root", "https://wechat.com", false},
+		{"wechat subdomain", "https://api.wechat.com/foo", false},
+		// Rejected: scheme.
+		{"http rejected", "http://ilinkai.weixin.qq.com", true},
+		{"file rejected", "file:///etc/passwd", true},
+		{"javascript rejected", "javascript:alert(1)", true},
+		// Rejected: host.
+		{"different domain", "https://evil.com", true},
+		{"weixin-look-alike suffix attack", "https://attacker.weixin.qq.com.evil.com", true},
+		{"wechat-look-alike suffix attack", "https://wechat.com.evil.com", true},
+		{"empty host", "https:///path", true},
+		{"localhost rejected", "https://localhost", true},
+		{"raw ip rejected", "https://127.0.0.1", true},
+		// Malformed.
+		{"unparseable", "://broken", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := parseILinkURL(tt.url)
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error for %q, got nil", tt.url)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error for %q: %v", tt.url, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #97. The CodeQL run on #97 flagged \"Uncontrolled data used in network request\" (1 critical) on the new \`notifyLifecycle\` call. The alert went out with the merge — this PR closes it by gating every outbound URL construction in \`internal/weixin/ilink.go\` through a host allowlist.

The same SSRF-shaped pattern (parse a credentials-derived \`baseURL\`, do not check the host) had been present on every other endpoint in this file for a long time; CodeQL only fires on new code, so it surfaced only for \`notifyLifecycle\`. Fixing the underlying pattern instead of just the one new call closes both the alert and the broader exposure.

## What changed

- New \`parseILinkURL(rawURL)\`: accepts only \`https://\` URLs whose host is \`weixin.qq.com\` / \`wechat.com\` or a subdomain of either. \`weixin.qq.com\` is the China brand (matches upstream constants \`DEFAULT_BASE_URL\`, \`CDN_BASE_URL\`, \`FIXED_BASE_URL\`); \`wechat.com\` is the international brand (IDC \`redirect_host\` responses may use either family).
- All \`url.Parse(apiBaseURL)\` call sites (9 endpoints) routed through the validator.
- \`UploadToCDN\` validates the final URL (server-provided \`uploadFullURL\` or constructed \`cdnBaseURL + /upload?...\`).
- \`DownloadFromCDN\` validates the final URL (server-provided \`fullURL\` or constructed \`cdnBaseURL + /download?...\`).
- \`PollLoginStatus\` also picks up the validator (previously did hand-rolled \`url.Parse\` plus a stale manual header).

The check is case-insensitive, ignores ports, and resists suffix look-alike attacks like \`attacker.weixin.qq.com.evil.com\` (rejected because \`url.Hostname()\` returns the full bare host which doesn't end with an allowed suffix).

## Tests

\`TestParseILinkURL\` covers 18 cases:
- Allowed: both brands at root and subdomain depth, with port, case-insensitive (8 cases)
- Rejected schemes: \`http://\`, \`file://\`, \`javascript:\` (3 cases)
- Rejected hosts: unrelated domain, suffix look-alike attacks against both brands, empty host, \`localhost\`, raw IP (6 cases)
- Malformed URL: \`://broken\` (1 case)

\`go build ./...\`, \`go vet ./...\`, and \`go test ./internal/{weixin,imbridge,imbridgesvc}/...\` all pass locally.

## Test plan

- [ ] CodeQL re-scan on this PR shows 0 critical alerts (the previous alert at \`internal/weixin/ilink.go:1020\` should resolve)
- [ ] No regression in QR login / inbound polling / outbound send against a real iLink bot (URL hosts unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)