### PR TITLE
fix(sdk): remove envs() cache — every call queries gateway

### DIFF
--- a/sdk/python/src/agentserver_sdk/ctx.py
+++ b/sdk/python/src/agentserver_sdk/ctx.py
@@ -1,12 +1,13 @@
 """Ctx — the workspace-scoped SDK handle bundled into every notebook kernel.
 
-`Ctx.from_env()` constructs a lazy handle (no I/O). The first `await
-ctx.envs()` calls the gateway's REST endpoint.
+`Ctx.from_env()` constructs a lazy handle (no I/O). Every `await ctx.envs()`
+hits the gateway's REST endpoint — there is no client-side caching, because
+executors come and go and the right answer is whatever the gateway sees
+right now.
 """
 
 from __future__ import annotations
 
-import asyncio
 import os
 
 from .client import HTTPClient
@@ -18,8 +19,6 @@ from .types import ToolMetadata
 class Ctx:
     def __init__(self, client: HTTPClient) -> None:
         self._client = client
-        self._envs_lock = asyncio.Lock()
-        self._envs_cache: list[Env] | None = None
 
     @classmethod
     def from_env(cls) -> "Ctx":
@@ -32,14 +31,9 @@ class Ctx:
         return cls(HTTPClient(url, token))
 
     async def envs(self) -> list[Env]:
-        """List envs in the workspace. Caches inside Ctx for the kernel
-        lifetime — call `refresh()` to clear the cache."""
-        async with self._envs_lock:
-            if self._envs_cache is None:
-                self._envs_cache = await self._fetch_envs()
-        return list(self._envs_cache)
-
-    async def _fetch_envs(self) -> list[Env]:
+        """List envs currently connected to the workspace. Hits the gateway
+        on every call — executors connect/disconnect, and a stale list is
+        usually worse than a fresh HTTP round-trip."""
         listing = await self._client.post("/api/sdk/envs/list", {})
         envs: list[Env] = []
         for e in listing.get("envs", []):
@@ -57,11 +51,6 @@ class Ctx:
             if e.name == name:
                 return e
         raise KeyError(f"env not found: {name}")
-
-    async def refresh(self) -> None:
-        """Clear the env cache so the next `envs()` call refetches from the gateway."""
-        async with self._envs_lock:
-            self._envs_cache = None
 
     async def close(self) -> None:
         await self._client.close()

--- a/sdk/python/tests/test_ctx.py
+++ b/sdk/python/tests/test_ctx.py
@@ -26,7 +26,9 @@ async def test_envs_returns_parsed_list(stub_client):
     assert result[0].tools[0].name == "shell"
 
 
-async def test_envs_cached_until_refresh(stub_client):
+async def test_envs_hits_gateway_every_call(stub_client):
+    """Each envs() call must hit the gateway — there is no client-side cache,
+    because executors come and go and only the gateway knows the truth."""
     client, stub = stub_client
     ctx = Ctx(client)
     calls = {"n": 0}
@@ -38,11 +40,8 @@ async def test_envs_cached_until_refresh(stub_client):
     stub.register("POST", "/api/sdk/envs/list", envs)
     await ctx.envs()
     await ctx.envs()
-    assert calls["n"] == 1
-
-    await ctx.refresh()
     await ctx.envs()
-    assert calls["n"] == 2
+    assert calls["n"] == 3
 
 
 async def test_env_by_name_returns_matching_env(stub_client):
@@ -82,30 +81,3 @@ async def test_from_env_reads_env_vars(monkeypatch, stub_client):
     ctx = Ctx.from_env()
     assert ctx._client.base_url == "http://stub"
     await ctx.close()
-
-
-async def test_envs_concurrent_callers_share_cache(stub_client):
-    """Two concurrent envs() calls should only trigger one /api/sdk/envs/list fetch."""
-    import asyncio
-
-    client, stub = stub_client
-    ctx = Ctx(client)
-    calls = {"n": 0}
-
-    async def envs(body, query):
-        calls["n"] += 1
-        return 200, {
-            "envs": [
-                {"name": "alpha", "type": "shell", "tools": []},
-                {"name": "beta", "type": "shell", "tools": []},
-            ]
-        }
-
-    stub.register("POST", "/api/sdk/envs/list", envs)
-    a, b = await asyncio.gather(ctx.envs(), ctx.envs())
-    assert {e.name for e in a} == {e.name for e in b}
-    for x, y in zip(
-        sorted(a, key=lambda e: e.name), sorted(b, key=lambda e: e.name), strict=True
-    ):
-        assert x is y
-    assert calls["n"] == 1


### PR DESCRIPTION
## Symptom

In a Jupyter notebook kernel, `await ctx.envs()` returned `[]` even after a new executor was registered and connected.

Concrete repro: the kernel called `envs()` once before \`windows-ggl\` came online → got \`[]\` → cache pinned to \`[]\` for the rest of the kernel's life. Subsequent calls (after the executor connected) silently kept returning \`[]\`. Reset only via \`await ctx.refresh()\` or kernel restart — neither of which is discoverable from a user staring at an empty list.

## Root cause

\`Ctx._envs_cache\` was kernel-lifetime with manual \`refresh()\`. For executors — which connect and disconnect arbitrarily — that's the wrong default:

- Stale empty list silently breaks user code.
- Stale non-empty list silently breaks tool calls against a now-gone executor.

## Fix

Drop \`_envs_cache\`, \`_envs_lock\`, \`refresh()\`. Every \`envs()\` call hits \`POST /api/sdk/envs/list\`. The endpoint is cheap (in-memory lookup on the gateway side, no DB query for the connected set) and the truth lives there, not on the client. A few extra round-trips per notebook are cheaper than silent wrong answers.

## Test plan

- [x] \`pytest sdk/python\` — 35 passed
- [x] Verified test \`test_envs_hits_gateway_every_call\` now asserts \`calls["n"] == 3\` after three \`envs()\` invocations (was \`== 1\` with old cache test)
- [ ] After merge → chart 0.61.3 publishes new \`agentserver-jupyter\` image → restart Jupyter sandbox → \`await ctx.envs()\` returns \`windows-ggl\` on first call

🤖 Generated with [Claude Code](https://claude.com/claude-code)