### PR TITLE
fix(codex-im): auto-retry on thread-not-found (CXG restart recovery)

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.60.17
-appVersion: "0.60.17"
+version: 0.60.18
+appVersion: "0.60.18"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/internal/server/codex_im_inbound.go
+++ b/internal/server/codex_im_inbound.go
@@ -115,13 +115,38 @@ func (h *codexInboundHandler) processTurn(ctx context.Context, req codexInboundR
 		Params:      params,
 	})
 	if err != nil {
-		log.Printf("codex_im: cxg call: %v", err)
+		log.Printf("codex_im: cxg call channel=%s user=%s: %v", req.ChannelID, externalID, err)
 		h.sendError(ctx, req, "⚠️ Codex 处理失败，请稍后重试")
 		return
 	}
 
-	// Transport-layer failure.
+	// Detect thread-not-found across all error surfaces: transport.message
+	// (when codex returns -32600 on turn/start because thread is unknown,
+	// e.g. after CXG restart wiped supervisor state) and turn.error.message
+	// (less common — codex completed a turn but reports thread error in
+	// its body). On match: clear the stored thread, retry ONCE with a
+	// fresh thread, and use the new response.
+	if sess.CodexThreadID != nil && cresp.Transport != nil && isThreadNotFoundErr(cresp.Transport.Message) {
+		log.Printf("codex_im: thread %s not found (channel=%s user=%s), clearing and retrying", *sess.CodexThreadID, req.ChannelID, externalID)
+		if err := h.sessions.SetSessionCodexThreadID(ctx, sess.ID, nil); err != nil {
+			log.Printf("codex_im: clear thread id: %v", err)
+		}
+		sess.CodexThreadID = nil
+		cresp, err = h.codex.RunTurn(ctx, CodexTurnRequest{
+			WorkspaceID: req.WorkspaceID,
+			ThreadID:    nil,
+			Params:      params,
+		})
+		if err != nil {
+			log.Printf("codex_im: cxg retry channel=%s user=%s: %v", req.ChannelID, externalID, err)
+			h.sendError(ctx, req, "⚠️ Codex 处理失败，请稍后重试")
+			return
+		}
+	}
+
+	// Transport-layer failure (after potential retry above).
 	if cresp.Transport != nil {
+		log.Printf("codex_im: transport=%s channel=%s user=%s msg=%s", cresp.Transport.Code, req.ChannelID, externalID, cresp.Transport.Message)
 		h.sendError(ctx, req, transportToUserMessage(cresp.Transport))
 		return
 	}
@@ -172,18 +197,19 @@ func (h *codexInboundHandler) processTurn(ctx context.Context, req codexInboundR
 				return
 			}
 		}
-		// Heuristic: thread-not-found.
+		// Heuristic: thread-not-found inside turn.error (rare — codex
+		// usually reports this as an RPC error on turn/start, caught
+		// above as transport. Kept as defensive fallback.)
 		msg := ""
 		if turn.Error != nil {
 			msg = turn.Error.Message
 		}
-		lo := strings.ToLower(msg)
-		if strings.Contains(lo, "thread") && (strings.Contains(lo, "not found") || strings.Contains(lo, "unknown") || strings.Contains(lo, "missing")) {
+		if isThreadNotFoundErr(msg) {
 			_ = h.sessions.SetSessionCodexThreadID(ctx, sess.ID, nil)
 			h.sendError(ctx, req, "⚠️ 会话已重置，请重发消息")
 			return
 		}
-		log.Printf("codex_im: turn failed: %s", msg)
+		log.Printf("codex_im: turn failed channel=%s user=%s: %s", req.ChannelID, externalID, msg)
 		h.sendError(ctx, req, "⚠️ Codex 处理失败")
 	case "interrupted":
 		h.sendError(ctx, req, "⚠️ 处理已取消，请重发")
@@ -195,6 +221,24 @@ func (h *codexInboundHandler) processTurn(ctx context.Context, req codexInboundR
 
 // lastAgentMessageText scans the items list in reverse for the last
 // {type:"agentMessage"} entry and returns its text. Returns "" if none.
+// isThreadNotFoundErr is a substring heuristic over codex error messages.
+// Codex doesn't expose a stable error code for "thread doesn't exist
+// (perhaps because we restarted and lost in-memory state)", so we sniff
+// for the human-readable text. Examples seen in the wild:
+//
+//	codex rpc error -32600: thread not found: 019e4130-...
+//	thread "thr-abc" unknown
+//	missing thread
+func isThreadNotFoundErr(msg string) bool {
+	lo := strings.ToLower(msg)
+	if !strings.Contains(lo, "thread") {
+		return false
+	}
+	return strings.Contains(lo, "not found") ||
+		strings.Contains(lo, "unknown") ||
+		strings.Contains(lo, "missing")
+}
+
 func lastAgentMessageText(items []json.RawMessage) string {
 	for i := len(items) - 1; i >= 0; i-- {
 		var shell struct {

--- a/internal/server/codex_im_inbound_test.go
+++ b/internal/server/codex_im_inbound_test.go
@@ -62,13 +62,19 @@ func (f *fakeSessionStore) CreateSession(ctx context.Context, workspaceID, exter
 	return sessionView{ID: "sess-created", CodexThreadID: nil}, nil
 }
 
-// fakeCodexClient lets us inject CXG responses.
+// fakeCodexClient lets us inject CXG responses. If turnFn is set it
+// takes precedence (per-call dynamic behavior, e.g. for retry tests);
+// otherwise the static resp/err pair is returned.
 type fakeCodexClient struct {
-	resp *CodexTurnResponse
-	err  error
+	resp   *CodexTurnResponse
+	err    error
+	turnFn func(req CodexTurnRequest) (*CodexTurnResponse, error)
 }
 
-func (f *fakeCodexClient) RunTurn(_ context.Context, _ CodexTurnRequest) (*CodexTurnResponse, error) {
+func (f *fakeCodexClient) RunTurn(_ context.Context, req CodexTurnRequest) (*CodexTurnResponse, error) {
+	if f.turnFn != nil {
+		return f.turnFn(req)
+	}
 	return f.resp, f.err
 }
 
@@ -310,3 +316,82 @@ func waitFor(t *testing.T, cond func() bool) {
 }
 
 func strPtr(s string) *string { return &s }
+
+func TestCodexInboundRetriesOnThreadNotFound(t *testing.T) {
+	sendURL, sends, stop := newCapturingImbridge(t)
+	defer stop()
+
+	var calls int
+	var clearedThread bool
+	h := newCodexInboundHandler(
+		&fakeCodexClient{
+			turnFn: func(req CodexTurnRequest) (*CodexTurnResponse, error) {
+				calls++
+				if calls == 1 {
+					if req.ThreadID == nil || *req.ThreadID != "thr-stale" {
+						t.Errorf("first call: ThreadID=%v want thr-stale", req.ThreadID)
+					}
+					return &CodexTurnResponse{
+						ThreadID:  "thr-stale",
+						Transport: &CodexTransportError{Code: "wsDisconnect", Message: "codex rpc error -32600: thread not found: thr-stale"},
+					}, nil
+				}
+				// Second call should have ThreadID=nil (cleared).
+				if req.ThreadID != nil {
+					t.Errorf("retry call: ThreadID=%v want nil", req.ThreadID)
+				}
+				return &CodexTurnResponse{
+					ThreadID: "thr-fresh",
+					Turn:     json.RawMessage(`{"id":"trn-1","status":"completed","items":[{"type":"agentMessage","id":"m","text":"recovered"}],"itemsView":"full","error":null}`),
+				}, nil
+			},
+		},
+		&fakeSessionStore{
+			get: func(_ context.Context, _, _ string) (sessionView, error) {
+				return sessionView{ID: "sess-1", CodexThreadID: strPtr("thr-stale")}, nil
+			},
+			set: func(_ context.Context, _ string, tid *string) error {
+				if tid == nil {
+					clearedThread = true
+				}
+				return nil
+			},
+		},
+		sendURL, "",
+	)
+	defer h.Close()
+
+	r := newCodexInboundRequest(map[string]any{
+		"channel_id": "ch", "workspace_id": "ws", "wechat_user_id": "u", "text": "hi",
+	})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	waitFor(t, func() bool { return len(sends.Load().([]*capturedSend)) == 1 })
+
+	if calls != 2 {
+		t.Errorf("calls=%d want 2 (initial + retry)", calls)
+	}
+	if !clearedThread {
+		t.Error("expected SetSessionCodexThreadID(nil) to be called")
+	}
+	if got := sends.Load().([]*capturedSend)[0].text; got != "recovered" {
+		t.Errorf("text=%q want recovered", got)
+	}
+}
+
+func TestIsThreadNotFoundErr(t *testing.T) {
+	cases := map[string]bool{
+		"codex rpc error -32600: thread not found: abc": true,
+		`thread "thr-abc" unknown`:                      true,
+		"missing thread":                                true,
+		"some other error":                              false,
+		"thread is in progress":                         false,
+		"":                                              false,
+		"connection closed":                             false,
+	}
+	for in, want := range cases {
+		if got := isThreadNotFoundErr(in); got != want {
+			t.Errorf("isThreadNotFoundErr(%q) = %v, want %v", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

After CXG pod restart, the previously persisted \`codex_thread_id\` in agent_sessions becomes stale (codex's in-memory thread registry is gone). Sending a new message hits codex with \`thread/start\` carrying that stale id; codex returns RPC error \`-32600: thread not found\`. Broker classifies this as \`transport=wsDisconnect\`, handler sends \"⚠️ Codex 处理失败，请稍后重试\" without recovering — user has to retry manually (and they'd hit it again because the bad id stays in DB).

## Fix

- New \`isThreadNotFoundErr\` heuristic: substring match on \"thread\" + (\"not found\" / \"unknown\" / \"missing\")
- Handler: after the first \`RunTurn\`, if \`transport.message\` matches AND we sent a non-nil ThreadID, clear stored thread_id and retry ONCE with \`ThreadID=nil\`. Single-shot retry — second failure falls through to normal error path.
- Same heuristic applied to \`turn.error.message\` (defensive fallback for the rare case where codex completes a turn but reports a thread error inside the body).
- All error log lines now include \`channel=...\` and \`user=...\` for production debugging (the empty-text path / transport failure had no correlation info before).

## Test

- \`TestCodexInboundRetriesOnThreadNotFound\` — fake codex returns thread-not-found on first call, success on second; verifies thread cleared + retried + correct text delivered
- \`TestIsThreadNotFoundErr\` — pins the substring heuristic against 7 cases (positive + negative)
- All existing \`internal/server/...\` tests still pass under \`-race\`

Bumps chart **0.60.17 → 0.60.18**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)