### PR TITLE
chore(chart): 0.61.6 → 0.61.7 — Windows cwd fix on a fresh version

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.61.6
-appVersion: "0.61.6"
+version: 0.61.7
+appVersion: "0.61.7"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
v0.61.6 was tagged before #116 (omit empty cwd from process/start) merged. The chart 0.61.6 publish that ran on the tag does NOT contain the fix.

Bumping to 0.61.7 so the next publish ships the Windows cwd fix on a clean, non-overlapping version line — no overwriting a released artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)