### PR TITLE
feat: codex-pin machinery + exec-gateway bounded resources (PR 1/3)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,18 @@ jobs:
       - name: Test
         run: go test ./... -count=1 -timeout 5m
 
+  codex-pin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Verify codex-pin
+        run: make codex-pin-check
+
   build-server:
     runs-on: ubuntu-latest
     needs: [test]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev build clean frontend backend agent agent-all llmproxy credentialproxy test docker docker-agent docker-llmproxy docker-credentialproxy docker-openclaw docker-all
+.PHONY: dev build clean frontend backend agent agent-all llmproxy credentialproxy test docker docker-agent docker-llmproxy docker-credentialproxy docker-openclaw docker-all codex-pin-check codex-pin-bump
 
 # Development: run frontend dev server + Go backend
 dev:
@@ -69,3 +69,10 @@ jupyter-image:
 jupyter-smoke: jupyter-image
 	mkdir -p notebook/smoke-workspace
 	docker compose -f notebook/docker-compose.smoke.yml up --build
+
+codex-pin-check:
+	go run ./cmd/check-codex-pin
+
+codex-pin-bump:
+	@if [ -z "$(TAG)" ]; then echo "usage: make codex-pin-bump TAG=rust-v0.x.y"; exit 2; fi
+	@scripts/codex-pin-bump.sh $(TAG)

--- a/cmd/check-codex-pin/main.go
+++ b/cmd/check-codex-pin/main.go
@@ -1,0 +1,3 @@
+package main
+
+func main() {}

--- a/cmd/check-codex-pin/main.go
+++ b/cmd/check-codex-pin/main.go
@@ -1,3 +1,74 @@
 package main
 
-func main() {}
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func main() {
+	pinPath := flag.String("pin", "codex-pin.json", "path to codex-pin.json (relative to repo root or absolute)")
+	repoRoot := flag.String("repo-root", ".", "path to this repo's root")
+	upstreamSource := flag.String("upstream-source", "", "local path to upstream codex checkout (if empty, the program clones the pinned tag to a temp dir)")
+	flag.Parse()
+
+	upstream := *upstreamSource
+	if upstream == "" {
+		var cleanup func()
+		var err error
+		upstream, cleanup, err = cloneUpstream(*pinPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "clone upstream: %v\n", err)
+			os.Exit(2)
+		}
+		defer cleanup()
+	}
+
+	report, err := Verify(*pinPath, *repoRoot, upstream)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "verify: %v\n", err)
+		os.Exit(2)
+	}
+	if len(report.Mismatches) == 0 {
+		fmt.Println("codex-pin: OK")
+		return
+	}
+	fmt.Fprintf(os.Stderr, "codex-pin: %d mismatch(es):\n", len(report.Mismatches))
+	for _, m := range report.Mismatches {
+		fmt.Fprintf(os.Stderr, "  %s [%s] want=%s got=%s\n", m.File, m.Reason, m.Want, m.Got)
+	}
+	os.Exit(1)
+}
+
+func cloneUpstream(pinPath string) (string, func(), error) {
+	pinBytes, err := os.ReadFile(pinPath)
+	if err != nil {
+		return "", nil, fmt.Errorf("read pin: %w", err)
+	}
+	var pin struct {
+		Tag string `json:"tag"`
+	}
+	if err := json.Unmarshal(pinBytes, &pin); err != nil {
+		return "", nil, fmt.Errorf("parse pin: %w", err)
+	}
+	if pin.Tag == "" {
+		return "", nil, fmt.Errorf("pin has empty tag")
+	}
+	tmp, err := os.MkdirTemp("", "codex-pin-*")
+	if err != nil {
+		return "", nil, err
+	}
+	cleanup := func() { os.RemoveAll(tmp) }
+	dst := filepath.Join(tmp, "codex")
+	cmd := exec.Command("git", "clone", "--depth", "1", "--branch", pin.Tag, "https://github.com/openai/codex.git", dst)
+	cmd.Stdout = os.Stderr // git progress to stderr, keep our stdout clean
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("git clone %s: %w", pin.Tag, err)
+	}
+	return dst, cleanup, nil
+}

--- a/cmd/check-codex-pin/testdata/upstream-drift/codex-rs/app-server-protocol/src/protocol/v1.rs
+++ b/cmd/check-codex-pin/testdata/upstream-drift/codex-rs/app-server-protocol/src/protocol/v1.rs
@@ -1,0 +1,1 @@
+// fixture v1.rs

--- a/cmd/check-codex-pin/testdata/upstream-drift/codex-rs/app-server-protocol/src/protocol/v2/item.rs
+++ b/cmd/check-codex-pin/testdata/upstream-drift/codex-rs/app-server-protocol/src/protocol/v2/item.rs
@@ -1,0 +1,1 @@
+// drifted item.rs

--- a/cmd/check-codex-pin/testdata/upstream-drift/codex-rs/app-server-protocol/src/protocol/v2/mcp.rs
+++ b/cmd/check-codex-pin/testdata/upstream-drift/codex-rs/app-server-protocol/src/protocol/v2/mcp.rs
@@ -1,0 +1,1 @@
+// fixture mcp.rs

--- a/cmd/check-codex-pin/testdata/upstream-drift/codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto
+++ b/cmd/check-codex-pin/testdata/upstream-drift/codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto
@@ -1,0 +1,37 @@
+syntax = "proto3";
+
+package codex.exec_server.relay.v1;
+
+message RelayMessageFrame {
+  uint32 version = 1;
+  string stream_id = 2;
+  uint32 ack = 3;
+  uint32 ack_bits = 4;
+
+  oneof body {
+    RelayData data = 5;
+    RelayAck ack_frame = 6;
+    RelayResume resume = 7;
+    RelayReset reset = 8;
+    RelayHeartbeat heartbeat = 9;
+  }
+}
+
+message RelayData {
+  uint32 seq = 1;
+  uint32 segment_index = 2;
+  uint32 segment_count = 3;
+  bytes payload = 4;
+}
+
+message RelayAck {}
+
+message RelayResume {
+  uint32 next_seq = 1;
+}
+
+message RelayReset {
+  string reason = 1;
+}
+
+message RelayHeartbeat {}

--- a/cmd/check-codex-pin/testdata/upstream-ok/codex-rs/app-server-protocol/src/protocol/v1.rs
+++ b/cmd/check-codex-pin/testdata/upstream-ok/codex-rs/app-server-protocol/src/protocol/v1.rs
@@ -1,0 +1,1 @@
+// fixture v1.rs

--- a/cmd/check-codex-pin/testdata/upstream-ok/codex-rs/app-server-protocol/src/protocol/v2/item.rs
+++ b/cmd/check-codex-pin/testdata/upstream-ok/codex-rs/app-server-protocol/src/protocol/v2/item.rs
@@ -1,0 +1,1 @@
+// fixture item.rs

--- a/cmd/check-codex-pin/testdata/upstream-ok/codex-rs/app-server-protocol/src/protocol/v2/mcp.rs
+++ b/cmd/check-codex-pin/testdata/upstream-ok/codex-rs/app-server-protocol/src/protocol/v2/mcp.rs
@@ -1,0 +1,1 @@
+// fixture mcp.rs

--- a/cmd/check-codex-pin/testdata/upstream-ok/codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto
+++ b/cmd/check-codex-pin/testdata/upstream-ok/codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto
@@ -1,0 +1,37 @@
+syntax = "proto3";
+
+package codex.exec_server.relay.v1;
+
+message RelayMessageFrame {
+  uint32 version = 1;
+  string stream_id = 2;
+  uint32 ack = 3;
+  uint32 ack_bits = 4;
+
+  oneof body {
+    RelayData data = 5;
+    RelayAck ack_frame = 6;
+    RelayResume resume = 7;
+    RelayReset reset = 8;
+    RelayHeartbeat heartbeat = 9;
+  }
+}
+
+message RelayData {
+  uint32 seq = 1;
+  uint32 segment_index = 2;
+  uint32 segment_count = 3;
+  bytes payload = 4;
+}
+
+message RelayAck {}
+
+message RelayResume {
+  uint32 next_seq = 1;
+}
+
+message RelayReset {
+  string reason = 1;
+}
+
+message RelayHeartbeat {}

--- a/cmd/check-codex-pin/verify.go
+++ b/cmd/check-codex-pin/verify.go
@@ -1,0 +1,142 @@
+package main
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+)
+
+// Pin mirrors the shape of codex-pin.json.
+type Pin struct {
+	UpstreamRepo             string                       `json:"upstream_repo"`
+	Tag                      string                       `json:"tag"`
+	Sha                      string                       `json:"sha"`
+	TrackedFiles             map[string]string            `json:"tracked_files"`
+	NormalizedEquivalentFiles map[string]NormalizedEntry  `json:"normalized_equivalent_files"`
+	ApprovalMethods          []string                     `json:"approval_methods"`
+}
+
+// NormalizedEntry describes a file that is equivalent to an upstream file after normalization.
+type NormalizedEntry struct {
+	UpstreamPath    string `json:"upstream_path"`
+	NormalizedSha256 string `json:"normalized_sha256"`
+	Comment         string `json:"comment"`
+}
+
+// Mismatch records a single verification failure.
+type Mismatch struct {
+	File   string
+	Reason string
+	Want   string
+	Got    string
+}
+
+// Report holds all mismatches found by Verify.
+type Report struct {
+	Mismatches []Mismatch
+}
+
+// goPackageRe matches lines of the form:
+//
+//	option go_package = "...";
+//
+// The pattern uses .* (not [^;]*) so that semicolons embedded inside the
+// quoted package path (e.g. "github.com/…;relaypb") are handled correctly.
+// In (?m) mode, . does not cross newlines, so the match stays on one line.
+var goPackageRe = regexp.MustCompile(`(?m)^option go_package[[:space:]]*=.*;\s*$`)
+
+// multiBlankRe matches two or more consecutive newlines.
+var multiBlankRe = regexp.MustCompile(`\n{2,}`)
+
+// normalize strips `option go_package = ...;` lines and squeezes multiple
+// consecutive blank lines into one.
+func normalize(content []byte) []byte {
+	// Normalise line endings to \n so the regex is line-end agnostic.
+	b := bytes.ReplaceAll(content, []byte("\r\n"), []byte("\n"))
+	b = goPackageRe.ReplaceAll(b, nil)
+	b = multiBlankRe.ReplaceAll(b, []byte("\n"))
+	return b
+}
+
+// hexSHA256 returns the hex-encoded SHA-256 of data.
+func hexSHA256(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// Verify reads the pin file at pinPath and checks:
+//  1. Every entry in tracked_files: the file at <upstreamRoot>/<upstream-path>
+//     must have the expected sha256.
+//  2. Every entry in normalized_equivalent_files: the file at <repoRoot>/<our-path>,
+//     after normalization, must have the expected normalized_sha256.
+//
+// It returns a Report containing all mismatches found (not just the first).
+func Verify(pinPath, repoRoot, upstreamRoot string) (*Report, error) {
+	raw, err := os.ReadFile(pinPath)
+	if err != nil {
+		return nil, fmt.Errorf("read pin file %s: %w", pinPath, err)
+	}
+
+	var pin Pin
+	if err := json.Unmarshal(raw, &pin); err != nil {
+		return nil, fmt.Errorf("parse pin file %s: %w", pinPath, err)
+	}
+
+	report := &Report{}
+
+	// --- Check tracked_files -------------------------------------------------
+	for upstreamPath, wantSha := range pin.TrackedFiles {
+		abs := filepath.Join(upstreamRoot, upstreamPath)
+		data, err := os.ReadFile(abs)
+		if err != nil {
+			report.Mismatches = append(report.Mismatches, Mismatch{
+				File:   upstreamPath,
+				Reason: "tracked-sha",
+				Want:   wantSha,
+				Got:    fmt.Sprintf("read error: %v", err),
+			})
+			continue
+		}
+		got := hexSHA256(data)
+		if got != wantSha {
+			report.Mismatches = append(report.Mismatches, Mismatch{
+				File:   upstreamPath,
+				Reason: "tracked-sha",
+				Want:   wantSha,
+				Got:    got,
+			})
+		}
+	}
+
+	// --- Check normalized_equivalent_files -----------------------------------
+	for ourPath, entry := range pin.NormalizedEquivalentFiles {
+		abs := filepath.Join(repoRoot, ourPath)
+		data, err := os.ReadFile(abs)
+		if err != nil {
+			report.Mismatches = append(report.Mismatches, Mismatch{
+				File:   ourPath,
+				Reason: "normalized-equivalent",
+				Want:   entry.NormalizedSha256,
+				Got:    fmt.Sprintf("read error: %v", err),
+			})
+			continue
+		}
+		norm := normalize(data)
+		got := hexSHA256(norm)
+		if got != entry.NormalizedSha256 {
+			report.Mismatches = append(report.Mismatches, Mismatch{
+				File:   ourPath,
+				Reason: "normalized-equivalent",
+				Want:   entry.NormalizedSha256,
+				Got:    got,
+			})
+		}
+	}
+
+	return report, nil
+}

--- a/cmd/check-codex-pin/verify.go
+++ b/cmd/check-codex-pin/verify.go
@@ -53,13 +53,14 @@ var goPackageRe = regexp.MustCompile(`(?m)^option go_package[[:space:]]*=.*;\s*$
 // multiBlankRe matches two or more consecutive newlines.
 var multiBlankRe = regexp.MustCompile(`\n{2,}`)
 
-// normalize strips `option go_package = ...;` lines and squeezes multiple
-// consecutive blank lines into one.
+// normalize strips the `option go_package = ...;` directive and collapses any
+// run of 2+ consecutive newlines to exactly one blank line (preserves the
+// standard between-message separator).
 func normalize(content []byte) []byte {
 	// Normalise line endings to \n so the regex is line-end agnostic.
 	b := bytes.ReplaceAll(content, []byte("\r\n"), []byte("\n"))
 	b = goPackageRe.ReplaceAll(b, nil)
-	b = multiBlankRe.ReplaceAll(b, []byte("\n"))
+	b = multiBlankRe.ReplaceAll(b, []byte("\n\n"))
 	return b
 }
 
@@ -96,9 +97,9 @@ func Verify(pinPath, repoRoot, upstreamRoot string) (*Report, error) {
 		if err != nil {
 			report.Mismatches = append(report.Mismatches, Mismatch{
 				File:   upstreamPath,
-				Reason: "tracked-sha",
+				Reason: "missing",
 				Want:   wantSha,
-				Got:    fmt.Sprintf("read error: %v", err),
+				Got:    err.Error(),
 			})
 			continue
 		}
@@ -120,9 +121,9 @@ func Verify(pinPath, repoRoot, upstreamRoot string) (*Report, error) {
 		if err != nil {
 			report.Mismatches = append(report.Mismatches, Mismatch{
 				File:   ourPath,
-				Reason: "normalized-equivalent",
+				Reason: "missing",
 				Want:   entry.NormalizedSha256,
-				Got:    fmt.Sprintf("read error: %v", err),
+				Got:    err.Error(),
 			})
 			continue
 		}

--- a/cmd/check-codex-pin/verify_test.go
+++ b/cmd/check-codex-pin/verify_test.go
@@ -1,0 +1,241 @@
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// sha256OfFile returns the hex-encoded SHA-256 of the named file's contents.
+func sha256OfFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// sha256OfNormalizedFile reads the file, normalizes it, and returns its hex SHA-256.
+func sha256OfNormalizedFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	norm := normalize(b)
+	sum := sha256.Sum256(norm)
+	return hex.EncodeToString(sum[:])
+}
+
+// writePin marshals pin to JSON in a temp dir and returns the path.
+func writePin(t *testing.T, pin Pin) string {
+	t.Helper()
+	b, err := json.MarshalIndent(pin, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "codex-pin.json")
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// fixtureDir is the testdata root relative to this file.
+const fixtureDir = "testdata"
+
+// upstreamOK is the "everything matches" upstream fixture tree.
+const upstreamOK = fixtureDir + "/upstream-ok"
+
+// upstreamDrift has a modified item.rs.
+const upstreamDrift = fixtureDir + "/upstream-drift"
+
+// makeRepoRoot writes a fake repo with internal/relaypb/relay.proto set to
+// content and returns the root dir.
+func makeRepoRoot(t *testing.T, protoContent string) string {
+	t.Helper()
+	root := t.TempDir()
+	dir := filepath.Join(root, "internal", "relaypb")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "relay.proto")
+	if err := os.WriteFile(path, []byte(protoContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+// TestVerify_OK: fixture tree matches pin → no mismatches.
+func TestVerify_OK(t *testing.T) {
+	protoUpstreamPath := upstreamOK + "/codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto"
+
+	// The normalized sha of the upstream proto == sha of our proto after normalize.
+	// We verify both are the same by computing them from the fixture.
+	normalizedSha := sha256OfNormalizedFile(t, protoUpstreamPath)
+
+	// Build the pin with shas derived from the OK fixtures.
+	pin := Pin{
+		UpstreamRepo: "openai/codex",
+		Tag:          "rust-v0.131.0-alpha.22",
+		Sha:          "d2c823dc87c863bedeb3752e997facdf7c1b5aad",
+		TrackedFiles: map[string]string{
+			"codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto":   sha256OfFile(t, upstreamOK+"/codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto"),
+			"codex-rs/app-server-protocol/src/protocol/v1.rs":                    sha256OfFile(t, upstreamOK+"/codex-rs/app-server-protocol/src/protocol/v1.rs"),
+			"codex-rs/app-server-protocol/src/protocol/v2/item.rs":               sha256OfFile(t, upstreamOK+"/codex-rs/app-server-protocol/src/protocol/v2/item.rs"),
+			"codex-rs/app-server-protocol/src/protocol/v2/mcp.rs":                sha256OfFile(t, upstreamOK+"/codex-rs/app-server-protocol/src/protocol/v2/mcp.rs"),
+		},
+		NormalizedEquivalentFiles: map[string]NormalizedEntry{
+			"internal/relaypb/relay.proto": {
+				UpstreamPath:     "codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto",
+				NormalizedSha256: normalizedSha,
+				Comment:          "test",
+			},
+		},
+	}
+	pinPath := writePin(t, pin)
+
+	// Our local proto is our real relay.proto (which has the go_package line).
+	// After normalization it must equal the upstream fixture.
+	// Read the real proto and write it into a fake repo root.
+	realProto, err := os.ReadFile("../../internal/relaypb/relay.proto")
+	if err != nil {
+		t.Fatalf("read real relay.proto: %v", err)
+	}
+	repoRoot := makeRepoRoot(t, string(realProto))
+
+	report, err := Verify(pinPath, repoRoot, upstreamOK)
+	if err != nil {
+		t.Fatalf("Verify returned error: %v", err)
+	}
+	if len(report.Mismatches) != 0 {
+		t.Errorf("expected 0 mismatches, got %d:", len(report.Mismatches))
+		for _, m := range report.Mismatches {
+			t.Errorf("  file=%s reason=%s want=%s got=%s", m.File, m.Reason, m.Want, m.Got)
+		}
+	}
+}
+
+// TestVerify_TrackedSha_DriftDetected: upstream item.rs changed → 1 mismatch.
+func TestVerify_TrackedSha_DriftDetected(t *testing.T) {
+	protoUpstreamPath := upstreamOK + "/codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto"
+	normalizedSha := sha256OfNormalizedFile(t, protoUpstreamPath)
+
+	// Use OK shas for tracked_files — but the drift fixture has a different item.rs.
+	// So the sha in the pin still points to the OK content, but upstream-drift has changed content.
+	pin := Pin{
+		UpstreamRepo: "openai/codex",
+		Tag:          "rust-v0.131.0-alpha.22",
+		Sha:          "d2c823dc87c863bedeb3752e997facdf7c1b5aad",
+		TrackedFiles: map[string]string{
+			"codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto":   sha256OfFile(t, upstreamOK+"/codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto"),
+			"codex-rs/app-server-protocol/src/protocol/v1.rs":                    sha256OfFile(t, upstreamOK+"/codex-rs/app-server-protocol/src/protocol/v1.rs"),
+			// Pin has the OK sha, but the drift fixture has a different file.
+			"codex-rs/app-server-protocol/src/protocol/v2/item.rs": sha256OfFile(t, upstreamOK+"/codex-rs/app-server-protocol/src/protocol/v2/item.rs"),
+			"codex-rs/app-server-protocol/src/protocol/v2/mcp.rs":  sha256OfFile(t, upstreamOK+"/codex-rs/app-server-protocol/src/protocol/v2/mcp.rs"),
+		},
+		NormalizedEquivalentFiles: map[string]NormalizedEntry{
+			"internal/relaypb/relay.proto": {
+				UpstreamPath:     "codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto",
+				NormalizedSha256: normalizedSha,
+				Comment:          "test",
+			},
+		},
+	}
+	pinPath := writePin(t, pin)
+
+	realProto, err := os.ReadFile("../../internal/relaypb/relay.proto")
+	if err != nil {
+		t.Fatalf("read real relay.proto: %v", err)
+	}
+	repoRoot := makeRepoRoot(t, string(realProto))
+
+	// Use the DRIFT upstream tree — item.rs content has changed.
+	report, err := Verify(pinPath, repoRoot, upstreamDrift)
+	if err != nil {
+		t.Fatalf("Verify returned error: %v", err)
+	}
+
+	const wantFile = "codex-rs/app-server-protocol/src/protocol/v2/item.rs"
+	const wantReason = "tracked-sha"
+
+	if len(report.Mismatches) != 1 {
+		t.Fatalf("expected exactly 1 mismatch, got %d: %+v", len(report.Mismatches), report.Mismatches)
+	}
+	m := report.Mismatches[0]
+	if m.File != wantFile {
+		t.Errorf("mismatch.File = %q, want %q", m.File, wantFile)
+	}
+	if m.Reason != wantReason {
+		t.Errorf("mismatch.Reason = %q, want %q", m.Reason, wantReason)
+	}
+}
+
+// TestVerify_NormalizedEquivalent_Mismatch: our proto has a different schema → mismatch.
+func TestVerify_NormalizedEquivalent_Mismatch(t *testing.T) {
+	protoUpstreamPath := upstreamOK + "/codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto"
+	normalizedSha := sha256OfNormalizedFile(t, protoUpstreamPath)
+
+	pin := Pin{
+		UpstreamRepo: "openai/codex",
+		Tag:          "rust-v0.131.0-alpha.22",
+		Sha:          "d2c823dc87c863bedeb3752e997facdf7c1b5aad",
+		TrackedFiles: map[string]string{
+			"codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto":   sha256OfFile(t, upstreamOK+"/codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto"),
+			"codex-rs/app-server-protocol/src/protocol/v1.rs":                    sha256OfFile(t, upstreamOK+"/codex-rs/app-server-protocol/src/protocol/v1.rs"),
+			"codex-rs/app-server-protocol/src/protocol/v2/item.rs":               sha256OfFile(t, upstreamOK+"/codex-rs/app-server-protocol/src/protocol/v2/item.rs"),
+			"codex-rs/app-server-protocol/src/protocol/v2/mcp.rs":                sha256OfFile(t, upstreamOK+"/codex-rs/app-server-protocol/src/protocol/v2/mcp.rs"),
+		},
+		NormalizedEquivalentFiles: map[string]NormalizedEntry{
+			"internal/relaypb/relay.proto": {
+				UpstreamPath:     "codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto",
+				NormalizedSha256: normalizedSha,
+				Comment:          "test",
+			},
+		},
+	}
+	pinPath := writePin(t, pin)
+
+	// Write a proto that differs in schema (not just go_package), so normalization
+	// will still produce a different sha.
+	brokenProto := `syntax = "proto3";
+
+package codex.exec_server.relay.v1;
+
+option go_package = "github.com/agentserver/agentserver/internal/relaypb;relaypb";
+
+// This file has a completely different schema — extra field added.
+message RelayMessageFrame {
+  uint32 version = 1;
+  string stream_id = 2;
+  uint32 ack = 3;
+  uint32 ack_bits = 4;
+  string extra_field = 99;
+}
+`
+	repoRoot := makeRepoRoot(t, brokenProto)
+
+	report, err := Verify(pinPath, repoRoot, upstreamOK)
+	if err != nil {
+		t.Fatalf("Verify returned error: %v", err)
+	}
+
+	const wantFile = "internal/relaypb/relay.proto"
+	const wantReason = "normalized-equivalent"
+
+	var found *Mismatch
+	for i := range report.Mismatches {
+		if report.Mismatches[i].File == wantFile && report.Mismatches[i].Reason == wantReason {
+			found = &report.Mismatches[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatalf("expected a mismatch with file=%q reason=%q, got: %+v", wantFile, wantReason, report.Mismatches)
+	}
+}

--- a/cmd/check-codex-pin/verify_test.go
+++ b/cmd/check-codex-pin/verify_test.go
@@ -176,6 +176,58 @@ func TestVerify_TrackedSha_DriftDetected(t *testing.T) {
 	}
 }
 
+// TestVerify_MissingTrackedFile: pin references item.rs but the file is absent → 1 mismatch with reason "missing".
+func TestVerify_MissingTrackedFile(t *testing.T) {
+	// Pin references item.rs, but upstreamRoot doesn't have it (we delete the file).
+	upstreamRoot := t.TempDir()
+	// Lay down only 3 of the 4 files (deliberately missing item.rs)
+	must := func(path, content string) {
+		full := filepath.Join(upstreamRoot, path)
+		if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	must("codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto", "// proto\n")
+	must("codex-rs/app-server-protocol/src/protocol/v1.rs", "// v1\n")
+	must("codex-rs/app-server-protocol/src/protocol/v2/mcp.rs", "// mcp\n")
+	// NOT writing item.rs — that's the test point
+
+	tracked := map[string]string{
+		"codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto": sha256OfFile(t, filepath.Join(upstreamRoot, "codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto")),
+		"codex-rs/app-server-protocol/src/protocol/v1.rs":                 sha256OfFile(t, filepath.Join(upstreamRoot, "codex-rs/app-server-protocol/src/protocol/v1.rs")),
+		"codex-rs/app-server-protocol/src/protocol/v2/item.rs":            "0000000000000000000000000000000000000000000000000000000000000000",
+		"codex-rs/app-server-protocol/src/protocol/v2/mcp.rs":             sha256OfFile(t, filepath.Join(upstreamRoot, "codex-rs/app-server-protocol/src/protocol/v2/mcp.rs")),
+	}
+	// No normalized_equivalent_files needed for this test
+	pin := Pin{
+		UpstreamRepo:    "openai/codex",
+		Tag:             "test",
+		Sha:             "test",
+		TrackedFiles:    tracked,
+		ApprovalMethods: []string{"item/commandExecution/requestApproval"},
+	}
+	pinPath := writePin(t, pin)
+	repoRoot := t.TempDir() // empty repo root is fine — no normalized check
+
+	report, err := Verify(pinPath, repoRoot, upstreamRoot)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if len(report.Mismatches) != 1 {
+		t.Fatalf("want 1 mismatch (missing item.rs), got %d: %+v", len(report.Mismatches), report.Mismatches)
+	}
+	m := report.Mismatches[0]
+	if m.File != "codex-rs/app-server-protocol/src/protocol/v2/item.rs" {
+		t.Errorf("File: got %q, want item.rs", m.File)
+	}
+	if m.Reason != "missing" {
+		t.Errorf("Reason: got %q, want missing", m.Reason)
+	}
+}
+
 // TestVerify_NormalizedEquivalent_Mismatch: our proto has a different schema → mismatch.
 func TestVerify_NormalizedEquivalent_Mismatch(t *testing.T) {
 	protoUpstreamPath := upstreamOK + "/codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto"

--- a/codex-pin.json
+++ b/codex-pin.json
@@ -1,0 +1,25 @@
+{
+  "upstream_repo": "openai/codex",
+  "tag": "rust-v0.131.0-alpha.22",
+  "sha": "d2c823dc87c863bedeb3752e997facdf7c1b5aad",
+  "tracked_files": {
+    "codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto": "44959c98baa1b6400a1e8757e58f74f34be89f29b52cbfb314e1312a5014835c",
+    "codex-rs/app-server-protocol/src/protocol/v1.rs": "bad23c6a31e0b65123f5643c9c9223a62d8fb9a93954f5f2a3ea15eea45de4fb",
+    "codex-rs/app-server-protocol/src/protocol/v2/item.rs": "ea27c007b73d569a6d8392afb533240ad44dd3c8d048bfe37659e56e0ed02a3d",
+    "codex-rs/app-server-protocol/src/protocol/v2/mcp.rs": "3cf6bc25e9fd9656e589ff838bf99a1c9a6cc35cdb61372ef6907c34f311bf51"
+  },
+  "normalized_equivalent_files": {
+    "internal/relaypb/relay.proto": {
+      "upstream_path": "codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto",
+      "normalized_sha256": "44959c98baa1b6400a1e8757e58f74f34be89f29b52cbfb314e1312a5014835c",
+      "comment": "Strip Go-only `option go_package = \"...\";` directive and squeeze consecutive blank lines, then compare schemas. Required because agentserver's protoc-gen-go needs this directive; upstream's prost (Rust) doesn't."
+    }
+  },
+  "approval_methods": [
+    "item/commandExecution/requestApproval",
+    "item/fileChange/requestApproval",
+    "item/permissions/requestApproval",
+    "item/tool/requestUserInput",
+    "mcpServer/elicitation/request"
+  ]
+}

--- a/codex-pin.json
+++ b/codex-pin.json
@@ -1,7 +1,7 @@
 {
   "upstream_repo": "openai/codex",
   "tag": "rust-v0.131.0-alpha.22",
-  "sha": "d2c823dc87c863bedeb3752e997facdf7c1b5aad",
+  "sha": "9b8cf56cdefb09f54564ccc295fd42f6647f558f",
   "tracked_files": {
     "codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto": "44959c98baa1b6400a1e8757e58f74f34be89f29b52cbfb314e1312a5014835c",
     "codex-rs/app-server-protocol/src/protocol/v1.rs": "bad23c6a31e0b65123f5643c9c9223a62d8fb9a93954f5f2a3ea15eea45de4fb",
@@ -12,7 +12,7 @@
     "internal/relaypb/relay.proto": {
       "upstream_path": "codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto",
       "normalized_sha256": "44959c98baa1b6400a1e8757e58f74f34be89f29b52cbfb314e1312a5014835c",
-      "comment": "Strip Go-only `option go_package = \"...\";` directive and squeeze consecutive blank lines, then compare schemas. Required because agentserver's protoc-gen-go needs this directive; upstream's prost (Rust) doesn't."
+      "comment": "Strip Go-only `option go_package = \"...\";` directive and collapse runs of 2+ consecutive newlines to one blank line, then compare schemas. Required because agentserver's protoc-gen-go needs this directive; upstream's prost (Rust) doesn't. Must stay in sync with cmd/check-codex-pin/verify.go::normalize()."
     }
   },
   "approval_methods": [

--- a/docs/superpowers/plans/2026-05-20-codex-pin-and-exec-gateway-hardening.md
+++ b/docs/superpowers/plans/2026-05-20-codex-pin-and-exec-gateway-hardening.md
@@ -1,0 +1,1281 @@
+# codex-pin + exec-gateway hardening (PR 1) — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement PR 1 from the [Full Upstream Alignment spec](../specs/2026-05-20-codex-gateway-full-alignment-design.md): pin agentserver to a specific upstream `openai/codex` tag with CI-enforced drift detection, and close three operational gaps in `codex-exec-gateway` (unbounded read limits, no idle reaper, no per-executor stream cap).
+
+**Architecture:** Add a Go-based pin checker (`cmd/check-codex-pin`) that verifies sha256 of upstream-tracked protocol artifacts against a checked-in `codex-pin.json`. Extend `codexexecgateway.Config` with three new bounded-resource knobs and wire them into the inbound/bridge ws lifecycle.
+
+**Tech Stack:** Go, `nhooyr.io/websocket`, `google.golang.org/protobuf/proto`, plain `os/exec` for git clone, GitHub Actions for CI.
+
+---
+
+## File structure
+
+**Create:**
+- `codex-pin.json` — repo root, JSON manifest pinning upstream tag + sha256 of tracked files
+- `cmd/check-codex-pin/main.go` — CLI program: verifies pin against an upstream copy
+- `cmd/check-codex-pin/verify.go` — core verification logic (separated for testability)
+- `cmd/check-codex-pin/verify_test.go` — unit tests with fixture-based offline mode
+- `cmd/check-codex-pin/testdata/upstream-ok/` — fixture: minimal upstream tree matching pin
+- `cmd/check-codex-pin/testdata/upstream-drift/` — fixture: one file with mutated sha
+
+**Modify:**
+- `Makefile` — add `codex-pin-check` and `codex-pin-bump` targets
+- `.github/workflows/build.yml` — add pin-check job (parallel to existing `test` job)
+- `internal/codexexecgateway/config.go` — add `MaxFrameBytes`, `BridgeIdleTimeout`, `MaxStreamsPerExecutor` fields + env loaders
+- `internal/codexexecgateway/inbound.go` — replace `SetReadLimit(-1)` with `SetReadLimit(cfg.MaxFrameBytes)`; pass config into `newInboundConn`
+- `internal/codexexecgateway/bridge.go` — replace `SetReadLimit(-1)`; check stream cap before `addRoute`; return 503 on cap exceeded; touch lastActivity on first frame
+- `internal/codexexecgateway/multiplex.go` — add `lastActivity atomic.Int64` to `bridgeSession`; add `streamCount()` method; `inboundConn.startIdleReaper(idleTimeout)` goroutine that sends `RelayReset` and closes idle sessions
+- `internal/codexexecgateway/server.go` — pass `cfg` into `newInboundConn` and bridge handler; start idle reaper
+
+**Test:**
+- `cmd/check-codex-pin/verify_test.go` — pin verification tests
+- `internal/codexexecgateway/inbound_test.go` — add test for `SetReadLimit` enforcement
+- `internal/codexexecgateway/bridge_test.go` — add tests for stream cap
+- `internal/codexexecgateway/multiplex_test.go` — add tests for idle reaper
+
+---
+
+## Task 1: Bootstrap `codex-pin.json`
+
+**Files:**
+- Create: `codex-pin.json`
+
+- [ ] **Step 1: Resolve upstream tag sha**
+
+Run:
+```bash
+git ls-remote https://github.com/openai/codex.git refs/tags/rust-v0.131.0-alpha.22 | awk '{print $1}'
+```
+
+Record the sha printed (used as `<UPSTREAM_SHA>` below).
+
+- [ ] **Step 2: Compute sha256 of current relay.proto (after stripping the Go-specific `option go_package` directive)**
+
+Our local `internal/relaypb/relay.proto` is upstream's `codex.exec_server.relay.v1.proto` PLUS one local-only line: `option go_package = "github.com/agentserver/agentserver/internal/relaypb;relaypb";` (needed for `protoc-gen-go`; upstream doesn't need it because they use Rust's `prost`).
+
+So byte-equality with upstream is impossible; we instead compare the schemas after stripping that directive (and any consecutive blank line that followed it):
+
+```bash
+sed -E '/^option go_package[[:space:]]*=/,/^$/d' internal/relaypb/relay.proto | sha256sum | awk '{print $1}'
+```
+
+Record the sha (used as `<RELAY_PROTO_NORMALIZED_SHA256>` below).
+
+- [ ] **Step 3: Fetch upstream blob shas for the tracked files**
+
+Run (replace `<UPSTREAM_SHA>` with the value from Step 1):
+```bash
+mkdir -p /tmp/codex-pin-bootstrap && cd /tmp/codex-pin-bootstrap
+git clone --depth 1 --branch rust-v0.131.0-alpha.22 https://github.com/openai/codex.git
+cd codex
+for f in \
+  codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto \
+  codex-rs/app-server-protocol/src/protocol/v1.rs \
+  codex-rs/app-server-protocol/src/protocol/v2/item.rs \
+  codex-rs/app-server-protocol/src/protocol/v2/mcp.rs ; do
+  printf '%s  %s\n' "$(sha256sum "$f" | awk '{print $1}')" "$f"
+done
+```
+
+Record each sha for the JSON below.
+
+- [ ] **Step 4: Verify upstream and local relay.proto match after strip-normalization**
+
+Run:
+```bash
+tmp_upstream=$(mktemp -d)
+git clone --depth 1 --branch rust-v0.131.0-alpha.22 https://github.com/openai/codex.git "$tmp_upstream/codex"
+upstream_norm=$(sed -E '/^option go_package[[:space:]]*=/,/^$/d' "$tmp_upstream/codex/codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto" | sha256sum | awk '{print $1}')
+local_norm=$(sed -E '/^option go_package[[:space:]]*=/,/^$/d' internal/relaypb/relay.proto | sha256sum | awk '{print $1}')
+if [ "$upstream_norm" != "$local_norm" ]; then
+  echo "MISMATCH after strip-normalize"; echo "upstream_norm=$upstream_norm"; echo "local_norm=$local_norm"
+  exit 1
+fi
+echo "normalized schemas match: $upstream_norm"
+rm -rf "$tmp_upstream"
+```
+
+Record `<RELAY_PROTO_NORMALIZED_SHA256>` = the matching value.
+
+- [ ] **Step 5: Write `codex-pin.json` at repo root**
+
+```json
+{
+  "upstream_repo": "openai/codex",
+  "tag": "rust-v0.131.0-alpha.22",
+  "sha": "<UPSTREAM_SHA>",
+  "tracked_files": {
+    "codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto": "<sha-from-step-3>",
+    "codex-rs/app-server-protocol/src/protocol/v1.rs": "<sha-from-step-3>",
+    "codex-rs/app-server-protocol/src/protocol/v2/item.rs": "<sha-from-step-3>",
+    "codex-rs/app-server-protocol/src/protocol/v2/mcp.rs": "<sha-from-step-3>"
+  },
+  "normalized_equivalent_files": {
+    "internal/relaypb/relay.proto": {
+      "upstream_path": "codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto",
+      "normalized_sha256": "<RELAY_PROTO_NORMALIZED_SHA256>",
+      "comment": "Strip Go-only `option go_package = \"...\";` directive and the blank line that follows it, then compare schemas. Required because agentserver's protoc-gen-go needs this directive; upstream's prost (Rust) doesn't."
+    }
+  },
+  "approval_methods": [
+    "item/commandExecution/requestApproval",
+    "item/fileChange/requestApproval",
+    "item/permissions/requestApproval",
+    "item/tool/requestUserInput",
+    "mcpServer/elicitation/request"
+  ]
+}
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add codex-pin.json
+git commit -m "feat(codex-pin): bootstrap pin to rust-v0.131.0-alpha.22"
+```
+
+---
+
+## Task 2: `verify.go` — core verification logic (TDD)
+
+**Files:**
+- Create: `cmd/check-codex-pin/verify.go`
+- Create: `cmd/check-codex-pin/verify_test.go`
+- Create: `cmd/check-codex-pin/testdata/upstream-ok/` (fixture tree)
+- Create: `cmd/check-codex-pin/testdata/upstream-drift/`
+
+- [ ] **Step 1: Create fixture directories**
+
+```bash
+mkdir -p cmd/check-codex-pin/testdata/upstream-ok/codex-rs/exec-server/src/proto
+mkdir -p cmd/check-codex-pin/testdata/upstream-ok/codex-rs/app-server-protocol/src/protocol/v2
+
+# Copy the real relay.proto (it's our canonical "upstream-ok" copy)
+cp internal/relaypb/relay.proto cmd/check-codex-pin/testdata/upstream-ok/codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto
+
+# Minimal stand-ins for v1.rs/item.rs/mcp.rs — content doesn't matter, only the sha
+echo "// fixture v1.rs" > cmd/check-codex-pin/testdata/upstream-ok/codex-rs/app-server-protocol/src/protocol/v1.rs
+echo "// fixture item.rs" > cmd/check-codex-pin/testdata/upstream-ok/codex-rs/app-server-protocol/src/protocol/v2/item.rs
+echo "// fixture mcp.rs" > cmd/check-codex-pin/testdata/upstream-ok/codex-rs/app-server-protocol/src/protocol/v2/mcp.rs
+
+# Drift fixture: same files but item.rs has a different sha
+cp -r cmd/check-codex-pin/testdata/upstream-ok cmd/check-codex-pin/testdata/upstream-drift
+echo "// drifted item.rs" > cmd/check-codex-pin/testdata/upstream-drift/codex-rs/app-server-protocol/src/protocol/v2/item.rs
+```
+
+- [ ] **Step 2: Write the failing test for "OK case"**
+
+`cmd/check-codex-pin/verify_test.go`:
+```go
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func mustHashFile(t *testing.T, path string) string {
+	t.Helper()
+	b, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+func writePinFile(t *testing.T, tracked map[string]string) string {
+	t.Helper()
+	pin := Pin{
+		UpstreamRepo: "openai/codex",
+		Tag:          "rust-v0.131.0-alpha.22",
+		Sha:          "deadbeef",
+		TrackedFiles: tracked,
+		ByteIdenticalFiles: map[string]string{
+			"internal/relaypb/relay.proto": "codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto",
+		},
+		ApprovalMethods: []string{
+			"item/commandExecution/requestApproval",
+			"item/fileChange/requestApproval",
+			"item/permissions/requestApproval",
+			"item/tool/requestUserInput",
+			"mcpServer/elicitation/request",
+		},
+	}
+	b, _ := json.Marshal(pin)
+	path := filepath.Join(t.TempDir(), "codex-pin.json")
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatalf("write pin: %v", err)
+	}
+	return path
+}
+
+func TestVerify_OK(t *testing.T) {
+	upstream := "testdata/upstream-ok"
+	tracked := map[string]string{
+		"codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto": mustHashFile(t, filepath.Join(upstream, "codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto")),
+		"codex-rs/app-server-protocol/src/protocol/v1.rs":                 mustHashFile(t, filepath.Join(upstream, "codex-rs/app-server-protocol/src/protocol/v1.rs")),
+		"codex-rs/app-server-protocol/src/protocol/v2/item.rs":            mustHashFile(t, filepath.Join(upstream, "codex-rs/app-server-protocol/src/protocol/v2/item.rs")),
+		"codex-rs/app-server-protocol/src/protocol/v2/mcp.rs":             mustHashFile(t, filepath.Join(upstream, "codex-rs/app-server-protocol/src/protocol/v2/mcp.rs")),
+	}
+	pinPath := writePinFile(t, tracked)
+
+	// repo root for byte-identical check: use the upstream fixture as if it's our repo,
+	// so internal/relaypb/relay.proto points at the same file as the tracked proto.
+	repoRoot := t.TempDir()
+	internalDir := filepath.Join(repoRoot, "internal/relaypb")
+	if err := os.MkdirAll(internalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := os.ReadFile(filepath.Join(upstream, "codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto"))
+	if err := os.WriteFile(filepath.Join(internalDir, "relay.proto"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := Verify(pinPath, repoRoot, upstream)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if len(report.Mismatches) != 0 {
+		t.Fatalf("expected no mismatches, got %+v", report.Mismatches)
+	}
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails (no `Pin` type yet)**
+
+Run: `go test ./cmd/check-codex-pin -run TestVerify_OK -v`
+Expected: FAIL (build error — `Pin`/`Verify` undefined)
+
+- [ ] **Step 4: Implement minimal `verify.go`**
+
+`cmd/check-codex-pin/verify.go`:
+```go
+package main
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Pin mirrors codex-pin.json.
+type Pin struct {
+	UpstreamRepo       string            `json:"upstream_repo"`
+	Tag                string            `json:"tag"`
+	Sha                string            `json:"sha"`
+	TrackedFiles       map[string]string `json:"tracked_files"`        // path-in-upstream → sha256
+	ByteIdenticalFiles map[string]string `json:"byte_identical_files"` // path-in-this-repo → path-in-upstream
+	ApprovalMethods    []string          `json:"approval_methods"`
+}
+
+// Mismatch describes one failing assertion.
+type Mismatch struct {
+	File   string
+	Reason string // "tracked-sha", "byte-identical", "missing"
+	Want   string
+	Got    string
+}
+
+// Report aggregates all mismatches from a Verify call.
+type Report struct {
+	Mismatches []Mismatch
+}
+
+// Verify checks the pin against an upstream source tree (already checked out
+// somewhere local). repoRoot is the root of THIS repo (so byte-identical
+// checks can read our own files).
+func Verify(pinPath, repoRoot, upstreamRoot string) (*Report, error) {
+	rep := &Report{}
+	pinBytes, err := os.ReadFile(pinPath)
+	if err != nil {
+		return nil, fmt.Errorf("read pin: %w", err)
+	}
+	var pin Pin
+	if err := json.Unmarshal(pinBytes, &pin); err != nil {
+		return nil, fmt.Errorf("parse pin: %w", err)
+	}
+
+	for relPath, wantSha := range pin.TrackedFiles {
+		abs := filepath.Join(upstreamRoot, relPath)
+		got, err := hashFile(abs)
+		if err != nil {
+			rep.Mismatches = append(rep.Mismatches, Mismatch{File: relPath, Reason: "missing", Want: wantSha, Got: err.Error()})
+			continue
+		}
+		if got != wantSha {
+			rep.Mismatches = append(rep.Mismatches, Mismatch{File: relPath, Reason: "tracked-sha", Want: wantSha, Got: got})
+		}
+	}
+
+	for ourPath, upstreamPath := range pin.ByteIdenticalFiles {
+		our, errOur := hashFile(filepath.Join(repoRoot, ourPath))
+		ups, errUps := hashFile(filepath.Join(upstreamRoot, upstreamPath))
+		if errOur != nil {
+			rep.Mismatches = append(rep.Mismatches, Mismatch{File: ourPath, Reason: "missing", Got: errOur.Error()})
+			continue
+		}
+		if errUps != nil {
+			rep.Mismatches = append(rep.Mismatches, Mismatch{File: upstreamPath, Reason: "missing", Got: errUps.Error()})
+			continue
+		}
+		if our != ups {
+			rep.Mismatches = append(rep.Mismatches, Mismatch{File: ourPath, Reason: "byte-identical", Want: ups, Got: our})
+		}
+	}
+
+	return rep, nil
+}
+
+func hashFile(path string) (string, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:]), nil
+}
+```
+
+Also create a stub `main.go` so the package builds:
+```go
+package main
+
+func main() {}
+```
+
+- [ ] **Step 5: Run OK test, verify it passes**
+
+Run: `go test ./cmd/check-codex-pin -run TestVerify_OK -v`
+Expected: PASS
+
+- [ ] **Step 6: Add drift test**
+
+Append to `verify_test.go`:
+```go
+func TestVerify_DriftDetected(t *testing.T) {
+	upstream := "testdata/upstream-drift"
+	// Pin uses the OK fixture's shas; upstream-drift mutated item.rs.
+	tracked := map[string]string{
+		"codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto": mustHashFile(t, "testdata/upstream-ok/codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto"),
+		"codex-rs/app-server-protocol/src/protocol/v1.rs":                 mustHashFile(t, "testdata/upstream-ok/codex-rs/app-server-protocol/src/protocol/v1.rs"),
+		"codex-rs/app-server-protocol/src/protocol/v2/item.rs":            mustHashFile(t, "testdata/upstream-ok/codex-rs/app-server-protocol/src/protocol/v2/item.rs"),
+		"codex-rs/app-server-protocol/src/protocol/v2/mcp.rs":             mustHashFile(t, "testdata/upstream-ok/codex-rs/app-server-protocol/src/protocol/v2/mcp.rs"),
+	}
+	pinPath := writePinFile(t, tracked)
+
+	repoRoot := t.TempDir()
+	internalDir := filepath.Join(repoRoot, "internal/relaypb")
+	if err := os.MkdirAll(internalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b, _ := os.ReadFile(filepath.Join(upstream, "codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto"))
+	if err := os.WriteFile(filepath.Join(internalDir, "relay.proto"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := Verify(pinPath, repoRoot, upstream)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if len(report.Mismatches) != 1 {
+		t.Fatalf("expected exactly 1 mismatch (item.rs drift), got %d: %+v", len(report.Mismatches), report.Mismatches)
+	}
+	m := report.Mismatches[0]
+	if m.File != "codex-rs/app-server-protocol/src/protocol/v2/item.rs" {
+		t.Errorf("mismatch file: got %q, want item.rs", m.File)
+	}
+	if m.Reason != "tracked-sha" {
+		t.Errorf("mismatch reason: got %q, want tracked-sha", m.Reason)
+	}
+}
+```
+
+- [ ] **Step 7: Run drift test, verify it passes (verify.go already handles it)**
+
+Run: `go test ./cmd/check-codex-pin -run TestVerify_DriftDetected -v`
+Expected: PASS
+
+- [ ] **Step 8: Add byte-identical-mismatch test**
+
+```go
+func TestVerify_ByteIdenticalMismatch(t *testing.T) {
+	upstream := "testdata/upstream-ok"
+	tracked := map[string]string{
+		"codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto": mustHashFile(t, filepath.Join(upstream, "codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto")),
+		"codex-rs/app-server-protocol/src/protocol/v1.rs":                 mustHashFile(t, filepath.Join(upstream, "codex-rs/app-server-protocol/src/protocol/v1.rs")),
+		"codex-rs/app-server-protocol/src/protocol/v2/item.rs":            mustHashFile(t, filepath.Join(upstream, "codex-rs/app-server-protocol/src/protocol/v2/item.rs")),
+		"codex-rs/app-server-protocol/src/protocol/v2/mcp.rs":             mustHashFile(t, filepath.Join(upstream, "codex-rs/app-server-protocol/src/protocol/v2/mcp.rs")),
+	}
+	pinPath := writePinFile(t, tracked)
+
+	repoRoot := t.TempDir()
+	internalDir := filepath.Join(repoRoot, "internal/relaypb")
+	if err := os.MkdirAll(internalDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Write a DIFFERENT relay.proto in our repo — should trip the byte-identical check.
+	if err := os.WriteFile(filepath.Join(internalDir, "relay.proto"), []byte("// mutated proto\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	report, err := Verify(pinPath, repoRoot, upstream)
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	found := false
+	for _, m := range report.Mismatches {
+		if m.File == "internal/relaypb/relay.proto" && m.Reason == "byte-identical" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected byte-identical mismatch on relay.proto, got %+v", report.Mismatches)
+	}
+}
+```
+
+Run: `go test ./cmd/check-codex-pin -v`
+Expected: all 3 tests PASS
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add cmd/check-codex-pin/
+git commit -m "feat(codex-pin): verifier with sha + byte-identical checks"
+```
+
+---
+
+## Task 3: `main.go` — CLI wrapper that fetches upstream and runs Verify
+
+**Files:**
+- Modify: `cmd/check-codex-pin/main.go`
+
+- [ ] **Step 1: Write `main.go`**
+
+```go
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func main() {
+	pinPath := flag.String("pin", "codex-pin.json", "path to codex-pin.json")
+	repoRoot := flag.String("repo-root", ".", "path to this repo's root")
+	upstreamSource := flag.String("upstream-source", "", "local path to upstream codex checkout (if empty, will clone)")
+	flag.Parse()
+
+	upstream := *upstreamSource
+	if upstream == "" {
+		var err error
+		upstream, err = cloneUpstream(*pinPath)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "clone upstream: %v\n", err)
+			os.Exit(2)
+		}
+		defer os.RemoveAll(upstream)
+	}
+
+	report, err := Verify(*pinPath, *repoRoot, upstream)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "verify: %v\n", err)
+		os.Exit(2)
+	}
+	if len(report.Mismatches) == 0 {
+		fmt.Println("codex-pin: OK")
+		return
+	}
+	fmt.Fprintf(os.Stderr, "codex-pin: %d mismatch(es):\n", len(report.Mismatches))
+	for _, m := range report.Mismatches {
+		fmt.Fprintf(os.Stderr, "  %s [%s] want=%s got=%s\n", m.File, m.Reason, m.Want, m.Got)
+	}
+	os.Exit(1)
+}
+
+func cloneUpstream(pinPath string) (string, error) {
+	pinBytes, err := os.ReadFile(pinPath)
+	if err != nil {
+		return "", err
+	}
+	var pin struct {
+		Tag string `json:"tag"`
+	}
+	if err := json.Unmarshal(pinBytes, &pin); err != nil {
+		return "", err
+	}
+	tmp, err := os.MkdirTemp("", "codex-pin-*")
+	if err != nil {
+		return "", err
+	}
+	dst := filepath.Join(tmp, "codex")
+	cmd := exec.Command("git", "clone", "--depth", "1", "--branch", pin.Tag, "https://github.com/openai/codex.git", dst)
+	cmd.Stdout = os.Stderr // git progress to stderr, keep stdout clean for our output
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		os.RemoveAll(tmp)
+		return "", fmt.Errorf("git clone: %w", err)
+	}
+	return dst, nil
+}
+
+```
+
+Top-of-file imports in `main.go`:
+```go
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+```
+
+- [ ] **Step 2: Verify it builds**
+
+Run: `go build ./cmd/check-codex-pin`
+Expected: success, binary produced at `./check-codex-pin` (delete after: `rm check-codex-pin`)
+
+- [ ] **Step 3: Run offline against fixture**
+
+```bash
+go run ./cmd/check-codex-pin -pin cmd/check-codex-pin/testdata/upstream-ok-pin.json -repo-root cmd/check-codex-pin/testdata/upstream-ok -upstream-source cmd/check-codex-pin/testdata/upstream-ok
+```
+
+Expected: error — `upstream-ok-pin.json` doesn't exist yet. (This is fine; the offline smoke is covered by unit tests.)
+
+- [ ] **Step 4: Run online against real upstream**
+
+```bash
+go run ./cmd/check-codex-pin
+```
+
+Expected: prints `codex-pin: OK` (since the codex-pin.json bootstrapped in Task 1 should match upstream).
+
+If it fails with mismatches, double-check Task 1's sha values.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add cmd/check-codex-pin/main.go
+git commit -m "feat(codex-pin): CLI wrapper with online git-clone fetcher"
+```
+
+---
+
+## Task 4: Makefile targets
+
+**Files:**
+- Modify: `Makefile`
+
+- [ ] **Step 1: Add targets**
+
+Append to `Makefile`:
+```makefile
+codex-pin-check:
+	go run ./cmd/check-codex-pin
+
+codex-pin-bump:
+	@if [ -z "$(TAG)" ]; then echo "usage: make codex-pin-bump TAG=rust-v0.x.y"; exit 2; fi
+	@echo "Bumping codex-pin to $(TAG)..."
+	@tmp=$$(mktemp -d) && \
+	  git clone --depth 1 --branch $(TAG) https://github.com/openai/codex.git $$tmp/codex && \
+	  sha=$$(cd $$tmp/codex && git rev-parse HEAD) && \
+	  relay_sha=$$(sha256sum $$tmp/codex/codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto | awk '{print $$1}') && \
+	  v1_sha=$$(sha256sum $$tmp/codex/codex-rs/app-server-protocol/src/protocol/v1.rs | awk '{print $$1}') && \
+	  item_sha=$$(sha256sum $$tmp/codex/codex-rs/app-server-protocol/src/protocol/v2/item.rs | awk '{print $$1}') && \
+	  mcp_sha=$$(sha256sum $$tmp/codex/codex-rs/app-server-protocol/src/protocol/v2/mcp.rs | awk '{print $$1}') && \
+	  cp $$tmp/codex/codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto internal/relaypb/relay.proto && \
+	  echo "{" > codex-pin.json && \
+	  echo "  \"upstream_repo\": \"openai/codex\"," >> codex-pin.json && \
+	  echo "  \"tag\": \"$(TAG)\"," >> codex-pin.json && \
+	  echo "  \"sha\": \"$$sha\"," >> codex-pin.json && \
+	  echo "  \"tracked_files\": {" >> codex-pin.json && \
+	  echo "    \"codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto\": \"$$relay_sha\"," >> codex-pin.json && \
+	  echo "    \"codex-rs/app-server-protocol/src/protocol/v1.rs\": \"$$v1_sha\"," >> codex-pin.json && \
+	  echo "    \"codex-rs/app-server-protocol/src/protocol/v2/item.rs\": \"$$item_sha\"," >> codex-pin.json && \
+	  echo "    \"codex-rs/app-server-protocol/src/protocol/v2/mcp.rs\": \"$$mcp_sha\"" >> codex-pin.json && \
+	  echo "  }," >> codex-pin.json && \
+	  echo "  \"byte_identical_files\": {" >> codex-pin.json && \
+	  echo "    \"internal/relaypb/relay.proto\": \"codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto\"" >> codex-pin.json && \
+	  echo "  }," >> codex-pin.json && \
+	  echo "  \"approval_methods\": [" >> codex-pin.json && \
+	  echo "    \"item/commandExecution/requestApproval\"," >> codex-pin.json && \
+	  echo "    \"item/fileChange/requestApproval\"," >> codex-pin.json && \
+	  echo "    \"item/permissions/requestApproval\"," >> codex-pin.json && \
+	  echo "    \"item/tool/requestUserInput\"," >> codex-pin.json && \
+	  echo "    \"mcpServer/elicitation/request\"" >> codex-pin.json && \
+	  echo "  ]" >> codex-pin.json && \
+	  echo "}" >> codex-pin.json && \
+	  rm -rf $$tmp && \
+	  echo "Bumped to $(TAG). Verify with: make codex-pin-check"
+```
+
+Also extend the `.PHONY` line at the top of the Makefile:
+```makefile
+.PHONY: dev build clean frontend backend agent agent-all llmproxy credentialproxy test docker docker-agent docker-llmproxy docker-credentialproxy docker-openclaw docker-all codex-pin-check codex-pin-bump
+```
+
+- [ ] **Step 2: Smoke test**
+
+Run: `make codex-pin-check`
+Expected: `codex-pin: OK`
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Makefile
+git commit -m "feat(codex-pin): make targets codex-pin-check and codex-pin-bump"
+```
+
+---
+
+## Task 5: CI integration
+
+**Files:**
+- Modify: `.github/workflows/build.yml`
+
+- [ ] **Step 1: Add `codex-pin-check` job**
+
+Insert after the existing `test:` job (parallel to `build-server:`):
+
+```yaml
+  codex-pin:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Verify codex-pin
+        run: make codex-pin-check
+```
+
+- [ ] **Step 2: Verify YAML is valid**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build.yml'))"`
+Expected: no output (no exception)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/build.yml
+git commit -m "ci: add codex-pin verification job"
+```
+
+---
+
+## Task 6: exec-gateway Config — three new bounded-resource knobs
+
+**Files:**
+- Modify: `internal/codexexecgateway/config.go`
+- Modify: `internal/codexexecgateway/config_test.go`
+
+- [ ] **Step 1: Write failing test for defaults + env override**
+
+In `config_test.go`, append:
+```go
+func TestLoadConfig_BoundedResourceDefaults(t *testing.T) {
+	setRequiredConfigEnv(t)  // helper that sets DB URL + HMAC secret + internal secret
+	cfg, err := LoadConfigFromEnv()
+	if err != nil {
+		t.Fatalf("LoadConfigFromEnv: %v", err)
+	}
+	if cfg.MaxFrameBytes != 16*1024*1024 {
+		t.Errorf("MaxFrameBytes default: got %d, want 16 MiB", cfg.MaxFrameBytes)
+	}
+	if cfg.BridgeIdleTimeout != 5*time.Minute {
+		t.Errorf("BridgeIdleTimeout default: got %v, want 5m", cfg.BridgeIdleTimeout)
+	}
+	if cfg.MaxStreamsPerExecutor != 32 {
+		t.Errorf("MaxStreamsPerExecutor default: got %d, want 32", cfg.MaxStreamsPerExecutor)
+	}
+}
+
+func TestLoadConfig_BoundedResourceEnvOverride(t *testing.T) {
+	setRequiredConfigEnv(t)
+	t.Setenv("CXG_MAX_FRAME_BYTES", "1048576")            // 1 MiB
+	t.Setenv("CXG_BRIDGE_IDLE_TIMEOUT", "30s")
+	t.Setenv("CXG_MAX_STREAMS_PER_EXECUTOR", "8")
+	cfg, err := LoadConfigFromEnv()
+	if err != nil {
+		t.Fatalf("LoadConfigFromEnv: %v", err)
+	}
+	if cfg.MaxFrameBytes != 1024*1024 {
+		t.Errorf("MaxFrameBytes override: got %d, want 1 MiB", cfg.MaxFrameBytes)
+	}
+	if cfg.BridgeIdleTimeout != 30*time.Second {
+		t.Errorf("BridgeIdleTimeout override: got %v, want 30s", cfg.BridgeIdleTimeout)
+	}
+	if cfg.MaxStreamsPerExecutor != 8 {
+		t.Errorf("MaxStreamsPerExecutor override: got %d, want 8", cfg.MaxStreamsPerExecutor)
+	}
+}
+```
+
+If `setRequiredConfigEnv` doesn't already exist in `config_test.go`, define it inline at the top of the file:
+```go
+func setRequiredConfigEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("CXG_DATABASE_URL", "postgres://test")
+	t.Setenv("CXG_CAPTOKEN_HMAC_SECRET", "test-secret-32-bytes-minimum-aaaa")
+	t.Setenv("CXG_INTERNAL_SHARED_SECRET", "test-internal")
+}
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+Run: `go test ./internal/codexexecgateway -run TestLoadConfig_BoundedResource -v`
+Expected: FAIL (compile error — fields don't exist)
+
+- [ ] **Step 3: Add fields to `Config`**
+
+In `config.go`, inside the `Config` struct (before the closing brace):
+```go
+	// MaxFrameBytes caps each inbound/bridge ws frame. Default 16 MiB.
+	// Override via CXG_MAX_FRAME_BYTES. Frames exceeding this are
+	// rejected with close code 1009 (Message Too Big) by nhooyr.
+	MaxFrameBytes int64
+	// BridgeIdleTimeout is how long a bridge session can be silent
+	// (no in/out frames) before the gateway sends RelayReset and
+	// closes the bridge ws. Default 5m. Override via
+	// CXG_BRIDGE_IDLE_TIMEOUT.
+	BridgeIdleTimeout time.Duration
+	// MaxStreamsPerExecutor bounds concurrent /bridge sessions per
+	// executor. Default 32. Beyond this, /bridge returns 503. Override
+	// via CXG_MAX_STREAMS_PER_EXECUTOR.
+	MaxStreamsPerExecutor int
+```
+
+- [ ] **Step 4: Wire env loaders in `LoadConfigFromEnv`**
+
+After `LogLevel: slog.LevelInfo,` (inside the `Config{}` literal):
+```go
+		MaxFrameBytes:         parseInt64Or("CXG_MAX_FRAME_BYTES", 16*1024*1024),
+		BridgeIdleTimeout:     parseDurationOr("CXG_BRIDGE_IDLE_TIMEOUT", 5*time.Minute),
+		MaxStreamsPerExecutor: parseIntOr("CXG_MAX_STREAMS_PER_EXECUTOR", 32),
+```
+
+Add `parseInt64Or` near `parseIntOr` (likely at the bottom of `config.go`):
+```go
+func parseInt64Or(key string, def int64) int64 {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return def
+	}
+	return n
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `go test ./internal/codexexecgateway -run TestLoadConfig -v`
+Expected: PASS (both new tests + any pre-existing config tests)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/codexexecgateway/config.go internal/codexexecgateway/config_test.go
+git commit -m "feat(codex-exec-gateway): config knobs for bounded resources"
+```
+
+---
+
+## Task 7: Apply `MaxFrameBytes` (replace `SetReadLimit(-1)`)
+
+**Files:**
+- Modify: `internal/codexexecgateway/inbound.go:54`
+- Modify: `internal/codexexecgateway/bridge.go:99`
+- Modify: `internal/codexexecgateway/server.go` (pass cfg to handlers)
+- Modify: `internal/codexexecgateway/multiplex.go` (newInboundConn takes maxFrameBytes)
+
+- [ ] **Step 1: Write failing test — oversized inbound frame is rejected**
+
+Append to `internal/codexexecgateway/inbound_test.go`:
+```go
+func TestInbound_RejectsOversizedFrame(t *testing.T) {
+	cfg := newTestConfig(t)
+	cfg.MaxFrameBytes = 1024 // 1 KiB cap for the test
+	srv := newTestServerWithConfig(t, cfg)
+	exeID, token := registerTestExecutor(t, srv)
+
+	// Connect as inbound
+	ws := dialInbound(t, srv, exeID, token)
+	defer ws.Close(websocket.StatusNormalClosure, "")
+
+	// Write a frame larger than the cap. Use a valid RelayMessageFrame
+	// envelope so the close is for size, not parse failure.
+	big := make([]byte, 2048)
+	frame := &relaypb.RelayMessageFrame{
+		Version: 1, StreamId: "test",
+		Body: &relaypb.RelayMessageFrame_Data{Data: &relaypb.RelayData{
+			Seq: 1, SegmentIndex: 0, SegmentCount: 1, Payload: big,
+		}},
+	}
+	b, _ := proto.Marshal(frame)
+	if err := ws.Write(context.Background(), websocket.MessageBinary, b); err != nil {
+		// Some implementations error on Write; the close should still come back on Read.
+		t.Logf("write returned: %v (acceptable)", err)
+	}
+
+	// Read should now fail with close code 1009 (MessageTooBig).
+	_, _, err := ws.Read(context.Background())
+	if err == nil {
+		t.Fatal("expected ws.Read to fail after oversized frame")
+	}
+	var ce websocket.CloseError
+	if errors.As(err, &ce) && ce.Code != websocket.StatusMessageTooBig {
+		t.Errorf("got close code %d, want 1009 (MessageTooBig)", ce.Code)
+	}
+}
+```
+
+Note: `newTestServerWithConfig`, `registerTestExecutor`, `dialInbound`, and `newTestConfig` may need to be added or extended; check existing `*_test.go` helpers and reuse/extend them. If they don't exist, define them in a new `internal/codexexecgateway/testhelpers_test.go`. (Keep test code minimal — extend, don't rewrite.)
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `go test ./internal/codexexecgateway -run TestInbound_RejectsOversizedFrame -v`
+Expected: FAIL — either compile error (missing helpers) or the read succeeds (no limit applied yet).
+
+- [ ] **Step 3: Wire `MaxFrameBytes` through to `newInboundConn`**
+
+In `multiplex.go`, change `newInboundConn` signature:
+```go
+func newInboundConn(exeID string, ws *websocket.Conn, logger *slog.Logger) *inboundConn {
+```
+to:
+```go
+func newInboundConn(exeID string, ws *websocket.Conn, logger *slog.Logger, maxFrameBytes int64) *inboundConn {
+```
+Inside, before returning:
+```go
+	ws.SetReadLimit(maxFrameBytes)
+```
+
+In `inbound.go:54`, delete:
+```go
+	ws.SetReadLimit(-1) // codex exec-server streams large process/read responses
+```
+and update the `newInboundConn` call (a few lines down) to pass `s.config.MaxFrameBytes`:
+```go
+	ic := newInboundConn(exeID, ws, s.logger.With("exe_id", exeID), s.config.MaxFrameBytes)
+```
+
+In `bridge.go:99`, replace:
+```go
+	bridgeWS.SetReadLimit(-1)
+```
+with:
+```go
+	bridgeWS.SetReadLimit(s.config.MaxFrameBytes)
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+Run: `go test ./internal/codexexecgateway -run TestInbound_RejectsOversizedFrame -v`
+Expected: PASS
+
+- [ ] **Step 5: Run full test suite to confirm no regressions**
+
+Run: `go test ./internal/codexexecgateway -count=1`
+Expected: all pre-existing tests still PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/codexexecgateway/
+git commit -m "feat(codex-exec-gateway): bound ws read with MaxFrameBytes"
+```
+
+---
+
+## Task 8: Per-executor stream cap (`MaxStreamsPerExecutor`)
+
+**Files:**
+- Modify: `internal/codexexecgateway/multiplex.go` — `streamCount() int` method on `*inboundConn`
+- Modify: `internal/codexexecgateway/bridge.go` — return 503 when exceeded
+- Modify: `internal/codexexecgateway/bridge_test.go` — add cap-enforcement test
+
+- [ ] **Step 1: Write failing test — 33rd bridge returns 503 with cap=32**
+
+Append to `bridge_test.go`:
+```go
+func TestBridge_StreamCapReturns503(t *testing.T) {
+	cfg := newTestConfig(t)
+	cfg.MaxStreamsPerExecutor = 2 // small cap to keep test fast
+	srv := newTestServerWithConfig(t, cfg)
+	exeID, _ := registerTestExecutor(t, srv)
+	dialInboundAndKeepAlive(t, srv, exeID) // helper: holds inbound conn open
+
+	// Dial 2 bridges successfully
+	for i := 0; i < 2; i++ {
+		ws := dialBridge(t, srv, exeID, fmt.Sprintf("stream-%d", i))
+		defer ws.Close(websocket.StatusNormalClosure, "")
+	}
+
+	// 3rd dial should be rejected with 503
+	resp, err := dialBridgeRaw(t, srv, exeID, "stream-3")
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("got status %d, want 503", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Retry-After"); got == "" {
+		t.Errorf("missing Retry-After header")
+	}
+}
+```
+
+Helpers (`dialBridge`, `dialInboundAndKeepAlive`, `dialBridgeRaw`) may already exist — check `bridge_test.go` / `multiplex_e2e_test.go`. Extend or add as needed; keep them minimal.
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `go test ./internal/codexexecgateway -run TestBridge_StreamCapReturns503 -v`
+Expected: FAIL — 3rd dial succeeds (no cap yet).
+
+- [ ] **Step 3: Add `streamCount()` method to `inboundConn`**
+
+In `multiplex.go`, after the existing `lookup` method, add:
+```go
+// streamCount returns the number of currently registered routes.
+func (i *inboundConn) streamCount() int {
+	i.routesMu.RLock()
+	defer i.routesMu.RUnlock()
+	return len(i.routes)
+}
+```
+
+- [ ] **Step 4: Add pre-upgrade cap check in bridge handler**
+
+In `bridge.go`, find the section where the handler has just resolved `inbound` (via `s.registry.Get(exeID)` or equivalent) and is about to call `websocket.Accept`. Insert a cap check **before** the `websocket.Accept` call:
+
+```go
+	if cap := s.config.MaxStreamsPerExecutor; cap > 0 && inbound.streamCount() >= cap {
+		s.logger.Warn("bridge: per-executor stream cap exceeded",
+			"exe_id", exeID, "cap", cap, "current", inbound.streamCount())
+		w.Header().Set("Retry-After", "30")
+		http.Error(w, "too many concurrent streams for this executor", http.StatusServiceUnavailable)
+		return
+	}
+```
+
+(Race note: this check is intentionally not atomic with the eventual `addRoute`. In practice bridge dials are sequential per env-mcp, and any concurrent dial slipping past the cap will succeed at `addRoute`. Accept this; the cap is a guardrail, not a strict invariant.)
+
+If you cannot find a clear "have `inbound`, about to Accept" point — `bridge.go` doesn't currently fetch the inbound until after the upgrade because it needs the streamID — then the cap check has to move post-upgrade. In that case:
+1. Do the Accept and Resume-frame parsing as today.
+2. Just before the existing `inbound.addRoute(...)`, check `if cap > 0 && inbound.streamCount() >= cap`.
+3. If exceeded, write a `RelayReset{reason:"cap-exceeded"}` over the bridge ws, then `bridgeWS.Close(websocket.StatusTryAgainLater, "cap exceeded")`. Do not call `addRoute`.
+4. Update the test to dial the ws, expect the Resume frame to be ack'd, then expect a Reset frame with reason "cap-exceeded" within 100ms, then expect the ws to close with code 1013.
+
+Read `bridge.go` lines 90-150 to pick the right placement; document the chosen path in a `// Per-executor stream cap (PR 1):` comment.
+
+- [ ] **Step 5: Run test, verify pass**
+
+Run: `go test ./internal/codexexecgateway -run TestBridge_StreamCapReturns503 -v`
+Expected: PASS
+
+- [ ] **Step 6: Run full suite**
+
+Run: `go test ./internal/codexexecgateway -count=1`
+Expected: all PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/codexexecgateway/
+git commit -m "feat(codex-exec-gateway): cap concurrent bridges per executor"
+```
+
+---
+
+## Task 9: Per-bridge idle timeout
+
+**Files:**
+- Modify: `internal/codexexecgateway/multiplex.go` — `bridgeSession.lastActivity` atomic; `inboundConn.startIdleReaper`
+- Modify: `internal/codexexecgateway/inbound.go` — touch lastActivity on each routed frame
+- Modify: `internal/codexexecgateway/bridge.go` — touch lastActivity on outbound frames; start reaper
+- Modify: `internal/codexexecgateway/multiplex_test.go` — add idle timeout test
+
+- [ ] **Step 1: Write failing test — idle bridge dies after timeout**
+
+Append to `multiplex_test.go`:
+```go
+func TestIdleReaper_ClosesIdleBridgeAndSendsReset(t *testing.T) {
+	cfg := newTestConfig(t)
+	cfg.BridgeIdleTimeout = 200 * time.Millisecond
+	srv := newTestServerWithConfig(t, cfg)
+	exeID, _ := registerTestExecutor(t, srv)
+	inboundWS := dialInbound(t, srv, exeID, /* token from registry */ "")
+	defer inboundWS.Close(websocket.StatusNormalClosure, "")
+
+	bridgeWS := dialBridge(t, srv, exeID, "stream-idle")
+	// (dialBridge already sends the Resume frame internally)
+
+	// Don't send any further frames; wait 2× timeout.
+	time.Sleep(450 * time.Millisecond)
+
+	// bridgeWS.Read should now error (closed by reaper).
+	_, _, err := bridgeWS.Read(context.Background())
+	if err == nil {
+		t.Fatal("expected bridge ws to be closed after idle timeout")
+	}
+
+	// inboundWS should have received a Reset frame for this stream.
+	gotReset := false
+	deadline := time.Now().Add(300 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		mt, data, rerr := inboundWS.Read(ctx)
+		cancel()
+		if rerr != nil {
+			break
+		}
+		if mt != websocket.MessageBinary {
+			continue
+		}
+		var f relaypb.RelayMessageFrame
+		if proto.Unmarshal(data, &f) != nil {
+			continue
+		}
+		if r, ok := f.Body.(*relaypb.RelayMessageFrame_Reset_); ok && f.StreamId == "stream-idle" && r.Reset_.Reason == "idle-timeout" {
+			gotReset = true
+			break
+		}
+	}
+	if !gotReset {
+		t.Fatal("expected RelayReset{reason:idle-timeout} on inbound for stream-idle")
+	}
+}
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `go test ./internal/codexexecgateway -run TestIdleReaper -v -timeout 10s`
+Expected: FAIL — bridge stays open forever.
+
+- [ ] **Step 3: Add `lastActivity` to `bridgeSession`**
+
+In `multiplex.go`, find the `bridgeSession` struct and add (before `closed`):
+```go
+	lastActivity atomic.Int64 // unix nanos, updated on every frame touching this session
+```
+
+Add a helper:
+```go
+func (b *bridgeSession) touch() {
+	b.lastActivity.Store(time.Now().UnixNano())
+}
+```
+
+Initialize on construction (find where bridgeSession is created in `bridge.go`):
+```go
+	session := &bridgeSession{
+		streamID: streamID, inbound: inbound, bridgeWS: bridgeWS,
+		closed: make(chan struct{}),
+	}
+	session.touch() // start ticking from session-create time
+```
+
+- [ ] **Step 4: Touch on every routed frame**
+
+In `inbound.go`'s reader loop (the section that does `routes[frame.StreamId]` lookup and writes to the bridge ws), after a successful lookup:
+```go
+	if b, ok := ic.lookup(frame.StreamId); ok {
+		b.touch()
+		// existing write to bridge ws
+	}
+```
+
+In `bridge.go`'s outbound pump (the goroutine that reads from `bridgeWS` and writes to inbound), after each successful read:
+```go
+	session.touch()
+```
+
+- [ ] **Step 5: Implement `startIdleReaper`**
+
+In `multiplex.go`, add:
+```go
+// startIdleReaper runs until i.closed. Every idleTimeout/4 (min 50ms),
+// it scans routes and closes any session whose lastActivity is older
+// than idleTimeout. On close, sends a RelayReset frame to inbound (so
+// the executor's relay layer tears down its per-stream JSON-RPC
+// session) and closes the bridge ws.
+func (i *inboundConn) startIdleReaper(ctx context.Context, idleTimeout time.Duration) {
+	if idleTimeout <= 0 {
+		return
+	}
+	tick := idleTimeout / 4
+	if tick < 50*time.Millisecond {
+		tick = 50 * time.Millisecond
+	}
+	t := time.NewTicker(tick)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-i.closed:
+			return
+		case <-t.C:
+			i.reapIdle(ctx, idleTimeout)
+		}
+	}
+}
+
+func (i *inboundConn) reapIdle(ctx context.Context, idleTimeout time.Duration) {
+	cutoff := time.Now().Add(-idleTimeout).UnixNano()
+	i.routesMu.RLock()
+	candidates := []*bridgeSession{}
+	for _, b := range i.routes {
+		if b.lastActivity.Load() < cutoff {
+			candidates = append(candidates, b)
+		}
+	}
+	i.routesMu.RUnlock()
+
+	for _, b := range candidates {
+		resetFrame := &relaypb.RelayMessageFrame{
+			Version: 1, StreamId: b.streamID,
+			Body: &relaypb.RelayMessageFrame_Reset_{Reset_: &relaypb.RelayReset{Reason: "idle-timeout"}},
+		}
+		data, err := proto.Marshal(resetFrame)
+		if err != nil {
+			i.logger.Warn("reaper: marshal reset", "stream_id", b.streamID, "err", err)
+			continue
+		}
+		if werr := i.write(ctx, websocket.MessageBinary, data); werr != nil {
+			i.logger.Warn("reaper: write reset to inbound", "stream_id", b.streamID, "err", werr)
+		}
+		i.removeRoute(b.streamID, b)
+		b.close(nil)
+		i.logger.Info("reaper: closed idle bridge", "stream_id", b.streamID, "timeout", idleTimeout)
+	}
+}
+```
+
+Add imports to `multiplex.go` if missing:
+```go
+import (
+	"sync/atomic"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	"github.com/agentserver/agentserver/internal/relaypb"
+)
+```
+
+- [ ] **Step 6: Start the reaper when inbound connects**
+
+In `inbound.go`, after `newInboundConn(...)` and before the reader loop:
+```go
+	go ic.startIdleReaper(r.Context(), s.config.BridgeIdleTimeout)
+```
+
+- [ ] **Step 7: Run test, verify pass**
+
+Run: `go test ./internal/codexexecgateway -run TestIdleReaper -v -timeout 10s`
+Expected: PASS
+
+- [ ] **Step 8: Run full suite — ensure no flakes in existing tests**
+
+Run: `go test ./internal/codexexecgateway -count=3 -timeout 60s`
+(Run 3× to catch race conditions from the new reaper goroutine.)
+Expected: all PASS, no flakes.
+
+- [ ] **Step 9: Run with -race**
+
+Run: `go test ./internal/codexexecgateway -race -count=1 -timeout 120s`
+Expected: PASS, no race warnings.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add internal/codexexecgateway/
+git commit -m "feat(codex-exec-gateway): per-bridge idle timeout reaper"
+```
+
+---
+
+## Task 10: Final verification
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `make test`
+Expected: PASS
+
+- [ ] **Step 2: Run pin check**
+
+Run: `make codex-pin-check`
+Expected: `codex-pin: OK`
+
+- [ ] **Step 3: Confirm CI YAML is loaded by GitHub Actions linter (optional)**
+
+If `gh` CLI is available:
+```bash
+gh workflow view build.yml
+```
+Expected: prints the workflow definition without error.
+
+- [ ] **Step 4: Final commit if anything was tweaked**
+
+```bash
+git status   # should be clean
+```
+
+If clean, the PR is ready. Push and open the PR:
+```bash
+git push -u origin <branch-name>
+gh pr create --title "feat: codex-pin + exec-gateway bounded resources" \
+  --body "$(cat <<'EOF'
+## Summary
+- Pin agentserver protocol assumptions to upstream codex tag `rust-v0.131.0-alpha.22`
+- CI fails on drift via `make codex-pin-check`
+- exec-gateway: bound ws frames (16 MiB default), per-bridge idle timeout (5 min default), per-executor stream cap (32 default)
+
+Spec: `docs/superpowers/specs/2026-05-20-codex-gateway-full-alignment-design.md` (PR 1 of 3)
+
+## Test plan
+- [ ] `make test` passes locally
+- [ ] `make codex-pin-check` passes locally
+- [ ] CI green
+EOF
+)"
+```
+
+---
+
+## Self-review notes
+
+Spec coverage check:
+- Gap 1 (codex-pin) → Tasks 1–5
+- Gap 2 (bounded reads) → Task 7
+- Gap 3 (idle timeout + stream cap) → Tasks 8 (cap) + 9 (idle)
+
+Type consistency: `Config.MaxFrameBytes` is `int64` (matches `ws.SetReadLimit`'s signature in nhooyr); `MaxStreamsPerExecutor` is `int` (matches `streamCount() int` and the comparison in `bridge.go`); `BridgeIdleTimeout` is `time.Duration` (matches `startIdleReaper` and the reaper logic).
+
+No placeholders. All code blocks are concrete; the only `<...>` markers in the plan are values that must be computed from a live `git ls-remote` / `sha256sum` at Task 1, which is itself the instruction to produce them.

--- a/docs/superpowers/specs/2026-05-20-codex-gateway-full-alignment-design.md
+++ b/docs/superpowers/specs/2026-05-20-codex-gateway-full-alignment-design.md
@@ -1,0 +1,218 @@
+# codex-app-gateway + codex-exec-gateway — Full Upstream Alignment
+
+**Status:** draft
+**Date:** 2026-05-20
+**Owner:** agentserver / codex integration
+**Pin target:** upstream `openai/codex` tag **`rust-v0.131.0-alpha.22`** (latest stable as of 2026-05-20)
+
+**Scope correction note (2026-05-20):** initial audit understated how much of the alignment work was already in place. The transparent JSON-RPC ws reverse proxy, the `wsbridge.Interceptor` filter abstraction, the supervisor lifecycle, and the bounded 64 MiB read limit on the app-gw side are **already implemented**. This spec only covers the concrete remaining gaps.
+
+**Sibling specs:**
+- [`2026-05-17-codex-exec-gateway-bridge-multiplexing.md`](2026-05-17-codex-exec-gateway-bridge-multiplexing.md) — relay frame multiplexing; this spec extends with operational limits
+
+## Goal
+
+Close five concrete gaps that prevent codex-app-gateway and codex-exec-gateway from being **provably aligned** with a pinned upstream codex version, and prevent silent drift from re-introducing the misalignments after they're fixed.
+
+## What's already done (no work needed)
+
+These were missing from the original audit but exist today:
+
+| Component | Where |
+|---|---|
+| Transparent JSON-RPC ws reverse proxy | `internal/codexappgateway/server.go:264` `/codex-app/ws` and `/` route to `handleCodexAppWS` |
+| Bidirectional frame pump | `internal/wsbridge/wsbridge.go::RunProxy` and `RunProxyWithInterceptor` |
+| Filter abstraction (forward / rewrite / drop / short-circuit) | `wsbridge.Interceptor` with `DropFrame` sentinel — exactly the design pattern needed |
+| Subprocess supervisor + GC | `supervisor.EnsureSubprocess` + `Touch`-based idle reaper |
+| Bearer auth + workspace binding | `auth.ExtractBearer` + `auth.Verify` |
+| 64 MiB read limit on caller ws | `userWS.SetReadLimit(maxWSFrameBytes)` at server.go:319 |
+| Short-circuit response pattern | `oplog.TryHandleOperationsList` demonstrates `userWS.Write(...) + return DropFrame` |
+| Approval reply schemas | `broker/protocol.go::approvalReply` (4 methods + default fallback) with embedded comments referencing upstream `v2/` enum variants |
+
+The transparent proxy is **already** the way new SDK clients talk to the gateway. Upstream codex methods added in `rust-v0.131.0` (e.g., `thread/fork`, `thread/goal/*`, `turn/steer`) **already work** through `/codex-app/ws` without any gateway code change — the audit's "5 methods only" finding was only true for the REST `/turn` path going through `broker`.
+
+## Five gaps
+
+### Gap 1 — codex-pin machinery (versioned alignment proof)
+
+No mechanism today guarantees the gateway's protocol assumptions match a specific upstream version. `internal/relaypb/relay.proto` is byte-identical to upstream `codex.exec_server.relay.v1.proto` at commit `ac466c0dbd` purely by manual copy; nothing fails the build if upstream diverges or our copy rots. Same for `approvalReply`'s embedded payload shapes — they reference v2 enum variants in comments only.
+
+**Fix:**
+- `codex-pin.json` at repo root pins upstream tag + sha + sha256 of tracked artifacts:
+  - `codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto`
+  - `codex-rs/app-server-protocol/src/protocol/v1.rs` (InitializeParams schema)
+  - `codex-rs/app-server-protocol/src/protocol/v2/{item,mcp,notification}.rs` (approval/elicitation method names + response shapes)
+- `cmd/check-codex-pin/main.go` (Go program; invoked from CI and from `make codex-pin-check`):
+  1. Read `codex-pin.json`.
+  2. `git ls-remote https://github.com/openai/codex.git refs/tags/<tag>` — assert sha matches.
+  3. For each tracked file, fetch the blob at the pinned sha (via GitHub API or shallow clone), compute sha256, fail on mismatch.
+  4. Assert `internal/relaypb/relay.proto` matches the upstream relay proto byte-for-byte.
+  5. Grep upstream `v2/` for `requestApproval` / `elicitation/request` method strings; fail if any not listed in `broker/protocol.go::approvalReply`'s switch.
+  6. **Soft check**: if upstream `main` has moved past the pinned sha for any tracked file, emit a CI warning with one-line diff. Non-fatal.
+- `make codex-pin-bump TAG=<new-tag>`:
+  - Re-runs the verification against the new tag.
+  - Updates `codex-pin.json` with new shas.
+  - Overwrites `internal/relaypb/relay.proto` from upstream, regenerates `relay.pb.go`.
+  - Warns if new approval methods exist that aren't in `approvalReply` — engineer adds them and commits.
+
+### Gap 2 — exec-gateway unbounded reads
+
+`inbound.go:54` and `bridge.go:99` both call `ws.SetReadLimit(-1)`. The comment on inbound says it's because "codex exec-server streams large process/read responses" but no upper bound exists — a buggy or hostile executor can write multi-GiB frames and exhaust gateway memory.
+
+**Fix:**
+- Replace both with `ws.SetReadLimit(cfg.MaxFrameBytes)`. Default 16 MiB — well above any legitimate `process/read` chunk (codex-rs uses ~64 KiB-ish chunks by default) but bounded.
+- Make it configurable via `CODEX_EXEC_GATEWAY_MAX_FRAME_BYTES` env var for emergency override.
+- On read-limit violation, the existing `nhooyr/websocket` library closes with code 1009 (Message Too Big), which the bridge client's relay layer will surface as a stream error.
+
+### Gap 3 — exec-gateway per-bridge idle timeout & stream cap
+
+A bridge session (client `BridgeClient` ↔ gateway) can wedge silently if neither side sends frames. Today nothing reaps it; the inbound executor connection holds a route entry forever. With multiplexing landed (2026-05-17 spec), unbounded orphaned routes hurt: each one is a UUID slot, a goroutine, and a per-route mutex on the inbound writer.
+
+**Fix:**
+- Per-bridge idle timeout. Default 5 min, configurable. On idle expiry, gateway sends `RelayMessageFrame{body: Reset{reason:"idle-timeout"}}` on both the bridge ws and the inbound ws (so the executor's per-stream JSON-RPC session terminates cleanly), then closes the bridge ws. Inbound conn unaffected.
+- Per-executor concurrent-bridge cap. Default 32 (the 2026-05-17 spec didn't bound this; in practice each is one MCP child × one tool concurrency = needs to scale with sub-agent count, 32 is generous). Beyond cap, `/bridge/{exe_id}` returns 503.
+
+### Gap 4 — ApprovalFilter missing on transparent ws path
+
+Today only the REST `/turn` path (through `broker`) intercepts and auto-accepts approval requests. The transparent `/codex-app/ws` path forwards them to the caller. As noted in `broker/protocol.go::approvalReply`'s comment, this rarely fires in practice (codex is configured with `default_tools_approval_mode = "approve"`), but it's a real divergence between paths and a foot-gun if a caller doesn't implement the protocol.
+
+**Fix:**
+- Move `approvalReply` from `broker/protocol.go` to a new `internal/codexappgateway/approvalfilter/` package.
+- In `handleCodexAppWS`, add an `OnServerFrame` callback to the `wsbridge.Interceptor` that:
+  - Parses the frame as JSON-RPC.
+  - If `method` matches an approval method and `id` is present (server-to-client request), call `approvalReply(method)`, write the synthesized response back through `childWS.Write(...)`, return `DropFrame` to swallow the frame so the caller never sees it.
+  - Otherwise return `nil` (forward unchanged).
+- Tests: spin up a fake `app-server` that pushes each of the 5 approval methods; assert gateway responds in <100ms and caller sees no frame.
+
+### Gap 5 — broker still sends bogus `protocolVersion` + 25+ methods unreachable via REST
+
+`broker/conn.go:55` includes `"protocolVersion":"2025-06-18"` in `initialize`. Upstream `InitializeParams` has no such field — serde silently drops it. Harmless but wrong, and confusing future readers.
+
+Separately, the broker hardcodes only 3 RPCs (`thread/start`, `turn/start`, `turn/interrupt`), so REST `/turn` callers cannot reach `thread/resume`, `thread/fork`, `thread/list`, `turn/steer`, etc. The REST `/turn` API surface is intentionally narrow ("run one turn, return the result"), so most of these have no REST analogue and don't need exposure. But the broker-as-a-library is also indirectly used (e.g., `oplog/operations_list_test.go` shows oplog hooking the broker's flow); a future internal caller might need other methods.
+
+**Fix:**
+- **Surgical**: remove `"protocolVersion":"2025-06-18"` field from the `initialize` payload at `broker/conn.go:55`. No behavior change.
+- **Consolidation (deduplicate with transparent path)**: refactor `broker.Conn` to internally use the same `wsbridge.RunProxyWithInterceptor` + supervisor pattern that `handleCodexAppWS` uses, with a small in-process JSON-RPC client driving the REST→ws translation. Concretely:
+  - Extract `proxyOptions` struct from `handleCodexAppWS` (filter chain + supervisor key + caller ws).
+  - REST `/turn` handler builds an in-process pipe-pair (or a goroutine-local JSON-RPC channel) that plays the role of `userWS`, drives `initialize` → optional `thread/start` → `turn/start` → wait for `turn/completed`, then closes.
+  - Delete `broker/conn.go`'s bespoke read loop, ID tracking, and approval handling (now in shared filter).
+  - Net change: `broker/` shrinks by ~300 LOC; `internal/codexappgateway/restadapter/` gains ~150 LOC; `approvalfilter/` gains ~80 LOC.
+- All existing tests in `turn_api_test.go`, `integration_test.go`, `broker/conn_*_test.go` either pass unchanged (REST adapter tests) or migrate to test the shared proxy core (former broker tests). Approval tests migrate to `approvalfilter/`.
+
+## Migration plan
+
+Three PRs. Order is: pin machinery + exec-gw hardening together (low risk, no app-gw refactor), then app-gw filter port, then REST consolidation.
+
+### PR 1 — codex-pin + exec-gateway hardening
+- Add `codex-pin.json`, `scripts/check-codex-pin.sh`, CI wiring.
+- exec-gw: `SetReadLimit(MaxFrameBytes)`, `BridgeIdleTimeout`, `MaxStreamsPerExecutor`.
+- Tests: pin verification (golden + drift); exec-gw limit enforcement.
+- ~600 LOC scripts/Go + ~400 test LOC. **~2 days.**
+
+### PR 2 — ApprovalFilter on transparent ws + delete bogus protocolVersion field
+- New `internal/codexappgateway/approvalfilter/` package (move + tidy current `approvalReply`).
+- `handleCodexAppWS` adds `OnServerFrame` callback wiring the filter.
+- Delete `"protocolVersion":"2025-06-18"` field from `broker/conn.go:55`.
+- Tests: per-method approval interception against fake app-server.
+- ~150 LOC + ~250 test LOC. **~half day.**
+
+### PR 3 — REST /turn pivots to shared proxy core
+- Extract proxy plumbing from `handleCodexAppWS` into a reusable `proxy.Run(opts)` function.
+- REST `/turn` rewrites internally to use the same primitives.
+- Delete duplicated logic in `broker/conn.go`.
+- All existing tests must pass without modification (this is a behavior-preserving refactor).
+- Net ~−300 LOC + minor test migrations. **~1-1.5 days.**
+
+**Total: ~3.5-4 days, 3 reviewable PRs.**
+
+## Wire protocol details
+
+### Approval interceptor (Gap 4) — handler shape
+
+```go
+// internal/codexappgateway/approvalfilter/filter.go
+package approvalfilter
+
+// Reply returns ({jsonrpc, id, result}) for an approval-style server-to-client
+// request. Caller is responsible for writing the bytes back upstream.
+// Returns nil if method is not an approval method.
+func Reply(frame []byte) (response []byte, isApproval bool) { ... }
+
+// Methods returns the exhaustive set of approval method names. Used by
+// codex-pin's CI check to detect upstream additions.
+func Methods() []string {
+    return []string{
+        "item/commandExecution/requestApproval",
+        "item/fileChange/requestApproval",
+        "item/permissions/requestApproval",
+        "item/tool/requestUserInput",
+        "mcpServer/elicitation/request",
+    }
+}
+```
+
+Wired into `handleCodexAppWS`:
+
+```go
+intc := wsbridge.Interceptor{
+    OnServerFrame: func(frame []byte) []byte {
+        if resp, ok := approvalfilter.Reply(frame); ok {
+            // synthesized response goes back to upstream subprocess
+            _ = childWS.Write(ctx, websocket.MessageText, resp)
+            return wsbridge.DropFrame    // caller never sees the request
+        }
+        // ... existing oplog logic
+        return nil
+    },
+}
+```
+
+### codex-pin.json initial state
+
+```json
+{
+  "upstream_repo": "openai/codex",
+  "tag": "rust-v0.131.0-alpha.22",
+  "sha": "<resolved at PR-1 authoring time>",
+  "tracked_files": {
+    "codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto": "<sha256 from upstream>",
+    "codex-rs/app-server-protocol/src/protocol/v1.rs": "<sha256>",
+    "codex-rs/app-server-protocol/src/protocol/v2/item.rs": "<sha256>",
+    "codex-rs/app-server-protocol/src/protocol/v2/mcp.rs": "<sha256>"
+  },
+  "approval_methods": [
+    "item/commandExecution/requestApproval",
+    "item/fileChange/requestApproval",
+    "item/permissions/requestApproval",
+    "item/tool/requestUserInput",
+    "mcpServer/elicitation/request"
+  ]
+}
+```
+
+The initial CI run after PR 1 lands should pass without any extra change, because `internal/relaypb/relay.proto` is already byte-identical to upstream `ac466c0dbd`, which is the relay.proto introduction and has not changed since.
+
+## Testing
+
+- **Pin check golden**: `codex-pin.json` matches upstream at the pinned sha. Corrupt the JSON, assert CI fails with a specific error pointing to the mismatched field.
+- **Pin check drift**: fake `git ls-remote` returning a newer upstream sha; assert soft warning emitted, hard exit code 0.
+- **exec-gw read limit**: write a 17 MiB frame from a fake executor; assert close code 1009 and no panic; gateway memory does not balloon.
+- **exec-gw idle timeout**: idle bridge dies after configured timeout, `RelayReset` sent on both legs; assert inbound conn survives.
+- **exec-gw stream cap**: 33rd concurrent `/bridge/{exe_id}` dial returns 503 with `Retry-After`.
+- **Approval filter**: for each of the 5 methods, fake app-server pushes the request; assert response written upstream within 100ms, caller's `ReadJSON` never sees the request frame.
+- **REST behavior preservation**: full `turn_api_test.go` and `integration_test.go` suites pass with byte-identical responses before and after PR 3.
+
+## Risks
+
+1. **PR 3 refactor depth**. The broker has tests that assert on specific internal IDs (`conn_turn_test.go:31`); some may need updates if the proxy core uses a different ID-allocation strategy. Mitigation: keep ID allocation policy identical (`atomic.Int64` starting at 1) in the proxy core; tests pass unchanged.
+2. **codex-pin bump cadence**. If the pinned tag lags upstream main by months, the soft drift warning becomes noise. Mitigation: include in the bump justfile target a quick "preview diff" step so engineers can decide whether to absorb the upstream changes; recommend monthly review at minimum.
+3. **Approval method additions upstream**. Upstream may add a new `requestApproval` variant we miss. The pin's grep check catches this on bump but not in real time. Mitigation: the existing `approvalReply`'s `default:` branch returns `{}` (empty object) which most approval responses accept as a degraded but non-stalling reply.
+
+## Out of scope
+
+- Per-workspace approval policy (confirmed deferred 2026-05-20).
+- Exit-code propagation for `codex exec-server` (needs upstream protocol change).
+- SSE streaming on REST `/turn` (separate spec if needed).
+- Vendoring Go bindings for upstream Rust types (unnecessary with transparent passthrough).
+- `opencode-app-gateway` alignment (separate gateway, separate spec).
+- Capability downgrade for older codex binary versions (implement only if a real deployment needs it).

--- a/docs/superpowers/specs/2026-05-20-codex-gateway-full-alignment-design.md
+++ b/docs/superpowers/specs/2026-05-20-codex-gateway-full-alignment-design.md
@@ -1,6 +1,6 @@
 # codex-app-gateway + codex-exec-gateway — Full Upstream Alignment
 
-**Status:** draft
+**Status:** PR 1 + PR 2 in flight; **PR 3 deferred** — see § "PR 3 deferral note" near the bottom of this file
 **Date:** 2026-05-20
 **Owner:** agentserver / codex integration
 **Pin target:** upstream `openai/codex` tag **`rust-v0.131.0-alpha.22`** (latest stable as of 2026-05-20)
@@ -216,3 +216,28 @@ The initial CI run after PR 1 lands should pass without any extra change, becaus
 - Vendoring Go bindings for upstream Rust types (unnecessary with transparent passthrough).
 - `opencode-app-gateway` alignment (separate gateway, separate spec).
 - Capability downgrade for older codex binary versions (implement only if a real deployment needs it).
+
+## PR 3 deferral note (2026-05-20)
+
+Original migration plan had three PRs. PR 1 (codex-pin + exec-gw hardening) and PR 2 (transparent ws ApprovalFilter + drop bogus `protocolVersion` field) landed all five **functional** gaps from the audit baseline:
+
+| Gap | Closed by |
+|---|---|
+| 1. No upstream version pinning | PR 1 (`codex-pin.json` + CI lint + `make codex-pin-bump`) |
+| 2. exec-gw unbounded ws reads | PR 1 (`MaxFrameBytes` default 16 MiB) |
+| 3. exec-gw no idle reaper / stream cap | PR 1 (`BridgeIdleTimeout`, `MaxStreamsPerExecutor`) |
+| 4. Transparent ws path didn't auto-reply to approvals | PR 2 (`approvalfilter` package + `OnServerFrame` interceptor in `handleCodexAppWS`) |
+| 5a. Broker sent bogus `protocolVersion: "2025-06-18"` | PR 2 (field removed) |
+| 5b. Broker has only 2 RPC methods (thread/start + turn/start) | **Intentional**, see below |
+
+PR 3 was originally scoped to do a structural refactor: pivot the REST `/turn` handler to drive the shared transparent-proxy core via an in-process pipe-pair, so the broker's bespoke JSON-RPC client could be deleted. After PR 2 landed `approvalfilter` as a shared package, the actual code duplication this would eliminate is minimal:
+
+- Approval auto-reply logic: **already shared** via `approvalfilter`
+- Supervisor lifecycle: **already shared** via `supervisor.EnsureSubprocess`
+- The broker's `Conn` / `Pool` / `dispatchFrame` / `Turn` / `StartThread`: these implement a JSON-RPC **client** (sends requests, tracks IDs, waits for responses). The transparent ws path is a JSON-RPC **frame relay** (bidirectional, passes everything through). These are structurally different problems, not duplication.
+
+**Broker's narrow method set (gap 5b) is deliberate, not an oversight.** The REST `/turn` endpoint exists to wrap "send a turn, get the result" in one HTTP call. Callers that need full thread lifecycle (`thread/resume`, `thread/fork`, `thread/list`, `turn/steer`, etc.) should use the transparent `/codex-app/ws` endpoint, which exposes the entire codex v2 protocol with zero gateway code per new method. Expanding REST to mirror all 25+ JSON-RPC methods would re-introduce the maintenance burden that PR 1 + PR 2 were designed to eliminate.
+
+**Decision:** PR 3 as originally scoped is **not done**. The remaining `broker/conn.go` ~420 LOC of JSON-RPC-client code is the right abstraction for the REST adapter's purpose. Refactoring it for "consolidation" would add risk without commensurate benefit.
+
+If future work needs to expose additional thread/turn lifecycle operations to non-ws callers (e.g., HTTP-only clients that can't speak WebSocket), revisit this decision then — the natural extension is to add specific REST handlers for the needed methods, not a generic JSON-RPC-over-HTTP shim.

--- a/internal/codexexecgateway/bridge.go
+++ b/internal/codexexecgateway/bridge.go
@@ -200,6 +200,9 @@ func (s *Server) runBridgePump(ctx context.Context, session *bridgeSession) {
 			}
 			return
 		}
+		// Mark activity on every read from the bridge, even non-binary or
+		// wrong-stream_id ones — the connection IS being used.
+		session.touch()
 		if mt != websocket.MessageBinary {
 			continue
 		}

--- a/internal/codexexecgateway/bridge.go
+++ b/internal/codexexecgateway/bridge.go
@@ -96,7 +96,7 @@ func (s *Server) handleBridge(w http.ResponseWriter, r *http.Request) {
 		s.logger.Error("bridge: ws accept", "exe_id", exeID, "error", err)
 		return
 	}
-	bridgeWS.SetReadLimit(-1)
+	bridgeWS.SetReadLimit(s.config.MaxFrameBytes)
 
 	// 6. Peek the Resume frame — env-mcp's BridgeClient always sends it
 	// first on dial; that's where we learn the stream_id for routing.

--- a/internal/codexexecgateway/bridge.go
+++ b/internal/codexexecgateway/bridge.go
@@ -88,6 +88,20 @@ func (s *Server) handleBridge(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// 4b. Per-executor stream cap (PR 1 Gap 3): Strategy A — pre-upgrade HTTP 503.
+	// We do the check before websocket.Accept to fail-fast on capacity-exceeded
+	// dials. The check is intentionally not atomic with the eventual addRoute;
+	// concurrent dials slipping past will succeed at addRoute. Acceptable: the
+	// cap is a guardrail, not a strict invariant. Bridge dials are typically
+	// sequential per env-mcp. cap=0 means disabled (no enforcement).
+	if cap := s.config.MaxStreamsPerExecutor; cap > 0 && inbound.streamCount() >= cap {
+		s.logger.Warn("bridge: stream cap exceeded",
+			"exe_id", exeID, "cap", cap, "current", inbound.streamCount())
+		w.Header().Set("Retry-After", "30")
+		http.Error(w, "executor stream cap exceeded", http.StatusServiceUnavailable)
+		return
+	}
+
 	// 5. Upgrade caller to ws.
 	bridgeWS, err := websocket.Accept(w, r, &websocket.AcceptOptions{
 		InsecureSkipVerify: true, // auth already enforced above

--- a/internal/codexexecgateway/bridge_test.go
+++ b/internal/codexexecgateway/bridge_test.go
@@ -132,7 +132,7 @@ func TestBridge_Rejects503WhenExecutorOffline(t *testing.T) {
 func TestBridge_RejectsRevokedTurn(t *testing.T) {
 	hs, srv := newBridgeNoDBServer(t)
 	// Register a fake inbound so the revocation check is reached.
-	srv.registry.Register("exe_rev", newInboundConn("exe_rev", nil, nil))
+	srv.registry.Register("exe_rev", newInboundConn("exe_rev", nil, nil, 0))
 	now := time.Now().Unix()
 	srv.revoked.Add("trn_revoked", now+60)
 	tok := mintBridgeToken(srv.config.CapTokenHMACSecret, CapPayload{

--- a/internal/codexexecgateway/bridge_test.go
+++ b/internal/codexexecgateway/bridge_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -164,4 +165,140 @@ func TestBridge_RejectsRevokedTurn(t *testing.T) {
 //   - TestBridge_RejectsFirstFrameNonResume
 //   - TestBridge_TwoConcurrentBridgesShareInbound (in multiplex_e2e_test.go)
 //   - TestBridge_StreamIdCollisionEvictsFirst (in multiplex_e2e_test.go)
+
+// ---------- stream-cap test helpers ----------
+
+// dialBridgeWithStream opens a ws to /bridge/{exeID}, sends a Resume frame
+// with the given streamID, and returns the open ws (caller must close).
+// tok must be a valid cap-token for the server.
+func dialBridgeWithStream(t *testing.T, baseURL, exeID, streamID, tok string) *websocket.Conn {
+	t.Helper()
+	wsURL := "ws" + strings.TrimPrefix(baseURL, "http") + "/bridge/" + exeID
+	c, _, err := websocket.Dial(context.Background(), wsURL, &websocket.DialOptions{
+		HTTPHeader: http.Header{"Authorization": []string{"Bearer " + tok}},
+	})
+	if err != nil {
+		t.Fatalf("dialBridgeWithStream(%s): %v", streamID, err)
+	}
+	// Send Resume frame with the given streamID (reuse sendResume from multiplex_e2e_test.go).
+	sendResume(t, c, streamID)
+	return c
+}
+
+// dialBridgeHTTPOnly sends a WebSocket upgrade request to /bridge/{exeID}
+// but reads back the HTTP response instead of completing the handshake.
+// This lets the test inspect the status code when the server rejects the
+// request before upgrading (e.g. 503 for cap-exceeded).
+func dialBridgeHTTPOnly(t *testing.T, baseURL, exeID, tok string) *http.Response {
+	t.Helper()
+	url := baseURL + "/bridge/" + exeID
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+tok)
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Connection", "Upgrade")
+	req.Header.Set("Sec-WebSocket-Version", "13")
+	req.Header.Set("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+
+	// Use a plain http.Client — it will NOT follow the 101 upgrade and
+	// will return the raw response (including 4xx/5xx before upgrade).
+	client := &http.Client{
+		CheckRedirect: func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse },
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("dialBridgeHTTPOnly: %v", err)
+	}
+	return resp
+}
+
+// TestBridge_StreamCapEnforced verifies that when an executor already has
+// MaxStreamsPerExecutor concurrent bridge sessions, a new dial is rejected
+// with HTTP 503 + Retry-After header (Strategy A: pre-upgrade cap check).
+//
+// This test uses no database: it wires a fake inboundConn directly into
+// the registry and pre-fills its routes map to simulate "cap reached".
+// Because Strategy A rejects before websocket.Accept, the nil ws on the
+// fake inbound is never touched.
+//
+// TDD trace:
+//   - RED:  streamCount() doesn't exist → compile error; or cap check absent → 3rd dial succeeds (101).
+//   - GREEN: after adding streamCount() + pre-upgrade check in bridge.go → 503 returned.
+func TestBridge_StreamCapEnforced(t *testing.T) {
+	cfg := Config{
+		CapTokenHMACSecret:   []byte("k"),
+		InternalSharedSecret: "s",
+		MaxStreamsPerExecutor: 2,
+	}
+	srv, err := newServerNoStoreForTesting(cfg)
+	if err != nil {
+		t.Fatalf("newServerNoStoreForTesting: %v", err)
+	}
+	hs := httptest.NewServer(srv.Routes())
+	t.Cleanup(hs.Close)
+
+	exeID := "exe_cap"
+	// Build a fake inboundConn with 2 pre-registered routes (simulates cap reached).
+	fakeInbound := newInboundConn(exeID, nil, nil, 0)
+	fakeInbound.addRoute("stream-0", newBridgeSession("stream-0", fakeInbound, nil))
+	fakeInbound.addRoute("stream-1", newBridgeSession("stream-1", fakeInbound, nil))
+	srv.registry.Register(exeID, fakeInbound)
+
+	now := time.Now().Unix()
+	tok := mintBridgeToken(cfg.CapTokenHMACSecret, CapPayload{
+		TurnID: "trn_cap", WorkspaceID: "ws_1", IAT: now, EXP: now + 60,
+	})
+
+	// The dial must be rejected pre-upgrade: Strategy A → HTTP 503 + Retry-After.
+	resp := dialBridgeHTTPOnly(t, hs.URL, exeID, tok)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("got status %d, want 503", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Retry-After"); got == "" {
+		t.Errorf("missing Retry-After header on 503 response")
+	}
+}
+
+// TestBridge_StreamCapDisabledWhenZero verifies that MaxStreamsPerExecutor=0
+// means "disabled" — no cap is enforced even when the inbound already has routes.
+// Uses no database; the 503 path (cap check) is what we're verifying is absent.
+func TestBridge_StreamCapDisabledWhenZero(t *testing.T) {
+	cfg := Config{
+		CapTokenHMACSecret:   []byte("k"),
+		InternalSharedSecret: "s",
+		MaxStreamsPerExecutor: 0, // disabled
+	}
+	srv, err := newServerNoStoreForTesting(cfg)
+	if err != nil {
+		t.Fatalf("newServerNoStoreForTesting: %v", err)
+	}
+	hs := httptest.NewServer(srv.Routes())
+	t.Cleanup(hs.Close)
+
+	exeID := "exe_nocap"
+	// Build a fake inboundConn with routes already present.
+	fakeInbound := newInboundConn(exeID, nil, nil, 0)
+	fakeInbound.addRoute("stream-0", newBridgeSession("stream-0", fakeInbound, nil))
+	fakeInbound.addRoute("stream-1", newBridgeSession("stream-1", fakeInbound, nil))
+	srv.registry.Register(exeID, fakeInbound)
+
+	now := time.Now().Unix()
+	tok := mintBridgeToken(cfg.CapTokenHMACSecret, CapPayload{
+		TurnID: "trn_nocap", WorkspaceID: "ws_1", IAT: now, EXP: now + 60,
+	})
+
+	// With cap=0 (disabled), the request must NOT be rejected with 503.
+	// It will proceed to websocket.Accept — we send a proper ws dial so the
+	// server can upgrade, then read the response. Since the fake inbound ws
+	// is nil, the bridge will error out after upgrade, but we should NOT see
+	// a 503. A 101 (upgrade) or any non-503 error confirms the cap is off.
+	resp := dialBridgeHTTPOnly(t, hs.URL, exeID, tok)
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusServiceUnavailable {
+		t.Errorf("got 503 with cap=0 (disabled); cap should not be enforced")
+	}
+}
 

--- a/internal/codexexecgateway/config.go
+++ b/internal/codexexecgateway/config.go
@@ -35,6 +35,19 @@ type Config struct {
 	// RelayMaxPerWorkspace caps concurrent relays per workspace.
 	// Defaults to 16; protects gateway memory from runaway agents.
 	RelayMaxPerWorkspace int
+	// MaxFrameBytes caps each inbound/bridge ws frame. Default 16 MiB.
+	// Override via CXG_MAX_FRAME_BYTES. Frames exceeding this are
+	// rejected with close code 1009 (Message Too Big) by nhooyr.
+	MaxFrameBytes int64
+	// BridgeIdleTimeout is how long a bridge session can be silent
+	// (no in/out frames) before the gateway sends RelayReset and
+	// closes the bridge ws. Default 5m. Override via
+	// CXG_BRIDGE_IDLE_TIMEOUT.
+	BridgeIdleTimeout time.Duration
+	// MaxStreamsPerExecutor bounds concurrent /bridge sessions per
+	// executor. Default 32. Beyond this, /bridge returns 503.
+	// Override via CXG_MAX_STREAMS_PER_EXECUTOR.
+	MaxStreamsPerExecutor int
 	LogLevel             slog.Level
 }
 
@@ -61,6 +74,9 @@ func LoadConfigFromEnv() (Config, error) {
 		PublicHTTPSBaseURL:        os.Getenv("CXG_PUBLIC_HTTPS_BASE_URL"),
 		RelayDefaultTTL:           parseDurationOr("CXG_RELAY_DEFAULT_TTL", 5*time.Minute),
 		RelayMaxPerWorkspace:      parseIntOr("CXG_RELAY_MAX_PER_WORKSPACE", 16),
+		MaxFrameBytes:             parseInt64Or("CXG_MAX_FRAME_BYTES", 16*1024*1024),
+		BridgeIdleTimeout:         parseDurationOr("CXG_BRIDGE_IDLE_TIMEOUT", 5*time.Minute),
+		MaxStreamsPerExecutor:      parseIntOr("CXG_MAX_STREAMS_PER_EXECUTOR", 32),
 		LogLevel:                  slog.LevelInfo,
 	}
 	if cfg.DatabaseURL == "" {
@@ -107,6 +123,18 @@ func parseIntOr(key string, def int) int {
 		return def
 	}
 	n, err := strconv.Atoi(v)
+	if err != nil {
+		return def
+	}
+	return n
+}
+
+func parseInt64Or(key string, def int64) int64 {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	n, err := strconv.ParseInt(v, 10, 64)
 	if err != nil {
 		return def
 	}

--- a/internal/codexexecgateway/config_test.go
+++ b/internal/codexexecgateway/config_test.go
@@ -3,6 +3,7 @@ package codexexecgateway
 import (
 	"os"
 	"testing"
+	"time"
 )
 
 func TestLoadConfigFromEnv_Defaults(t *testing.T) {
@@ -24,5 +25,49 @@ func TestLoadConfigFromEnv_RequiresDB(t *testing.T) {
 	t.Setenv("CXG_INTERNAL_SHARED_SECRET", "intern")
 	if _, err := LoadConfigFromEnv(); err == nil {
 		t.Fatal("expected error when CXG_DATABASE_URL unset")
+	}
+}
+
+func setRequiredConfigEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("CXG_DATABASE_URL", "postgres://test")
+	t.Setenv("CXG_CAPTOKEN_HMAC_SECRET", "test-secret-32-bytes-minimum-aaaa")
+	t.Setenv("CXG_INTERNAL_SHARED_SECRET", "test-internal")
+}
+
+func TestLoadConfig_BoundedResourceDefaults(t *testing.T) {
+	setRequiredConfigEnv(t)
+	cfg, err := LoadConfigFromEnv()
+	if err != nil {
+		t.Fatalf("LoadConfigFromEnv: %v", err)
+	}
+	if cfg.MaxFrameBytes != 16*1024*1024 {
+		t.Errorf("MaxFrameBytes default: got %d, want 16 MiB (%d)", cfg.MaxFrameBytes, 16*1024*1024)
+	}
+	if cfg.BridgeIdleTimeout != 5*time.Minute {
+		t.Errorf("BridgeIdleTimeout default: got %v, want 5m", cfg.BridgeIdleTimeout)
+	}
+	if cfg.MaxStreamsPerExecutor != 32 {
+		t.Errorf("MaxStreamsPerExecutor default: got %d, want 32", cfg.MaxStreamsPerExecutor)
+	}
+}
+
+func TestLoadConfig_BoundedResourceEnvOverride(t *testing.T) {
+	setRequiredConfigEnv(t)
+	t.Setenv("CXG_MAX_FRAME_BYTES", "1048576")
+	t.Setenv("CXG_BRIDGE_IDLE_TIMEOUT", "30s")
+	t.Setenv("CXG_MAX_STREAMS_PER_EXECUTOR", "8")
+	cfg, err := LoadConfigFromEnv()
+	if err != nil {
+		t.Fatalf("LoadConfigFromEnv: %v", err)
+	}
+	if cfg.MaxFrameBytes != 1024*1024 {
+		t.Errorf("MaxFrameBytes override: got %d, want 1 MiB", cfg.MaxFrameBytes)
+	}
+	if cfg.BridgeIdleTimeout != 30*time.Second {
+		t.Errorf("BridgeIdleTimeout override: got %v, want 30s", cfg.BridgeIdleTimeout)
+	}
+	if cfg.MaxStreamsPerExecutor != 8 {
+		t.Errorf("MaxStreamsPerExecutor override: got %d, want 8", cfg.MaxStreamsPerExecutor)
 	}
 }

--- a/internal/codexexecgateway/handlers_internal_api_test.go
+++ b/internal/codexexecgateway/handlers_internal_api_test.go
@@ -40,7 +40,7 @@ func TestInternalConnected_ReturnsIntersection(t *testing.T) {
 		store.CreateExecutor(context.Background(), e, "h")
 		store.BindWorkspaceExecutor(context.Background(), "ws_a", e.ExeID, e.ExeID, "", e.ExeID == "exe_on")
 	}
-	srv.registry.Register("exe_on", newInboundConn("exe_on", nil, nil))
+	srv.registry.Register("exe_on", newInboundConn("exe_on", nil, nil, 0))
 
 	req, _ := http.NewRequest(http.MethodGet,
 		hs.URL+"/api/exec-gateway/connected?workspace_id=ws_a", nil)

--- a/internal/codexexecgateway/inbound.go
+++ b/internal/codexexecgateway/inbound.go
@@ -51,9 +51,7 @@ func (s *Server) handleInbound(w http.ResponseWriter, r *http.Request) {
 		s.logger.Error("inbound: ws accept", "exe_id", exeID, "error", err)
 		return
 	}
-	ws.SetReadLimit(-1) // codex exec-server streams large process/read responses
-
-	ic := newInboundConn(exeID, ws, s.logger.With("exe_id", exeID))
+	ic := newInboundConn(exeID, ws, s.logger.With("exe_id", exeID), s.config.MaxFrameBytes)
 	if evicted := s.registry.Register(exeID, ic); evicted != nil {
 		s.logger.Info("inbound: evicted prior conn", "exe_id", exeID)
 		evicted.close(nil)

--- a/internal/codexexecgateway/inbound.go
+++ b/internal/codexexecgateway/inbound.go
@@ -67,6 +67,11 @@ func (s *Server) handleInbound(w http.ResponseWriter, r *http.Request) {
 	defer stopKeepAlive()
 	go wsbridge.KeepAlive(keepAliveCtx, ws, 30*time.Second)
 
+	// Idle bridge reaper: per-stream timeout enforcement. Closes silent
+	// /bridge sessions after BridgeIdleTimeout and emits RelayReset to
+	// the executor's relay layer. Cancelled by r.Context() (ws close).
+	go ic.startIdleReaper(r.Context(), s.config.BridgeIdleTimeout)
+
 	// Reader loop: parse each binary frame as a RelayMessageFrame,
 	// route Data/Reset by stream_id, drop Ack/Resume/Heartbeat (those
 	// are rendezvous-internal per the upstream relay spec — exec-server
@@ -113,6 +118,10 @@ func (s *Server) runInboundReader(ctx context.Context, ic *inboundConn) {
 			ic.logger.Debug("inbound: no route for stream", "stream_id", frame.StreamId)
 			continue
 		}
+		// Mark activity BEFORE the (potentially blocking) bridge write so
+		// the reaper doesn't false-positive a session that's actively
+		// pumping but momentarily slow.
+		b.touch()
 		if err := b.write(ctx, mt, data); err != nil {
 			ic.logger.Warn("inbound: bridge write failed; closing route", "stream_id", frame.StreamId, "error", err)
 			b.close(err)

--- a/internal/codexexecgateway/inbound_test.go
+++ b/internal/codexexecgateway/inbound_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/agentserver/agentserver/internal/relaypb"
 	"golang.org/x/crypto/bcrypt"
+	"google.golang.org/protobuf/proto"
 	"nhooyr.io/websocket"
 )
 
@@ -15,6 +17,21 @@ func newInboundTestServer(t *testing.T) (*httptest.Server, *Server) {
 	t.Helper()
 	store := newTestStore(t)
 	cfg := Config{CapTokenHMACSecret: []byte("k"), InternalSharedSecret: "s"}
+	srv, err := NewServer(cfg, store)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	hs := httptest.NewServer(srv.Routes())
+	t.Cleanup(hs.Close)
+	return hs, srv
+}
+
+// newTestServerWithConfig mirrors newInboundTestServer but accepts a
+// fully-constructed Config. The caller can override any field (e.g.
+// MaxFrameBytes) while still getting a real DB-backed store.
+func newTestServerWithConfig(t *testing.T, cfg Config) (*httptest.Server, *Server) {
+	t.Helper()
+	store := newTestStore(t)
 	srv, err := NewServer(cfg, store)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
@@ -116,4 +133,86 @@ func TestInbound_EvictsOldConn(t *testing.T) {
 	if _, ok := srv.registry.Lookup("exe_inb3"); !ok {
 		t.Fatal("registry should hold c2 for exe_inb3 after eviction")
 	}
+}
+
+// TestInbound_RejectsOversizedFrame verifies that newInboundConn enforces
+// maxFrameBytes so that a frame larger than the cap is rejected with close
+// code 1009 (MessageTooBig).
+//
+// The test wires up a real ws pair via httptest so it exercises
+// nhooyr/websocket's SetReadLimit enforcement without a database.
+//
+// TDD trace:
+//   - RED:  compile fails because newInboundConn has no maxFrameBytes param.
+//   - RED:  after adding the param but before adding ws.SetReadLimit, the
+//           server accepts the oversized frame and Read succeeds → FAIL.
+//   - GREEN: after ws.SetReadLimit(maxFrameBytes) is called inside
+//            newInboundConn, Read returns close 1009 → PASS.
+func TestInbound_RejectsOversizedFrame(t *testing.T) {
+	const limitBytes int64 = 1024
+
+	// serverIC will hold the inboundConn created by the server handler so
+	// the test can drain it cleanly.
+	var serverIC *inboundConn
+
+	hs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			return
+		}
+		// newInboundConn must call ws.SetReadLimit(maxFrameBytes).
+		ic := newInboundConn("exe_bigframe", ws, nil, limitBytes)
+		serverIC = ic
+		// Run the reader so the ws actually processes frames.
+		for {
+			if _, _, err := ic.ws.Read(r.Context()); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(hs.Close)
+
+	ctx := context.Background()
+	wsURL := "ws" + hs.URL[len("http"):]
+	c, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close(websocket.StatusNormalClosure, "test done")
+
+	// Build a valid RelayMessageFrame with a payload well above the 1 KiB cap.
+	big := make([]byte, 2048)
+	frame := &relaypb.RelayMessageFrame{
+		Version:  1,
+		StreamId: "test-stream",
+		Body: &relaypb.RelayMessageFrame_Data{Data: &relaypb.RelayData{
+			Seq:          1,
+			SegmentIndex: 0,
+			SegmentCount: 1,
+			Payload:      big,
+		}},
+	}
+	b, err := proto.Marshal(frame)
+	if err != nil {
+		t.Fatalf("marshal frame: %v", err)
+	}
+	if int64(len(b)) <= limitBytes {
+		t.Fatalf("test frame is not large enough: %d bytes (need > %d)", len(b), limitBytes)
+	}
+
+	// Write may return an error on its own, or the close arrives on Read.
+	_ = c.Write(ctx, websocket.MessageBinary, b)
+
+	// Read should return a close with code 1009 (MessageTooBig).
+	readCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+	_, _, rerr := c.Read(readCtx)
+	if rerr == nil {
+		t.Fatal("expected ws.Read to fail after oversized frame")
+	}
+	if got := websocket.CloseStatus(rerr); got != websocket.StatusMessageTooBig {
+		t.Errorf("close code: got %d, want %d (MessageTooBig); err=%v",
+			got, websocket.StatusMessageTooBig, rerr)
+	}
+	_ = serverIC // referenced to avoid "declared and not used"
 }

--- a/internal/codexexecgateway/multiplex.go
+++ b/internal/codexexecgateway/multiplex.go
@@ -5,7 +5,11 @@ import (
 	"errors"
 	"log/slog"
 	"sync"
+	"sync/atomic"
+	"time"
 
+	"github.com/agentserver/agentserver/internal/relaypb"
+	"google.golang.org/protobuf/proto"
 	"nhooyr.io/websocket"
 )
 
@@ -132,18 +136,31 @@ type bridgeSession struct {
 
 	writeMu sync.Mutex // serialise bridgeWS.Write (inbound reader is the only writer today, but defends against future use)
 
+	// lastActivity tracks the most recent frame routed through this
+	// session (either direction) as unix nanos. Read by the idle reaper
+	// goroutine, written by inbound's reader and the bridge pump.
+	// atomic.Int64 makes both safe under `-race` without a mutex.
+	lastActivity atomic.Int64
+
 	closeOnce sync.Once
 	closed    chan struct{}
 	closeErr  error
 }
 
 func newBridgeSession(streamID string, inbound *inboundConn, bridgeWS *websocket.Conn) *bridgeSession {
-	return &bridgeSession{
+	b := &bridgeSession{
 		streamID: streamID,
 		inbound:  inbound,
 		bridgeWS: bridgeWS,
 		closed:   make(chan struct{}),
 	}
+	b.touch()
+	return b
+}
+
+// touch updates lastActivity to now. Safe for concurrent use.
+func (b *bridgeSession) touch() {
+	b.lastActivity.Store(time.Now().UnixNano())
 }
 
 func (b *bridgeSession) write(ctx context.Context, mt websocket.MessageType, data []byte) error {
@@ -160,4 +177,74 @@ func (b *bridgeSession) close(err error) {
 			_ = b.bridgeWS.Close(websocket.StatusNormalClosure, "bridge session closed")
 		}
 	})
+}
+
+// startIdleReaper runs until ctx is done or i.closed fires. Every
+// idleTimeout/4 (clamped to >= 50ms), it scans i.routes and closes any
+// session whose lastActivity is older than idleTimeout. On close, it
+// sends a RelayMessageFrame{Reset{reason:"idle-timeout"}} on the inbound
+// ws so the executor's relay layer can tear down its per-stream JSON-RPC
+// session, removes the route, and closes the bridge ws.
+//
+// idleTimeout <= 0 disables the reaper (returns immediately).
+func (i *inboundConn) startIdleReaper(ctx context.Context, idleTimeout time.Duration) {
+	if idleTimeout <= 0 {
+		return
+	}
+	tick := idleTimeout / 4
+	if tick < 50*time.Millisecond {
+		tick = 50 * time.Millisecond
+	}
+	t := time.NewTicker(tick)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-i.closed:
+			return
+		case <-t.C:
+			i.reapIdle(ctx, idleTimeout)
+		}
+	}
+}
+
+// reapIdle scans the routes table for sessions whose lastActivity is
+// older than idleTimeout, then for each: sends a Reset frame to the
+// inbound (executor) ws, removes the route, and closes the bridge ws.
+//
+// The candidate list is collected under routesMu.RLock; the close work
+// happens after the lock is released to avoid holding routesMu across
+// blocking ws.Write calls.
+func (i *inboundConn) reapIdle(ctx context.Context, idleTimeout time.Duration) {
+	cutoff := time.Now().Add(-idleTimeout).UnixNano()
+	i.routesMu.RLock()
+	var candidates []*bridgeSession
+	for _, b := range i.routes {
+		if b.lastActivity.Load() < cutoff {
+			candidates = append(candidates, b)
+		}
+	}
+	i.routesMu.RUnlock()
+
+	for _, b := range candidates {
+		resetFrame := &relaypb.RelayMessageFrame{
+			Version:  1,
+			StreamId: b.streamID,
+			Body: &relaypb.RelayMessageFrame_Reset_{
+				Reset_: &relaypb.RelayReset{Reason: "idle-timeout"},
+			},
+		}
+		data, err := proto.Marshal(resetFrame)
+		if err != nil {
+			i.logger.Warn("reaper: marshal reset", "stream_id", b.streamID, "err", err)
+		} else {
+			if werr := i.write(ctx, websocket.MessageBinary, data); werr != nil {
+				i.logger.Warn("reaper: write reset to inbound", "stream_id", b.streamID, "err", werr)
+			}
+		}
+		i.removeRoute(b.streamID, b)
+		b.close(nil)
+		i.logger.Info("reaper: closed idle bridge", "stream_id", b.streamID, "timeout", idleTimeout)
+	}
 }

--- a/internal/codexexecgateway/multiplex.go
+++ b/internal/codexexecgateway/multiplex.go
@@ -38,9 +38,12 @@ type inboundConn struct {
 	closeErr  error
 }
 
-func newInboundConn(exeID string, ws *websocket.Conn, logger *slog.Logger) *inboundConn {
+func newInboundConn(exeID string, ws *websocket.Conn, logger *slog.Logger, maxFrameBytes int64) *inboundConn {
 	if logger == nil {
 		logger = slog.Default()
+	}
+	if ws != nil {
+		ws.SetReadLimit(maxFrameBytes)
 	}
 	return &inboundConn{
 		exeID:  exeID,

--- a/internal/codexexecgateway/multiplex.go
+++ b/internal/codexexecgateway/multiplex.go
@@ -83,6 +83,15 @@ func (i *inboundConn) lookup(streamID string) (*bridgeSession, bool) {
 	return b, ok
 }
 
+// streamCount returns the number of currently registered routes (i.e.
+// concurrent /bridge sessions for this executor). Used by the bridge
+// handler to enforce MaxStreamsPerExecutor.
+func (i *inboundConn) streamCount() int {
+	i.routesMu.RLock()
+	defer i.routesMu.RUnlock()
+	return len(i.routes)
+}
+
 // write sends a frame to the inbound under writeMu. Concurrent writers
 // (multiple bridge sessions) are serialised here.
 func (i *inboundConn) write(ctx context.Context, mt websocket.MessageType, data []byte) error {

--- a/internal/codexexecgateway/multiplex_test.go
+++ b/internal/codexexecgateway/multiplex_test.go
@@ -9,7 +9,7 @@ import (
 // of the same stream_id from multiple goroutines. No panics, final
 // map state matches the last writer.
 func TestInboundConn_AddRemoveRouteRace(t *testing.T) {
-	i := newInboundConn("exe_x", nil, nil)
+	i := newInboundConn("exe_x", nil, nil, 0)
 	a := &bridgeSession{streamID: "s1", closed: make(chan struct{})}
 	b := &bridgeSession{streamID: "s1", closed: make(chan struct{})}
 
@@ -44,7 +44,7 @@ func TestInboundConn_AddRemoveRouteRace(t *testing.T) {
 // TestInboundConn_AddRouteEvictsPrior: a second addRoute for the same
 // stream_id returns the prior session so the caller can close it.
 func TestInboundConn_AddRouteEvictsPrior(t *testing.T) {
-	i := newInboundConn("exe_x", nil, nil)
+	i := newInboundConn("exe_x", nil, nil, 0)
 	a := &bridgeSession{streamID: "s1", closed: make(chan struct{})}
 	b := &bridgeSession{streamID: "s1", closed: make(chan struct{})}
 
@@ -63,7 +63,7 @@ func TestInboundConn_AddRouteEvictsPrior(t *testing.T) {
 // TestInboundConn_CloseIdempotent: multiple close() calls don't panic
 // and only run cleanup once (closed channel close + route fan-out).
 func TestInboundConn_CloseIdempotent(t *testing.T) {
-	i := newInboundConn("exe_x", nil, nil)
+	i := newInboundConn("exe_x", nil, nil, 0)
 	// Don't add real bridge sessions (they'd try to close nil ws). The
 	// idempotency check is just that close() doesn't double-close
 	// channels or panic.

--- a/internal/codexexecgateway/reaper_test.go
+++ b/internal/codexexecgateway/reaper_test.go
@@ -1,0 +1,302 @@
+package codexexecgateway
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/agentserver/agentserver/internal/relaypb"
+	"google.golang.org/protobuf/proto"
+	"nhooyr.io/websocket"
+)
+
+// wsPair stands up a tiny httptest server that ws-accepts a single
+// connection and returns the server-side *websocket.Conn plus a
+// client-side *websocket.Conn (dialed by the helper).
+//
+// The accepted server-side ws is exposed via a channel so the test can
+// inject it into newInboundConn / newBridgeSession before driving
+// reaper behavior.
+//
+// Cleanup uses CloseNow (no close handshake) so test teardown doesn't
+// block on the peer reading the close frame.
+func wsPair(t *testing.T) (server *websocket.Conn, client *websocket.Conn) {
+	t.Helper()
+	srvCh := make(chan *websocket.Conn, 1)
+	hs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			t.Errorf("ws accept: %v", err)
+			return
+		}
+		srvCh <- ws
+		// Park here so the http handler doesn't return (which would close
+		// the ws). The test cancels via ws.Close from either side OR via
+		// httptest.Server's shutdown (which cancels r.Context()).
+		<-r.Context().Done()
+	}))
+	t.Cleanup(hs.Close)
+
+	wsURL := "ws" + hs.URL[len("http"):]
+	c, _, err := websocket.Dial(context.Background(), wsURL, nil)
+	if err != nil {
+		t.Fatalf("ws dial: %v", err)
+	}
+	t.Cleanup(func() { _ = c.CloseNow() })
+
+	select {
+	case s := <-srvCh:
+		t.Cleanup(func() { _ = s.CloseNow() })
+		return s, c
+	case <-time.After(2 * time.Second):
+		t.Fatal("server-side ws never arrived")
+		return nil, nil
+	}
+}
+
+// TestIdleReaper_ClosesIdleBridgeAndSendsReset verifies that when a bridge
+// session has no activity for longer than BridgeIdleTimeout, the reaper:
+//  1. Sends a RelayMessageFrame{body: Reset{reason:"idle-timeout"}} on the
+//     inbound ws (so the executor's relay layer tears down its per-stream
+//     JSON-RPC session), AND
+//  2. Closes the bridge ws (so the env-mcp child sees connection closed).
+//
+// TDD trace:
+//   - RED:  bridgeSession.lastActivity / touch() / startIdleReaper don't
+//     exist → compile error. Or, once helpers exist but reaper isn't
+//     wired, the bridge ws stays open forever and the inbound side never
+//     receives a Reset frame → test times out / fails.
+//   - GREEN: after wiring lastActivity + touch() + startIdleReaper + the
+//     "spawn reaper" hook in handleInbound, both assertions pass.
+func TestIdleReaper_ClosesIdleBridgeAndSendsReset(t *testing.T) {
+	// Set up a real ws pair for the inbound so we can read the Reset
+	// frame the reaper writes. Set up a separate real ws pair for the
+	// bridge so we can observe it closing.
+	inboundServerWS, inboundClientWS := wsPair(t)
+	bridgeServerWS, bridgeClientWS := wsPair(t)
+
+	exeID := "exe_idle"
+	streamID := "stream_idle"
+	ic := newInboundConn(exeID, inboundServerWS, nil, 16*1024*1024)
+	session := newBridgeSession(streamID, ic, bridgeServerWS)
+	if evicted := ic.addRoute(streamID, session); evicted != nil {
+		t.Fatalf("unexpected eviction: %v", evicted)
+	}
+
+	// Start the reaper with a short timeout. The reaper runs in its own
+	// goroutine; we feed it a fresh ctx tied to this test.
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	idle := 150 * time.Millisecond
+	go ic.startIdleReaper(ctx, idle)
+
+	// Read on the inbound client side. Should get a Reset frame within
+	// timeout*~2 (one tick interval = timeout/4, then on next tick the
+	// session is idle past the cutoff).
+	readCtx, readCancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer readCancel()
+	mt, data, err := inboundClientWS.Read(readCtx)
+	if err != nil {
+		t.Fatalf("inbound read failed: %v", err)
+	}
+	if mt != websocket.MessageBinary {
+		t.Fatalf("inbound got non-binary frame: %v", mt)
+	}
+	var frame relaypb.RelayMessageFrame
+	if err := proto.Unmarshal(data, &frame); err != nil {
+		t.Fatalf("unmarshal reset frame: %v", err)
+	}
+	if frame.StreamId != streamID {
+		t.Errorf("reset frame stream_id = %q, want %q", frame.StreamId, streamID)
+	}
+	reset, ok := frame.Body.(*relaypb.RelayMessageFrame_Reset_)
+	if !ok {
+		t.Fatalf("frame body is not Reset: %T", frame.Body)
+	}
+	if reset.Reset_.Reason != "idle-timeout" {
+		t.Errorf("reset reason = %q, want %q", reset.Reset_.Reason, "idle-timeout")
+	}
+
+	// The bridge ws should have been closed by the reaper. Wait for the
+	// closed channel on the session OR a read error on bridgeClientWS.
+	select {
+	case <-session.closed:
+		// good
+	case <-time.After(2 * time.Second):
+		t.Fatal("session.closed never fired after idle reap")
+	}
+	// And on the bridge client side, a Read should return an error
+	// (since the server-side ws is closed).
+	readCtx2, readCancel2 := context.WithTimeout(context.Background(), 1*time.Second)
+	defer readCancel2()
+	if _, _, err := bridgeClientWS.Read(readCtx2); err == nil {
+		t.Error("bridge client Read should have errored after reaper closed bridge ws")
+	}
+
+	// And the route should be unregistered.
+	if _, ok := ic.lookup(streamID); ok {
+		t.Errorf("route for %q still present after reap", streamID)
+	}
+}
+
+// TestIdleReaper_PreservesActiveBridge: a bridge that touches activity
+// periodically (faster than the idle timeout) is NOT reaped, even after
+// waiting longer than the idle timeout.
+func TestIdleReaper_PreservesActiveBridge(t *testing.T) {
+	inboundServerWS, inboundClientWS := wsPair(t)
+	bridgeServerWS, _ := wsPair(t)
+
+	exeID := "exe_active"
+	streamID := "stream_active"
+	ic := newInboundConn(exeID, inboundServerWS, nil, 16*1024*1024)
+	session := newBridgeSession(streamID, ic, bridgeServerWS)
+	if evicted := ic.addRoute(streamID, session); evicted != nil {
+		t.Fatalf("unexpected eviction: %v", evicted)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	idle := 150 * time.Millisecond
+	go ic.startIdleReaper(ctx, idle)
+
+	// Touch the session every 50ms for ~400ms (well past idle timeout).
+	// Reaper must NOT reap it.
+	touchCtx, touchCancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer touchCancel()
+	for {
+		session.touch()
+		select {
+		case <-touchCtx.Done():
+			goto done
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+done:
+
+	// Bridge should still be alive.
+	select {
+	case <-session.closed:
+		t.Fatal("active session was reaped despite touches")
+	default:
+	}
+
+	// And the route should still be registered.
+	if _, ok := ic.lookup(streamID); !ok {
+		t.Error("route was removed despite active touches")
+	}
+
+	// And no Reset frame should have been written to the inbound. Use a
+	// short read timeout — Read should NOT succeed.
+	noReadCtx, noReadCancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer noReadCancel()
+	if _, _, err := inboundClientWS.Read(noReadCtx); err == nil {
+		t.Error("inbound should not have received a Reset frame for an active session")
+	}
+}
+
+// TestIdleReaper_DisabledWhenTimeoutZero: BridgeIdleTimeout <= 0 means
+// reaper returns immediately and does not periodically scan.
+func TestIdleReaper_DisabledWhenTimeoutZero(t *testing.T) {
+	inboundServerWS, _ := wsPair(t)
+	bridgeServerWS, _ := wsPair(t)
+
+	exeID := "exe_disabled"
+	streamID := "stream_disabled"
+	ic := newInboundConn(exeID, inboundServerWS, nil, 16*1024*1024)
+	session := newBridgeSession(streamID, ic, bridgeServerWS)
+	ic.addRoute(streamID, session)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	// Disabled: zero timeout. startIdleReaper must return early without
+	// scanning. We verify by waiting some time, then checking the session
+	// is still alive (even though its lastActivity is unset).
+	done := make(chan struct{})
+	go func() {
+		ic.startIdleReaper(ctx, 0)
+		close(done)
+	}()
+	select {
+	case <-done:
+		// reaper exited immediately — good
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("startIdleReaper(0) should return immediately")
+	}
+
+	// Session must still be alive.
+	select {
+	case <-session.closed:
+		t.Fatal("session was closed despite reaper being disabled")
+	default:
+	}
+}
+
+// TestIdleReaper_ExitsOnContextCancel: a running reaper exits cleanly
+// when its ctx is cancelled. No goroutine leak.
+func TestIdleReaper_ExitsOnContextCancel(t *testing.T) {
+	inboundServerWS, _ := wsPair(t)
+
+	ic := newInboundConn("exe_ctx", inboundServerWS, nil, 16*1024*1024)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		ic.startIdleReaper(ctx, 100*time.Millisecond)
+		close(done)
+	}()
+
+	// Let it spin once.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+		// exited — good
+	case <-time.After(1 * time.Second):
+		t.Fatal("reaper did not exit after context cancel")
+	}
+}
+
+// TestIdleReaper_ExitsOnInboundClose: a running reaper exits cleanly
+// when the inbound's closed channel fires.
+func TestIdleReaper_ExitsOnInboundClose(t *testing.T) {
+	inboundServerWS, inboundClientWS := wsPair(t)
+
+	ic := newInboundConn("exe_close", inboundServerWS, nil, 16*1024*1024)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	done := make(chan struct{})
+	go func() {
+		ic.startIdleReaper(ctx, 100*time.Millisecond)
+		close(done)
+	}()
+
+	// Drain the client side so ic.close()'s ws.Close handshake can
+	// complete (the close handshake requires the peer to read the close
+	// frame and respond). Without this drain, ic.close() blocks on the
+	// handshake forever.
+	clientDrainCtx, clientDrainCancel := context.WithCancel(context.Background())
+	t.Cleanup(clientDrainCancel)
+	go func() {
+		for {
+			if _, _, err := inboundClientWS.Read(clientDrainCtx); err != nil {
+				return
+			}
+		}
+	}()
+
+	// Let the reaper spin once.
+	time.Sleep(50 * time.Millisecond)
+	ic.close(nil)
+
+	select {
+	case <-done:
+		// exited — good
+	case <-time.After(2 * time.Second):
+		t.Fatal("reaper did not exit after inbound.close()")
+	}
+}

--- a/internal/codexexecgateway/registry_test.go
+++ b/internal/codexexecgateway/registry_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func newFakeInbound(exeID string) *inboundConn {
-	return newInboundConn(exeID, nil, nil) // ws=nil is fine for identity-only tests
+	return newInboundConn(exeID, nil, nil, 0) // ws=nil is fine for identity-only tests
 }
 
 func TestConnRegistry_RegisterAndLookup(t *testing.T) {

--- a/internal/relaypb/relay.proto
+++ b/internal/relaypb/relay.proto
@@ -4,7 +4,6 @@ package codex.exec_server.relay.v1;
 
 option go_package = "github.com/agentserver/agentserver/internal/relaypb;relaypb";
 
-
 message RelayMessageFrame {
   uint32 version = 1;
   string stream_id = 2;

--- a/scripts/codex-pin-bump.sh
+++ b/scripts/codex-pin-bump.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Bump the upstream codex pin to a new tag.
+# Usage: scripts/codex-pin-bump.sh rust-v0.132.0-alpha.1
+set -euo pipefail
+
+TAG="${1:?usage: $0 <upstream-tag>}"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+echo "Cloning openai/codex@$TAG..." >&2
+git clone --depth 1 --branch "$TAG" https://github.com/openai/codex.git "$tmp/codex" >&2
+
+upstream_sha="$(cd "$tmp/codex" && git rev-parse HEAD)"
+
+sha_of() { sha256sum "$1" | awk '{print $1}'; }
+
+relay_proto_upstream="$tmp/codex/codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto"
+relay_sha="$(sha_of "$relay_proto_upstream")"
+v1_sha="$(sha_of "$tmp/codex/codex-rs/app-server-protocol/src/protocol/v1.rs")"
+item_sha="$(sha_of "$tmp/codex/codex-rs/app-server-protocol/src/protocol/v2/item.rs")"
+mcp_sha="$(sha_of "$tmp/codex/codex-rs/app-server-protocol/src/protocol/v2/mcp.rs")"
+
+# Overwrite our relay.proto with upstream content + inject `option go_package` directive.
+# The directive goes immediately after the `package ...;` line (matching the existing layout).
+{
+  awk '
+    /^package codex\.exec_server\.relay\.v1;$/ {
+      print
+      print ""
+      print "option go_package = \"github.com/agentserver/agentserver/internal/relaypb;relaypb\";"
+      next
+    }
+    { print }
+  ' "$relay_proto_upstream"
+} > "$REPO_ROOT/internal/relaypb/relay.proto"
+
+# Compute normalized sha (must match what verify.go's normalize() produces).
+# normalize() does:
+#   1. Convert CRLF to LF
+#   2. Strip lines matching: ^option go_package[[:space:]]*=.*;\s*$
+#   3. Replace runs of 2+ newlines with exactly 2 newlines (one blank line)
+normalized_sha="$(
+  cat "$REPO_ROOT/internal/relaypb/relay.proto" | \
+  tr -d '\r' | \
+  sed -E '/^option[[:space:]]+go_package[[:space:]]*=.*;[[:space:]]*$/d' | \
+  perl -0777 -pe 's/\n{2,}/\n\n/g' | \
+  sha256sum | awk '{print $1}'
+)"
+
+cat > "$REPO_ROOT/codex-pin.json" <<EOF
+{
+  "upstream_repo": "openai/codex",
+  "tag": "$TAG",
+  "sha": "$upstream_sha",
+  "tracked_files": {
+    "codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto": "$relay_sha",
+    "codex-rs/app-server-protocol/src/protocol/v1.rs": "$v1_sha",
+    "codex-rs/app-server-protocol/src/protocol/v2/item.rs": "$item_sha",
+    "codex-rs/app-server-protocol/src/protocol/v2/mcp.rs": "$mcp_sha"
+  },
+  "normalized_equivalent_files": {
+    "internal/relaypb/relay.proto": {
+      "upstream_path": "codex-rs/exec-server/src/proto/codex.exec_server.relay.v1.proto",
+      "normalized_sha256": "$normalized_sha",
+      "comment": "Strip Go-only \`option go_package = \"...\";\` directive and collapse runs of 2+ consecutive newlines to one blank line, then compare schemas. Required because agentserver's protoc-gen-go needs this directive; upstream's prost (Rust) doesn't. Must stay in sync with cmd/check-codex-pin/verify.go::normalize()."
+    }
+  },
+  "approval_methods": [
+    "item/commandExecution/requestApproval",
+    "item/fileChange/requestApproval",
+    "item/permissions/requestApproval",
+    "item/tool/requestUserInput",
+    "mcpServer/elicitation/request"
+  ]
+}
+EOF
+
+echo "Bumped codex-pin.json and internal/relaypb/relay.proto to $TAG." >&2
+echo "Next: run 'make codex-pin-check' to verify the new pin." >&2


### PR DESCRIPTION
## Summary

PR 1 of 3 from spec [`2026-05-20-codex-gateway-full-alignment-design.md`](docs/superpowers/specs/2026-05-20-codex-gateway-full-alignment-design.md). Closes 3 of 5 gaps preventing provable alignment between agentserver and upstream `openai/codex`.

### What lands

**codex-pin machinery (Gap 1) — make upstream alignment provable**

- `codex-pin.json` — pins agentserver to `rust-v0.131.0-alpha.22` with sha256 of 4 upstream protocol files
- `cmd/check-codex-pin/` — Go verifier with offline (fixture) + online (git clone) modes
- `scripts/codex-pin-bump.sh` + `make codex-pin-bump TAG=...` — re-regenerate `codex-pin.json` + `internal/relaypb/relay.proto` from a new upstream tag
- `make codex-pin-check` — verify pin is in sync with upstream
- CI: new `codex-pin` job on `build.yml`, runs in parallel with `test`

Handles the local divergence in `internal/relaypb/relay.proto` (extra `option go_package` line for Go codegen) via strip-normalize comparison. The normalization logic in `verify.go::normalize()` and the bump script's sha computation MUST stay in sync — this is documented in the `codex-pin.json` comment field.

**exec-gateway operational hardening (Gaps 2 + 3)**

3 new bounded-resource knobs in `codexexecgateway.Config`:
- `MaxFrameBytes` (default 16 MiB, env `CXG_MAX_FRAME_BYTES`) — replaces `SetReadLimit(-1)` on both inbound and bridge ws
- `BridgeIdleTimeout` (default 5 min, env `CXG_BRIDGE_IDLE_TIMEOUT`) — reaper goroutine sends `RelayReset{reason:"idle-timeout"}` and closes idle bridges
- `MaxStreamsPerExecutor` (default 32, env `CXG_MAX_STREAMS_PER_EXECUTOR`) — pre-upgrade HTTP 503 + `Retry-After: 30` when cap reached

## Out of scope (deferred to PR 2 / 3)

- ApprovalFilter on transparent `/codex-app/ws` path (Gap 4) — PR 2
- REST `/turn` pivot to shared proxy core + delete bogus `protocolVersion` field (Gap 5) — PR 3

## Test plan

- [x] `make codex-pin-check` returns `codex-pin: OK` against real upstream
- [x] `make codex-pin-bump TAG=rust-v0.131.0-alpha.22` produces no diff against committed state (idempotent for the pinned tag)
- [x] `go test ./...` all PASS
- [x] `go test ./internal/codexexecgateway -race -count=3` clean
- [x] `go vet ./...` clean
- [x] 4 verifier tests + 2 config tests + 1 oversized-frame test + 2 stream-cap tests + 5 reaper tests all pass
- [ ] CI green on this PR

## Audit findings driving this work

See [`docs/superpowers/specs/2026-05-20-codex-gateway-full-alignment-design.md`](docs/superpowers/specs/2026-05-20-codex-gateway-full-alignment-design.md) "Audit baseline" table. Original audit conducted 2026-05-20; this PR closes the high-severity drift detection gap and the medium-severity exec-gw resource gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)