### PR TITLE
chore(helm): annotate pod template with chart version (auto-roll on chart bump)

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.61.7
-appVersion: "0.61.7"
+version: 0.61.8
+appVersion: "0.61.8"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/deploy/helm/agentserver/templates/cc-broker.yaml
+++ b/deploy/helm/agentserver/templates/cc-broker.yaml
@@ -36,6 +36,8 @@ spec:
       app: {{ .Release.Name }}-ccbroker
   template:
     metadata:
+      annotations:
+        agentserver.x-k8s.io/chart-version: {{ .Chart.AppVersion | quote }}
       labels:
         app: {{ .Release.Name }}-ccbroker
     spec:

--- a/deploy/helm/agentserver/templates/codex-app-gateway.yaml
+++ b/deploy/helm/agentserver/templates/codex-app-gateway.yaml
@@ -38,6 +38,8 @@ spec:
       app: {{ .Release.Name }}-codex-app-gateway
   template:
     metadata:
+      annotations:
+        agentserver.x-k8s.io/chart-version: {{ .Chart.AppVersion | quote }}
       labels:
         app: {{ .Release.Name }}-codex-app-gateway
     spec:

--- a/deploy/helm/agentserver/templates/codex-exec-gateway.yaml
+++ b/deploy/helm/agentserver/templates/codex-exec-gateway.yaml
@@ -27,6 +27,8 @@ spec:
       app: {{ .Release.Name }}-codex-exec-gateway
   template:
     metadata:
+      annotations:
+        agentserver.x-k8s.io/chart-version: {{ .Chart.AppVersion | quote }}
       labels:
         app: {{ .Release.Name }}-codex-exec-gateway
     spec:

--- a/deploy/helm/agentserver/templates/credentialproxy.yaml
+++ b/deploy/helm/agentserver/templates/credentialproxy.yaml
@@ -12,6 +12,8 @@ spec:
       app: {{ .Release.Name }}-credentialproxy
   template:
     metadata:
+      annotations:
+        agentserver.x-k8s.io/chart-version: {{ .Chart.AppVersion | quote }}
       labels:
         app: {{ .Release.Name }}-credentialproxy
     spec:

--- a/deploy/helm/agentserver/templates/deployment.yaml
+++ b/deploy/helm/agentserver/templates/deployment.yaml
@@ -17,6 +17,8 @@ spec:
       app: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+        agentserver.x-k8s.io/chart-version: {{ .Chart.AppVersion | quote }}
       labels:
         app: {{ .Release.Name }}
     spec:

--- a/deploy/helm/agentserver/templates/executor-registry.yaml
+++ b/deploy/helm/agentserver/templates/executor-registry.yaml
@@ -27,6 +27,8 @@ spec:
       app: {{ .Release.Name }}-executor-registry
   template:
     metadata:
+      annotations:
+        agentserver.x-k8s.io/chart-version: {{ .Chart.AppVersion | quote }}
       labels:
         app: {{ .Release.Name }}-executor-registry
     spec:

--- a/deploy/helm/agentserver/templates/hydra.yaml
+++ b/deploy/helm/agentserver/templates/hydra.yaml
@@ -34,6 +34,8 @@ spec:
       app.kubernetes.io/component: hydra
   template:
     metadata:
+      annotations:
+        agentserver.x-k8s.io/chart-version: {{ .Chart.AppVersion | quote }}
       labels:
         app.kubernetes.io/component: hydra
     spec:

--- a/deploy/helm/agentserver/templates/imbridge.yaml
+++ b/deploy/helm/agentserver/templates/imbridge.yaml
@@ -16,6 +16,8 @@ spec:
       app: {{ .Release.Name }}-imbridge
   template:
     metadata:
+      annotations:
+        agentserver.x-k8s.io/chart-version: {{ .Chart.AppVersion | quote }}
       labels:
         app: {{ .Release.Name }}-imbridge
     spec:

--- a/deploy/helm/agentserver/templates/llmproxy.yaml
+++ b/deploy/helm/agentserver/templates/llmproxy.yaml
@@ -11,6 +11,8 @@ spec:
       app: {{ .Release.Name }}-llmproxy
   template:
     metadata:
+      annotations:
+        agentserver.x-k8s.io/chart-version: {{ .Chart.AppVersion | quote }}
       labels:
         app: {{ .Release.Name }}-llmproxy
     spec:

--- a/deploy/helm/agentserver/templates/sandboxproxy.yaml
+++ b/deploy/helm/agentserver/templates/sandboxproxy.yaml
@@ -11,6 +11,8 @@ spec:
       app: {{ .Release.Name }}-sandboxproxy
   template:
     metadata:
+      annotations:
+        agentserver.x-k8s.io/chart-version: {{ .Chart.AppVersion | quote }}
       labels:
         app: {{ .Release.Name }}-sandboxproxy
     spec:


### PR DESCRIPTION
## Why

Chart 0.61.6 → 0.61.7 bump deployed cleanly (helm release at 0.61.7) but \`codex-exec-gateway\` pod stayed at the 3h-old image — because nothing in its \`deployment.spec.template\` changed. With image tag pinned to \`:main\` and no template diff, k8s deployment controller saw identical spec → no rolling update → pod kept the cached image from when it last started.

Required a manual \`kubectl rollout restart deploy/agentserver-codex-exec-gateway\` to pick up the fix that 0.61.7 was supposed to ship — the deploy was effectively a no-op until someone noticed.

Every chart version bump (and there have been a lot lately) has the same shape: the operator runs \`pulumi up\`, helm release advances, image registry has the new \`:main\` tag, but pods don't restart. Symptoms range from \"oh I need to remember to rollout restart\" to \"the bug is still there because the pod never picked up the fix\".

## Fix

Every \`Deployment\`'s pod template now carries:

\`\`\`yaml
template:
  metadata:
    annotations:
      agentserver.x-k8s.io/chart-version: {{ .Chart.AppVersion | quote }}
\`\`\`

The annotation flows through Helm into the pod template, so any chart version bump changes the template hash → k8s triggers a rolling update on the deployment → new \`:main\` image gets pulled. Zero-downtime because all five sidecars already have \`strategy: RollingUpdate, maxUnavailable: 0, maxSurge: 1\` from #107.

Applied to all 10 Deployment templates: \`agentserver\`, \`hydra\`, \`llmproxy\`, \`credentialproxy\`, \`sandboxproxy\`, \`executor-registry\`, \`codex-app-gateway\`, \`codex-exec-gateway\`, \`cc-broker\`, \`imbridge\`. Skipped the hydra-client-setup Job (its name already includes \`.Chart.Version\` so each version cuts a new Job).

Bumps chart 0.61.7 → 0.61.8 so this release itself proves the mechanism: deploying 0.61.8 should roll every Deployment without any manual restart.

## Test plan

- [x] \`helm template\` renders cleanly with annotation in all 10 deployments
- [ ] After merge → chart 0.61.8 publishes → \`pulumi up -s nj-prod\` → \`kubectl -n agentserver get pods\` shows ALL deployments rolled to new pods within 1-2 minutes, no manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)