### PR TITLE
fix(bridge): omit empty cwd/env/arg0 from process/start params (fixes Windows ERROR_DIRECTORY 267)

### DIFF
--- a/internal/envtools/bridge/types.go
+++ b/internal/envtools/bridge/types.go
@@ -51,11 +51,15 @@ type ExecInitializeResult struct {
 type ProcessStartParams struct {
 	ProcessID string            `json:"processId"`
 	Argv      []string          `json:"argv"`
-	Cwd       string            `json:"cwd"`
-	Env       map[string]string `json:"env"`
+	// Cwd: when empty, omit from the wire so exec-server inherits its
+	// own working directory. Sending "" was treated by Windows
+	// exec-server as a literal (invalid) path → os error 267
+	// "目录名称无效".
+	Cwd       string            `json:"cwd,omitempty"`
+	Env       map[string]string `json:"env,omitempty"`
 	TTY       bool              `json:"tty"`
 	PipeStdin bool              `json:"pipeStdin"`
-	Arg0      *string           `json:"arg0"`
+	Arg0      *string           `json:"arg0,omitempty"`
 }
 
 type ProcessStartResult struct {


### PR DESCRIPTION
## Symptom

Windows executor, called from Jupyter SDK after #114 landed:

\`\`\`
ToolError: windows-ggl/shell: [exec failed to start:
process/start: 目录名称无效。 (os error 267) (code=-32603)]
\`\`\`

(\"目录名称无效\" = ERROR_DIRECTORY)

## Cause

#114 stopped the shell tool from defaulting cwd to \"/tmp\" (correct fix — /tmp doesn't exist on Windows). The replacement passes \`Cwd: a.Cwd\` verbatim, so when the SDK call doesn't include cwd the gateway sends \`Cwd: \"\"\` into \`bridge.ProcessStartParams\`. Without omitempty that serializes as wire field \`\"cwd\": \"\"\`. Windows exec-server treats \"\" as a literal (invalid) path → ERROR_DIRECTORY 267.

POSIX exec-servers happen to accept \"\" as \"keep current dir\", which is why this didn't blow up before #114 — the gateway was always sending \`\"/tmp\"\`, so empty cwd was never tested.

## Fix

Add \`omitempty\` to \`Cwd\`, \`Env\`, and \`Arg0\` on \`bridge.ProcessStartParams\`. When the SDK omits cwd, exec-server inherits its own working directory — the only sane cross-platform default. \`TTY\` and \`PipeStdin\` stay as explicit booleans (false has semantic meaning for exec-server's stream handling, omitempty would hide it).

## Test plan

- [x] \`go test ./internal/envtools/... ./internal/codexexecgateway/...\` — green
- [ ] After chart 0.61.6 publishes + codex-exec-gateway pod restart, \`await win.shell([\"cmd\",\"/c\",\"hostname && systeminfo | findstr OS\"])\` works on the Windows executor

🤖 Generated with [Claude Code](https://claude.com/claude-code)