### PR TITLE
fix(helm): RollingUpdate strategy for 5 sidecar deployments — eliminates 503 during rollouts

### DIFF
--- a/deploy/helm/agentserver/templates/cc-broker.yaml
+++ b/deploy/helm/agentserver/templates/cc-broker.yaml
@@ -27,7 +27,10 @@ metadata:
 spec:
   replicas: {{ .Values.ccbroker.replicaCount }}
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app: {{ .Release.Name }}-ccbroker
@@ -37,6 +40,7 @@ spec:
         app: {{ .Release.Name }}-ccbroker
     spec:
       serviceAccountName: {{ .Release.Name }}
+      terminationGracePeriodSeconds: 30
       initContainers:
         {{- if .Values.postgresql.enabled }}
         - name: wait-for-postgresql
@@ -136,6 +140,10 @@ spec:
               port: {{ .Values.ccbroker.port }}
             initialDelaySeconds: 3
             periodSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 10"]
           {{- with .Values.ccbroker.resources }}
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/deploy/helm/agentserver/templates/codex-app-gateway.yaml
+++ b/deploy/helm/agentserver/templates/codex-app-gateway.yaml
@@ -29,7 +29,10 @@ metadata:
 spec:
   replicas: {{ .Values.codexAppGateway.replicaCount }}
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app: {{ .Release.Name }}-codex-app-gateway
@@ -39,6 +42,7 @@ spec:
         app: {{ .Release.Name }}-codex-app-gateway
     spec:
       serviceAccountName: {{ .Release.Name }}
+      terminationGracePeriodSeconds: 30
       containers:
         - name: codex-app-gateway
           image: "{{ .Values.codexAppGateway.image.repository }}:{{ .Values.codexAppGateway.image.tag }}"
@@ -147,6 +151,10 @@ spec:
               port: {{ .Values.codexAppGateway.port }}
             initialDelaySeconds: 3
             periodSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 10"]
           {{- with .Values.codexAppGateway.resources }}
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/deploy/helm/agentserver/templates/codex-exec-gateway.yaml
+++ b/deploy/helm/agentserver/templates/codex-exec-gateway.yaml
@@ -18,7 +18,10 @@ metadata:
 spec:
   replicas: {{ .Values.codexExecGateway.replicaCount }}
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app: {{ .Release.Name }}-codex-exec-gateway
@@ -28,6 +31,7 @@ spec:
         app: {{ .Release.Name }}-codex-exec-gateway
     spec:
       serviceAccountName: {{ .Release.Name }}
+      terminationGracePeriodSeconds: 30
       initContainers:
         {{- if .Values.postgresql.enabled }}
         - name: wait-for-postgresql
@@ -125,6 +129,10 @@ spec:
               port: {{ .Values.codexExecGateway.port }}
             initialDelaySeconds: 3
             periodSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 10"]
           {{- with .Values.codexExecGateway.resources }}
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/deploy/helm/agentserver/templates/executor-registry.yaml
+++ b/deploy/helm/agentserver/templates/executor-registry.yaml
@@ -18,7 +18,10 @@ metadata:
 spec:
   replicas: {{ .Values.executorRegistry.replicaCount }}
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app: {{ .Release.Name }}-executor-registry
@@ -28,6 +31,7 @@ spec:
         app: {{ .Release.Name }}-executor-registry
     spec:
       serviceAccountName: {{ .Release.Name }}
+      terminationGracePeriodSeconds: 30
       initContainers:
         {{- if .Values.postgresql.enabled }}
         - name: wait-for-postgresql
@@ -88,6 +92,10 @@ spec:
               port: {{ .Values.executorRegistry.port }}
             initialDelaySeconds: 3
             periodSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 10"]
           {{- with .Values.executorRegistry.resources }}
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}

--- a/deploy/helm/agentserver/templates/imbridge.yaml
+++ b/deploy/helm/agentserver/templates/imbridge.yaml
@@ -7,7 +7,10 @@ metadata:
 spec:
   replicas: 1
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
   selector:
     matchLabels:
       app: {{ .Release.Name }}-imbridge
@@ -16,6 +19,7 @@ spec:
       labels:
         app: {{ .Release.Name }}-imbridge
     spec:
+      terminationGracePeriodSeconds: 30
       {{- if .Values.postgresql.enabled }}
       initContainers:
         - name: wait-for-postgresql
@@ -63,6 +67,10 @@ spec:
               port: {{ .Values.imbridge.port }}
             initialDelaySeconds: 3
             periodSeconds: 5
+          lifecycle:
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 10"]
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
## Root cause

Every `pulumi up` / `kubectl rollout restart` triggered:

```
Error: executor registry request failed (503 Service Unavailable): no healthy upstream
```

from Windows `codex exec-server --remote` clients (and any other long-lived caller). Reproduced consistently across the last several chart bumps.

The 5 sidecar deployments — `executor-registry`, `codex-exec-gateway`, `codex-app-gateway`, `cc-broker`, `imbridge` — all use:

```yaml
strategy:
  type: Recreate
replicas: 1   # from values.yaml
```

`Recreate` semantics: **kill the old pod first**, then start the new one. During the 10–30s gap the Service has zero endpoints, so Envoy/Istio answers every request with `503 no healthy upstream`. This is structural, not flaky.

## Fix

Per deployment:

```yaml
strategy:
  type: RollingUpdate
  rollingUpdate:
    maxUnavailable: 0
    maxSurge: 1
terminationGracePeriodSeconds: 30
# main container:
lifecycle:
  preStop:
    exec:
      command: ["sh", "-c", "sleep 10"]
```

- `maxUnavailable: 0, maxSurge: 1` — new pod must reach Ready before the old pod is torn down. Zero-downtime even at `replicas: 1`.
- `preStop sleep 10` — on termination, hold SIGTERM for 10s so Istio/cilium endpoint cache propagates and in-flight requests stop being routed to the dying pod.
- `terminationGracePeriodSeconds: 30` — accommodate the preStop sleep plus normal graceful drain.

All 5 services are stateless API processes in front of Postgres — `Recreate` was over-cautious early default with no real constraint behind it.

The remaining deployments (`agentserver`, `hydra`, `credentialproxy`, `sandboxproxy`, `llmproxy`) don't set `strategy:` explicitly and so already use the k8s default RollingUpdate. They lack `preStop` too, but they're not the source of the 503s in this incident — leaving that as a separate cleanup.

## Verification

`helm template` renders cleanly with all 5 toggles enabled; spot-checked each rendered deployment shows:

- `strategy.type: RollingUpdate`
- `rollingUpdate.maxUnavailable: 0` / `maxSurge: 1`
- `terminationGracePeriodSeconds: 30`
- container `lifecycle.preStop.exec.command: ["sh", "-c", "sleep 10"]`

## Test plan

- [ ] Merge → wait for `publish-helm` to push chart 0.61.1
- [ ] `pulumi up -s nj-prod` (no-op other than chart bump)
- [ ] `kubectl rollout restart deploy/agentserver-executor-registry` while running `watch -n1 'kubectl -n agentserver get pods -l app=agentserver-executor-registry'` — confirm new pod becomes Ready before old pod terminates
- [ ] During the rollout, run from a remote client: `codex exec-server --remote https://codex-exec.agent.cs.ac.cn --executor-id X --name test` — should NOT see `503 no healthy upstream`

🤖 Generated with [Claude Code](https://claude.com/claude-code)