### PR TITLE
fix(server): use distinct env var for codex REST URL

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.60.14
-appVersion: "0.60.14"
+version: 0.60.15
+appVersion: "0.60.15"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/deploy/helm/agentserver/templates/deployment.yaml
+++ b/deploy/helm/agentserver/templates/deployment.yaml
@@ -163,6 +163,10 @@ spec:
             {{- if .Values.codexAppGateway.enabled }}
             - name: CODEX_APP_GATEWAY_URL
               value: {{ printf "ws://%s-codex-app-gateway.%s.svc:%v/notebook/ws" .Release.Name .Release.Namespace (int .Values.codexAppGateway.port) | quote }}
+            # REST base URL for /api/turns (codex routing path, e.g. WeChat).
+            # Distinct from the ws URL above which is consumed by the jupyter SDK.
+            - name: CODEX_APP_GATEWAY_REST_URL
+              value: {{ printf "http://%s-codex-app-gateway.%s.svc:%v" .Release.Name .Release.Namespace (int .Values.codexAppGateway.port) | quote }}
             - name: CODEX_INBOUND_HMAC_SECRET
               valueFrom:
                 secretKeyRef:

--- a/internal/server/codex_client.go
+++ b/internal/server/codex_client.go
@@ -7,8 +7,42 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 )
+
+// resolveCodexGatewayRESTURL returns the base URL of codex-app-gateway's
+// REST surface (the host that serves POST /api/turns). Resolution order:
+//
+//  1. CODEX_APP_GATEWAY_REST_URL — explicit, e.g. "http://cxg.svc:8086"
+//  2. CODEX_APP_GATEWAY_URL with the well-known "/notebook/ws" suffix
+//     stripped and the scheme rewritten ws→http / wss→https. This is the
+//     existing chart-emitted env var used by jupyter SDK pods; we accept
+//     it as a fallback so a deployment upgraded mid-stream keeps working.
+//  3. "" — caller treats as "feature disabled".
+//
+// Returns "" when neither var is set or the URL is unusable.
+func resolveCodexGatewayRESTURL() string {
+	if v := strings.TrimSpace(os.Getenv("CODEX_APP_GATEWAY_REST_URL")); v != "" {
+		return strings.TrimRight(v, "/")
+	}
+	v := strings.TrimSpace(os.Getenv("CODEX_APP_GATEWAY_URL"))
+	if v == "" {
+		return ""
+	}
+	v = strings.TrimSuffix(v, "/notebook/ws")
+	v = strings.TrimRight(v, "/")
+	switch {
+	case strings.HasPrefix(v, "ws://"):
+		return "http://" + strings.TrimPrefix(v, "ws://")
+	case strings.HasPrefix(v, "wss://"):
+		return "https://" + strings.TrimPrefix(v, "wss://")
+	case strings.HasPrefix(v, "http://"), strings.HasPrefix(v, "https://"):
+		return v
+	}
+	return ""
+}
 
 // CodexClient calls codex-app-gateway's POST /api/turns.
 type CodexClient struct {

--- a/internal/server/codex_client_test.go
+++ b/internal/server/codex_client_test.go
@@ -9,6 +9,39 @@ import (
 	"testing"
 )
 
+func TestResolveCodexGatewayRESTURL(t *testing.T) {
+	cases := []struct {
+		name     string
+		restEnv  string
+		urlEnv   string
+		want     string
+	}{
+		// Explicit REST var wins.
+		{"rest var set", "http://cxg.svc:8086", "ws://cxg.svc:8086/notebook/ws", "http://cxg.svc:8086"},
+		{"rest var trims trailing slash", "http://cxg.svc:8086/", "", "http://cxg.svc:8086"},
+		// Fallback derive from the legacy ws URL the chart emits.
+		{"ws fallback strips notebook path + swaps scheme", "", "ws://cxg.svc:8086/notebook/ws", "http://cxg.svc:8086"},
+		{"wss fallback", "", "wss://cxg.example.com/notebook/ws", "https://cxg.example.com"},
+		{"ws fallback no path", "", "ws://cxg.svc:8086", "http://cxg.svc:8086"},
+		// Already an http URL — pass through.
+		{"http passthrough", "", "http://cxg.svc:8086", "http://cxg.svc:8086"},
+		{"https passthrough", "", "https://cxg.example.com", "https://cxg.example.com"},
+		// Unusable / empty.
+		{"both empty", "", "", ""},
+		{"unknown scheme", "", "tcp://cxg:8086", ""},
+		{"whitespace only", "   ", "  ", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv("CODEX_APP_GATEWAY_REST_URL", c.restEnv)
+			t.Setenv("CODEX_APP_GATEWAY_URL", c.urlEnv)
+			if got := resolveCodexGatewayRESTURL(); got != c.want {
+				t.Errorf("got %q want %q", got, c.want)
+			}
+		})
+	}
+}
+
 func TestCodexClientPostsExpectedBody(t *testing.T) {
 	var gotBody []byte
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -280,9 +280,11 @@ func (s *Server) Router() http.Handler {
 	})
 
 	// Codex routing path: WeChat (and other channels) with routing_mode="codex"
-	// land here. Skipped when CODEX_APP_GATEWAY_URL is unset (e.g. dev env without
-	// CXG deployed) so this PR is safe to merge before the gateway is rolled out.
-	if cxgURL := os.Getenv("CODEX_APP_GATEWAY_URL"); cxgURL != "" {
+	// land here. Skipped when neither CODEX_APP_GATEWAY_REST_URL nor
+	// CODEX_APP_GATEWAY_URL is set, so dev envs without CXG silently disable
+	// the endpoint.
+	if cxgURL := resolveCodexGatewayRESTURL(); cxgURL != "" {
+		log.Printf("server: codex routing endpoint enabled, cxg=%s", cxgURL)
 		codexClient := NewCodexClient(cxgURL, os.Getenv("INTERNAL_API_SECRET"))
 		imbridgeSendURL := s.IMBridgeURL
 		if imbridgeSendURL == "" {
@@ -301,7 +303,7 @@ func (s *Server) Router() http.Handler {
 			codexHandler.ServeHTTP(w, r)
 		})
 	} else {
-		log.Printf("server: CODEX_APP_GATEWAY_URL unset; codex routing endpoint disabled")
+		log.Printf("server: codex routing endpoint disabled (set CODEX_APP_GATEWAY_REST_URL to enable)")
 	}
 
 	// Agent registration (auth via OAuth Bearer token).


### PR DESCRIPTION
## Summary

Hotfix for #99 / v0.60.14 collision: `CODEX_APP_GATEWAY_URL` was already in use by the jupyter SDK injection path (`internal/sandbox/config.go`) as the **WebSocket URL** (`ws://...:8086/notebook/ws`). PR #99 reused the same env var for the new codex REST endpoint's **base URL**, so deployments running v0.60.14 would POST `ws://...:8086/notebook/ws/api/turns` and fail on scheme + path.

## Fix

- Add `CODEX_APP_GATEWAY_REST_URL` env var (distinct from the legacy ws-URL var).
- Chart emits both: ws URL for jupyter SDK, REST URL for `/api/turns`.
- `resolveCodexGatewayRESTURL` helper prefers the new var; falls back to deriving from the legacy var by stripping `/notebook/ws` and swapping ws→http / wss→https. **Deployments mid-upgrade keep working** without re-setting envs.
- Empty / unknown-scheme → return `""` (endpoint silently disabled, matches PR #99 behavior).

Bumps chart **0.60.14 → 0.60.15**.

## Test plan

- [x] `TestResolveCodexGatewayRESTURL` — 10 cases covering rest-var-wins, trailing-slash trim, ws/wss fallback, http/https passthrough, both-empty, unknown scheme, whitespace
- [x] `go build ./...`, `go test -race ./internal/server/...` all pass
- [ ] Pulumi up to 0.60.15; `kubectl exec` agentserver pod; verify `CODEX_APP_GATEWAY_REST_URL` is set
- [ ] Flip a WeChat channel to `routing_mode=codex`; send a message; expect a codex reply (this exercises the actual hot path that #99 left broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)