### PR TITLE
fix(broker): drain fake codex ws until client close (flaky test fix + 0.60.16)

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.60.15
-appVersion: "0.60.15"
+version: 0.60.16
+appVersion: "0.60.16"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/internal/codexappgateway/broker/testhelpers_test.go
+++ b/internal/codexappgateway/broker/testhelpers_test.go
@@ -13,6 +13,15 @@ import (
 
 // fakeCodexServer accepts one ws connection and runs `frame` against it.
 // frame receives Read/Write helpers and must replay codex behavior.
+//
+// After frame returns we block on a best-effort read until the client
+// closes the ws or the request context expires. Without this the
+// httptest server's defer-close races client-side readLoop dispatch of
+// the last queued notification (e.g. turn/completed): the close frame
+// arrives at the readLoop before the buffered turn/completed, the
+// loop fails all pending channels with "connection closed", and
+// Conn.Turn returns a transport error mid-test. Holding the ws open
+// until the client side closes makes the test robust on slow CI.
 func fakeCodexServer(t *testing.T, frame func(t *testing.T, ctx context.Context, c *websocket.Conn)) (wsURL string, stop func()) {
 	t.Helper()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -23,6 +32,13 @@ func fakeCodexServer(t *testing.T, frame func(t *testing.T, ctx context.Context,
 		}
 		defer c.Close(websocket.StatusNormalClosure, "")
 		frame(t, r.Context(), c)
+		// Drain until the client closes — keeps the ws open so any
+		// frames written above are delivered before we tear down.
+		for {
+			if _, _, err := c.Read(r.Context()); err != nil {
+				return
+			}
+		}
 	}))
 	url := "ws" + strings.TrimPrefix(srv.URL, "http")
 	return url, srv.Close


### PR DESCRIPTION
## Summary

v0.60.15 build failed on a CI flake in \`TestConnTurnSuccessful\`:
\`\`\`
failed to get reader: received close frame: status = StatusNormalClosure
\`\`\`

The httptest fakeCodexServer deferred \`c.Close(...)\` when the frame closure returned. With slow CI scheduling, that close frame can hit the client's readLoop before the still-buffered \`turn/completed\` notification, so the loop fails all pending channels with "connection closed", and \`Conn.Turn\` returns transport-level error mid-test. Local \`-race -count=50\` never reproduced; CI scheduler did.

## Fix

In \`fakeCodexServer\`, after the frame closure returns, drain client-side reads until the client closes the ws. Keeps the server-side ws open long enough for queued frames to flush.

\`-race -count=20\` locally: clean.

## Versioning

Bumps chart **0.60.15 → 0.60.16**. The v0.60.15 git tag stays (no image was published — build failed before push), serves as a paper trail.

## Test plan
- [x] \`go test -race -count=20 ./internal/codexappgateway/broker/\`
- [x] \`go build ./...\`
- [ ] v0.60.16 build workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)