### PR TITLE
chore(chart): 0.61.3 → 0.61.4 — ship SDK envs() no-cache fix

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.61.3
-appVersion: "0.61.3"
+version: 0.61.4
+appVersion: "0.61.4"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
v0.61.3 was tagged at 1d28dc0 (UI default-tab fix #110) **before** SDK fix #111 merged. Chart 0.61.3 ships a jupyter image built against the still-caching SDK.

Bumping to 0.61.4 so the next chart publish rebuilds jupyter against the no-cache SDK. After this merges + publishes, a Jupyter sandbox restart will reliably show `windows-ggl` (and any future executor that connects after the kernel started) via `await ctx.envs()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)