### PR TITLE
fix(envtools): default cwd to "." for Windows compat

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.61.8
-appVersion: "0.61.8"
+version: 0.61.9
+appVersion: "0.61.9"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/internal/envtools/tools/shell.go
+++ b/internal/envtools/tools/shell.go
@@ -88,13 +88,22 @@ func (t *ShellTool) Call(ctx context.Context, raw json.RawMessage) (MCPCallToolR
 	}
 
 	pid := fmt.Sprintf("shell-%d", t.pidSeq.Add(1))
-	// Pass cwd + env through verbatim. Empty env means exec-server inherits
-	// its own environment, which is correct cross-platform behavior — the
-	// prior hardcoded POSIX PATH broke Windows executors.
+	// Default cwd to "." (current dir of the exec-server process) when the
+	// caller doesn't supply one. exec-server's ProcessStartParams treats
+	// cwd as a required string — sending "" fails on Windows with
+	// ERROR_DIRECTORY 267; omitting it fails with `missing field "cwd"`.
+	// "." is the one value that's valid on both POSIX and Windows.
+	cwd := a.Cwd
+	if cwd == "" {
+		cwd = "."
+	}
+	// Env stays nil — exec-server inherits its own environment, which is
+	// correct cross-platform behavior. The prior hardcoded POSIX PATH
+	// broke Windows executors.
 	startParams, _ := json.Marshal(bridge.ProcessStartParams{
 		ProcessID: pid,
 		Argv:      a.Command,
-		Cwd:       a.Cwd,
+		Cwd:       cwd,
 		Env:       nil,
 		TTY:       false,
 		PipeStdin: false,

--- a/internal/envtools/tools/unified_exec.go
+++ b/internal/envtools/tools/unified_exec.go
@@ -134,11 +134,18 @@ func (t *UnifiedExecTool) Call(ctx context.Context, raw json.RawMessage) (MCPCal
 		return errResult(fmt.Sprintf("environment %q unavailable: %v", a.EnvironmentID, err)), nil
 	}
 	pid := fmt.Sprintf("uexec-%d", t.pidSeq.Add(1))
+	// Same cross-platform cwd default as ShellTool — exec-server requires
+	// cwd to be present, "" trips Windows ERROR_DIRECTORY 267, "." is the
+	// one value valid everywhere.
+	cwd := a.Cwd
+	if cwd == "" {
+		cwd = "."
+	}
 	startParams, _ := json.Marshal(bridge.ProcessStartParams{
 		ProcessID: pid,
 		Argv:      a.Command,
-		Cwd:       a.Cwd,
-		Env:       map[string]string{"PATH": "/usr/bin:/bin:/usr/local/bin"},
+		Cwd:       cwd,
+		Env:       nil,
 		TTY:       a.TTY,
 		PipeStdin: a.PipeStdin,
 	})


### PR DESCRIPTION
## Symptom

After #116 + 0.61.7 deployed:

```
ToolError: windows-ggl/shell: [exec failed to start:
process/start: missing field `cwd` (code=-32602)]
```

## Cause

#116 added omitempty to `bridge.ProcessStartParams.Cwd` to fix the original Windows error (`ERROR_DIRECTORY 267` when sending `cwd: ""`). That worked on the Go-side gateway, but exposed that **codex exec-server (Rust) treats `cwd` as a required field** — missing → `missing field 'cwd'` (JSON-RPC -32602).

So both extremes fail:
- `cwd: ""` → Windows CreateProcessW rejects → 267
- field absent → Rust deserializer rejects → -32602

## Fix

Default `a.Cwd` to `"."` in `shell.go` and `unified_exec.go` when the caller doesn't pass one. `"."` means "current directory of the exec-server process" and is valid on **both** POSIX and Windows. Always-present, always-valid.

`omitempty` on the wire struct stays — Env and Arg0 are `Option<T>` in Rust and benefit from being omitted when nil.

Also drops the POSIX PATH override in `unified_exec.go` (same Windows-breaking issue as the one fixed for `shell.go` in #114).

## Test plan

- [x] `go test ./internal/envtools/tools/` — green
- [ ] After chart 0.61.9 publishes + exec-gateway pod rolls (now automatic via #119), `await win.shell(["cmd","/c","hostname && systeminfo | findstr OS"])` succeeds on Windows executor

🤖 Generated with [Claude Code](https://claude.com/claude-code)