### PR TITLE
fix(ui): single source of truth for sandbox state

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.61.3
-appVersion: "0.61.3"
+version: 0.61.4
+appVersion: "0.61.4"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>agentserver</title>
-    <script type="module" crossorigin src="/assets/index-C691jMjc.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-D-zOev-p.css">
+    <script type="module" crossorigin src="/assets/index-BIopQav6.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-DBHJUdt6.css">
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -39,12 +39,18 @@ function WorkspaceDetailRoute({
   onRename,
   initialTab,
   sandboxOverride,
+  sandboxes,
+  setSandboxes,
+  refreshSandboxes,
 }: {
   workspaces: Workspace[]
   workspacesLoaded: boolean
   onRename?: (id: string, name: string) => void
   initialTab?: WorkspaceTab
   sandboxOverride?: React.ReactNode
+  sandboxes: Sandbox[]
+  setSandboxes: React.Dispatch<React.SetStateAction<Sandbox[]>>
+  refreshSandboxes: () => void
 }) {
   const { workspaceId, tab: tabSlug } = useParams<{ workspaceId: string; tab?: string }>()
   if (!workspacesLoaded) {
@@ -67,6 +73,9 @@ function WorkspaceDetailRoute({
       onRename={onRename}
       initialTab={resolvedInitial}
       sandboxOverride={sandboxOverride}
+      sandboxes={sandboxes}
+      setSandboxes={setSandboxes}
+      refreshSandboxes={refreshSandboxes}
     />
   )
 }
@@ -312,6 +321,9 @@ export default function App() {
             workspacesLoaded={workspacesLoaded}
             onRename={handleRenameWorkspace}
             initialTab="overview"
+            sandboxes={sandboxes}
+            setSandboxes={setSandboxes}
+            refreshSandboxes={refreshSandboxes}
           />
         } />
         <Route
@@ -322,6 +334,9 @@ export default function App() {
               workspacesLoaded={workspacesLoaded}
               onRename={handleRenameWorkspace}
               initialTab="sandbox"
+              sandboxes={sandboxes}
+              setSandboxes={setSandboxes}
+              refreshSandboxes={refreshSandboxes}
               sandboxOverride={
                 <SandboxDetailRoute
                   sandboxes={sandboxes}
@@ -346,6 +361,9 @@ export default function App() {
               workspacesLoaded={workspacesLoaded}
               onRename={handleRenameWorkspace}
               initialTab="overview"
+              sandboxes={sandboxes}
+              setSandboxes={setSandboxes}
+              refreshSandboxes={refreshSandboxes}
             />
           }
         />

--- a/web/src/components/WorkspaceDetail.tsx
+++ b/web/src/components/WorkspaceDetail.tsx
@@ -85,6 +85,13 @@ interface WorkspaceDetailProps {
   onRename?: (id: string, name: string) => void
   initialTab?: Tab
   sandboxOverride?: React.ReactNode
+  // Optional: when provided (by App.tsx), sandbox state is shared with the
+  // top-level SandboxDetailRoute so a freshly-created sandbox is visible
+  // there immediately. ManageWorkspaces (which has no nested detail route)
+  // omits these and SandboxPanel falls back to its own local state.
+  sandboxes?: Sandbox[]
+  setSandboxes?: React.Dispatch<React.SetStateAction<Sandbox[]>>
+  refreshSandboxes?: () => void
 }
 
 // Mapping from Tab key to URL slug. Tabs share their key as slug unless
@@ -113,7 +120,7 @@ export function tabFromSlug(slug: string | undefined): Tab | undefined {
   return SLUG_TO_TAB[slug]
 }
 
-export function WorkspaceDetail({ workspace, onRename, initialTab, sandboxOverride }: WorkspaceDetailProps) {
+export function WorkspaceDetail({ workspace, onRename, initialTab, sandboxOverride, sandboxes, setSandboxes, refreshSandboxes }: WorkspaceDetailProps) {
   const navigate = useNavigate()
   const location = useLocation()
 
@@ -239,7 +246,14 @@ export function WorkspaceDetail({ workspace, onRename, initialTab, sandboxOverri
             <RemoteExecutorsPanel workspaceId={workspace.id} />
           )}
           {tab === 'sandbox' && (
-            sandboxOverride ?? <SandboxPanel workspaceId={workspace.id} />
+            sandboxOverride ?? (
+              <SandboxPanel
+                workspaceId={workspace.id}
+                externalSandboxes={sandboxes}
+                externalSetSandboxes={setSandboxes}
+                externalRefresh={refreshSandboxes}
+              />
+            )
           )}
           {tab === 'llm' && (
             <LLMTab workspaceId={workspace.id} />
@@ -368,13 +382,33 @@ function BrowsersPanel({ workspaceId }: { workspaceId: string }) {
   )
 }
 
-function SandboxPanel({ workspaceId }: { workspaceId: string }) {
-  const [sandboxes, setSandboxes] = useState<Sandbox[]>([])
+function SandboxPanel({
+  workspaceId,
+  externalSandboxes,
+  externalSetSandboxes,
+  externalRefresh,
+}: {
+  workspaceId: string
+  externalSandboxes?: Sandbox[]
+  externalSetSandboxes?: React.Dispatch<React.SetStateAction<Sandbox[]>>
+  externalRefresh?: () => void
+}) {
   const [creating, setCreating] = useState(false)
-  const refresh = useCallback(() => {
-    listSandboxes(workspaceId).then(setSandboxes).catch(() => {})
+  // Fallback local state for callers (e.g. ManageWorkspaces) that don't
+  // share sandbox state at a higher level. When external state is supplied
+  // we use that instead so other routes see updates immediately.
+  const [localSandboxes, setLocalSandboxes] = useState<Sandbox[]>([])
+  const localRefresh = useCallback(() => {
+    listSandboxes(workspaceId).then(setLocalSandboxes).catch(() => {})
   }, [workspaceId])
-  useEffect(() => { refresh() }, [refresh])
+  useEffect(() => {
+    if (!externalSandboxes) localRefresh()
+  }, [externalSandboxes, localRefresh])
+
+  const sandboxes = externalSandboxes ?? localSandboxes
+  const setSandboxes = externalSetSandboxes ?? setLocalSandboxes
+  const refresh = externalRefresh ?? localRefresh
+
   return (
     <SandboxList
       selectedWorkspaceId={workspaceId}


### PR DESCRIPTION
## Summary
After creating a sandbox, the redirect to `/w/<wsId>/sandboxes/<newId>` rendered \"Sandbox not found\" until refresh.

Root cause: two independent sandbox arrays — App.tsx (read by `SandboxDetailRoute`) and a local one in `WorkspaceDetail`'s `SandboxPanel` (mutated on create). The create only updated the latter; App's stayed stale.

Fix: thread App.tsx's sandbox state through `WorkspaceDetailRoute` → `WorkspaceDetail` → `SandboxPanel`. `SandboxPanel` falls back to its own local state when no external state is supplied (legacy `/workspaces` route continues to work unchanged).

Bump chart to 0.61.4.

## Test plan
- [ ] Create a sandbox from the Sandboxes tab → detail page loads without "not found"
- [ ] Open the legacy /workspaces page → sandboxes list still loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)