### PR TITLE
fix(envtools+sdk): straighten shell + read_file contract

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.61.4
-appVersion: "0.61.4"
+version: 0.61.5
+appVersion: "0.61.5"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/internal/envtools/tools/fs.go
+++ b/internal/envtools/tools/fs.go
@@ -87,8 +87,15 @@ func (t *ReadFileTool) Call(ctx context.Context, raw json.RawMessage) (MCPCallTo
 	if a.Limit > 0 && a.Limit < len(data) {
 		data = data[:a.Limit]
 	}
+	// Return the file as base64 in both Content (so the SDK decoder finds
+	// it in items[].text) and structuredContent.encoding (so the decoder
+	// knows to decode). Returning `string(data)` for binary files corrupted
+	// any byte sequence not valid UTF-8 — base64 keeps the round-trip clean.
+	encoded := base64.StdEncoding.EncodeToString(data)
+	sc, _ := json.Marshal(map[string]any{"encoding": "base64", "path": a.Path})
 	return MCPCallToolResult{
-		Content: []MCPToolContent{{Type: "text", Text: string(data)}},
+		Content:           []MCPToolContent{{Type: "text", Text: encoded}},
+		StructuredContent: sc,
 	}, nil
 }
 

--- a/internal/envtools/tools/shell.go
+++ b/internal/envtools/tools/shell.go
@@ -13,13 +13,15 @@ import (
 )
 
 // shellSchema is the JSON schema for the `shell` tool's arguments.
-// environment_id is required; cwd defaults to /tmp when omitted.
+// environment_id and command (argv) are required; cwd is the executor's
+// current directory when omitted (cross-platform safe — no /tmp default
+// that would break on Windows executors).
 var shellSchema = json.RawMessage(`{
   "type": "object",
   "properties": {
     "environment_id": {"type": "string", "description": "Target environment's name from list_environments output (e.g. hpc-kunshan)"},
-    "command": {"type": "array", "items": {"type": "string"}, "description": "argv as a list of strings"},
-    "cwd": {"type": "string", "description": "Working directory; defaults to /tmp"},
+    "command": {"type": "array", "items": {"type": "string"}, "description": "argv as a list of strings; wrap shell commands with [\"sh\",\"-c\",...] or [\"cmd\",\"/c\",...] explicitly"},
+    "cwd": {"type": "string", "description": "Working directory; executor's current dir when omitted"},
     "timeout_ms": {"type": "integer", "description": "Per-call wait cap; defaults to 60000"}
   },
   "required": ["environment_id", "command"]
@@ -65,10 +67,9 @@ func (t *ShellTool) Call(ctx context.Context, raw json.RawMessage) (MCPCallToolR
 	if len(a.Command) == 0 {
 		return errResult("command must be a non-empty array"), nil
 	}
-	cwd := a.Cwd
-	if cwd == "" {
-		cwd = "/tmp"
-	}
+	// Pass cwd through verbatim — empty string lets exec-server pick its
+	// own current directory, which is the only sane cross-platform default
+	// (the prior /tmp default broke Windows executors).
 	exeID, err := t.resolver.Resolve(ctx, a.EnvironmentID)
 	if err != nil {
 		return errResult(err.Error()), nil
@@ -87,11 +88,14 @@ func (t *ShellTool) Call(ctx context.Context, raw json.RawMessage) (MCPCallToolR
 	}
 
 	pid := fmt.Sprintf("shell-%d", t.pidSeq.Add(1))
+	// Pass cwd + env through verbatim. Empty env means exec-server inherits
+	// its own environment, which is correct cross-platform behavior — the
+	// prior hardcoded POSIX PATH broke Windows executors.
 	startParams, _ := json.Marshal(bridge.ProcessStartParams{
 		ProcessID: pid,
 		Argv:      a.Command,
-		Cwd:       cwd,
-		Env:       map[string]string{"PATH": "/usr/bin:/bin:/usr/local/bin"},
+		Cwd:       a.Cwd,
+		Env:       nil,
 		TTY:       false,
 		PipeStdin: false,
 	})
@@ -136,6 +140,9 @@ func (t *ShellTool) Call(ctx context.Context, raw json.RawMessage) (MCPCallToolR
 		}
 	}
 
+	// Human-readable text fallback (for clients that don't read
+	// structuredContent). Programmatic clients should use the
+	// structuredContent fields below.
 	var text strings.Builder
 	if stdout.Len() > 0 {
 		text.WriteString(stdout.String())
@@ -155,10 +162,30 @@ func (t *ShellTool) Call(ctx context.Context, raw json.RawMessage) (MCPCallToolR
 		text.WriteString("\n[exec timed out without exit signal]")
 	}
 
-	isErr := failure != nil || (exitCode != nil && *exitCode != 0) || exitCode == nil
+	// Build structuredContent — the SDK reads exit_code / stdout / stderr
+	// directly from here, so non-zero exit must NOT be flagged as
+	// IsError. IsError is reserved for "tool itself failed" — failure to
+	// start the process, or the process never returned an exit signal
+	// (timed out). A program exiting 1 because a search found no matches
+	// is a legitimate result, not a tool error.
+	sc := map[string]any{
+		"stdout":    stdout.String(),
+		"stderr":    stderr.String(),
+		"exit_code": nil,
+	}
+	if exitCode != nil {
+		sc["exit_code"] = *exitCode
+	}
+	if failure != nil {
+		sc["failure"] = *failure
+	}
+	scRaw, _ := json.Marshal(sc)
+
+	isErr := failure != nil || exitCode == nil
 	return MCPCallToolResult{
-		Content: []MCPToolContent{{Type: "text", Text: text.String()}},
-		IsError: isErr,
+		Content:           []MCPToolContent{{Type: "text", Text: text.String()}},
+		StructuredContent: scRaw,
+		IsError:           isErr,
 	}, nil
 }
 

--- a/internal/envtools/tools/types.go
+++ b/internal/envtools/tools/types.go
@@ -16,9 +16,15 @@ type Tool interface {
 }
 
 // MCPCallToolResult is the response body of `tools/call`.
+//
+// StructuredContent carries machine-readable fields (e.g. shell's
+// stdout/stderr/exit_code) parallel to the human-readable Content text.
+// Per MCP spec it's an arbitrary JSON object; we use RawMessage so each
+// tool can shape it as needed without a wider schema.
 type MCPCallToolResult struct {
-	Content []MCPToolContent `json:"content"`
-	IsError bool             `json:"isError"`
+	Content           []MCPToolContent `json:"content"`
+	StructuredContent json.RawMessage  `json:"structuredContent,omitempty"`
+	IsError           bool             `json:"isError"`
 }
 
 type MCPToolContent struct {

--- a/sdk/python/src/agentserver_sdk/env.py
+++ b/sdk/python/src/agentserver_sdk/env.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
@@ -68,10 +69,43 @@ class Env:
 
     # ---------- core typed wrappers ----------
 
-    async def shell(self, command: str, *, timeout: int | None = None) -> ShellResult:
-        args: dict[str, Any] = {"command": command}
+    async def shell(
+        self,
+        command: str | Sequence[str],
+        *,
+        timeout: float | None = None,
+        cwd: str | None = None,
+    ) -> ShellResult:
+        """Run a command on the executor and return its full output.
+
+        `command` is argv-style. Pass a list to exec directly without a
+        shell (`["hostname"]`, `["ls", "-la"]`). To get shell features
+        (pipes, redirects, env expansion) wrap the command yourself —
+        POSIX executor: `["sh", "-c", "ls | wc -l"]`,
+        Windows executor: `["cmd", "/c", "dir /b"]` or
+                          `["powershell", "-NoProfile", "-Command", "..."]`.
+
+        A bare string is treated as a single argv token (`"hostname"` →
+        `["hostname"]`). It is NOT shell-wrapped — multi-token strings
+        like `"ls -la"` will fail to exec.
+
+        `timeout` is in seconds (forwarded as `timeout_ms`). The exec-server
+        sees this as a soft cap on how long it waits for output, not a
+        hard kill — long-running commands that hit the timeout return
+        with `exit_code is None` and `failure` set.
+
+        A non-zero exit_code is NOT a tool error — `ShellResult` carries
+        it and the caller decides what to do.
+        """
+        if isinstance(command, str):
+            argv: list[str] = [command]
+        else:
+            argv = list(command)
+        args: dict[str, Any] = {"command": argv}
         if timeout is not None:
-            args["timeout_s"] = timeout
+            args["timeout_ms"] = int(timeout * 1000)
+        if cwd is not None:
+            args["cwd"] = cwd
         raw = await self.call("shell", args)
         return ShellResult.from_mcp(raw)
 

--- a/sdk/python/tests/test_env.py
+++ b/sdk/python/tests/test_env.py
@@ -27,13 +27,75 @@ async def test_call_injects_environment_id(stub_client):
 
     async def tool(body, query):
         assert body["arguments"]["environment_id"] == "alpha"
-        assert body["arguments"]["command"] == "ls"
+        assert body["arguments"]["command"] == ["ls"]
         assert body["tool"] == "shell"
         return 200, {"isError": False, "content": [], "structuredContent": {}}
 
     stub.register("POST", "/api/sdk/envs/alpha/tool/call", tool)
     env = make_env(client, tools=[_tool("shell")])
-    await env.call("shell", {"command": "ls"})
+    await env.call("shell", {"command": ["ls"]})
+
+
+async def test_shell_str_wraps_as_single_argv(stub_client):
+    """A bare-string command must be sent as ["cmd"] — not the string itself —
+    so the server's argv contract holds. Multi-token strings are the caller's
+    responsibility to wrap with sh -c / cmd /c."""
+    client, stub = stub_client
+    received = {}
+
+    async def tool(body, query):
+        received.update(body)
+        return 200, {
+            "structuredContent": {"stdout": "out", "stderr": "", "exit_code": 0},
+            "content": [{"type": "text", "text": "out"}],
+            "isError": False,
+        }
+
+    stub.register("POST", "/api/sdk/envs/alpha/tool/call", tool)
+    env = make_env(client, tools=[_tool("shell")])
+    await env.shell("hostname")
+    assert received["arguments"]["command"] == ["hostname"]
+
+
+async def test_shell_list_passed_through_and_timeout_in_ms(stub_client):
+    client, stub = stub_client
+    received = {}
+
+    async def tool(body, query):
+        received.update(body)
+        return 200, {
+            "structuredContent": {"stdout": "", "stderr": "", "exit_code": 0},
+            "content": [{"type": "text", "text": ""}],
+            "isError": False,
+        }
+
+    stub.register("POST", "/api/sdk/envs/alpha/tool/call", tool)
+    env = make_env(client, tools=[_tool("shell")])
+    await env.shell(["sh", "-c", "ls | wc -l"], timeout=2.5, cwd="/work")
+    args = received["arguments"]
+    assert args["command"] == ["sh", "-c", "ls | wc -l"]
+    assert args["timeout_ms"] == 2500
+    assert args["cwd"] == "/work"
+
+
+async def test_shell_non_zero_exit_does_not_raise(stub_client):
+    """Server contract change in 0.61.5: non-zero exit ships in
+    ShellResult.exit_code with isError=False. Only failure-to-start /
+    timeout-without-exit get isError=True."""
+    client, stub = stub_client
+
+    async def tool(body, query):
+        return 200, {
+            "structuredContent": {"stdout": "", "stderr": "no match", "exit_code": 1},
+            "content": [{"type": "text", "text": "no match\n[exit_code=1]"}],
+            "isError": False,
+        }
+
+    stub.register("POST", "/api/sdk/envs/alpha/tool/call", tool)
+    env = make_env(client, tools=[_tool("shell")])
+    r = await env.shell(["grep", "x", "/etc/hosts"])
+    assert r.exit_code == 1
+    assert r.stderr == "no match"
 
 
 async def test_shell_returns_shell_result(stub_client):


### PR DESCRIPTION
## Why

Surfaced when actually using \`await env.shell(...)\` against a Windows executor from a Jupyter notebook:

\`\`\`
ToolError: windows-ggl/shell: invalid arguments:
json: cannot unmarshal string into Go struct field shellArgs.command of type []string
\`\`\`

Three tangled bugs in one round-trip — fixing together because they all show up the moment anyone calls \`shell()\`.

## The three bugs

1. **SDK sends \`command: str\`, server wants \`[]string\`** → straight 400. Fix: \`env.shell\` accepts \`str | Sequence[str]\`; a bare string becomes a single argv token (\`\"hostname\"\` → \`[\"hostname\"]\`). Multi-token / shell-feature commands must be wrapped explicitly: POSIX \`[\"sh\",\"-c\",\"ls | wc -l\"]\`, Windows \`[\"cmd\",\"/c\",\"dir /b\"]\`.
2. **\`timeout_s\` vs \`timeout_ms\`** silently ignored (Go decoder gave 0 → 60s default). Fix: \`int(timeout * 1000)\`.
3. **Server set \`isError=true\` on any non-zero exit** → SDK raised ToolError for normal failures (grep no-match, findstr no-match, …). \`isError\` is reserved for \"the tool itself broke\" — a program exiting 1 is a result, not a tool error. Fix: \`shell.go\` only sets \`isError\` when the process failed to start or never returned an exit signal.

## Structural cleanups bundled in

4. **shell emits \`structuredContent\`** with \`{stdout, stderr, exit_code, failure?}\`. Previously text-only → SDK's \`ShellResult.from_mcp\` defaulted exit_code to 0 and lumped everything into stdout. SDK tests already expected this shape — server just hadn't been producing it.
5. **\`read_file\` base64-encodes its output** + \`structuredContent.encoding: \"base64\"\`. Returning raw bytes as Go \`string()\` silently corrupted any non-UTF8 file. SDK decoder already handled base64 path.
6. **shell drops hardcoded \`/tmp\` cwd + \`PATH=/usr/bin:/bin:/usr/local/bin\` override** — both broke Windows executors. Empty values mean exec-server inherits its own, which is the only sane cross-platform default.

## Chart

0.61.4 → 0.61.5 so jupyter rebuilds with the new SDK and codex-exec-gateway rebuilds with the new shell + read_file handlers.

## Test plan

- [x] \`go test ./internal/envtools/... ./internal/codexexecgateway/...\` — green
- [x] \`pytest sdk/python\` — 38 passed
- [ ] After merge → chart 0.61.5 publishes → restart jupyter sandbox + restart codex-exec-gateway → \`await env.shell([\"hostname\"])\` returns \`ShellResult(stdout=\"...\", exit_code=0)\`
- [ ] \`await env.shell([\"cmd\",\"/c\",\"hostname && systeminfo | findstr OS\"])\` works (the original failing command)
- [ ] \`await env.shell([\"grep\",\"x\",\"/nonexistent\"])\` returns \`ShellResult(exit_code != 0)\` without raising

🤖 Generated with [Claude Code](https://claude.com/claude-code)