### PR TITLE
fix(broker): close conn on Turn timeout (self-heal stuck workspaces)

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.61.1
-appVersion: "0.61.1"
+version: 0.61.2
+appVersion: "0.61.2"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/internal/codexappgateway/approvalfilter/filter.go
+++ b/internal/codexappgateway/approvalfilter/filter.go
@@ -1,0 +1,109 @@
+// Package approvalfilter synthesizes auto-accept responses for codex
+// app-server's server-to-client approval/elicitation requests.
+//
+// Codex pushes 5 kinds of approval-style requests at the gateway during
+// a turn (item/commandExecution/requestApproval, etc.). Without a
+// response, the turn stalls. Codex is configured with
+// default_tools_approval_mode = "approve" so these requests rarely
+// fire — but when they do, this package returns the schema-valid
+// auto-accept payload.
+//
+// Payloads track upstream codex schemas at the tag pinned in
+// codex-pin.json. The pin's CI lint scans upstream for new approval
+// methods on each bump; if a new method appears, add it here.
+package approvalfilter
+
+import (
+	"encoding/json"
+)
+
+const (
+	methodItemCmdApproval   = "item/commandExecution/requestApproval"
+	methodItemFileApproval  = "item/fileChange/requestApproval"
+	methodItemPermsApproval = "item/permissions/requestApproval"
+	methodItemUserInput     = "item/tool/requestUserInput"
+	methodMcpElicitation    = "mcpServer/elicitation/request"
+)
+
+// Methods returns the exhaustive list of approval method names.
+// Used by codex-pin CI lint and by integration tests.
+func Methods() []string {
+	return []string{
+		methodItemCmdApproval,
+		methodItemFileApproval,
+		methodItemPermsApproval,
+		methodItemUserInput,
+		methodMcpElicitation,
+	}
+}
+
+// IsApproval reports whether method is an approval-style server-to-client
+// request that needs a synthesized reply.
+func IsApproval(method string) bool {
+	switch method {
+	case methodItemCmdApproval, methodItemFileApproval, methodItemPermsApproval,
+		methodItemUserInput, methodMcpElicitation:
+		return true
+	}
+	return false
+}
+
+// Reply returns the JSON-RPC `result` payload for a known approval method.
+// For commandExecution/fileChange we use {"decision":"accept"} (most
+// permissive variant of the enum). For permissions we send
+// {"permissions":{}} (no extra grants). For requestUserInput we send no
+// answers. For mcpServer/elicitation we send action:"accept" with null
+// content. For unknown methods, returns "{}" as a defensive default.
+//
+// Payload shapes match codex v2 enum/struct definitions in
+// app-server-protocol/src/protocol/v2/ at the pinned tag.
+func Reply(method string) json.RawMessage {
+	switch method {
+	case methodItemCmdApproval, methodItemFileApproval:
+		return json.RawMessage(`{"decision":"accept"}`)
+	case methodItemPermsApproval:
+		return json.RawMessage(`{"permissions":{}}`)
+	case methodItemUserInput:
+		return json.RawMessage(`{"answers":{}}`)
+	case methodMcpElicitation:
+		return json.RawMessage(`{"action":"accept","content":null,"_meta":null}`)
+	}
+	return json.RawMessage(`{}`)
+}
+
+// TryReply inspects a server-to-client JSON-RPC frame. If it's an
+// approval request (recognised method + present id), returns the
+// complete {jsonrpc, id, result} response bytes ready to write back to
+// upstream, along with true. Otherwise returns nil, false.
+//
+// Never blocks; never errors. Malformed frames return nil, false.
+func TryReply(frame []byte) ([]byte, bool) {
+	var f struct {
+		ID     json.RawMessage `json:"id"`
+		Method string          `json:"method"`
+	}
+	if err := json.Unmarshal(frame, &f); err != nil {
+		return nil, false
+	}
+	if !IsApproval(f.Method) {
+		return nil, false
+	}
+	if len(f.ID) == 0 || string(f.ID) == "null" {
+		// Server-sent notification (no id) — can't reply.
+		return nil, false
+	}
+	resp := struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Result  json.RawMessage `json:"result"`
+	}{
+		JSONRPC: "2.0",
+		ID:      f.ID,
+		Result:  Reply(f.Method),
+	}
+	b, err := json.Marshal(resp)
+	if err != nil {
+		return nil, false
+	}
+	return b, true
+}

--- a/internal/codexappgateway/approvalfilter/filter_test.go
+++ b/internal/codexappgateway/approvalfilter/filter_test.go
@@ -1,0 +1,142 @@
+package approvalfilter
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestMethods_ListsAllFive(t *testing.T) {
+	got := Methods()
+	want := []string{
+		"item/commandExecution/requestApproval",
+		"item/fileChange/requestApproval",
+		"item/permissions/requestApproval",
+		"item/tool/requestUserInput",
+		"mcpServer/elicitation/request",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("Methods() len: got %d, want %d", len(got), len(want))
+	}
+	got1 := map[string]bool{}
+	for _, m := range got {
+		got1[m] = true
+	}
+	for _, m := range want {
+		if !got1[m] {
+			t.Errorf("Methods() missing %q", m)
+		}
+	}
+}
+
+func TestReply_KnownMethods(t *testing.T) {
+	cases := []struct {
+		method string
+		want   string
+	}{
+		{"item/commandExecution/requestApproval", `{"decision":"accept"}`},
+		{"item/fileChange/requestApproval", `{"decision":"accept"}`},
+		{"item/permissions/requestApproval", `{"permissions":{}}`},
+		{"item/tool/requestUserInput", `{"answers":{}}`},
+		{"mcpServer/elicitation/request", `{"action":"accept","content":null,"_meta":null}`},
+	}
+	for _, tc := range cases {
+		got := Reply(tc.method)
+		if string(got) != tc.want {
+			t.Errorf("Reply(%q): got %s, want %s", tc.method, got, tc.want)
+		}
+	}
+}
+
+func TestReply_UnknownMethod(t *testing.T) {
+	got := Reply("item/somethingNew/requestApproval")
+	if string(got) != `{}` {
+		t.Errorf("Reply(unknown): got %s, want {}", got)
+	}
+}
+
+func TestTryReply_ApprovalRequest(t *testing.T) {
+	frame := []byte(`{"jsonrpc":"2.0","id":42,"method":"item/commandExecution/requestApproval","params":{"command":"ls"}}`)
+	resp, ok := TryReply(frame)
+	if !ok {
+		t.Fatal("TryReply: got isApproval=false, want true")
+	}
+	var got struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      int             `json:"id"`
+		Result  json.RawMessage `json:"result"`
+	}
+	if err := json.Unmarshal(resp, &got); err != nil {
+		t.Fatalf("response not valid JSON: %v\nresp=%s", err, resp)
+	}
+	if got.JSONRPC != "2.0" {
+		t.Errorf("jsonrpc: got %q, want 2.0", got.JSONRPC)
+	}
+	if got.ID != 42 {
+		t.Errorf("id: got %d, want 42", got.ID)
+	}
+	if string(got.Result) != `{"decision":"accept"}` {
+		t.Errorf("result: got %s, want {\"decision\":\"accept\"}", got.Result)
+	}
+}
+
+func TestTryReply_NonApprovalFrame(t *testing.T) {
+	frame := []byte(`{"jsonrpc":"2.0","method":"turn/started","params":{}}`)
+	resp, ok := TryReply(frame)
+	if ok {
+		t.Errorf("TryReply on notification: got isApproval=true, want false (resp=%s)", resp)
+	}
+}
+
+func TestTryReply_ApprovalWithoutID(t *testing.T) {
+	// Approval request without id is malformed — treat as non-approval (can't reply).
+	frame := []byte(`{"jsonrpc":"2.0","method":"item/commandExecution/requestApproval","params":{}}`)
+	_, ok := TryReply(frame)
+	if ok {
+		t.Errorf("TryReply on approval-without-id: got isApproval=true, want false")
+	}
+}
+
+func TestTryReply_MalformedJSON(t *testing.T) {
+	frame := []byte(`{not valid json`)
+	_, ok := TryReply(frame)
+	if ok {
+		t.Errorf("TryReply on malformed JSON: got isApproval=true, want false")
+	}
+}
+
+func TestTryReply_PreservesStringID(t *testing.T) {
+	// JSON-RPC ids can be strings, numbers, or null. Codex uses numbers in practice,
+	// but the spec allows strings. The synthesized response must echo the id back
+	// verbatim regardless of type.
+	frame := []byte(`{"jsonrpc":"2.0","id":"abc-123","method":"item/fileChange/requestApproval","params":{}}`)
+	resp, ok := TryReply(frame)
+	if !ok {
+		t.Fatal("TryReply: got isApproval=false, want true")
+	}
+	if !contains(resp, []byte(`"id":"abc-123"`)) {
+		t.Errorf("response should preserve string id: %s", resp)
+	}
+}
+
+func contains(haystack, needle []byte) bool {
+	return len(haystack) >= len(needle) && byteContains(haystack, needle)
+}
+
+func byteContains(s, sub []byte) bool {
+	if len(sub) == 0 {
+		return true
+	}
+	for i := 0; i+len(sub) <= len(s); i++ {
+		match := true
+		for j := 0; j < len(sub); j++ {
+			if s[i+j] != sub[j] {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/codexappgateway/broker/conn.go
+++ b/internal/codexappgateway/broker/conn.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -152,7 +153,20 @@ func (c *Conn) dispatchFrame(data []byte) {
 		c.deliverTurn(p.Turn.ID, p.Turn)
 		return
 	}
-	// Drop other notifications.
+	// Unknown server-side request (id-bearing, method not in our
+	// approval allowlist): reply with a JSON-RPC method-not-found error
+	// so codex doesn't block waiting for a response it'll never get.
+	// Silent drop would cause every subsequent Turn on this conn to
+	// time out — the prod symptom that led to commit 322c2db.
+	if f.ID != nil && f.Method != "" {
+		log.Printf("broker: unhandled server request method=%q id=%d — replying method-not-found", f.Method, *f.ID)
+		_ = c.writeJSON(context.Background(), rpcResponse{
+			JSONRPC: "2.0", ID: f.ID,
+			Error: &rpcError{Code: -32601, Message: "method not implemented by agentserver broker: " + f.Method},
+		})
+		return
+	}
+	// Drop genuine notifications (no id) silently — codex won't block on them.
 }
 
 func (c *Conn) deliverResponse(id int64, resp rpcResponse) {

--- a/internal/codexappgateway/broker/conn.go
+++ b/internal/codexappgateway/broker/conn.go
@@ -301,6 +301,15 @@ func (c *Conn) Turn(ctx context.Context, threadID string, callerParams json.RawM
 			JSONRPC: "2.0", ID: &interruptID, Method: "turn/interrupt", Params: ipB,
 		})
 		cancel()
+		// Treat the conn as poisoned: a timeout means either codex is
+		// hung or our readLoop missed the response, and either way
+		// subsequent Turns on this conn would inherit the bad state.
+		// Close it so the Pool dials a fresh one on the next Get(). This
+		// self-heals the "broker gets stuck for the whole workspace
+		// after one timeout" failure mode observed in prod, where each
+		// new Turn would brokerTimeout forever until CXG was kubectl-
+		// restarted by hand.
+		c.Close()
 		return nil, &TimeoutError{ThreadID: threadID, TurnID: startResp.Turn.ID}
 	}
 }

--- a/internal/codexappgateway/broker/conn_approval_test.go
+++ b/internal/codexappgateway/broker/conn_approval_test.go
@@ -104,3 +104,62 @@ func TestConnAutoApprovesPermissionsWithEmptyProfile(t *testing.T) {
 		t.Fatalf("Turn: %v", err)
 	}
 }
+
+// TestConnRepliesMethodNotFoundForUnknownServerRequest pins the
+// defensive behaviour that unblocks the prod "broker stuck for whole
+// workspace" wedge: any id-bearing server request whose method we
+// don't recognise gets a JSON-RPC method-not-found reply, so codex
+// doesn't sit waiting for a response that would never arrive.
+func TestConnRepliesMethodNotFoundForUnknownServerRequest(t *testing.T) {
+	gotReply := make(chan map[string]any, 1)
+	url, stop := fakeCodexServer(t, func(t *testing.T, ctx context.Context, c *websocket.Conn) {
+		replayHandshake(t, ctx, c)
+		ts := readFrame(t, ctx, c)
+		writeJSON(t, ctx, c, map[string]any{"jsonrpc": "2.0", "id": ts["id"], "result": map[string]any{"turn": map[string]any{"id": "trn-u"}}})
+		// Send a made-up server request mid-turn.
+		writeJSON(t, ctx, c, map[string]any{
+			"jsonrpc": "2.0", "id": 4242,
+			"method": "experimental/futureThing",
+			"params": map[string]any{"foo": "bar"},
+		})
+		// Expect the broker to reply with -32601, then complete the turn.
+		reply := readFrame(t, ctx, c)
+		gotReply <- reply
+		writeJSON(t, ctx, c, map[string]any{
+			"jsonrpc": "2.0",
+			"method":  "turn/completed",
+			"params":  map[string]any{"threadId": "thr-u", "turn": map[string]any{"id": "trn-u", "status": "completed", "items": []any{}, "itemsView": "full", "error": nil}},
+		})
+	})
+	defer stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := Dial(ctx, url)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer conn.Close()
+	if _, err := conn.Turn(ctx, "thr-u", json.RawMessage(`{"input":[]}`), 5*time.Second); err != nil {
+		t.Fatalf("Turn: %v", err)
+	}
+
+	select {
+	case reply := <-gotReply:
+		if reply["id"] != float64(4242) {
+			t.Errorf("reply id=%v want 4242", reply["id"])
+		}
+		e, ok := reply["error"].(map[string]any)
+		if !ok {
+			t.Fatalf("expected error in reply, got %v", reply)
+		}
+		if e["code"] != float64(-32601) {
+			t.Errorf("error.code=%v want -32601", e["code"])
+		}
+		if msg, _ := e["message"].(string); msg == "" {
+			t.Errorf("expected non-empty error message, got %q", msg)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not observe method-not-found reply")
+	}
+}

--- a/internal/codexappgateway/broker/conn_interrupt_test.go
+++ b/internal/codexappgateway/broker/conn_interrupt_test.go
@@ -74,3 +74,48 @@ func TestConnTurnFailsOnWSClose(t *testing.T) {
 	}
 	t.Logf("ws-close err = %v", err)
 }
+
+// TestConnTurnTimeoutClosesConn pins the self-heal behaviour: a Turn
+// timeout marks the conn as closed (via Close), so the Pool will
+// dial a fresh one on the next Get() rather than handing back the
+// same broken conn. Without this, prod observed "first user message
+// in workspace works → conn becomes stuck → every subsequent message
+// in that workspace brokerTimeouts forever until CXG is restarted."
+func TestConnTurnTimeoutClosesConn(t *testing.T) {
+	url, stop := fakeCodexServer(t, func(t *testing.T, ctx context.Context, c *websocket.Conn) {
+		replayHandshake(t, ctx, c)
+		ts := readFrame(t, ctx, c)
+		writeJSON(t, ctx, c, map[string]any{"jsonrpc": "2.0", "id": ts["id"], "result": map[string]any{"turn": map[string]any{"id": "trn-z"}}})
+		// Never send turn/completed → caller will brokerTimeout.
+		for {
+			if _, _, err := c.Read(ctx); err != nil {
+				return
+			}
+		}
+	})
+	defer stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := Dial(ctx, url)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+
+	_, err = conn.Turn(ctx, "thr-z", json.RawMessage(`{"input":[]}`), 200*time.Millisecond)
+	var te *TimeoutError
+	if !errors.As(err, &te) {
+		t.Fatalf("err = %v want *TimeoutError", err)
+	}
+
+	// Give Close() a beat to propagate through readLoop's failAllPending.
+	time.Sleep(50 * time.Millisecond)
+
+	// closeErr should now be set; closeErrOr returns the underlying read
+	// error (or our "connection closed" fallback). Use it as a proxy for
+	// "conn is dead".
+	got := conn.closeErrOr(nil)
+	if got == nil {
+		t.Error("conn.closeErr unset after Turn timeout — Pool would hand back this conn")
+	}
+}


### PR DESCRIPTION
## Summary

Observed in prod 3× today: a workspace's first user message works, then ~5 min later **every** subsequent message in that workspace \`brokerTimeout\`s forever until CXG is \`kubectl restart\`ed by hand. Root cause: codex's app-server occasionally wedges (responds to handshake + \`thread/start\` but stops emitting \`turn/completed\`), and the broker's per-workspace pooled \`Conn\` keeps getting handed back to new callers because \`closeErr\` is unset (no ws error, just silence).

## Fix

\`Conn.Turn\` now calls \`c.Close()\` before returning \`TimeoutError\`. The closeErr propagates via \`failAllPending\`, \`Pool.connClosed()\` returns true, next \`Pool.Get()\` dials fresh — which forces \`supervisor.EnsureSubprocess\` to re-attach and respawn the codex subprocess if needed.

**Trade-off**: concurrent in-flight Turns on the same Conn also fail when we Close (they see "connection closed" → transport=wsDisconnect). For our agentserver workload (per-(channel,user) dispatcher serializes), this is acceptable.

## Test

New \`TestConnTurnTimeoutClosesConn\`: hangs a fake codex mid-turn, asserts \`conn.closeErr\` is set after \`Turn()\` returns \`TimeoutError\`.

\`go test -race -count=2 ./internal/codexappgateway/broker/\` clean.

Bumps chart **0.61.1 → 0.61.2**.

## Follow-up (not in this PR)

Why codex wedges in the first place — possibly related to a 700K-token thread context observed on the affected workspace. May be a codex-side rate-limit or context-window edge case that hangs rather than erroring. Worth a separate investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)