### PR TITLE
fix(broker): inject item/completed payloads into Turn.items

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.60.16
-appVersion: "0.60.16"
+version: 0.60.17
+appVersion: "0.60.17"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/internal/codexappgateway/broker/conn.go
+++ b/internal/codexappgateway/broker/conn.go
@@ -21,8 +21,9 @@ type Conn struct {
 	nextID  atomic.Int64
 
 	mu           sync.Mutex
-	pendingResp  map[int64]chan rpcResponse  // request id → 1-buffered chan
-	pendingTurns map[string]chan turnPayload // turn id → 1-buffered chan
+	pendingResp  map[int64]chan rpcResponse   // request id → 1-buffered chan
+	pendingTurns map[string]chan turnPayload  // turn id → 1-buffered chan
+	itemsByTurn  map[string][]json.RawMessage // turn id → accumulated item/completed payloads
 
 	closeOnce sync.Once
 	closed    chan struct{}
@@ -47,6 +48,7 @@ func Dial(ctx context.Context, wsURL string) (*Conn, error) {
 		ws:           ws,
 		pendingResp:  make(map[int64]chan rpcResponse),
 		pendingTurns: make(map[string]chan turnPayload),
+		itemsByTurn:  make(map[string][]json.RawMessage),
 		closed:       make(chan struct{}),
 	}
 
@@ -127,6 +129,21 @@ func (c *Conn) dispatchFrame(data []byte) {
 		})
 		return
 	}
+	if f.Method == "item/completed" {
+		// Codex emits items incrementally via item/completed; turn/completed's
+		// Turn.items is empty (items_view: NotLoaded). Accumulate so we can
+		// inject the items into the final Turn payload at delivery time.
+		var p itemCompletedParams
+		if err := json.Unmarshal(f.Params, &p); err != nil {
+			return
+		}
+		if p.TurnID != "" && len(p.Item) > 0 {
+			c.mu.Lock()
+			c.itemsByTurn[p.TurnID] = append(c.itemsByTurn[p.TurnID], p.Item)
+			c.mu.Unlock()
+		}
+		return
+	}
 	if f.Method == "turn/completed" {
 		var p turnCompletedParams
 		if err := json.Unmarshal(f.Params, &p); err != nil {
@@ -151,11 +168,47 @@ func (c *Conn) deliverResponse(id int64, resp rpcResponse) {
 func (c *Conn) deliverTurn(turnID string, payload turnPayload) {
 	c.mu.Lock()
 	ch, ok := c.pendingTurns[turnID]
+	items := c.itemsByTurn[turnID]
 	delete(c.pendingTurns, turnID)
+	delete(c.itemsByTurn, turnID)
 	c.mu.Unlock()
-	if ok {
-		ch <- payload
+	if !ok {
+		return
 	}
+	// Inject the accumulated item/completed payloads into Turn.items.
+	// turn/completed's Turn.items is empty in codex's v2 protocol
+	// (TurnItemsView::NotLoaded); the items arrived as separate
+	// item/completed notifications. Without this merge, REST callers
+	// see an empty items list and can't pull the agentMessage text.
+	if len(items) > 0 {
+		if merged, err := mergeItemsIntoTurnRaw(payload.Raw, items); err == nil {
+			payload.Raw = merged
+		}
+	}
+	ch <- payload
+}
+
+// mergeItemsIntoTurnRaw replaces the "items" field of a codex Turn JSON
+// payload with the supplied items slice and returns the re-serialized
+// bytes. The original payload is parsed into an ordered map so unknown
+// fields and field order are preserved across codex protocol updates.
+func mergeItemsIntoTurnRaw(raw json.RawMessage, items []json.RawMessage) (json.RawMessage, error) {
+	if len(raw) == 0 {
+		return raw, nil
+	}
+	var m map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return raw, err
+	}
+	itemsRaw, err := json.Marshal(items)
+	if err != nil {
+		return raw, err
+	}
+	m["items"] = itemsRaw
+	// Caller's lastAgentMessageText scans by item type, so this is
+	// sufficient — itemsView still says "notLoaded" but we don't
+	// promise to update it.
+	return json.Marshal(m)
 }
 
 func (c *Conn) failAllPending(err error) {
@@ -167,6 +220,9 @@ func (c *Conn) failAllPending(err error) {
 	for tid, ch := range c.pendingTurns {
 		close(ch)
 		delete(c.pendingTurns, tid)
+	}
+	for tid := range c.itemsByTurn {
+		delete(c.itemsByTurn, tid)
 	}
 	c.mu.Unlock()
 	c.closeErr.CompareAndSwap(nil, &errHolder{err})
@@ -235,6 +291,7 @@ func (c *Conn) Turn(ctx context.Context, threadID string, callerParams json.RawM
 	case <-tctx.Done():
 		c.mu.Lock()
 		delete(c.pendingTurns, startResp.Turn.ID)
+		delete(c.itemsByTurn, startResp.Turn.ID)
 		c.mu.Unlock()
 		// Best-effort interrupt so codex doesn't keep working.
 		bgCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)

--- a/internal/codexappgateway/broker/conn_turn_test.go
+++ b/internal/codexappgateway/broker/conn_turn_test.go
@@ -172,3 +172,74 @@ func TestTurnCallerCtxCancelCleansPendingResp(t *testing.T) {
 		t.Errorf("pendingResp leaked %d entries", n)
 	}
 }
+
+// TestConnTurnAccumulatesItemsFromItemCompleted verifies that items
+// streamed via item/completed notifications during a turn end up
+// injected into the final Turn.items list when delivered to Turn().
+// Codex v2 sends turn/completed with TurnItemsView::NotLoaded (empty
+// items) and emits items separately during the stream; without
+// accumulation the REST caller sees no agentMessage.
+func TestConnTurnAccumulatesItemsFromItemCompleted(t *testing.T) {
+	url, stop := fakeCodexServer(t, func(t *testing.T, ctx context.Context, c *websocket.Conn) {
+		replayHandshake(t, ctx, c)
+		ts := readFrame(t, ctx, c)
+		writeJSON(t, ctx, c, map[string]any{
+			"jsonrpc": "2.0", "id": ts["id"],
+			"result": map[string]any{"turn": map[string]any{"id": "trn-a"}},
+		})
+		// Stream two item/completed events (reasoning + agentMessage),
+		// then turn/completed with EMPTY Turn.items (the v2-faithful shape).
+		writeJSON(t, ctx, c, map[string]any{
+			"jsonrpc": "2.0", "method": "item/completed",
+			"params": map[string]any{
+				"threadId": "thr-a", "turnId": "trn-a",
+				"item": map[string]any{"type": "reasoning", "id": "r1", "summary": []any{"thinking..."}, "content": []any{}},
+			},
+		})
+		writeJSON(t, ctx, c, map[string]any{
+			"jsonrpc": "2.0", "method": "item/completed",
+			"params": map[string]any{
+				"threadId": "thr-a", "turnId": "trn-a",
+				"item": map[string]any{"type": "agentMessage", "id": "m1", "text": "hello"},
+			},
+		})
+		writeJSON(t, ctx, c, map[string]any{
+			"jsonrpc": "2.0", "method": "turn/completed",
+			"params": map[string]any{
+				"threadId": "thr-a",
+				"turn": map[string]any{
+					"id": "trn-a", "status": "completed",
+					"items": []any{}, "itemsView": "notLoaded", "error": nil,
+				},
+			},
+		})
+	})
+	defer stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := Dial(ctx, url)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer conn.Close()
+
+	raw, err := conn.Turn(ctx, "thr-a", json.RawMessage(`{"input":[{"type":"text","text":"hi"}]}`), 5*time.Second)
+	if err != nil {
+		t.Fatalf("Turn: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	items, ok := got["items"].([]any)
+	if !ok || len(items) != 2 {
+		t.Fatalf("expected 2 injected items, got %v", got["items"])
+	}
+	last := items[len(items)-1].(map[string]any)
+	if last["type"] != "agentMessage" || last["text"] != "hello" {
+		t.Errorf("last item = %v, want agentMessage/hello", last)
+	}
+	// Suppress unused-import warning on slow CI re-runs.
+	_ = runtime.NumGoroutine()
+}

--- a/internal/codexappgateway/broker/protocol.go
+++ b/internal/codexappgateway/broker/protocol.go
@@ -85,6 +85,18 @@ type turnCompletedParams struct {
 	Turn     turnPayload `json:"turn"`
 }
 
+// itemCompletedParams is the params shape of an `item/completed`
+// server notification (codex v2 ItemCompletedNotification). Items are
+// emitted incrementally during a turn; the broker accumulates them by
+// turnId and injects the full list into the final Turn payload at
+// delivery time, since turn/completed's own Turn.items is empty
+// (TurnItemsView::NotLoaded in v2 notifications).
+type itemCompletedParams struct {
+	Item     json.RawMessage `json:"item"`
+	ThreadID string          `json:"threadId"`
+	TurnID   string          `json:"turnId"`
+}
+
 // turnPayload exposes only the routing key. The full object is in Raw
 // for verbatim REST passthrough.
 type turnPayload struct {


### PR DESCRIPTION
## Summary

Hotfix for the runtime failure observed in v0.60.16: a WeChat user sends a message, codex generates a perfect reply, but the user sees \"⚠️ Codex 没有返回文本内容\".

## Root cause

Codex v2 emits \`turn/completed\` with \`TurnItemsView::NotLoaded\` and an **empty** \`Turn.items\`. The actual items arrive incrementally as separate \`item/completed\` notifications during the stream. PR #99's broker only listened for \`turn/completed\` and ignored \`item/completed\` → REST callers saw empty items → \`lastAgentMessageText\` found no \`agentMessage\` → user got the empty-text fallback message.

Verified by inspecting the codex session rollout on the live pod: the agentMessage was generated server-side as expected.

## Fix

- \`Conn.itemsByTurn map[string][]json.RawMessage\` — accumulate item payloads keyed by turnId
- \`dispatchFrame\` appends on \`item/completed\`
- \`deliverTurn\` calls \`mergeItemsIntoTurnRaw\` to re-serialize the Turn payload with items injected, preserving all other fields
- Cleanup on Turn timeout + failAllPending

Bumps chart **0.60.16 → 0.60.17**.

## Test

- New \`TestConnTurnAccumulatesItemsFromItemCompleted\`: streams reasoning + agentMessage via \`item/completed\` then \`turn/completed\` with empty items, asserts the merged Turn has both items.
- \`go test -race ./internal/codexappgateway/broker/\` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)