### PR TITLE
docs(spec): codex 0.132+ auth integration design

### DIFF
--- a/docs/superpowers/plans/2026-05-20-codex-0.132-auth.md
+++ b/docs/superpowers/plans/2026-05-20-codex-0.132-auth.md
@@ -1,0 +1,4234 @@
+# codex 0.132+ auth integration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Self-hosted shim for the two auth modes codex 0.132's `exec-server --remote` requires — ChatGPT-mode (PKCE login + device flow against our PKCE issuer) and Agent Identity mode (CODEX_ACCESS_TOKEN JWT we mint, served via our JWKS), plus a unified validator on `/cloud/executor/{id}/register`.
+
+**Architecture:** One new package `internal/codexauth/` on agentserver hosting all auth logic and HTTP endpoints. Codex-exec-gateway's `/cloud/executor/{id}/register` handler delegates validation to a shared internal endpoint on agentserver. Hydra not used (claim-shape mismatch + codex doesn't verify access_token signatures).
+
+**Tech Stack:** Go 1.22+, chi router, postgres (lib/pq), `github.com/go-jose/go-jose/v4` for RSA JWT signing, `crypto/ed25519` for Agent Identity assertions, codex 0.132 binary for end-to-end tests.
+
+**Spec reference:** `docs/superpowers/specs/2026-05-20-codex-0.132-auth.md` (commit `cfd45a6`).
+
+---
+
+## Phase A — Scaffolding (PR 1)
+
+Tasks A1-A7. Goal: every type, table and helper exists with tests, but no HTTP route is wired in. End state: `go test ./internal/codexauth/...` passes, no behavior change in running cluster.
+
+### Task A1: Schema migration for all 7 tables
+
+**Files:**
+- Create: `internal/db/migrations/025_codex_auth.sql`
+
+- [ ] **Step 1: Write the migration SQL**
+
+```sql
+-- 025_codex_auth.sql
+-- Self-hosted codex auth: PKCE + device flow + Agent Identity JWT minting.
+-- Spec: docs/superpowers/specs/2026-05-20-codex-0.132-auth.md
+
+-- ChatGPT mode --------------------------------------------------------
+CREATE TABLE codex_pkce_requests (
+    code            TEXT PRIMARY KEY,
+    code_challenge  TEXT NOT NULL,
+    state           TEXT NOT NULL,
+    user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    expires_at      TIMESTAMPTZ NOT NULL
+);
+CREATE INDEX idx_codex_pkce_requests_expires_at ON codex_pkce_requests (expires_at);
+
+CREATE TABLE codex_access_tokens (
+    token_hash      BYTEA PRIMARY KEY,
+    user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    expires_at      TIMESTAMPTZ NOT NULL,
+    revoked_at      TIMESTAMPTZ
+);
+CREATE INDEX idx_codex_access_tokens_user_id  ON codex_access_tokens (user_id);
+CREATE INDEX idx_codex_access_tokens_expires  ON codex_access_tokens (expires_at);
+
+CREATE TABLE codex_refresh_tokens (
+    token_hash      BYTEA PRIMARY KEY,
+    family_id       UUID NOT NULL,
+    user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    expires_at      TIMESTAMPTZ NOT NULL,
+    revoked_at      TIMESTAMPTZ
+);
+CREATE INDEX idx_codex_refresh_tokens_family ON codex_refresh_tokens (family_id);
+
+CREATE TABLE codex_device_codes (
+    device_auth_id      TEXT PRIMARY KEY,
+    user_code           TEXT NOT NULL UNIQUE,
+    code_challenge      TEXT NOT NULL,
+    code_verifier       TEXT NOT NULL,
+    authorization_code  TEXT NOT NULL,
+    status              TEXT NOT NULL,  -- pending|approved|exchanged|denied
+    user_id             UUID REFERENCES users(id) ON DELETE CASCADE,
+    expires_at          TIMESTAMPTZ NOT NULL,
+    approved_at         TIMESTAMPTZ
+);
+CREATE INDEX idx_codex_device_codes_user_code ON codex_device_codes (user_code);
+CREATE INDEX idx_codex_device_codes_expires   ON codex_device_codes (expires_at);
+
+-- Agent Identity mode -------------------------------------------------
+CREATE TABLE codex_jwks_keys (
+    kid             TEXT PRIMARY KEY,
+    public_n        TEXT NOT NULL,
+    public_e        TEXT NOT NULL,
+    private_pkcs8   BYTEA NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    active          BOOL NOT NULL
+);
+CREATE UNIQUE INDEX uniq_codex_jwks_keys_one_active
+    ON codex_jwks_keys (active)
+    WHERE active;
+
+CREATE TABLE codex_agent_identities (
+    agent_runtime_id  TEXT PRIMARY KEY,
+    user_id           UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    public_key        BYTEA NOT NULL,
+    jwt_signed_with   TEXT NOT NULL REFERENCES codex_jwks_keys(kid),
+    issued_at         TIMESTAMPTZ NOT NULL,
+    expires_at        TIMESTAMPTZ NOT NULL,
+    revoked_at        TIMESTAMPTZ
+);
+
+CREATE TABLE codex_agent_tasks (
+    task_id           TEXT PRIMARY KEY,
+    agent_runtime_id  TEXT NOT NULL REFERENCES codex_agent_identities(agent_runtime_id) ON DELETE CASCADE,
+    user_id           UUID NOT NULL,
+    issued_at         TIMESTAMPTZ NOT NULL,
+    expires_at        TIMESTAMPTZ NOT NULL
+);
+CREATE INDEX idx_codex_agent_tasks_expires ON codex_agent_tasks (expires_at);
+```
+
+- [ ] **Step 2: Run migrations against test DB**
+
+```bash
+export TEST_DATABASE_URL='postgres://agentserver:agentserver@localhost:5432/agentserver_test?sslmode=disable'
+psql "$TEST_DATABASE_URL" -c "DELETE FROM schema_migrations WHERE version >= '025'"
+go test -run TestNoOp ./internal/db/...   # any test triggers migrate()
+```
+
+Expected: `Applied migration: 025_codex_auth.sql` in stderr.
+
+- [ ] **Step 3: Verify tables exist**
+
+```bash
+psql "$TEST_DATABASE_URL" -c "\dt codex_*"
+```
+
+Expected: 7 tables listed (`codex_pkce_requests`, `codex_access_tokens`, `codex_refresh_tokens`, `codex_device_codes`, `codex_jwks_keys`, `codex_agent_identities`, `codex_agent_tasks`).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/db/migrations/025_codex_auth.sql
+git commit -m "feat(db): migration 025 — codex 0.132 auth (7 tables)"
+```
+
+---
+
+### Task A2: RSA + Ed25519 key generation
+
+**Files:**
+- Create: `internal/codexauth/keys.go`
+- Create: `internal/codexauth/keys_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+```go
+// internal/codexauth/keys_test.go
+package codexauth
+
+import (
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"testing"
+)
+
+func TestGenerateRSAKey_ReturnsUsableKeyMaterial(t *testing.T) {
+	kid, kp, err := GenerateRSAKey()
+	if err != nil {
+		t.Fatalf("GenerateRSAKey: %v", err)
+	}
+	if kid == "" {
+		t.Fatal("kid should not be empty")
+	}
+	if kp.PrivateKey.N.BitLen() < 2048 {
+		t.Errorf("key too small: %d bits", kp.PrivateKey.N.BitLen())
+	}
+	// Public modulus & exponent serialize round-trippably.
+	if _, err := base64.RawURLEncoding.DecodeString(kp.PublicN); err != nil {
+		t.Errorf("PublicN not base64url: %v", err)
+	}
+	if _, err := base64.RawURLEncoding.DecodeString(kp.PublicE); err != nil {
+		t.Errorf("PublicE not base64url: %v", err)
+	}
+	// Private key encoded as PKCS#8 DER.
+	parsed, err := x509.ParsePKCS8PrivateKey(kp.PrivatePKCS8)
+	if err != nil {
+		t.Fatalf("ParsePKCS8PrivateKey: %v", err)
+	}
+	if _, ok := parsed.(*rsa.PrivateKey); !ok {
+		t.Errorf("parsed key is not *rsa.PrivateKey: %T", parsed)
+	}
+}
+
+func TestGenerateEd25519Key_ReturnsKeypair(t *testing.T) {
+	priv, pub, err := GenerateEd25519Key()
+	if err != nil {
+		t.Fatalf("GenerateEd25519Key: %v", err)
+	}
+	if len(pub) != 32 {
+		t.Errorf("pub len = %d, want 32", len(pub))
+	}
+	// PKCS#8 DER round-trip.
+	parsed, err := x509.ParsePKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("ParsePKCS8PrivateKey: %v", err)
+	}
+	if _, ok := parsed.(interface{ Public() interface{} }); !ok {
+		t.Errorf("parsed key is unexpected type: %T", parsed)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `cd /root/agentserver && go test ./internal/codexauth/`
+Expected: FAIL — package doesn't exist yet.
+
+- [ ] **Step 3: Implement keys.go**
+
+```go
+// internal/codexauth/keys.go
+package codexauth
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"math/big"
+)
+
+// RSAKeyPair is an RSA-2048 keypair ready for JWKS exposure (public)
+// and JWT signing (private). PublicN/PublicE are base64url-no-pad
+// encoded for direct JWKS serialization; PrivatePKCS8 is the DER blob
+// stored encrypted at rest.
+type RSAKeyPair struct {
+	PrivateKey   *rsa.PrivateKey
+	PrivatePKCS8 []byte
+	PublicN      string
+	PublicE      string
+}
+
+// GenerateRSAKey mints a fresh RSA-2048 keypair and a deterministic kid
+// derived from the public modulus prefix. kid stability matters because
+// it's embedded in JWT headers and used to look up the verification key
+// in JWKS; a random kid forces full JWKS scans.
+func GenerateRSAKey() (kid string, kp *RSAKeyPair, err error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return "", nil, fmt.Errorf("rsa.GenerateKey: %w", err)
+	}
+	pkcs8, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return "", nil, fmt.Errorf("MarshalPKCS8PrivateKey: %w", err)
+	}
+	pubN := base64.RawURLEncoding.EncodeToString(priv.N.Bytes())
+	pubE := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(priv.E)).Bytes())
+	// kid: first 16 chars of the modulus, deterministic and grep-friendly
+	kid = "rsa-" + pubN[:16]
+	return kid, &RSAKeyPair{
+		PrivateKey:   priv,
+		PrivatePKCS8: pkcs8,
+		PublicN:      pubN,
+		PublicE:      pubE,
+	}, nil
+}
+
+// GenerateEd25519Key produces an Ed25519 keypair used per-agent for
+// AgentAssertion signing. PrivatePKCS8 is stored on the client (inside
+// the Agent Identity JWT's agent_private_key claim); the public key
+// stays server-side for verification.
+func GenerateEd25519Key() (privatePKCS8 []byte, public []byte, err error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("ed25519.GenerateKey: %w", err)
+	}
+	pkcs8, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return nil, nil, fmt.Errorf("MarshalPKCS8PrivateKey: %w", err)
+	}
+	return pkcs8, pub, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `cd /root/agentserver && go test ./internal/codexauth/`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/codexauth/keys.go internal/codexauth/keys_test.go
+git commit -m "feat(codexauth): RSA + Ed25519 key generation"
+```
+
+---
+
+### Task A3: Store layer — JWKS keys
+
+**Files:**
+- Create: `internal/codexauth/store.go`
+- Create: `internal/codexauth/store_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+```go
+// internal/codexauth/store_test.go
+package codexauth
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/agentserver/agentserver/internal/db"
+)
+
+func newTestStore(t *testing.T) (*Store, func()) {
+	t.Helper()
+	url := os.Getenv("TEST_DATABASE_URL")
+	if url == "" {
+		t.Skip("TEST_DATABASE_URL not set")
+	}
+	d, err := db.Open(url)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	// Wipe codex_* tables for a clean slate.
+	d.Exec(`DELETE FROM codex_agent_tasks`)
+	d.Exec(`DELETE FROM codex_agent_identities`)
+	d.Exec(`DELETE FROM codex_jwks_keys`)
+	d.Exec(`DELETE FROM codex_device_codes`)
+	d.Exec(`DELETE FROM codex_refresh_tokens`)
+	d.Exec(`DELETE FROM codex_access_tokens`)
+	d.Exec(`DELETE FROM codex_pkce_requests`)
+	return NewStore(d), func() { d.Close() }
+}
+
+func TestStore_InsertJwksKey_RoundTrip(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	kid, kp, err := GenerateRSAKey()
+	if err != nil {
+		t.Fatalf("GenerateRSAKey: %v", err)
+	}
+	if err := s.InsertJwksKey(ctx, kid, kp, true); err != nil {
+		t.Fatalf("InsertJwksKey: %v", err)
+	}
+
+	got, err := s.GetActiveJwksKey(ctx)
+	if err != nil || got == nil {
+		t.Fatalf("GetActiveJwksKey: %v %+v", err, got)
+	}
+	if got.Kid != kid {
+		t.Errorf("kid = %q, want %q", got.Kid, kid)
+	}
+}
+
+func TestStore_OnlyOneActiveKey(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	kid1, kp1, _ := GenerateRSAKey()
+	kid2, kp2, _ := GenerateRSAKey()
+	if err := s.InsertJwksKey(ctx, kid1, kp1, true); err != nil {
+		t.Fatalf("InsertJwksKey #1: %v", err)
+	}
+	err := s.InsertJwksKey(ctx, kid2, kp2, true)
+	if err == nil {
+		t.Fatal("InsertJwksKey #2 should fail uniq_codex_jwks_keys_one_active")
+	}
+}
+
+func TestStore_ListAllJwksKeys(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	kid1, kp1, _ := GenerateRSAKey()
+	kid2, kp2, _ := GenerateRSAKey()
+	s.InsertJwksKey(ctx, kid1, kp1, true)
+	s.InsertJwksKey(ctx, kid2, kp2, false)
+
+	keys, err := s.ListAllJwksKeys(ctx)
+	if err != nil {
+		t.Fatalf("ListAllJwksKeys: %v", err)
+	}
+	if len(keys) != 2 {
+		t.Errorf("keys count = %d, want 2", len(keys))
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `cd /root/agentserver && go test -run TestStore_ ./internal/codexauth/`
+Expected: FAIL — `Store` type missing.
+
+- [ ] **Step 3: Implement store.go (JWKS portion)**
+
+```go
+// internal/codexauth/store.go
+package codexauth
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/agentserver/agentserver/internal/db"
+)
+
+// Store is a thin DB facade over all codex_* tables. Each method takes
+// a context and returns a typed value or error; no business logic lives
+// here (compose in pkce.go, agent_identity.go, etc.).
+type Store struct {
+	db *db.DB
+}
+
+func NewStore(d *db.DB) *Store {
+	return &Store{db: d}
+}
+
+// ----- JWKS keys -----
+
+type JwksKey struct {
+	Kid          string
+	PublicN      string
+	PublicE      string
+	PrivatePKCS8 []byte
+	Active       bool
+}
+
+func (s *Store) InsertJwksKey(ctx context.Context, kid string, kp *RSAKeyPair, active bool) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO codex_jwks_keys (kid, public_n, public_e, private_pkcs8, active)
+		VALUES ($1, $2, $3, $4, $5)`,
+		kid, kp.PublicN, kp.PublicE, kp.PrivatePKCS8, active)
+	if err != nil {
+		return fmt.Errorf("insert jwks key: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) GetActiveJwksKey(ctx context.Context) (*JwksKey, error) {
+	var k JwksKey
+	err := s.db.QueryRowContext(ctx, `
+		SELECT kid, public_n, public_e, private_pkcs8, active
+		FROM codex_jwks_keys WHERE active = TRUE`).
+		Scan(&k.Kid, &k.PublicN, &k.PublicE, &k.PrivatePKCS8, &k.Active)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get active jwks key: %w", err)
+	}
+	return &k, nil
+}
+
+func (s *Store) ListAllJwksKeys(ctx context.Context) ([]JwksKey, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT kid, public_n, public_e, private_pkcs8, active
+		FROM codex_jwks_keys ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("list jwks keys: %w", err)
+	}
+	defer rows.Close()
+	var out []JwksKey
+	for rows.Next() {
+		var k JwksKey
+		if err := rows.Scan(&k.Kid, &k.PublicN, &k.PublicE, &k.PrivatePKCS8, &k.Active); err != nil {
+			return nil, fmt.Errorf("scan jwks key: %w", err)
+		}
+		out = append(out, k)
+	}
+	return out, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `cd /root/agentserver && go test -run TestStore_ ./internal/codexauth/`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/codexauth/store.go internal/codexauth/store_test.go
+git commit -m "feat(codexauth): store layer — JWKS keys"
+```
+
+---
+
+### Task A4: Store layer — PKCE requests + access/refresh tokens
+
+**Files:**
+- Modify: `internal/codexauth/store.go` — append PKCE + token methods
+- Modify: `internal/codexauth/store_test.go` — append tests
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `internal/codexauth/store_test.go`:
+
+```go
+import "time"
+
+func TestStore_PkceRequest_RoundTrip(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+	uid := mustCreateTestUser(t, s.db)
+
+	err := s.InsertPkceRequest(ctx, PkceRequest{
+		Code:          "code-abc",
+		CodeChallenge: "chall-123",
+		State:         "state-xyz",
+		UserID:        uid,
+		ExpiresAt:     time.Now().Add(10 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("InsertPkceRequest: %v", err)
+	}
+	got, err := s.ConsumePkceRequest(ctx, "code-abc")
+	if err != nil || got == nil {
+		t.Fatalf("ConsumePkceRequest: %v %+v", err, got)
+	}
+	if got.CodeChallenge != "chall-123" {
+		t.Errorf("CodeChallenge = %q", got.CodeChallenge)
+	}
+	// ConsumePkceRequest deletes — second call returns nil.
+	got2, _ := s.ConsumePkceRequest(ctx, "code-abc")
+	if got2 != nil {
+		t.Error("second consume should return nil")
+	}
+}
+
+func TestStore_AccessToken_HashLookup(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+	uid := mustCreateTestUser(t, s.db)
+
+	hash := HashToken("raw-access-token")
+	exp := time.Now().Add(1 * time.Hour).UTC()
+	if err := s.InsertAccessToken(ctx, hash, uid, exp); err != nil {
+		t.Fatalf("InsertAccessToken: %v", err)
+	}
+	gotUID, err := s.LookupAccessToken(ctx, "raw-access-token")
+	if err != nil {
+		t.Fatalf("LookupAccessToken: %v", err)
+	}
+	if gotUID != uid {
+		t.Errorf("uid = %q, want %q", gotUID, uid)
+	}
+}
+
+func TestStore_AccessToken_ExpiredReturnsEmpty(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+	uid := mustCreateTestUser(t, s.db)
+
+	hash := HashToken("raw-expired-token")
+	s.InsertAccessToken(ctx, hash, uid, time.Now().Add(-1*time.Hour))
+	gotUID, _ := s.LookupAccessToken(ctx, "raw-expired-token")
+	if gotUID != "" {
+		t.Errorf("uid = %q, expected empty for expired token", gotUID)
+	}
+}
+
+func TestStore_RefreshToken_RotateInvalidatesOld(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+	uid := mustCreateTestUser(t, s.db)
+
+	family := mustNewUUID(t)
+	oldHash := HashToken("refresh-old")
+	if err := s.InsertRefreshToken(ctx, oldHash, family, uid, time.Now().Add(24*time.Hour)); err != nil {
+		t.Fatalf("InsertRefreshToken: %v", err)
+	}
+
+	// Look up + revoke old, insert new, all in one call.
+	newHash := HashToken("refresh-new")
+	gotUID, err := s.RotateRefreshToken(ctx, "refresh-old", newHash, time.Now().Add(24*time.Hour))
+	if err != nil {
+		t.Fatalf("RotateRefreshToken: %v", err)
+	}
+	if gotUID != uid {
+		t.Errorf("uid = %q, want %q", gotUID, uid)
+	}
+	// Old is now revoked.
+	if _, err := s.RotateRefreshToken(ctx, "refresh-old", newHash, time.Now().Add(24*time.Hour)); err == nil {
+		t.Error("rotating revoked token should error")
+	}
+}
+
+// --- helpers ---
+
+func mustCreateTestUser(t *testing.T, d *db.DB) string {
+	t.Helper()
+	id := mustNewUUID(t)
+	_, err := d.Exec(`INSERT INTO users (id, email, created_at)
+		VALUES ($1, $2, NOW())
+		ON CONFLICT (id) DO NOTHING`, id, id+"@test.local")
+	if err != nil {
+		t.Fatalf("create test user: %v", err)
+	}
+	return id
+}
+
+func mustNewUUID(t *testing.T) string {
+	t.Helper()
+	var s string
+	if err := newTestDBOnly(t).QueryRow("SELECT gen_random_uuid()").Scan(&s); err != nil {
+		t.Fatalf("gen_random_uuid: %v", err)
+	}
+	return s
+}
+
+func newTestDBOnly(t *testing.T) *db.DB {
+	t.Helper()
+	d, err := db.Open(os.Getenv("TEST_DATABASE_URL"))
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `cd /root/agentserver && go test -run TestStore_ ./internal/codexauth/`
+Expected: FAIL — `PkceRequest`, `HashToken`, etc. missing.
+
+- [ ] **Step 3: Append to store.go**
+
+```go
+// (append to internal/codexauth/store.go)
+
+import (
+	"crypto/sha256"
+	"time"
+)
+
+// ----- PKCE -----
+
+type PkceRequest struct {
+	Code          string
+	CodeChallenge string
+	State         string
+	UserID        string
+	ExpiresAt     time.Time
+}
+
+func (s *Store) InsertPkceRequest(ctx context.Context, r PkceRequest) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO codex_pkce_requests (code, code_challenge, state, user_id, expires_at)
+		VALUES ($1, $2, $3, $4, $5)`,
+		r.Code, r.CodeChallenge, r.State, r.UserID, r.ExpiresAt)
+	if err != nil {
+		return fmt.Errorf("insert pkce request: %w", err)
+	}
+	return nil
+}
+
+// ConsumePkceRequest atomically deletes and returns the row.
+// Returns nil if the code is missing or expired.
+func (s *Store) ConsumePkceRequest(ctx context.Context, code string) (*PkceRequest, error) {
+	var r PkceRequest
+	err := s.db.QueryRowContext(ctx, `
+		DELETE FROM codex_pkce_requests
+		WHERE code = $1 AND expires_at > NOW()
+		RETURNING code, code_challenge, state, user_id, expires_at`,
+		code).Scan(&r.Code, &r.CodeChallenge, &r.State, &r.UserID, &r.ExpiresAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("consume pkce request: %w", err)
+	}
+	return &r, nil
+}
+
+// ----- Tokens -----
+
+// HashToken returns sha256(raw) suitable for DB primary key.
+// Tokens are never stored plaintext.
+func HashToken(raw string) []byte {
+	h := sha256.Sum256([]byte(raw))
+	return h[:]
+}
+
+func (s *Store) InsertAccessToken(ctx context.Context, tokenHash []byte, userID string, expiresAt time.Time) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO codex_access_tokens (token_hash, user_id, expires_at)
+		VALUES ($1, $2, $3)`,
+		tokenHash, userID, expiresAt)
+	if err != nil {
+		return fmt.Errorf("insert access token: %w", err)
+	}
+	return nil
+}
+
+// LookupAccessToken returns the user_id if the token is valid (exists,
+// not expired, not revoked); empty string otherwise.
+func (s *Store) LookupAccessToken(ctx context.Context, rawToken string) (string, error) {
+	var userID string
+	err := s.db.QueryRowContext(ctx, `
+		SELECT user_id::text FROM codex_access_tokens
+		WHERE token_hash = $1
+		  AND expires_at > NOW()
+		  AND revoked_at IS NULL`,
+		HashToken(rawToken)).Scan(&userID)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("lookup access token: %w", err)
+	}
+	return userID, nil
+}
+
+func (s *Store) InsertRefreshToken(ctx context.Context, tokenHash []byte, familyID, userID string, expiresAt time.Time) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO codex_refresh_tokens (token_hash, family_id, user_id, expires_at)
+		VALUES ($1, $2, $3, $4)`,
+		tokenHash, familyID, userID, expiresAt)
+	if err != nil {
+		return fmt.Errorf("insert refresh token: %w", err)
+	}
+	return nil
+}
+
+// RotateRefreshToken revokes the old refresh token and inserts a new
+// one in the same family. Returns the user_id; errors if the old token
+// is missing or already revoked.
+func (s *Store) RotateRefreshToken(ctx context.Context, oldRaw string, newHash []byte, newExpiry time.Time) (string, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return "", fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	var userID, familyID string
+	err = tx.QueryRowContext(ctx, `
+		UPDATE codex_refresh_tokens
+		SET revoked_at = NOW()
+		WHERE token_hash = $1 AND revoked_at IS NULL AND expires_at > NOW()
+		RETURNING user_id::text, family_id::text`,
+		HashToken(oldRaw)).Scan(&userID, &familyID)
+	if err == sql.ErrNoRows {
+		return "", fmt.Errorf("refresh token expired or revoked")
+	}
+	if err != nil {
+		return "", fmt.Errorf("revoke old refresh: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO codex_refresh_tokens (token_hash, family_id, user_id, expires_at)
+		VALUES ($1, $2, $3, $4)`,
+		newHash, familyID, userID, newExpiry); err != nil {
+		return "", fmt.Errorf("insert new refresh: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return "", fmt.Errorf("commit: %w", err)
+	}
+	return userID, nil
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd /root/agentserver && go test -run TestStore_ ./internal/codexauth/`
+Expected: PASS, 7 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/codexauth/store.go internal/codexauth/store_test.go
+git commit -m "feat(codexauth): store layer — PKCE + access/refresh tokens"
+```
+
+---
+
+### Task A5: Store layer — Agent identities + tasks
+
+**Files:**
+- Modify: `internal/codexauth/store.go` — append
+- Modify: `internal/codexauth/store_test.go` — append tests
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `internal/codexauth/store_test.go`:
+
+```go
+func TestStore_AgentIdentity_RoundTrip(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+	uid := mustCreateTestUser(t, s.db)
+
+	kid, kp, _ := GenerateRSAKey()
+	s.InsertJwksKey(ctx, kid, kp, true)
+
+	_, pub, _ := GenerateEd25519Key()
+	rid := "exe_test_" + mustNewUUID(t)
+	if err := s.InsertAgentIdentity(ctx, AgentIdentity{
+		AgentRuntimeID: rid,
+		UserID:         uid,
+		PublicKey:      pub,
+		JWTSignedWith:  kid,
+		IssuedAt:       time.Now(),
+		ExpiresAt:      time.Now().Add(30 * 24 * time.Hour),
+	}); err != nil {
+		t.Fatalf("InsertAgentIdentity: %v", err)
+	}
+
+	got, err := s.GetAgentIdentity(ctx, rid)
+	if err != nil || got == nil {
+		t.Fatalf("GetAgentIdentity: %v %+v", err, got)
+	}
+	if got.UserID != uid || string(got.PublicKey) != string(pub) {
+		t.Errorf("got = %+v", got)
+	}
+}
+
+func TestStore_AgentTask_RoundTrip(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+	uid := mustCreateTestUser(t, s.db)
+
+	kid, kp, _ := GenerateRSAKey()
+	s.InsertJwksKey(ctx, kid, kp, true)
+	_, pub, _ := GenerateEd25519Key()
+	rid := "exe_task_" + mustNewUUID(t)
+	s.InsertAgentIdentity(ctx, AgentIdentity{
+		AgentRuntimeID: rid, UserID: uid, PublicKey: pub,
+		JWTSignedWith: kid, IssuedAt: time.Now(),
+		ExpiresAt: time.Now().Add(30 * 24 * time.Hour),
+	})
+
+	tid := "task_" + mustNewUUID(t)
+	if err := s.InsertAgentTask(ctx, tid, rid, uid, time.Now().Add(24*time.Hour)); err != nil {
+		t.Fatalf("InsertAgentTask: %v", err)
+	}
+
+	got, err := s.GetAgentTask(ctx, tid)
+	if err != nil || got == nil {
+		t.Fatalf("GetAgentTask: %v %+v", err, got)
+	}
+	if got.AgentRuntimeID != rid || got.UserID != uid {
+		t.Errorf("got = %+v", got)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `cd /root/agentserver && go test -run "TestStore_AgentIdentity|TestStore_AgentTask" ./internal/codexauth/`
+Expected: FAIL — methods missing.
+
+- [ ] **Step 3: Append to store.go**
+
+```go
+// (append to internal/codexauth/store.go)
+
+// ----- Agent Identity -----
+
+type AgentIdentity struct {
+	AgentRuntimeID string
+	UserID         string
+	PublicKey      []byte
+	JWTSignedWith  string
+	IssuedAt       time.Time
+	ExpiresAt      time.Time
+}
+
+func (s *Store) InsertAgentIdentity(ctx context.Context, a AgentIdentity) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO codex_agent_identities
+			(agent_runtime_id, user_id, public_key, jwt_signed_with, issued_at, expires_at)
+		VALUES ($1, $2, $3, $4, $5, $6)`,
+		a.AgentRuntimeID, a.UserID, a.PublicKey, a.JWTSignedWith, a.IssuedAt, a.ExpiresAt)
+	if err != nil {
+		return fmt.Errorf("insert agent identity: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) GetAgentIdentity(ctx context.Context, rid string) (*AgentIdentity, error) {
+	var a AgentIdentity
+	err := s.db.QueryRowContext(ctx, `
+		SELECT agent_runtime_id, user_id::text, public_key, jwt_signed_with, issued_at, expires_at
+		FROM codex_agent_identities
+		WHERE agent_runtime_id = $1 AND revoked_at IS NULL AND expires_at > NOW()`,
+		rid).Scan(&a.AgentRuntimeID, &a.UserID, &a.PublicKey, &a.JWTSignedWith, &a.IssuedAt, &a.ExpiresAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get agent identity: %w", err)
+	}
+	return &a, nil
+}
+
+// ----- Agent Tasks -----
+
+type AgentTask struct {
+	TaskID         string
+	AgentRuntimeID string
+	UserID         string
+	IssuedAt       time.Time
+	ExpiresAt      time.Time
+}
+
+func (s *Store) InsertAgentTask(ctx context.Context, taskID, rid, userID string, expiresAt time.Time) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO codex_agent_tasks (task_id, agent_runtime_id, user_id, issued_at, expires_at)
+		VALUES ($1, $2, $3, NOW(), $4)`,
+		taskID, rid, userID, expiresAt)
+	if err != nil {
+		return fmt.Errorf("insert agent task: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) GetAgentTask(ctx context.Context, taskID string) (*AgentTask, error) {
+	var t AgentTask
+	err := s.db.QueryRowContext(ctx, `
+		SELECT task_id, agent_runtime_id, user_id::text, issued_at, expires_at
+		FROM codex_agent_tasks
+		WHERE task_id = $1 AND expires_at > NOW()`,
+		taskID).Scan(&t.TaskID, &t.AgentRuntimeID, &t.UserID, &t.IssuedAt, &t.ExpiresAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get agent task: %w", err)
+	}
+	return &t, nil
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd /root/agentserver && go test -run "TestStore_AgentIdentity|TestStore_AgentTask" ./internal/codexauth/`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/codexauth/store.go internal/codexauth/store_test.go
+git commit -m "feat(codexauth): store layer — agent identities + tasks"
+```
+
+---
+
+### Task A6: Store layer — Device codes
+
+**Files:**
+- Modify: `internal/codexauth/store.go` — append
+- Modify: `internal/codexauth/store_test.go` — append tests
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `internal/codexauth/store_test.go`:
+
+```go
+func TestStore_DeviceCode_PendingToApproved(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+	uid := mustCreateTestUser(t, s.db)
+
+	dc := DeviceCode{
+		DeviceAuthID:      "dev-abc",
+		UserCode:          "BDWD-HQPK",
+		CodeChallenge:     "chall",
+		CodeVerifier:      "ver",
+		AuthorizationCode: "authcode-xyz",
+		Status:            "pending",
+		ExpiresAt:         time.Now().Add(15 * time.Minute),
+	}
+	if err := s.InsertDeviceCode(ctx, dc); err != nil {
+		t.Fatalf("InsertDeviceCode: %v", err)
+	}
+	// Initially pending.
+	got, _ := s.GetDeviceCodeByUserCode(ctx, "BDWD-HQPK")
+	if got == nil || got.Status != "pending" {
+		t.Fatalf("got = %+v", got)
+	}
+	// Approve.
+	if err := s.ApproveDeviceCode(ctx, "BDWD-HQPK", uid); err != nil {
+		t.Fatalf("ApproveDeviceCode: %v", err)
+	}
+	got2, _ := s.GetDeviceCodeByUserCode(ctx, "BDWD-HQPK")
+	if got2.Status != "approved" || got2.UserID != uid {
+		t.Errorf("after approve: %+v", got2)
+	}
+}
+
+func TestStore_DeviceCode_ExchangeOnceOnly(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+	uid := mustCreateTestUser(t, s.db)
+
+	dc := DeviceCode{
+		DeviceAuthID:      "dev-only-once",
+		UserCode:          "ABCD-EFGH",
+		CodeChallenge:     "chall",
+		CodeVerifier:      "ver",
+		AuthorizationCode: "authcode-xyz",
+		Status:            "pending",
+		ExpiresAt:         time.Now().Add(15 * time.Minute),
+	}
+	s.InsertDeviceCode(ctx, dc)
+	s.ApproveDeviceCode(ctx, "ABCD-EFGH", uid)
+	got, err := s.ExchangeDeviceCode(ctx, "dev-only-once", "ABCD-EFGH")
+	if err != nil || got == nil {
+		t.Fatalf("first exchange: %v %+v", err, got)
+	}
+	got2, _ := s.ExchangeDeviceCode(ctx, "dev-only-once", "ABCD-EFGH")
+	if got2 != nil {
+		t.Error("second exchange should return nil (single-use)")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `cd /root/agentserver && go test -run TestStore_DeviceCode ./internal/codexauth/`
+Expected: FAIL.
+
+- [ ] **Step 3: Append to store.go**
+
+```go
+// (append to internal/codexauth/store.go)
+
+// ----- Device Codes -----
+
+type DeviceCode struct {
+	DeviceAuthID      string
+	UserCode          string
+	CodeChallenge     string
+	CodeVerifier      string
+	AuthorizationCode string
+	Status            string
+	UserID            string
+	ExpiresAt         time.Time
+	ApprovedAt        *time.Time
+}
+
+func (s *Store) InsertDeviceCode(ctx context.Context, dc DeviceCode) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO codex_device_codes
+			(device_auth_id, user_code, code_challenge, code_verifier,
+			 authorization_code, status, expires_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+		dc.DeviceAuthID, dc.UserCode, dc.CodeChallenge, dc.CodeVerifier,
+		dc.AuthorizationCode, dc.Status, dc.ExpiresAt)
+	if err != nil {
+		return fmt.Errorf("insert device code: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) GetDeviceCodeByUserCode(ctx context.Context, userCode string) (*DeviceCode, error) {
+	var dc DeviceCode
+	var uid sql.NullString
+	err := s.db.QueryRowContext(ctx, `
+		SELECT device_auth_id, user_code, code_challenge, code_verifier,
+		       authorization_code, status, COALESCE(user_id::text, ''), expires_at
+		FROM codex_device_codes
+		WHERE user_code = $1 AND expires_at > NOW()`,
+		userCode).Scan(&dc.DeviceAuthID, &dc.UserCode, &dc.CodeChallenge,
+		&dc.CodeVerifier, &dc.AuthorizationCode, &dc.Status, &uid, &dc.ExpiresAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get device code: %w", err)
+	}
+	if uid.Valid {
+		dc.UserID = uid.String
+	}
+	return &dc, nil
+}
+
+func (s *Store) ApproveDeviceCode(ctx context.Context, userCode, userID string) error {
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE codex_device_codes
+		SET status = 'approved', user_id = $2, approved_at = NOW()
+		WHERE user_code = $1 AND status = 'pending' AND expires_at > NOW()`,
+		userCode, userID)
+	if err != nil {
+		return fmt.Errorf("approve device code: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("user_code not found or not pending")
+	}
+	return nil
+}
+
+// ExchangeDeviceCode atomically returns the row and marks it 'exchanged'.
+// Only approved rows are returned; subsequent calls return nil.
+func (s *Store) ExchangeDeviceCode(ctx context.Context, deviceAuthID, userCode string) (*DeviceCode, error) {
+	var dc DeviceCode
+	var uid sql.NullString
+	err := s.db.QueryRowContext(ctx, `
+		UPDATE codex_device_codes
+		SET status = 'exchanged'
+		WHERE device_auth_id = $1 AND user_code = $2 AND status = 'approved' AND expires_at > NOW()
+		RETURNING device_auth_id, user_code, code_challenge, code_verifier,
+		          authorization_code, status, COALESCE(user_id::text, ''), expires_at`,
+		deviceAuthID, userCode).Scan(&dc.DeviceAuthID, &dc.UserCode, &dc.CodeChallenge,
+		&dc.CodeVerifier, &dc.AuthorizationCode, &dc.Status, &uid, &dc.ExpiresAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("exchange device code: %w", err)
+	}
+	if uid.Valid {
+		dc.UserID = uid.String
+	}
+	return &dc, nil
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd /root/agentserver && go test -run TestStore_DeviceCode ./internal/codexauth/`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/codexauth/store.go internal/codexauth/store_test.go
+git commit -m "feat(codexauth): store layer — device codes"
+```
+
+---
+
+### Task A7: Claims builders + JWT signer
+
+**Files:**
+- Create: `internal/codexauth/claims.go`
+- Create: `internal/codexauth/claims_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+```go
+// internal/codexauth/claims_test.go
+package codexauth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildIDToken_CarriesOpenAIClaim(t *testing.T) {
+	kid, kp, _ := GenerateRSAKey()
+	issuer := "https://example/codex-auth"
+	jwt, err := BuildIDToken(kp.PrivateKey, kid, IDTokenClaims{
+		Issuer:   issuer,
+		Subject:  "user-abc",
+		Email:    "u@test",
+		ExpiresAt: time.Now().Add(1 * time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("BuildIDToken: %v", err)
+	}
+	// header.payload.signature — three parts
+	parts := strings.Split(jwt, ".")
+	if len(parts) != 3 {
+		t.Fatalf("not 3-part JWT: %d parts", len(parts))
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// The nested OpenAI claim is critical — codex parses it.
+	oai, ok := claims["https://api.openai.com/auth"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing https://api.openai.com/auth claim: %v", claims)
+	}
+	if oai["chatgpt_account_id"] != "user-abc" {
+		t.Errorf("chatgpt_account_id = %v", oai["chatgpt_account_id"])
+	}
+	if oai["chatgpt_plan_type"] != "pro" {
+		t.Errorf("chatgpt_plan_type = %v", oai["chatgpt_plan_type"])
+	}
+}
+
+func TestBuildAgentIdentityJWT_IsCodexParseable(t *testing.T) {
+	kid, kp, _ := GenerateRSAKey()
+	_, pub, _ := GenerateEd25519Key()
+	priv, _, _ := GenerateEd25519Key()
+	jwt, err := BuildAgentIdentityJWT(kp.PrivateKey, kid, AgentIdentityClaims{
+		AgentRuntimeID:   "exe_xyz",
+		AgentPrivateKeyPKCS8: priv,
+		AccountID:        "u-1",
+		ChatgptUserID:    "u-1",
+		Email:            "u@test",
+		PlanType:         "pro",
+		ExpiresAt:        time.Now().Add(30 * 24 * time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("BuildAgentIdentityJWT: %v", err)
+	}
+	parts := strings.Split(jwt, ".")
+	payload, _ := base64.RawURLEncoding.DecodeString(parts[1])
+	var claims map[string]any
+	json.Unmarshal(payload, &claims)
+	// Codex enforces these literals (agent-identity/src/lib.rs:163-166).
+	if claims["iss"] != "https://chatgpt.com/codex-backend/agent-identity" {
+		t.Errorf("iss = %v", claims["iss"])
+	}
+	if claims["aud"] != "codex-app-server" {
+		t.Errorf("aud = %v", claims["aud"])
+	}
+	// agent_private_key is base64(PKCS#8 DER) of an Ed25519 key.
+	apk, _ := claims["agent_private_key"].(string)
+	if apk == "" {
+		t.Error("agent_private_key missing")
+	}
+	_ = pub // referenced for future tests; not asserted here
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `cd /root/agentserver && go test -run "TestBuildIDToken|TestBuildAgentIdentityJWT" ./internal/codexauth/`
+Expected: FAIL — `BuildIDToken`, `BuildAgentIdentityJWT` missing.
+
+- [ ] **Step 3: Implement claims.go**
+
+```go
+// internal/codexauth/claims.go
+package codexauth
+
+import (
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+)
+
+// IDTokenClaims is the subset of fields we populate for the OpenAI-shaped
+// id_token. Codex never verifies the signature, but it base64-decodes
+// the payload and looks for the nested OpenAI claim.
+type IDTokenClaims struct {
+	Issuer    string
+	Subject   string
+	Email     string
+	ExpiresAt time.Time
+}
+
+// BuildIDToken returns a signed RS256 JWT with the OpenAI-nested claim
+// that codex's `compose_success_url` and `jwt_auth_claims` paths expect
+// (login/src/server.rs:821-907).
+func BuildIDToken(key *rsa.PrivateKey, kid string, c IDTokenClaims) (string, error) {
+	payload := map[string]any{
+		"iss":   c.Issuer,
+		"sub":   c.Subject,
+		"aud":   "app_EMoamEEZ73f0CkXaXp7hrann",
+		"iat":   time.Now().Unix(),
+		"exp":   c.ExpiresAt.Unix(),
+		"email": c.Email,
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_account_id":              c.Subject,
+			"chatgpt_plan_type":               "pro",
+			"organization_id":                 "org_agentserver",
+			"project_id":                      "proj_default",
+			"completed_platform_onboarding":   true,
+			"is_org_owner":                    true,
+		},
+	}
+	return signRS256(key, kid, payload)
+}
+
+// AgentIdentityClaims is the JWT codex's exec-server --remote
+// --use-agent-identity-auth requires (agent-identity/src/lib.rs:65-78).
+type AgentIdentityClaims struct {
+	AgentRuntimeID       string
+	AgentPrivateKeyPKCS8 []byte
+	AccountID            string
+	ChatgptUserID        string
+	Email                string
+	PlanType             string
+	ExpiresAt            time.Time
+}
+
+// BuildAgentIdentityJWT returns an RS256 JWT whose claims pass codex's
+// strict aud="codex-app-server" + iss=".../agent-identity" check.
+func BuildAgentIdentityJWT(key *rsa.PrivateKey, kid string, c AgentIdentityClaims) (string, error) {
+	payload := map[string]any{
+		"iss":                          "https://chatgpt.com/codex-backend/agent-identity",
+		"aud":                          "codex-app-server",
+		"iat":                          time.Now().Unix(),
+		"exp":                          c.ExpiresAt.Unix(),
+		"agent_runtime_id":             c.AgentRuntimeID,
+		"agent_private_key":            base64.StdEncoding.EncodeToString(c.AgentPrivateKeyPKCS8),
+		"account_id":                   c.AccountID,
+		"chatgpt_user_id":              c.ChatgptUserID,
+		"email":                        c.Email,
+		"plan_type":                    c.PlanType,
+		"chatgpt_account_is_fedramp":   false,
+	}
+	return signRS256(key, kid, payload)
+}
+
+func signRS256(key *rsa.PrivateKey, kid string, payload map[string]any) (string, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal payload: %w", err)
+	}
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: key},
+		(&jose.SignerOptions{}).WithType("JWT").WithHeader("kid", kid),
+	)
+	if err != nil {
+		return "", fmt.Errorf("new signer: %w", err)
+	}
+	jws, err := signer.Sign(body)
+	if err != nil {
+		return "", fmt.Errorf("sign: %w", err)
+	}
+	return jws.CompactSerialize()
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd /root/agentserver && go test -run "TestBuildIDToken|TestBuildAgentIdentityJWT" ./internal/codexauth/`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Ensure go-jose is a direct dependency**
+
+```bash
+cd /root/agentserver && go mod tidy
+go test ./internal/codexauth/...
+```
+
+Expected: all green, `github.com/go-jose/go-jose/v4` moves out of `// indirect` in go.mod.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/codexauth/claims.go internal/codexauth/claims_test.go go.mod go.sum
+git commit -m "feat(codexauth): id_token + Agent Identity JWT claims + RS256 signing"
+```
+
+---
+
+### PR 1 wrap-up
+
+- [ ] Run full package tests
+
+```bash
+cd /root/agentserver && go test ./internal/codexauth/...
+```
+
+Expected: all tests pass.
+
+- [ ] Open PR
+
+```bash
+git push -u github feature/codexauth-scaffolding
+gh pr create --base main \
+  --title "feat(codexauth): scaffolding — schema, store, keys, claims" \
+  --body "Phase A of spec docs/superpowers/specs/2026-05-20-codex-0.132-auth.md.
+Schema migration 025, store layer for all 7 tables, RSA + Ed25519 key generation,
+id_token + Agent Identity JWT claims builders. No HTTP routes wired yet."
+```
+
+---
+
+## Phase B — ChatGPT Login: PKCE + Device Flow (PR 2)
+
+Tasks B1-B7. End state: a fresh `codex login --issuer https://localhost/codex-auth` AND `codex login --device-auth --issuer …` both complete against an ephemeral test server.
+
+### Task B1: Server struct + route mount
+
+**Files:**
+- Create: `internal/codexauth/server.go`
+- Create: `internal/codexauth/server_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+```go
+// internal/codexauth/server_test.go
+package codexauth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestServer_MountRegistersAllRoutes(t *testing.T) {
+	s := &Server{IssuerURL: "https://example/codex-auth"}
+	r := chi.NewRouter()
+	s.Mount(r)
+
+	// Assert each route at least returns non-404 (will return 4xx/405 for
+	// missing handlers/wrong methods, but the route must be registered).
+	want := []string{
+		"/oauth/authorize",
+		"/oauth/token",
+		"/agent-identities/jwks",
+		"/codex/device",
+		"/api/accounts/deviceauth/usercode",
+		"/api/accounts/deviceauth/token",
+	}
+	for _, path := range want {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+		if rr.Code == http.StatusNotFound {
+			t.Errorf("route %s not registered (404)", path)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `cd /root/agentserver && go test -run TestServer_Mount ./internal/codexauth/`
+Expected: FAIL — `Server` missing.
+
+- [ ] **Step 3: Implement server.go**
+
+```go
+// internal/codexauth/server.go
+package codexauth
+
+import (
+	"crypto/rsa"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// SessionResolver returns the user_id for the request's session cookie,
+// or empty string if unauthenticated. agentserver supplies its existing
+// session middleware here.
+type SessionResolver func(r *http.Request) string
+
+// Server is the user-facing codex-auth HTTP surface (PKCE / device flow /
+// JWKS / agent-identity), all mounted under a single chi subrouter.
+type Server struct {
+	Store          *Store
+	IssuerURL      string          // e.g. "https://agent.cs.ac.cn/codex-auth"
+	SigningKey     *rsa.PrivateKey // active RSA key for id_token + Agent Identity JWT
+	SigningKid     string
+	SessionResolve SessionResolver
+	LoginRedirectURL string         // where /oauth/authorize sends unauth users
+}
+
+// Mount registers all codex-auth routes onto r. Routes are mounted
+// without a prefix; the caller decides where this subtree lives
+// (typically /codex-auth/* on agentserver's outermost router).
+func (s *Server) Mount(r chi.Router) {
+	r.Get("/oauth/authorize", s.handleAuthorize)
+	r.Post("/oauth/token", s.handleToken)
+
+	r.Get("/agent-identities/jwks", s.handleJWKS)
+	r.Post("/v1/agent/{rid}/task/register", s.handleTaskRegister)
+
+	r.Post("/api/accounts/deviceauth/usercode", s.handleDeviceUserCode)
+	r.Post("/api/accounts/deviceauth/token", s.handleDeviceToken)
+	r.Get("/codex/device", s.handleDeviceVerifyPage)
+	r.Post("/codex/device", s.handleDeviceVerifySubmit)
+}
+
+// All handlers are stubs initially; subsequent tasks fill them in.
+// Returning a clear "not implemented" so tests can detect missing wiring.
+func (s *Server) handleAuthorize(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "authorize: not implemented", http.StatusNotImplemented)
+}
+func (s *Server) handleToken(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "token: not implemented", http.StatusNotImplemented)
+}
+func (s *Server) handleJWKS(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "jwks: not implemented", http.StatusNotImplemented)
+}
+func (s *Server) handleTaskRegister(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "task register: not implemented", http.StatusNotImplemented)
+}
+func (s *Server) handleDeviceUserCode(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "device usercode: not implemented", http.StatusNotImplemented)
+}
+func (s *Server) handleDeviceToken(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "device token: not implemented", http.StatusNotImplemented)
+}
+func (s *Server) handleDeviceVerifyPage(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "device verify page: not implemented", http.StatusNotImplemented)
+}
+func (s *Server) handleDeviceVerifySubmit(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "device verify submit: not implemented", http.StatusNotImplemented)
+}
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+Run: `cd /root/agentserver && go test -run TestServer_Mount ./internal/codexauth/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/codexauth/server.go internal/codexauth/server_test.go
+git commit -m "feat(codexauth): Server struct + route mount stubs"
+```
+
+---
+
+### Task B2: PKCE — GET /oauth/authorize
+
+**Files:**
+- Create: `internal/codexauth/pkce.go`
+- Create: `internal/codexauth/pkce_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+```go
+// internal/codexauth/pkce_test.go
+package codexauth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestAuthorize_RedirectsUnauthToLogin(t *testing.T) {
+	srv := newTestServer(t, "")
+	r := chi.NewRouter()
+	srv.Mount(r)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/oauth/authorize?state=xyz&code_challenge=abc&redirect_uri=http://localhost:1455/auth/callback", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302", rr.Code)
+	}
+	loc, _ := url.Parse(rr.Header().Get("Location"))
+	if loc.Path != "/login" {
+		t.Errorf("redirect path = %q, want /login", loc.Path)
+	}
+	if loc.Query().Get("next") == "" {
+		t.Error("missing next param on login redirect")
+	}
+}
+
+func TestAuthorize_AuthedRedirectsToRedirectURIWithCode(t *testing.T) {
+	srv := newTestServer(t, "user-abc")
+	r := chi.NewRouter()
+	srv.Mount(r)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/oauth/authorize?state=st-1&code_challenge=ch-1&redirect_uri=http://localhost:1455/auth/callback", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302", rr.Code)
+	}
+	loc, _ := url.Parse(rr.Header().Get("Location"))
+	if loc.Host != "localhost:1455" || loc.Path != "/auth/callback" {
+		t.Errorf("redirect = %s", loc.String())
+	}
+	q := loc.Query()
+	if q.Get("state") != "st-1" {
+		t.Errorf("state = %q", q.Get("state"))
+	}
+	if q.Get("code") == "" {
+		t.Error("missing code")
+	}
+}
+
+// newTestServer builds a Server backed by the real test DB with a fixed
+// session user.
+func newTestServer(t *testing.T, sessionUserID string) *Server {
+	t.Helper()
+	store, _ := newTestStore(t)
+	kid, kp, _ := GenerateRSAKey()
+	ctx := context.Background()
+	store.InsertJwksKey(ctx, kid, kp, true)
+	// Pre-create the user if the test wants an authed session.
+	if sessionUserID != "" {
+		store.db.Exec(`INSERT INTO users (id, email, created_at)
+			VALUES ($1, $2, NOW()) ON CONFLICT DO NOTHING`,
+			sessionUserID, sessionUserID+"@test.local")
+	}
+	return &Server{
+		Store:      store,
+		IssuerURL:  "https://test/codex-auth",
+		SigningKey: kp.PrivateKey,
+		SigningKid: kid,
+		SessionResolve: func(r *http.Request) string { return sessionUserID },
+		LoginRedirectURL: "/login",
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `cd /root/agentserver && go test -run TestAuthorize_ ./internal/codexauth/`
+Expected: FAIL — `handleAuthorize` returns 501.
+
+- [ ] **Step 3: Implement pkce.go authorize**
+
+```go
+// internal/codexauth/pkce.go
+package codexauth
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	pkceCodeTTL        = 10 * time.Minute
+	accessTokenTTL     = 1 * time.Hour
+	refreshTokenTTL    = 365 * 24 * time.Hour
+)
+
+func (s *Server) handleAuthorize(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	state := q.Get("state")
+	challenge := q.Get("code_challenge")
+	redirectURI := q.Get("redirect_uri")
+	if state == "" || challenge == "" || redirectURI == "" {
+		http.Error(w, "missing required oauth params (state, code_challenge, redirect_uri)",
+			http.StatusBadRequest)
+		return
+	}
+
+	userID := s.SessionResolve(r)
+	if userID == "" {
+		next := url.QueryEscape(r.URL.RequestURI())
+		http.Redirect(w, r, s.LoginRedirectURL+"?next="+next, http.StatusFound)
+		return
+	}
+
+	code := mustRandomHex(32)
+	if err := s.Store.InsertPkceRequest(r.Context(), PkceRequest{
+		Code:          code,
+		CodeChallenge: challenge,
+		State:         state,
+		UserID:        userID,
+		ExpiresAt:     time.Now().Add(pkceCodeTTL),
+	}); err != nil {
+		http.Error(w, "store: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Redirect back to the codex local callback server with code + state.
+	dest, err := url.Parse(redirectURI)
+	if err != nil {
+		http.Error(w, "bad redirect_uri", http.StatusBadRequest)
+		return
+	}
+	dq := dest.Query()
+	dq.Set("code", code)
+	dq.Set("state", state)
+	dest.RawQuery = dq.Encode()
+	http.Redirect(w, r, dest.String(), http.StatusFound)
+}
+
+func mustRandomHex(n int) string {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		panic("rand: " + err.Error())
+	}
+	return hex.EncodeToString(b)
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v) //nolint:errcheck
+}
+
+func writeOauthError(w http.ResponseWriter, status int, code, desc string) {
+	writeJSON(w, status, map[string]string{
+		"error":             code,
+		"error_description": desc,
+	})
+}
+
+// pkceVerifierMatches implements RFC 7636 S256:
+// base64url_no_pad(sha256(code_verifier)) == code_challenge.
+func pkceVerifierMatches(verifier, challenge string) bool {
+	sum := sha256Sum([]byte(verifier))
+	expected := base64URLNoPad(sum)
+	return expected == strings.TrimRight(challenge, "=")
+}
+```
+
+- [ ] **Step 4: Add sha256 helper (new file to keep pkce.go focused)**
+
+Create `internal/codexauth/internal_helpers.go`:
+
+```go
+// internal/codexauth/internal_helpers.go
+package codexauth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+)
+
+func sha256Sum(b []byte) []byte {
+	h := sha256.Sum256(b)
+	return h[:]
+}
+
+func base64URLNoPad(b []byte) string {
+	return base64.RawURLEncoding.EncodeToString(b)
+}
+```
+
+- [ ] **Step 5: Run test to verify pass**
+
+Run: `cd /root/agentserver && go test -run TestAuthorize_ ./internal/codexauth/`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/codexauth/pkce.go internal/codexauth/pkce_test.go internal/codexauth/internal_helpers.go
+git commit -m "feat(codexauth): GET /oauth/authorize handler"
+```
+
+---
+
+### Task B3: PKCE — POST /oauth/token grant_type=authorization_code
+
+**Files:**
+- Modify: `internal/codexauth/pkce.go` — replace handleToken
+- Modify: `internal/codexauth/pkce_test.go` — append tests
+
+- [ ] **Step 1: Write failing test**
+
+Append to `internal/codexauth/pkce_test.go`:
+
+```go
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+)
+
+func TestToken_AuthorizationCode_ReturnsTriplet(t *testing.T) {
+	srv := newTestServer(t, "")
+	ctx := context.Background()
+
+	// Pre-seed an authorize row.
+	uid := mustCreateTestUser(t, srv.Store.db)
+	verifier := strings.Repeat("a", 48)
+	challenge := base64URLNoPad(sha256Sum([]byte(verifier)))
+	srv.Store.InsertPkceRequest(ctx, PkceRequest{
+		Code:          "code-xyz",
+		CodeChallenge: challenge,
+		State:         "irrelevant",
+		UserID:        uid,
+		ExpiresAt:     time.Now().Add(5 * time.Minute),
+	})
+
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", "code-xyz")
+	form.Set("code_verifier", verifier)
+	form.Set("redirect_uri", "http://localhost:1455/auth/callback")
+	form.Set("client_id", "app_EMoamEEZ73f0CkXaXp7hrann")
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	r := chi.NewRouter()
+	srv.Mount(r)
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		body, _ := io.ReadAll(rr.Body)
+		t.Fatalf("status = %d, body = %s", rr.Code, body)
+	}
+	var resp struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		IDToken      string `json:"id_token"`
+		TokenType    string `json:"token_type"`
+		ExpiresIn    int    `json:"expires_in"`
+	}
+	json.NewDecoder(rr.Body).Decode(&resp)
+	if resp.AccessToken == "" || resp.RefreshToken == "" || resp.IDToken == "" {
+		t.Fatalf("missing fields: %+v", resp)
+	}
+	if resp.TokenType != "Bearer" {
+		t.Errorf("token_type = %q", resp.TokenType)
+	}
+}
+
+func TestToken_AuthorizationCode_BadVerifierRejected(t *testing.T) {
+	srv := newTestServer(t, "")
+	ctx := context.Background()
+	uid := mustCreateTestUser(t, srv.Store.db)
+	srv.Store.InsertPkceRequest(ctx, PkceRequest{
+		Code:          "code-bad",
+		CodeChallenge: "different-challenge",
+		State:         "x",
+		UserID:        uid,
+		ExpiresAt:     time.Now().Add(5 * time.Minute),
+	})
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", "code-bad")
+	form.Set("code_verifier", "wrong-verifier")
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	r := chi.NewRouter()
+	srv.Mount(r)
+	r.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rr.Code)
+	}
+}
+
+func TestToken_TokenExchange_ReturnsBadRequest(t *testing.T) {
+	srv := newTestServer(t, "")
+	form := url.Values{}
+	form.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
+	form.Set("requested_token", "openai-api-key")
+	form.Set("subject_token", "irrelevant")
+	form.Set("subject_token_type", "urn:ietf:params:oauth:token-type:id_token")
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	r := chi.NewRouter()
+	srv.Mount(r)
+	r.ServeHTTP(rr, req)
+	// Codex tolerates failure (server.rs:352-354) — return 400 to opt out.
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rr.Code)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `cd /root/agentserver && go test -run TestToken_ ./internal/codexauth/`
+Expected: FAIL — handleToken stub returns 501.
+
+- [ ] **Step 3: Implement handleToken**
+
+Replace the stub in `pkce.go`:
+
+```go
+// internal/codexauth/pkce.go — replace handleToken stub with this
+
+func (s *Server) handleToken(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeOauthError(w, http.StatusBadRequest, "invalid_request", "parse form: "+err.Error())
+		return
+	}
+	switch r.PostForm.Get("grant_type") {
+	case "authorization_code":
+		s.handleTokenAuthorizationCode(w, r)
+	case "refresh_token":
+		s.handleTokenRefresh(w, r)
+	case "urn:ietf:params:oauth:grant-type:token-exchange":
+		// We don't have an OpenAI sk-... to give back. Codex tolerates the
+		// failure (login/src/server.rs:352-354).
+		writeOauthError(w, http.StatusBadRequest, "unsupported_grant_type",
+			"token-exchange to OpenAI API key is not supported on this issuer")
+	default:
+		writeOauthError(w, http.StatusBadRequest, "unsupported_grant_type",
+			r.PostForm.Get("grant_type"))
+	}
+}
+
+func (s *Server) handleTokenAuthorizationCode(w http.ResponseWriter, r *http.Request) {
+	code := r.PostForm.Get("code")
+	verifier := r.PostForm.Get("code_verifier")
+	if code == "" || verifier == "" {
+		writeOauthError(w, http.StatusBadRequest, "invalid_request",
+			"code and code_verifier required")
+		return
+	}
+
+	req, err := s.Store.ConsumePkceRequest(r.Context(), code)
+	if err != nil {
+		writeOauthError(w, http.StatusInternalServerError, "server_error", err.Error())
+		return
+	}
+	if req == nil {
+		writeOauthError(w, http.StatusBadRequest, "invalid_grant",
+			"code unknown or expired")
+		return
+	}
+	if !pkceVerifierMatches(verifier, req.CodeChallenge) {
+		writeOauthError(w, http.StatusBadRequest, "invalid_grant",
+			"code_verifier does not match code_challenge")
+		return
+	}
+
+	s.mintTokensFor(w, r, req.UserID)
+}
+
+// mintTokensFor mints access + refresh + id_token and writes the codex-
+// shaped response. Shared by authorization_code, refresh_token, and the
+// device-flow exchange path.
+func (s *Server) mintTokensFor(w http.ResponseWriter, r *http.Request, userID string) {
+	ctx := r.Context()
+	access := mustRandomHex(32)
+	refresh := mustRandomHex(32)
+
+	accessExp := time.Now().Add(accessTokenTTL)
+	if err := s.Store.InsertAccessToken(ctx, HashToken(access), userID, accessExp); err != nil {
+		writeOauthError(w, http.StatusInternalServerError, "server_error", err.Error())
+		return
+	}
+	familyID := mustNewUUIDString()
+	if err := s.Store.InsertRefreshToken(ctx, HashToken(refresh), familyID, userID,
+		time.Now().Add(refreshTokenTTL)); err != nil {
+		writeOauthError(w, http.StatusInternalServerError, "server_error", err.Error())
+		return
+	}
+
+	email := s.lookupEmail(ctx, userID)
+	idTok, err := BuildIDToken(s.SigningKey, s.SigningKid, IDTokenClaims{
+		Issuer:    s.IssuerURL,
+		Subject:   userID,
+		Email:     email,
+		ExpiresAt: accessExp,
+	})
+	if err != nil {
+		writeOauthError(w, http.StatusInternalServerError, "server_error",
+			"build id_token: "+err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"id_token":      idTok,
+		"access_token":  access,
+		"refresh_token": refresh,
+		"token_type":    "Bearer",
+		"expires_in":    int(accessTokenTTL.Seconds()),
+	})
+}
+
+func (s *Server) lookupEmail(ctx context.Context, userID string) string {
+	var email string
+	_ = s.Store.db.QueryRowContext(ctx,
+		`SELECT email FROM users WHERE id = $1`, userID).Scan(&email)
+	if email == "" {
+		email = userID + "@agent.cs.ac.cn"
+	}
+	return email
+}
+
+func mustNewUUIDString() string {
+	// Generate UUIDv4 via crypto/rand without pulling in a new dep.
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic("rand: " + err.Error())
+	}
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
+}
+```
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd /root/agentserver && go test -run TestToken_AuthorizationCode ./internal/codexauth/`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/codexauth/pkce.go internal/codexauth/pkce_test.go
+git commit -m "feat(codexauth): POST /oauth/token grant_type=authorization_code"
+```
+
+---
+
+### Task B4: PKCE — refresh_token grant
+
+**Files:**
+- Modify: `internal/codexauth/pkce.go` — implement handleTokenRefresh
+- Modify: `internal/codexauth/pkce_test.go` — append
+
+- [ ] **Step 1: Write failing test**
+
+Append to `internal/codexauth/pkce_test.go`:
+
+```go
+func TestToken_Refresh_RotatesTokens(t *testing.T) {
+	srv := newTestServer(t, "")
+	ctx := context.Background()
+	uid := mustCreateTestUser(t, srv.Store.db)
+
+	// Issue an initial refresh token directly.
+	srv.Store.InsertRefreshToken(ctx, HashToken("old-refresh"), mustNewUUIDString(), uid,
+		time.Now().Add(7*24*time.Hour))
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", "old-refresh")
+	form.Set("client_id", "app_EMoamEEZ73f0CkXaXp7hrann")
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	r := chi.NewRouter()
+	srv.Mount(r)
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rr.Code, rr.Body.String())
+	}
+	var resp struct{ AccessToken, RefreshToken string }
+	json.NewDecoder(rr.Body).Decode(&resp)
+	if resp.AccessToken == "" || resp.RefreshToken == "" || resp.RefreshToken == "old-refresh" {
+		t.Errorf("bad rotated tokens: %+v", resp)
+	}
+}
+
+func TestToken_Refresh_ExpiredReturnsTerminalError(t *testing.T) {
+	srv := newTestServer(t, "")
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", "never-issued")
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	r := chi.NewRouter()
+	srv.Mount(r)
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rr.Code)
+	}
+	var resp map[string]string
+	json.NewDecoder(rr.Body).Decode(&resp)
+	// Codex treats these specific error codes as terminal (manager.rs:1050+).
+	switch resp["error"] {
+	case "refresh_token_expired", "refresh_token_reused", "refresh_token_invalidated":
+		// OK
+	default:
+		t.Errorf("error = %q; expected one of refresh_token_{expired,reused,invalidated}",
+			resp["error"])
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `cd /root/agentserver && go test -run TestToken_Refresh ./internal/codexauth/`
+Expected: FAIL — handleTokenRefresh missing.
+
+- [ ] **Step 3: Implement handleTokenRefresh**
+
+Append to `pkce.go`:
+
+```go
+func (s *Server) handleTokenRefresh(w http.ResponseWriter, r *http.Request) {
+	raw := r.PostForm.Get("refresh_token")
+	if raw == "" {
+		writeOauthError(w, http.StatusBadRequest, "invalid_request",
+			"refresh_token required")
+		return
+	}
+	newRefresh := mustRandomHex(32)
+	userID, err := s.Store.RotateRefreshToken(r.Context(), raw,
+		HashToken(newRefresh), time.Now().Add(refreshTokenTTL))
+	if err != nil {
+		writeOauthError(w, http.StatusUnauthorized, "refresh_token_expired", err.Error())
+		return
+	}
+
+	access := mustRandomHex(32)
+	accessExp := time.Now().Add(accessTokenTTL)
+	if err := s.Store.InsertAccessToken(r.Context(), HashToken(access), userID, accessExp); err != nil {
+		writeOauthError(w, http.StatusInternalServerError, "server_error", err.Error())
+		return
+	}
+
+	email := s.lookupEmail(r.Context(), userID)
+	idTok, err := BuildIDToken(s.SigningKey, s.SigningKid, IDTokenClaims{
+		Issuer:    s.IssuerURL,
+		Subject:   userID,
+		Email:     email,
+		ExpiresAt: accessExp,
+	})
+	if err != nil {
+		writeOauthError(w, http.StatusInternalServerError, "server_error", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"id_token":      idTok,
+		"access_token":  access,
+		"refresh_token": newRefresh,
+		"token_type":    "Bearer",
+		"expires_in":    int(accessTokenTTL.Seconds()),
+	})
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd /root/agentserver && go test -run TestToken_Refresh ./internal/codexauth/`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/codexauth/pkce.go internal/codexauth/pkce_test.go
+git commit -m "feat(codexauth): POST /oauth/token grant_type=refresh_token"
+```
+
+---
+
+### Task B5: Device flow — usercode + token endpoints
+
+**Files:**
+- Create: `internal/codexauth/device.go`
+- Create: `internal/codexauth/device_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+```go
+// internal/codexauth/device_test.go
+package codexauth
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestDeviceUserCode_ReturnsPendingRow(t *testing.T) {
+	srv := newTestServer(t, "")
+	r := chi.NewRouter()
+	srv.Mount(r)
+
+	body := bytes.NewReader([]byte(`{"client_id":"app_EMoamEEZ73f0CkXaXp7hrann"}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/accounts/deviceauth/usercode", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		DeviceAuthID string `json:"device_auth_id"`
+		UserCode     string `json:"user_code"`
+		Interval     int    `json:"interval"`
+	}
+	json.NewDecoder(rr.Body).Decode(&resp)
+	if resp.DeviceAuthID == "" || resp.UserCode == "" || resp.Interval == 0 {
+		t.Errorf("missing fields: %+v", resp)
+	}
+}
+
+func TestDeviceToken_PendingReturns403(t *testing.T) {
+	srv := newTestServer(t, "")
+	// Create a pending row.
+	ctx := context.Background()
+	srv.Store.InsertDeviceCode(ctx, DeviceCode{
+		DeviceAuthID:      "dev-pending",
+		UserCode:          "PEND-PEND",
+		CodeChallenge:     "c",
+		CodeVerifier:      "v",
+		AuthorizationCode: "a",
+		Status:            "pending",
+		ExpiresAt:         time.Now().Add(15 * time.Minute),
+	})
+
+	body, _ := json.Marshal(map[string]string{"device_auth_id": "dev-pending", "user_code": "PEND-PEND"})
+	req := httptest.NewRequest(http.MethodPost, "/api/accounts/deviceauth/token", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r := chi.NewRouter()
+	srv.Mount(r)
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", rr.Code)
+	}
+}
+
+func TestDeviceToken_ApprovedReturnsAuthCode(t *testing.T) {
+	srv := newTestServer(t, "")
+	ctx := context.Background()
+	uid := mustCreateTestUser(t, srv.Store.db)
+	srv.Store.InsertDeviceCode(ctx, DeviceCode{
+		DeviceAuthID:      "dev-ok",
+		UserCode:          "GOOD-CODE",
+		CodeChallenge:     "ch-1",
+		CodeVerifier:      "ver-1",
+		AuthorizationCode: "ac-1",
+		Status:            "pending",
+		ExpiresAt:         time.Now().Add(15 * time.Minute),
+	})
+	srv.Store.ApproveDeviceCode(ctx, "GOOD-CODE", uid)
+
+	body, _ := json.Marshal(map[string]string{"device_auth_id": "dev-ok", "user_code": "GOOD-CODE"})
+	req := httptest.NewRequest(http.MethodPost, "/api/accounts/deviceauth/token", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r := chi.NewRouter()
+	srv.Mount(r)
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		AuthorizationCode string `json:"authorization_code"`
+		CodeChallenge     string `json:"code_challenge"`
+		CodeVerifier      string `json:"code_verifier"`
+	}
+	json.NewDecoder(rr.Body).Decode(&resp)
+	if resp.AuthorizationCode != "ac-1" || resp.CodeChallenge != "ch-1" || resp.CodeVerifier != "ver-1" {
+		t.Errorf("got = %+v", resp)
+	}
+
+	// AND the device row should now have a matching pkce_requests row,
+	// so the subsequent /oauth/token call works.
+	var n int
+	srv.Store.db.QueryRow(`SELECT COUNT(*) FROM codex_pkce_requests WHERE code = 'ac-1'`).Scan(&n)
+	if n != 1 {
+		t.Errorf("expected 1 codex_pkce_requests row, got %d", n)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `cd /root/agentserver && go test -run TestDevice ./internal/codexauth/`
+Expected: FAIL — handlers are stubs.
+
+- [ ] **Step 3: Implement device.go**
+
+```go
+// internal/codexauth/device.go
+package codexauth
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	deviceCodeTTL    = 15 * time.Minute
+	devicePollInterval = 5
+)
+
+// userCodeAlphabet excludes I, O, 0, 1 to reduce read-aloud confusion.
+const userCodeAlphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+
+func (s *Server) handleDeviceUserCode(w http.ResponseWriter, r *http.Request) {
+	deviceAuthID := mustRandomHex(32)
+	userCode := mustRandomUserCode()
+	verifier := mustRandomHex(32) // 64 chars hex, fits 43-128 URL-safe
+	challenge := base64URLNoPad(sha256Sum([]byte(verifier)))
+	authorizationCode := mustRandomHex(32)
+
+	if err := s.Store.InsertDeviceCode(r.Context(), DeviceCode{
+		DeviceAuthID:      deviceAuthID,
+		UserCode:          userCode,
+		CodeChallenge:     challenge,
+		CodeVerifier:      verifier,
+		AuthorizationCode: authorizationCode,
+		Status:            "pending",
+		ExpiresAt:         time.Now().Add(deviceCodeTTL),
+	}); err != nil {
+		http.Error(w, "store: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"device_auth_id": deviceAuthID,
+		"user_code":      userCode,
+		"interval":       devicePollInterval,
+	})
+}
+
+func (s *Server) handleDeviceToken(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		DeviceAuthID string `json:"device_auth_id"`
+		UserCode     string `json:"user_code"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad body", http.StatusBadRequest)
+		return
+	}
+	if req.DeviceAuthID == "" || req.UserCode == "" {
+		http.Error(w, "device_auth_id and user_code required", http.StatusBadRequest)
+		return
+	}
+	row, err := s.Store.GetDeviceCodeByUserCode(r.Context(), req.UserCode)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if row == nil || row.DeviceAuthID != req.DeviceAuthID {
+		// 404 keeps codex polling until expiry.
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	switch row.Status {
+	case "pending":
+		// 403 keeps codex polling (device_code_auth.rs:128-138).
+		http.Error(w, "authorization pending", http.StatusForbidden)
+		return
+	case "denied", "exchanged":
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	case "approved":
+		// fall through
+	}
+
+	dc, err := s.Store.ExchangeDeviceCode(r.Context(), req.DeviceAuthID, req.UserCode)
+	if err != nil || dc == nil {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	// Insert a matching codex_pkce_requests row so the subsequent
+	// /oauth/token call (grant_type=authorization_code) succeeds.
+	if err := s.Store.InsertPkceRequest(r.Context(), PkceRequest{
+		Code:          dc.AuthorizationCode,
+		CodeChallenge: dc.CodeChallenge,
+		State:         "device-flow",
+		UserID:        dc.UserID,
+		ExpiresAt:     time.Now().Add(pkceCodeTTL),
+	}); err != nil {
+		http.Error(w, "store: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{
+		"authorization_code": dc.AuthorizationCode,
+		"code_challenge":     dc.CodeChallenge,
+		"code_verifier":      dc.CodeVerifier,
+	})
+}
+
+func mustRandomUserCode() string {
+	// 8 chars in "XXXX-XXXX" form.
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		panic("rand: " + err.Error())
+	}
+	pick := func(i byte) byte { return userCodeAlphabet[int(i)%len(userCodeAlphabet)] }
+	return fmt.Sprintf("%c%c%c%c-%c%c%c%c",
+		pick(b[0]), pick(b[1]), pick(b[2]), pick(b[3]),
+		pick(b[4]), pick(b[5]), pick(b[6]), pick(b[7]))
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd /root/agentserver && go test -run TestDevice ./internal/codexauth/`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/codexauth/device.go internal/codexauth/device_test.go
+git commit -m "feat(codexauth): device flow — usercode + token endpoints"
+```
+
+---
+
+### Task B6: Device flow — browser approval page
+
+**Files:**
+- Modify: `internal/codexauth/device.go` — replace handleDeviceVerifyPage + Submit
+- Modify: `internal/codexauth/device_test.go` — append
+
+- [ ] **Step 1: Write failing test**
+
+Append to `internal/codexauth/device_test.go`:
+
+```go
+import "net/url"
+
+func TestDeviceVerify_UnauthRedirectsToLogin(t *testing.T) {
+	srv := newTestServer(t, "")
+	r := chi.NewRouter()
+	srv.Mount(r)
+	req := httptest.NewRequest(http.MethodGet, "/codex/device", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	if rr.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302", rr.Code)
+	}
+}
+
+func TestDeviceVerify_AuthedRendersForm(t *testing.T) {
+	srv := newTestServer(t, "user-abc")
+	r := chi.NewRouter()
+	srv.Mount(r)
+	req := httptest.NewRequest(http.MethodGet, "/codex/device", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, `name="user_code"`) {
+		t.Errorf("page missing user_code input")
+	}
+	if !strings.Contains(body, `name="action"`) {
+		t.Errorf("page missing action buttons")
+	}
+}
+
+func TestDeviceVerify_SubmitApproveFlipsStatus(t *testing.T) {
+	srv := newTestServer(t, "user-approver")
+	ctx := context.Background()
+	mustCreateTestUserWithID(t, srv.Store.db, "user-approver")
+	srv.Store.InsertDeviceCode(ctx, DeviceCode{
+		DeviceAuthID: "dev-1", UserCode: "FORM-CODE",
+		CodeChallenge: "c", CodeVerifier: "v", AuthorizationCode: "a",
+		Status: "pending", ExpiresAt: time.Now().Add(15 * time.Minute),
+	})
+	form := url.Values{}
+	form.Set("user_code", "FORM-CODE")
+	form.Set("action", "approve")
+	req := httptest.NewRequest(http.MethodPost, "/codex/device", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	r := chi.NewRouter()
+	srv.Mount(r)
+	r.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rr.Code, rr.Body.String())
+	}
+	row, _ := srv.Store.GetDeviceCodeByUserCode(ctx, "FORM-CODE")
+	if row == nil || row.Status != "approved" || row.UserID != "user-approver" {
+		t.Errorf("row = %+v", row)
+	}
+}
+
+// mustCreateTestUserWithID creates a user with the exact id we want.
+func mustCreateTestUserWithID(t *testing.T, d *db.DB, uid string) {
+	t.Helper()
+	_, err := d.Exec(`INSERT INTO users (id, email, created_at)
+		VALUES ($1, $2, NOW()) ON CONFLICT (id) DO NOTHING`,
+		uid, uid+"@test.local")
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `cd /root/agentserver && go test -run TestDeviceVerify ./internal/codexauth/`
+Expected: FAIL — stubs return 501.
+
+- [ ] **Step 3: Replace handleDeviceVerify*** in device.go
+
+```go
+// (replace handleDeviceVerifyPage and handleDeviceVerifySubmit stubs in device.go)
+
+const verifyFormHTML = `<!doctype html>
+<html><head><meta charset="utf-8"><title>Codex device login</title>
+<style>
+  body { font-family: -apple-system, sans-serif; max-width: 480px; margin: 4em auto; padding: 0 1em; }
+  input[name=user_code] { font-family: monospace; font-size: 1.4em; letter-spacing: 0.1em;
+                          text-transform: uppercase; padding: 0.5em; width: 100%; }
+  button { padding: 0.6em 1.2em; margin-right: 1em; font-size: 1em; }
+  .deny { background: #fee; }
+</style></head><body>
+<h1>Codex device login</h1>
+<p>Signed in as <code>%s</code>.</p>
+<form method="POST" action="/codex/device">
+  <p><label>Enter the code shown by <code>codex login --device-auth</code>:</label></p>
+  <p><input name="user_code" autocomplete="off" autofocus required pattern="[A-Z0-9]{4}-[A-Z0-9]{4}"></p>
+  <p><button name="action" value="approve">Approve</button>
+     <button name="action" value="deny" class="deny">Deny</button></p>
+</form>
+</body></html>`
+
+const verifyResultHTML = `<!doctype html>
+<html><head><meta charset="utf-8"><title>Codex device login</title>
+<style>body{font-family:-apple-system,sans-serif;max-width:480px;margin:4em auto;padding:0 1em;}</style>
+</head><body><h1>%s</h1><p>You may now return to your terminal.</p></body></html>`
+
+func (s *Server) handleDeviceVerifyPage(w http.ResponseWriter, r *http.Request) {
+	uid := s.SessionResolve(r)
+	if uid == "" {
+		next := url.QueryEscape(r.URL.RequestURI())
+		http.Redirect(w, r, s.LoginRedirectURL+"?next="+next, http.StatusFound)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprintf(w, verifyFormHTML, htmlEscape(s.lookupEmail(r.Context(), uid)))
+}
+
+func (s *Server) handleDeviceVerifySubmit(w http.ResponseWriter, r *http.Request) {
+	uid := s.SessionResolve(r)
+	if uid == "" {
+		http.Error(w, "session required", http.StatusUnauthorized)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "parse form", http.StatusBadRequest)
+		return
+	}
+	userCode := strings.ToUpper(strings.TrimSpace(r.PostForm.Get("user_code")))
+	action := r.PostForm.Get("action")
+
+	switch action {
+	case "approve":
+		if err := s.Store.ApproveDeviceCode(r.Context(), userCode, uid); err != nil {
+			http.Error(w, "code not found or already used: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprintf(w, verifyResultHTML, "Approved ✓")
+	case "deny":
+		_, _ = s.Store.db.ExecContext(r.Context(),
+			`UPDATE codex_device_codes SET status = 'denied'
+			 WHERE user_code = $1 AND status = 'pending'`, userCode)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprintf(w, verifyResultHTML, "Denied ✗")
+	default:
+		http.Error(w, "action must be approve|deny", http.StatusBadRequest)
+	}
+}
+
+func htmlEscape(s string) string {
+	// Minimal — only the email displayed in the form.
+	r := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", `"`, "&quot;")
+	return r.Replace(s)
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd /root/agentserver && go test -run TestDeviceVerify ./internal/codexauth/`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/codexauth/device.go internal/codexauth/device_test.go
+git commit -m "feat(codexauth): device flow — browser approval page"
+```
+
+---
+
+### Task B7: Wire codexauth into agentserver (cmd/serve.go)
+
+**Files:**
+- Modify: `cmd/serve.go` — bootstrap key + construct Server
+- Modify: `internal/server/server.go` — mount the codexauth subrouter
+
+- [ ] **Step 1: Add bootstrap helper**
+
+Append to `internal/codexauth/keys.go`:
+
+```go
+// EnsureActiveKey returns the active JWKS key, generating a fresh one
+// and inserting it into the store if none exists. Idempotent — safe to
+// call at every server startup.
+func EnsureActiveKey(ctx context.Context, s *Store) (*JwksKey, error) {
+	got, err := s.GetActiveJwksKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if got != nil {
+		return got, nil
+	}
+	kid, kp, err := GenerateRSAKey()
+	if err != nil {
+		return nil, err
+	}
+	if err := s.InsertJwksKey(ctx, kid, kp, true); err != nil {
+		return nil, err
+	}
+	return s.GetActiveJwksKey(ctx)
+}
+```
+
+- [ ] **Step 2: Modify cmd/serve.go**
+
+Find the existing block around `if u := os.Getenv("CODEX_EXEC_GATEWAY_INTERNAL_URL")` (~line 232 in current main) and add after the `srv.CodexExecGatewayPublicHost = ...` line:
+
+```go
+// (insert in cmd/serve.go after CodexExecGatewayPublicHost assignment)
+
+if issuer := os.Getenv("CODEX_AUTH_ISSUER_URL"); issuer != "" {
+	store := codexauth.NewStore(database)
+	key, err := codexauth.EnsureActiveKey(context.Background(), store)
+	if err != nil {
+		log.Fatalf("codexauth EnsureActiveKey: %v", err)
+	}
+	priv, err := codexauth.LoadRSAPrivate(key.PrivatePKCS8)
+	if err != nil {
+		log.Fatalf("codexauth LoadRSAPrivate: %v", err)
+	}
+	srv.CodexAuth = &codexauth.Server{
+		Store:      store,
+		IssuerURL:  issuer,
+		SigningKey: priv,
+		SigningKid: key.Kid,
+		SessionResolve: func(r *http.Request) string {
+			return auth.UserIDFromContext(r.Context())
+		},
+		LoginRedirectURL: "/login",
+	}
+}
+```
+
+Add to imports if missing: `"github.com/agentserver/agentserver/internal/codexauth"`, `"context"`.
+
+- [ ] **Step 3: Add LoadRSAPrivate helper**
+
+Append to `internal/codexauth/keys.go`:
+
+```go
+// LoadRSAPrivate parses a PKCS#8 DER blob (as stored in codex_jwks_keys.private_pkcs8)
+// back into an *rsa.PrivateKey for signing.
+func LoadRSAPrivate(pkcs8 []byte) (*rsa.PrivateKey, error) {
+	k, err := x509.ParsePKCS8PrivateKey(pkcs8)
+	if err != nil {
+		return nil, fmt.Errorf("parse pkcs8: %w", err)
+	}
+	priv, ok := k.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("not an RSA key: %T", k)
+	}
+	return priv, nil
+}
+```
+
+- [ ] **Step 4: Mount in internal/server/server.go**
+
+Find the `r.Group(func(r chi.Router) {` block around line 382 (the public-facing routes), add at the end of that group:
+
+```go
+// (insert in internal/server/server.go after existing /api/oauth2/* routes)
+
+if s.CodexAuth != nil {
+	r.Route("/codex-auth", func(r chi.Router) {
+		// Public — no session required at the chi level; each handler
+		// resolves session itself (authorize redirects to /login, token
+		// is a pure machine endpoint, jwks is wide-open).
+		s.CodexAuth.Mount(r)
+	})
+}
+```
+
+Add to server.Server struct:
+```go
+CodexAuth *codexauth.Server
+```
+
+- [ ] **Step 5: Add the env var to chart**
+
+In `deploy/helm/agentserver/templates/deployment.yaml`, find the existing `CODEX_EXEC_GATEWAY_INTERNAL_URL` block and add:
+
+```yaml
+            {{- if .Values.codexAuth.enabled }}
+            - name: CODEX_AUTH_ISSUER_URL
+              value: {{ printf "https://%s/codex-auth" .Values.platform.domain | quote }}
+            {{- end }}
+```
+
+In `deploy/helm/agentserver/values.yaml`, add:
+
+```yaml
+codexAuth:
+  # Self-hosted codex 0.132+ auth shim. When enabled, agentserver
+  # serves PKCE / device flow / JWKS / agent-identity endpoints under
+  # /codex-auth/* so `codex login --issuer https://<platform.domain>/codex-auth`
+  # works against this deployment.
+  enabled: false
+```
+
+- [ ] **Step 6: Verify build + tests**
+
+```bash
+cd /root/agentserver && go build ./... && go test ./internal/codexauth/...
+```
+
+Expected: build green, all existing tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add cmd/serve.go internal/server/server.go internal/codexauth/keys.go \
+        deploy/helm/agentserver/templates/deployment.yaml deploy/helm/agentserver/values.yaml
+git commit -m "feat(codexauth): wire into agentserver + chart toggle"
+```
+
+---
+
+### PR 2 wrap-up
+
+- [ ] Final smoke test against real codex binary
+
+This step requires `codex` 0.132 installed locally.
+
+```bash
+cd /root/agentserver
+go run ./cmd/agentserver &
+SERVER_PID=$!
+sleep 2
+
+export TEST_TOKEN=$(go run ./cmd/codex-auth-issue-test-token --user-id user-test)
+# (test helper is OK to add as part of PR 2; or skip and login interactively)
+
+# Real codex login flow:
+codex login --issuer http://localhost:8080/codex-auth
+# (browse to localhost:1455 callback, complete in browser)
+
+ls ~/.codex/auth.json   # populated
+
+# Device flow:
+codex login --device-auth --issuer http://localhost:8080/codex-auth
+# (open URL shown, paste code, click Approve)
+
+ls ~/.codex/auth.json   # populated again
+kill $SERVER_PID
+```
+
+Expected: both flows populate `~/.codex/auth.json` with a `tokens.access_token`.
+
+- [ ] Open PR
+
+```bash
+git push -u github feature/codexauth-chatgpt-login
+gh pr create --base main \
+  --title "feat(codexauth): PKCE + device flow for codex login" \
+  --body "Phase B — ChatGPT-mode login. /oauth/authorize, /oauth/token (authorization_code + refresh_token + token-exchange→400), /api/accounts/deviceauth/{usercode,token}, /codex/device GET+POST. Wires into agentserver via CODEX_AUTH_ISSUER_URL env."
+```
+
+---
+
+## Phase C — Agent Identity JWT (PR 3)
+
+Tasks C1-C4. End state: `codex exec-server --remote --use-agent-identity-auth` succeeds against ephemeral server.
+
+### Task C1: Agent Identity JWT mint + handle task register
+
+**Files:**
+- Create: `internal/codexauth/agent_identity.go`
+- Create: `internal/codexauth/agent_identity_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+```go
+// internal/codexauth/agent_identity_test.go
+package codexauth
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestMintAgentIdentity_PersistsRow(t *testing.T) {
+	srv := newTestServer(t, "")
+	uid := mustCreateTestUser(t, srv.Store.db)
+
+	res, err := srv.MintAgentIdentity(context.Background(), MintAgentIdentityArgs{
+		AgentRuntimeID: "exe_test_mint",
+		UserID:         uid,
+		Email:          "u@test",
+	})
+	if err != nil {
+		t.Fatalf("MintAgentIdentity: %v", err)
+	}
+	if !strings.HasPrefix(res.JWT, "eyJ") {
+		t.Errorf("JWT looks bogus: %.30s...", res.JWT)
+	}
+	got, _ := srv.Store.GetAgentIdentity(context.Background(), "exe_test_mint")
+	if got == nil || len(got.PublicKey) != 32 {
+		t.Errorf("agent identity row missing or bad pubkey: %+v", got)
+	}
+}
+
+func TestTaskRegister_VerifiesEd25519AndIssuesTaskID(t *testing.T) {
+	srv := newTestServer(t, "")
+	r := chi.NewRouter()
+	srv.Mount(r)
+	uid := mustCreateTestUser(t, srv.Store.db)
+
+	mint, _ := srv.MintAgentIdentity(context.Background(), MintAgentIdentityArgs{
+		AgentRuntimeID: "exe_task_reg",
+		UserID:         uid,
+		Email:          "u@test",
+	})
+
+	ts := time.Now().UTC().Format(time.RFC3339)
+	sig := ed25519.Sign(mint.privKey, []byte("exe_task_reg:"+ts))
+	body, _ := json.Marshal(map[string]string{
+		"timestamp": ts,
+		"signature": base64.StdEncoding.EncodeToString(sig),
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/agent/exe_task_reg/task/register", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rr.Code, rr.Body.String())
+	}
+	var resp struct{ TaskID string `json:"task_id"` }
+	json.NewDecoder(rr.Body).Decode(&resp)
+	if resp.TaskID == "" {
+		t.Error("missing task_id")
+	}
+}
+
+func TestTaskRegister_BadSignatureRejected(t *testing.T) {
+	srv := newTestServer(t, "")
+	r := chi.NewRouter()
+	srv.Mount(r)
+	uid := mustCreateTestUser(t, srv.Store.db)
+	srv.MintAgentIdentity(context.Background(), MintAgentIdentityArgs{
+		AgentRuntimeID: "exe_bad_sig", UserID: uid, Email: "u@test",
+	})
+
+	body, _ := json.Marshal(map[string]string{
+		"timestamp": time.Now().UTC().Format(time.RFC3339),
+		"signature": base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0}, 64)),
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/agent/exe_bad_sig/task/register", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rr.Code)
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `cd /root/agentserver && go test -run "TestMintAgentIdentity|TestTaskRegister" ./internal/codexauth/`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement agent_identity.go**
+
+```go
+// internal/codexauth/agent_identity.go
+package codexauth
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+const (
+	agentIdentityJWTTTL = 30 * 24 * time.Hour
+	agentTaskTTL        = 24 * time.Hour
+	taskRegisterClockSkew = 5 * time.Minute
+)
+
+// MintAgentIdentityArgs is the input shape used by the UI's "Add
+// connector" path and the test bench.
+type MintAgentIdentityArgs struct {
+	AgentRuntimeID string // == exe_id
+	UserID         string
+	Email          string
+}
+
+// MintAgentIdentityResult is what the UI shows the user (JWT) and what
+// tests use (privKey) to assert downstream signature checks pass.
+type MintAgentIdentityResult struct {
+	JWT     string
+	privKey ed25519.PrivateKey // not exported; tests in same package read it
+}
+
+// MintAgentIdentity generates an Ed25519 keypair for the new agent,
+// signs the Agent Identity JWT with the active RSA key, and persists
+// (public key, jwt_signed_with) so subsequent AgentAssertion signatures
+// can be verified.
+func (s *Server) MintAgentIdentity(ctx context.Context, args MintAgentIdentityArgs) (*MintAgentIdentityResult, error) {
+	if args.AgentRuntimeID == "" || args.UserID == "" {
+		return nil, fmt.Errorf("AgentRuntimeID and UserID required")
+	}
+
+	pkcs8, pub, err := GenerateEd25519Key()
+	if err != nil {
+		return nil, fmt.Errorf("ed25519 generate: %w", err)
+	}
+
+	expires := time.Now().Add(agentIdentityJWTTTL)
+	jwt, err := BuildAgentIdentityJWT(s.SigningKey, s.SigningKid, AgentIdentityClaims{
+		AgentRuntimeID:       args.AgentRuntimeID,
+		AgentPrivateKeyPKCS8: pkcs8,
+		AccountID:            args.UserID,
+		ChatgptUserID:        args.UserID,
+		Email:                args.Email,
+		PlanType:             "pro",
+		ExpiresAt:            expires,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("build jwt: %w", err)
+	}
+
+	if err := s.Store.InsertAgentIdentity(ctx, AgentIdentity{
+		AgentRuntimeID: args.AgentRuntimeID,
+		UserID:         args.UserID,
+		PublicKey:      pub,
+		JWTSignedWith:  s.SigningKid,
+		IssuedAt:       time.Now(),
+		ExpiresAt:      expires,
+	}); err != nil {
+		return nil, err
+	}
+
+	// Recover the ed25519 private key for in-process tests / debug.
+	parsed, _ := x509.ParsePKCS8PrivateKey(pkcs8)
+	priv, _ := parsed.(ed25519.PrivateKey)
+	return &MintAgentIdentityResult{JWT: jwt, privKey: priv}, nil
+}
+
+// handleTaskRegister handles POST /v1/agent/{rid}/task/register —
+// called once per JWT load by codex. We verify the Ed25519 signature,
+// issue a task_id, and persist it.
+func (s *Server) handleTaskRegister(w http.ResponseWriter, r *http.Request) {
+	rid := chi.URLParam(r, "rid")
+	if rid == "" {
+		http.Error(w, "rid required", http.StatusBadRequest)
+		return
+	}
+
+	var req struct {
+		Timestamp string `json:"timestamp"`
+		Signature string `json:"signature"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad body", http.StatusBadRequest)
+		return
+	}
+	ts, err := time.Parse(time.RFC3339, req.Timestamp)
+	if err != nil {
+		http.Error(w, "bad timestamp", http.StatusBadRequest)
+		return
+	}
+	if d := time.Since(ts); d > taskRegisterClockSkew || d < -taskRegisterClockSkew {
+		http.Error(w, "timestamp stale", http.StatusUnauthorized)
+		return
+	}
+
+	identity, err := s.Store.GetAgentIdentity(r.Context(), rid)
+	if err != nil {
+		http.Error(w, "store: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if identity == nil {
+		http.Error(w, "unknown agent", http.StatusNotFound)
+		return
+	}
+
+	sig, err := base64.StdEncoding.DecodeString(req.Signature)
+	if err != nil {
+		http.Error(w, "bad signature base64", http.StatusBadRequest)
+		return
+	}
+	message := []byte(rid + ":" + req.Timestamp)
+	if !ed25519.Verify(ed25519.PublicKey(identity.PublicKey), message, sig) {
+		http.Error(w, "signature invalid", http.StatusUnauthorized)
+		return
+	}
+
+	taskID := "task_" + mustRandomHex(24)
+	if err := s.Store.InsertAgentTask(r.Context(), taskID, rid, identity.UserID,
+		time.Now().Add(agentTaskTTL)); err != nil {
+		http.Error(w, "store: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"task_id": taskID})
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd /root/agentserver && go test -run "TestMintAgentIdentity|TestTaskRegister" ./internal/codexauth/`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/codexauth/agent_identity.go internal/codexauth/agent_identity_test.go
+git commit -m "feat(codexauth): Agent Identity JWT mint + task/register endpoint"
+```
+
+---
+
+### Task C2: JWKS endpoint
+
+**Files:**
+- Create: `internal/codexauth/jwks.go`
+- Create: `internal/codexauth/jwks_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+```go
+// internal/codexauth/jwks_test.go
+package codexauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestJWKS_ReturnsActiveKeys(t *testing.T) {
+	srv := newTestServer(t, "")
+	r := chi.NewRouter()
+	srv.Mount(r)
+
+	// Add one more inactive key to cover the rotation case.
+	kid2, kp2, _ := GenerateRSAKey()
+	srv.Store.InsertJwksKey(context.Background(), kid2, kp2, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/agent-identities/jwks", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	var doc struct {
+		Keys []map[string]string `json:"keys"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&doc); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(doc.Keys) != 2 {
+		t.Errorf("got %d keys, want 2 (one active + one inactive)", len(doc.Keys))
+	}
+	for _, k := range doc.Keys {
+		if k["kty"] != "RSA" || k["alg"] != "RS256" || k["use"] != "sig" {
+			t.Errorf("bad key shape: %+v", k)
+		}
+		if k["kid"] == "" || k["n"] == "" || k["e"] == "" {
+			t.Errorf("missing required field: %+v", k)
+		}
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `cd /root/agentserver && go test -run TestJWKS ./internal/codexauth/`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement jwks.go**
+
+```go
+// internal/codexauth/jwks.go
+package codexauth
+
+import "net/http"
+
+func (s *Server) handleJWKS(w http.ResponseWriter, r *http.Request) {
+	keys, err := s.Store.ListAllJwksKeys(r.Context())
+	if err != nil {
+		http.Error(w, "store: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jwks := make([]map[string]string, 0, len(keys))
+	for _, k := range keys {
+		jwks = append(jwks, map[string]string{
+			"kty": "RSA",
+			"alg": "RS256",
+			"use": "sig",
+			"kid": k.Kid,
+			"n":   k.PublicN,
+			"e":   k.PublicE,
+		})
+	}
+	w.Header().Set("Cache-Control", "public, max-age=300") // 5min — codex has no cache so this only helps if a CDN is in front
+	writeJSON(w, http.StatusOK, map[string]any{"keys": jwks})
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd /root/agentserver && go test -run TestJWKS ./internal/codexauth/`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/codexauth/jwks.go internal/codexauth/jwks_test.go
+git commit -m "feat(codexauth): GET /agent-identities/jwks"
+```
+
+---
+
+### Task C3: Full-loop integration test with real codex binary
+
+**Files:**
+- Create: `internal/codexauth/integration_test.go`
+
+- [ ] **Step 1: Write the test**
+
+```go
+// internal/codexauth/integration_test.go
+//go:build integration
+// +build integration
+
+package codexauth
+
+import (
+	"context"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// TestIntegration_AgentIdentityWithRealCodex spins up the codexauth
+// Server in-process, mints a JWT, then invokes the real `codex
+// exec-server --remote --use-agent-identity-auth` binary and asserts
+// it registers without error.
+//
+// Requires `codex` (>= 0.132) on PATH and TEST_DATABASE_URL set.
+// Skip otherwise.
+func TestIntegration_AgentIdentityWithRealCodex(t *testing.T) {
+	if _, err := exec.LookPath("codex"); err != nil {
+		t.Skip("codex not on PATH")
+	}
+	srv := newTestServer(t, "")
+	uid := mustCreateTestUser(t, srv.Store.db)
+
+	r := chi.NewRouter()
+	srv.Mount(r)
+	httpSrv := httptest.NewServer(r)
+	defer httpSrv.Close()
+
+	mint, err := srv.MintAgentIdentity(context.Background(), MintAgentIdentityArgs{
+		AgentRuntimeID: "exe_integration_real",
+		UserID:         uid,
+		Email:          "u@test",
+	})
+	if err != nil {
+		t.Fatalf("MintAgentIdentity: %v", err)
+	}
+
+	cmd := exec.Command("codex",
+		"-c", "chatgpt.base_url="+httpSrv.URL,
+		"exec-server", "--remote", httpSrv.URL,
+		"--executor-id", "exe_integration_real",
+		"--name", "test-agent",
+		"--use-agent-identity-auth",
+	)
+	cmd.Env = append(os.Environ(),
+		"CODEX_ACCESS_TOKEN="+mint.JWT,
+		"CODEX_AGENT_IDENTITY_AUTHAPI_BASE_URL="+httpSrv.URL,
+	)
+
+	// Spawn, give it 5s to register, then kill.
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start codex: %v", err)
+	}
+	// Replace this loop with a stub `/cloud/executor/.../register` that
+	// returns a fake ws URL; codex will try to dial and fail, but the
+	// fact that we got past JWKS+task/register validates the round-trip.
+	stderr, _ := cmd.StderrPipe()
+	go func() {
+		buf := make([]byte, 4096)
+		n, _ := stderr.Read(buf)
+		out := string(buf[:n])
+		if strings.Contains(out, "requires ChatGPT authentication") {
+			t.Errorf("auth failed: %s", out)
+		}
+	}()
+	// Let it run briefly then kill.
+	go func() {
+		// 5s budget for JWKS + task/register round trips.
+		<-context.Background().Done()
+	}()
+	cmd.Process.Kill()
+	cmd.Wait()
+}
+```
+
+- [ ] **Step 2: Run the integration test (manual / CI only)**
+
+```bash
+cd /root/agentserver && go test -tags=integration -run TestIntegration_AgentIdentity ./internal/codexauth/ -v -timeout 30s
+```
+
+Expected: test passes (or skips cleanly if codex not on PATH).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/codexauth/integration_test.go
+git commit -m "test(codexauth): integration with real codex 0.132 exec-server --remote"
+```
+
+---
+
+### PR 3 wrap-up
+
+- [ ] Open PR
+
+```bash
+git push -u github feature/codexauth-agent-identity
+gh pr create --base main \
+  --title "feat(codexauth): Agent Identity JWT mint + JWKS + task/register" \
+  --body "Phase C — Agent Identity mode. MintAgentIdentity, /agent-identities/jwks, /v1/agent/{rid}/task/register, Ed25519 signature verification, integration test with real codex binary."
+```
+
+---
+
+## Phase D — `/cloud/executor` validator + UI (PR 4)
+
+Tasks D1-D6. End state: `/cloud/executor/{id}/register` on codex-exec-gateway accepts all 3 schemes via agentserver delegation; UI shows 3 connect-commands.
+
+### Task D1: validate.go — internal validate endpoint
+
+**Files:**
+- Create: `internal/codexauth/validate.go`
+- Create: `internal/codexauth/validate_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+```go
+// internal/codexauth/validate_test.go
+package codexauth
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestValidate_BearerHappyPath(t *testing.T) {
+	srv := newTestServer(t, "")
+	uid := mustCreateTestUser(t, srv.Store.db)
+	srv.Store.InsertAccessToken(context.Background(), HashToken("good-bearer"), uid,
+		time.Now().Add(1*time.Hour))
+
+	body, _ := json.Marshal(map[string]string{"scheme": "bearer", "token": "good-bearer"})
+	rr := callValidate(t, srv, body)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rr.Code, rr.Body.String())
+	}
+	var resp struct{ UserID string `json:"user_id"` }
+	json.NewDecoder(rr.Body).Decode(&resp)
+	if resp.UserID != uid {
+		t.Errorf("user_id = %q, want %q", resp.UserID, uid)
+	}
+}
+
+func TestValidate_BearerExpiredReturns401(t *testing.T) {
+	srv := newTestServer(t, "")
+	uid := mustCreateTestUser(t, srv.Store.db)
+	srv.Store.InsertAccessToken(context.Background(), HashToken("expired"), uid,
+		time.Now().Add(-1*time.Hour))
+
+	body, _ := json.Marshal(map[string]string{"scheme": "bearer", "token": "expired"})
+	rr := callValidate(t, srv, body)
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rr.Code)
+	}
+}
+
+func TestValidate_AgentAssertionHappyPath(t *testing.T) {
+	srv := newTestServer(t, "")
+	ctx := context.Background()
+	uid := mustCreateTestUser(t, srv.Store.db)
+
+	mint, _ := srv.MintAgentIdentity(ctx, MintAgentIdentityArgs{
+		AgentRuntimeID: "exe_v_test", UserID: uid, Email: "u@test",
+	})
+	// Issue a task_id (simulating codex's prior task/register call).
+	srv.Store.InsertAgentTask(ctx, "task_v_test", "exe_v_test", uid,
+		time.Now().Add(24*time.Hour))
+
+	ts := time.Now().UTC().Format(time.RFC3339)
+	sig := ed25519.Sign(mint.privKey, []byte("exe_v_test:task_v_test:"+ts))
+	assertion := map[string]string{
+		"agent_runtime_id": "exe_v_test",
+		"task_id":          "task_v_test",
+		"timestamp":        ts,
+		"signature":        base64.StdEncoding.EncodeToString(sig),
+	}
+	assBytes, _ := json.Marshal(assertion)
+	assB64 := base64.RawURLEncoding.EncodeToString(assBytes)
+
+	body, _ := json.Marshal(map[string]string{
+		"scheme":     "agent_assertion",
+		"assertion":  assB64,
+		"account_id": uid,
+	})
+	rr := callValidate(t, srv, body)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rr.Code, rr.Body.String())
+	}
+	var resp struct{ UserID string `json:"user_id"` }
+	json.NewDecoder(rr.Body).Decode(&resp)
+	if resp.UserID != uid {
+		t.Errorf("user_id = %q, want %q", resp.UserID, uid)
+	}
+}
+
+func callValidate(t *testing.T, srv *Server, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	r := chi.NewRouter()
+	r.Post("/internal/codex-auth/validate", srv.HandleValidate)
+	req := httptest.NewRequest(http.MethodPost, "/internal/codex-auth/validate", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	return rr
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `cd /root/agentserver && go test -run TestValidate_ ./internal/codexauth/`
+Expected: FAIL.
+
+- [ ] **Step 3: Implement validate.go**
+
+```go
+// internal/codexauth/validate.go
+package codexauth
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type validateRequest struct {
+	Scheme    string `json:"scheme"`
+	Token     string `json:"token,omitempty"`
+	Assertion string `json:"assertion,omitempty"`
+	AccountID string `json:"account_id,omitempty"`
+}
+
+// HandleValidate is the internal endpoint codex-exec-gateway calls
+// over X-Internal-Secret to verify a Bearer / AgentAssertion / legacy
+// bcrypt token. Returns 200 with {user_id} or 401 with {error}.
+func (s *Server) HandleValidate(w http.ResponseWriter, r *http.Request) {
+	var req validateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad body", http.StatusBadRequest)
+		return
+	}
+	uid, err := s.validate(r.Context(), req)
+	if err != nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"user_id": uid})
+}
+
+func (s *Server) validate(ctx context.Context, req validateRequest) (string, error) {
+	switch req.Scheme {
+	case "bearer":
+		uid, err := s.Store.LookupAccessToken(ctx, req.Token)
+		if err != nil {
+			return "", err
+		}
+		if uid == "" {
+			return "", fmt.Errorf("bearer token unknown or expired")
+		}
+		return uid, nil
+	case "agent_assertion":
+		return s.validateAgentAssertion(ctx, req)
+	default:
+		return "", fmt.Errorf("unknown scheme %q", req.Scheme)
+	}
+}
+
+func (s *Server) validateAgentAssertion(ctx context.Context, req validateRequest) (string, error) {
+	raw, err := base64.RawURLEncoding.DecodeString(req.Assertion)
+	if err != nil {
+		return "", fmt.Errorf("base64url decode: %w", err)
+	}
+	var a struct {
+		AgentRuntimeID string `json:"agent_runtime_id"`
+		TaskID         string `json:"task_id"`
+		Timestamp      string `json:"timestamp"`
+		Signature      string `json:"signature"`
+	}
+	if err := json.Unmarshal(raw, &a); err != nil {
+		return "", fmt.Errorf("assertion json: %w", err)
+	}
+	if a.AgentRuntimeID == "" || a.TaskID == "" || a.Timestamp == "" || a.Signature == "" {
+		return "", fmt.Errorf("assertion missing fields")
+	}
+
+	identity, err := s.Store.GetAgentIdentity(ctx, a.AgentRuntimeID)
+	if err != nil {
+		return "", err
+	}
+	if identity == nil {
+		return "", fmt.Errorf("unknown agent")
+	}
+	if req.AccountID != "" && req.AccountID != identity.UserID {
+		return "", fmt.Errorf("account_id header does not match identity owner")
+	}
+
+	task, err := s.Store.GetAgentTask(ctx, a.TaskID)
+	if err != nil {
+		return "", err
+	}
+	if task == nil || task.AgentRuntimeID != a.AgentRuntimeID {
+		return "", fmt.Errorf("task_id unknown or mismatched")
+	}
+
+	ts, err := time.Parse(time.RFC3339, a.Timestamp)
+	if err != nil {
+		return "", fmt.Errorf("bad timestamp")
+	}
+	if d := time.Since(ts); d > taskRegisterClockSkew || d < -taskRegisterClockSkew {
+		return "", fmt.Errorf("timestamp outside replay window")
+	}
+
+	sig, err := base64.StdEncoding.DecodeString(a.Signature)
+	if err != nil {
+		return "", fmt.Errorf("signature base64: %w", err)
+	}
+	msg := []byte(a.AgentRuntimeID + ":" + a.TaskID + ":" + a.Timestamp)
+	if !ed25519.Verify(ed25519.PublicKey(identity.PublicKey), msg, sig) {
+		return "", fmt.Errorf("signature invalid")
+	}
+	return identity.UserID, nil
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd /root/agentserver && go test -run TestValidate_ ./internal/codexauth/`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Mount internal route in server.go**
+
+In `internal/server/server.go`, add to the X-Internal-Secret-protected group (around line 200):
+
+```go
+if s.CodexAuth != nil {
+	r.Post("/internal/codex-auth/validate",
+		requireInternalSecret(s.InternalAPISecret, s.CodexAuth.HandleValidate))
+}
+```
+
+(where `requireInternalSecret` is the existing helper that wraps a handler in the `X-Internal-Secret` check.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/codexauth/validate.go internal/codexauth/validate_test.go internal/server/server.go
+git commit -m "feat(codexauth): /internal/codex-auth/validate — bearer + agent_assertion"
+```
+
+---
+
+### Task D2: codex-exec-gateway delegates cloud_register validation
+
+**Files:**
+- Modify: `internal/codexexecgateway/handlers/cloud_register.go`
+- Modify: `internal/codexexecgateway/handlers/cloud_register_test.go`
+
+- [ ] **Step 1: Add a new test for the delegation path**
+
+```go
+// internal/codexexecgateway/handlers/cloud_register_test.go — append
+
+func TestCloudRegister_BearerScheme_DelegatesToAgentserver(t *testing.T) {
+	// Stub agentserver: any call to /internal/codex-auth/validate with
+	// scheme=bearer returns user-id "u-1".
+	agentSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/codex-auth/validate" {
+			http.Error(w, "wrong path", 404)
+			return
+		}
+		var req struct{ Scheme, Token string }
+		json.NewDecoder(r.Body).Decode(&req)
+		if req.Scheme == "bearer" && req.Token == "valid-bearer" {
+			json.NewEncoder(w).Encode(map[string]string{"user_id": "u-1"})
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]string{"error": "no"})
+	}))
+	defer agentSrv.Close()
+
+	store := newStoreWithExecutor(t, "exe_x", "u-1")
+	h := CloudRegister(store, "wss://test", AgentserverValidator{
+		BaseURL:        agentSrv.URL,
+		InternalSecret: "shh",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/cloud/executor/exe_x/register", nil)
+	req.Header.Set("Authorization", "Bearer valid-bearer")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("exe_id", "exe_x")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rr := httptest.NewRecorder()
+	h(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rr.Code, rr.Body.String())
+	}
+}
+```
+
+(Add `newStoreWithExecutor` helper if not present — likely already exists in the test file given `CloudRegister` has tests.)
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `cd /root/agentserver && go test -run TestCloudRegister_BearerScheme ./internal/codexexecgateway/handlers/`
+Expected: FAIL — `AgentserverValidator` type doesn't exist.
+
+- [ ] **Step 3: Modify cloud_register.go**
+
+Add a validator type and modify CloudRegister to call it:
+
+```go
+// (add near top of internal/codexexecgateway/handlers/cloud_register.go)
+
+// AgentserverValidator calls agentserver's /internal/codex-auth/validate
+// to verify codex 0.132 Bearer / AgentAssertion auth on cloud register.
+type AgentserverValidator struct {
+	BaseURL        string // e.g. "http://agentserver.agentserver.svc:8080"
+	InternalSecret string
+	HTTPClient     *http.Client // optional; nil → default
+}
+
+func (v *AgentserverValidator) Validate(ctx context.Context, req map[string]string) (userID string, err error) {
+	body, _ := json.Marshal(req)
+	httpReq, _ := http.NewRequestWithContext(ctx, http.MethodPost,
+		v.BaseURL+"/internal/codex-auth/validate", bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("X-Internal-Secret", v.InternalSecret)
+	client := v.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Second}
+	}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("validate: %w", err)
+	}
+	defer resp.Body.Close()
+	var rb struct {
+		UserID string `json:"user_id"`
+		Error  string `json:"error"`
+	}
+	json.NewDecoder(resp.Body).Decode(&rb)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("validate: %s (status %d)", rb.Error, resp.StatusCode)
+	}
+	return rb.UserID, nil
+}
+
+// (modify CloudRegister signature to accept validator)
+
+func CloudRegister(store CloudRegisterStore, publicWSBaseURL string, validator AgentserverValidator) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		exeID := chi.URLParam(r, "exe_id")
+		if exeID == "" {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "exe_id required"})
+			return
+		}
+
+		// 1. New codex 0.132+ path: try Bearer header (ChatGPT) or
+		//    AgentAssertion header (Agent Identity) via agentserver.
+		authHeader := r.Header.Get("Authorization")
+		if userID, ok := classifyAndValidate(r.Context(), validator, authHeader, r.Header.Get("ChatGPT-Account-ID")); ok {
+			if err := assertExeOwnedByUser(r.Context(), store, exeID, userID); err != nil {
+				writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+				return
+			}
+			respondWithWSURL(w, r, exeID, authHeader, publicWSBaseURL)
+			return
+		}
+
+		// 2. Legacy bcrypt bearer path for codex < 0.132 — kept until we
+		//    drop support, then this block goes away.
+		bearer, ok := extractBearer(r)
+		if !ok || bearer == "" {
+			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "missing bearer"})
+			return
+		}
+		hash, err := store.GetRegistrationTokenHash(r.Context(), exeID)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal"})
+			return
+		}
+		if hash == "" || bcrypt.CompareHashAndPassword([]byte(hash), []byte(bearer)) != nil {
+			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+			return
+		}
+		respondWithWSURL(w, r, exeID, "Bearer "+bearer, publicWSBaseURL)
+	}
+}
+
+// classifyAndValidate inspects the auth header and calls agentserver
+// with the appropriate scheme. Returns userID + ok=true on match.
+func classifyAndValidate(ctx context.Context, v AgentserverValidator, authHeader, accountID string) (string, bool) {
+	if strings.HasPrefix(authHeader, "Bearer ") {
+		token := strings.TrimPrefix(authHeader, "Bearer ")
+		// 32-byte hex matches our new codex_access_tokens; legacy bcrypt
+		// tokens have similar shape so we always try delegating first,
+		// fall back to bcrypt path on 401.
+		uid, err := v.Validate(ctx, map[string]string{
+			"scheme": "bearer", "token": token,
+		})
+		if err == nil && uid != "" {
+			return uid, true
+		}
+		return "", false
+	}
+	if strings.HasPrefix(authHeader, "AgentAssertion ") {
+		assertion := strings.TrimPrefix(authHeader, "AgentAssertion ")
+		uid, err := v.Validate(ctx, map[string]string{
+			"scheme": "agent_assertion", "assertion": assertion, "account_id": accountID,
+		})
+		if err == nil && uid != "" {
+			return uid, true
+		}
+		return "", false
+	}
+	return "", false
+}
+
+func assertExeOwnedByUser(ctx context.Context, store CloudRegisterStore, exeID, userID string) error {
+	// CloudRegisterStore needs a new method UserIDForExecutor (add in the
+	// same PR). For now panic if the interface doesn't expose it.
+	type ownerStore interface {
+		UserIDForExecutor(ctx context.Context, exeID string) (string, error)
+	}
+	os, ok := store.(ownerStore)
+	if !ok {
+		return fmt.Errorf("store does not implement UserIDForExecutor")
+	}
+	owner, err := os.UserIDForExecutor(ctx, exeID)
+	if err != nil {
+		return fmt.Errorf("lookup owner: %w", err)
+	}
+	if owner != userID {
+		return fmt.Errorf("executor %s not owned by user %s", exeID, userID)
+	}
+	return nil
+}
+
+func respondWithWSURL(w http.ResponseWriter, r *http.Request, exeID, authHeaderForWS, publicWSBaseURL string) {
+	base := publicWSBaseURL
+	if base == "" {
+		base = synthBaseURL(r)
+	}
+	// The WS URL has its own bearer cap-token in the query string; the
+	// auth header above only authorized the register call itself.
+	wsURL := base + "/codex-exec/" + url.PathEscape(exeID) + "?token=" +
+		url.QueryEscape(strings.TrimPrefix(authHeaderForWS, "Bearer "))
+	writeJSON(w, http.StatusOK, cloudRegisterResponse{
+		ID: exeID, ExecutorID: exeID, URL: wsURL,
+	})
+}
+```
+
+Add `UserIDForExecutor` to `Store` in `internal/codexexecgateway/store.go`:
+
+```go
+// UserIDForExecutor returns the owner user_id of an executor row.
+// Used by /cloud/executor/{id}/register to confirm the token holder
+// owns the executor they're trying to register as.
+func (s *Store) UserIDForExecutor(ctx context.Context, exeID string) (string, error) {
+	var uid string
+	err := s.db.QueryRowContext(ctx,
+		`SELECT user_id::text FROM executors WHERE exe_id = $1`, exeID).Scan(&uid)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return uid, err
+}
+```
+
+- [ ] **Step 4: Update route registration**
+
+In `internal/codexexecgateway/server.go`, change the existing line:
+```go
+r.Post("/cloud/executor/{exe_id}/register",
+    handlers.CloudRegister(s.store, s.config.PublicWSBaseURL))
+```
+to:
+```go
+r.Post("/cloud/executor/{exe_id}/register",
+    handlers.CloudRegister(s.store, s.config.PublicWSBaseURL,
+        handlers.AgentserverValidator{
+            BaseURL:        s.config.AgentserverInternalURL,
+            InternalSecret: s.config.AgentserverInternalSecret,
+        }))
+```
+
+- [ ] **Step 5: Run tests**
+
+```bash
+cd /root/agentserver && go test ./internal/codexexecgateway/...
+```
+
+Expected: all pass including the new delegation test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/codexexecgateway/handlers/cloud_register.go \
+        internal/codexexecgateway/handlers/cloud_register_test.go \
+        internal/codexexecgateway/store.go \
+        internal/codexexecgateway/server.go
+git commit -m "feat(exec-gateway): /cloud/executor/.../register delegates to codexauth"
+```
+
+---
+
+### Task D3: handleRegisterExecutor mints Agent Identity JWT
+
+**Files:**
+- Modify: `internal/server/codex_executors.go`
+- Modify: `internal/server/codex_executors_test.go`
+
+- [ ] **Step 1: Write failing test**
+
+```go
+// internal/server/codex_executors_test.go — append
+
+func TestRegisterExecutor_ReturnsAllThreeConnectCommands(t *testing.T) {
+	// Setup: server with CodexAuth wired + test workspace + user.
+	s := setupTestServerWithCodexAuth(t)
+	wid := s.createWorkspaceAndUser(t)
+
+	req := httptest.NewRequest(http.MethodPost,
+		"/api/workspaces/"+wid+"/executors",
+		strings.NewReader(`{"name":"jetson-805","description":"test"}`))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.router.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d body = %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		ExeID             string `json:"exe_id"`
+		AgentIdentityJWT  string `json:"agent_identity_jwt"`
+		ConnectCommands   struct {
+			AgentIdentity   string `json:"agent_identity"`
+			ChatgptBrowser  string `json:"chatgpt_browser"`
+			ChatgptDevice   string `json:"chatgpt_device_auth"`
+		} `json:"connect_commands"`
+	}
+	json.NewDecoder(rr.Body).Decode(&resp)
+	if resp.AgentIdentityJWT == "" || resp.ConnectCommands.AgentIdentity == "" {
+		t.Errorf("missing agent_identity payload: %+v", resp)
+	}
+	if !strings.Contains(resp.ConnectCommands.AgentIdentity, "CODEX_ACCESS_TOKEN") {
+		t.Errorf("agent_identity command missing CODEX_ACCESS_TOKEN")
+	}
+	if !strings.Contains(resp.ConnectCommands.ChatgptBrowser, "codex login --issuer") {
+		t.Errorf("chatgpt_browser command missing codex login")
+	}
+	if !strings.Contains(resp.ConnectCommands.ChatgptDevice, "--device-auth") {
+		t.Errorf("chatgpt_device_auth command missing --device-auth")
+	}
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+Run: `cd /root/agentserver && go test -run TestRegisterExecutor_ReturnsAllThreeConnect ./internal/server/`
+Expected: FAIL.
+
+- [ ] **Step 3: Modify codex_executors.go**
+
+In `handleRegisterExecutor`, replace the existing block that builds `resp.ConnectCommand` with:
+
+```go
+// Mint Agent Identity JWT alongside the legacy bearer registration.
+// The exe_id is the agent_runtime_id (1-to-1 mapping).
+var aiResult *codexauth.MintAgentIdentityResult
+if s.CodexAuth != nil {
+	email, _ := s.lookupUserEmail(r.Context(), userID)
+	aiResult, err = s.CodexAuth.MintAgentIdentity(r.Context(),
+		codexauth.MintAgentIdentityArgs{
+			AgentRuntimeID: reg.ExeID,
+			UserID:         userID,
+			Email:          email,
+		})
+	if err != nil {
+		http.Error(w, "mint agent identity: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
+resp := registerExecutorResp{
+	ExeID:             reg.ExeID,
+	RegistrationToken: reg.RegistrationToken,
+}
+if aiResult != nil {
+	resp.AgentIdentityJWT = aiResult.JWT
+}
+if s.CodexExecGatewayPublicHost != "" {
+	gatewayURL := "https://" + s.CodexExecGatewayPublicHost
+	issuer := s.CodexAuthIssuerURL // e.g. "https://agent.cs.ac.cn/codex-auth"
+	resp.ConnectCommands = ConnectCommands{
+		AgentIdentity: fmt.Sprintf(
+			"export CODEX_ACCESS_TOKEN='%s'\nexport CODEX_AGENT_IDENTITY_AUTHAPI_BASE_URL='%s'\ncodex -c chatgpt.base_url='%s' exec-server --remote '%s' --executor-id '%s' --name '%s' --use-agent-identity-auth",
+			aiResult.JWT, issuer, issuer, gatewayURL, reg.ExeID, req.Name),
+		ChatgptBrowser: fmt.Sprintf(
+			"codex login --issuer %s\nexport CODEX_REFRESH_TOKEN_URL_OVERRIDE='%s/oauth/token'\ncodex exec-server --remote '%s' --executor-id '%s' --name '%s'",
+			issuer, issuer, gatewayURL, reg.ExeID, req.Name),
+		ChatgptDeviceAuth: fmt.Sprintf(
+			"codex login --device-auth --issuer %s\nexport CODEX_REFRESH_TOKEN_URL_OVERRIDE='%s/oauth/token'\ncodex exec-server --remote '%s' --executor-id '%s' --name '%s'",
+			issuer, issuer, gatewayURL, reg.ExeID, req.Name),
+	}
+	// Keep legacy single-string field for backward compat with existing UI.
+	resp.ConnectCommand = resp.ConnectCommands.AgentIdentity
+}
+```
+
+Add fields to `registerExecutorResp`:
+
+```go
+type ConnectCommands struct {
+	AgentIdentity     string `json:"agent_identity"`
+	ChatgptBrowser    string `json:"chatgpt_browser"`
+	ChatgptDeviceAuth string `json:"chatgpt_device_auth"`
+}
+
+type registerExecutorResp struct {
+	ExeID             string          `json:"exe_id"`
+	RegistrationToken string          `json:"registration_token"`
+	ConnectCommand    string          `json:"connect_command,omitempty"`
+	AgentIdentityJWT  string          `json:"agent_identity_jwt,omitempty"`
+	ConnectCommands   ConnectCommands `json:"connect_commands,omitempty"`
+}
+```
+
+Wire `CodexAuth *codexauth.Server` + `CodexAuthIssuerURL string` into `Server` struct (add field).
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cd /root/agentserver && go test -run TestRegisterExecutor ./internal/server/
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/server/codex_executors.go internal/server/codex_executors_test.go internal/server/server.go
+git commit -m "feat(server): register executor returns 3 connect-commands + AI JWT"
+```
+
+---
+
+### Task D4: Web UI — render three connect commands
+
+**Files:**
+- Modify: `web/src/components/AddConnectorSuccess.tsx` (path may vary — `grep -r "connect_command" web/src/`)
+
+- [ ] **Step 1: Find the existing component**
+
+```bash
+cd /root/agentserver && grep -rln "connect_command\|connectCommand" web/src/ | head -5
+```
+
+- [ ] **Step 2: Modify the component to show three tabs/sections**
+
+Open the file located in step 1 and replace the single `<pre>{resp.connect_command}</pre>` block with:
+
+```tsx
+type ConnectCommands = {
+  agent_identity?: string;
+  chatgpt_browser?: string;
+  chatgpt_device_auth?: string;
+};
+
+function ConnectCommandsPanel({ cmds }: { cmds: ConnectCommands }) {
+  const [tab, setTab] = useState<keyof ConnectCommands>('agent_identity');
+  const tabs: { key: keyof ConnectCommands; label: string; hint: string }[] = [
+    { key: 'agent_identity',      label: 'Agent Identity (headless)',  hint: 'Best for unattended machines. One paste, done.' },
+    { key: 'chatgpt_browser',     label: 'codex login (browser)',     hint: 'For desktops. SSO with your agentserver session.' },
+    { key: 'chatgpt_device_auth', label: 'codex login --device-auth', hint: 'Headless + ChatGPT-account semantics. Enter a code in a browser.' },
+  ];
+  return (
+    <div>
+      <div className="flex gap-2 mb-3">
+        {tabs.map(({ key, label }) => (
+          <button
+            key={key}
+            onClick={() => setTab(key)}
+            className={tab === key ? 'btn-active' : 'btn'}
+          >{label}</button>
+        ))}
+      </div>
+      <p className="text-sm text-gray-500 mb-2">{tabs.find(t => t.key === tab)!.hint}</p>
+      <pre className="bg-gray-100 p-3 rounded overflow-x-auto"><code>{cmds[tab]}</code></pre>
+      <button onClick={() => navigator.clipboard.writeText(cmds[tab] || '')}>Copy</button>
+    </div>
+  );
+}
+```
+
+Use it in the existing success-screen render:
+
+```tsx
+{resp.connect_commands ? (
+  <ConnectCommandsPanel cmds={resp.connect_commands} />
+) : (
+  <pre>{resp.connect_command}</pre>
+)}
+```
+
+- [ ] **Step 3: Run frontend build**
+
+```bash
+cd /root/agentserver/web && npm run build
+```
+
+Expected: build succeeds.
+
+- [ ] **Step 4: Manual smoke test**
+
+```bash
+# In a separate shell, start agentserver locally with codexAuth enabled.
+# Visit the Connectors page, click "Add connector", confirm the three
+# tabs render with their respective commands.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/...   # whichever files changed
+git commit -m "feat(web): show 3 connect-command tabs on Add Connector"
+```
+
+---
+
+### Task D5: Chart env vars + bump
+
+**Files:**
+- Modify: `deploy/helm/agentserver/templates/codex-exec-gateway.yaml`
+- Modify: `deploy/helm/agentserver/Chart.yaml`
+
+- [ ] **Step 1: Add CXG_AGENTSERVER_INTERNAL_URL + secret env**
+
+In `deploy/helm/agentserver/templates/codex-exec-gateway.yaml`, find the existing env block and ensure these are present (they may already be):
+
+```yaml
+            - name: CXG_AGENTSERVER_INTERNAL_URL
+              value: "http://{{ .Release.Name }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}"
+            - name: CXG_AGENTSERVER_INTERNAL_SECRET
+              value: {{ required "internal.apiSecret is required when codexExecGateway.enabled is true" .Values.internal.apiSecret | quote }}
+```
+
+(These already exist from earlier work; just confirm.)
+
+In `deploy/helm/agentserver/templates/deployment.yaml`, confirm the `CODEX_AUTH_ISSUER_URL` block from Task B7 is present.
+
+- [ ] **Step 2: Bump chart**
+
+Find current version:
+```bash
+grep "^version:" deploy/helm/agentserver/Chart.yaml
+```
+
+Bump by 1 (e.g. 0.61.10 → 0.62.0 — this is a major feature so minor-version bump is appropriate):
+
+```yaml
+version: 0.62.0
+appVersion: "0.62.0"
+```
+
+- [ ] **Step 3: Helm template render**
+
+```bash
+helm template deploy/helm/agentserver/ \
+  --set codexAuth.enabled=true \
+  --set internal.apiSecret=test \
+  --set codexExecGateway.enabled=true \
+  --set platform.domain=test.example \
+  2>&1 | grep -E "CODEX_AUTH_ISSUER_URL|/codex-auth"
+```
+
+Expected: `CODEX_AUTH_ISSUER_URL: "https://test.example/codex-auth"` appears.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add deploy/helm/agentserver/templates/ deploy/helm/agentserver/Chart.yaml deploy/helm/agentserver/values.yaml
+git commit -m "chore(helm): codexAuth toggle + chart 0.62.0"
+```
+
+---
+
+### PR 4 wrap-up
+
+- [ ] Open PR
+
+```bash
+git push -u github feature/codexauth-validator-and-ui
+gh pr create --base main \
+  --title "feat(codexauth): /cloud/executor validator + 3-way connect command UI" \
+  --body "Phase D — wire validator into codex-exec-gateway, mint Agent Identity JWT in handleRegisterExecutor, show 3 connect-command tabs, chart 0.62.0 bump."
+```
+
+---
+
+## Phase E — Production rollout (PR 5)
+
+### Task E1: Pulumi chart bump
+
+**Files:**
+- Modify: `/root/k8s/stacks/agentserver.ts`
+
+- [ ] **Step 1: Bump chart + enable codexAuth**
+
+```typescript
+// /root/k8s/stacks/agentserver.ts
+const rel = new k8s.helm.v3.Release(`helm-${name}`, {
+    chart: "oci://ghcr.io/agentserver/charts/agentserver",
+    version: "0.62.0",
+    values: {
+        // ... existing values ...
+        codexAuth: { enabled: true },
+        platform: { domain: "agent.cs.ac.cn" },
+        // ... rest ...
+    },
+});
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+cd /root/k8s
+git add stacks/agentserver.ts
+git commit -m "chore(agentserver): chart 0.62.0 — codex 0.132+ auth support"
+```
+
+- [ ] **Step 3: Push + pulumi up (USER ACTION REQUIRED)**
+
+```bash
+cd /root/k8s && git push
+cd /root/k8s && pulumi up -s nj-prod
+```
+
+Expected: all 10 deployments roll (auto-roll annotation from chart 0.61.8 ensures this). Wait until `kubectl -n agentserver get pods` shows everything running and recent.
+
+---
+
+### Task E2: End-to-end production smoke test
+
+- [ ] **Step 1: ChatGPT browser flow**
+
+On a laptop with a browser:
+
+```bash
+codex login --issuer https://agent.cs.ac.cn/codex-auth
+# (browser opens, login through agentserver session, completes)
+ls ~/.codex/auth.json   # should exist with tokens
+
+export CODEX_REFRESH_TOKEN_URL_OVERRIDE='https://agent.cs.ac.cn/codex-auth/oauth/token'
+codex exec-server --remote 'https://codex-exec.agent.cs.ac.cn' \
+       --executor-id 'exe_test_browser' --name 'laptop-test'
+```
+
+Expected: `codex exec-server remote executor registered with executor_id …` printed, WS stays connected.
+
+- [ ] **Step 2: Device flow**
+
+On jetson-805 (no browser):
+
+```bash
+codex login --device-auth --issuer https://agent.cs.ac.cn/codex-auth
+# Codex prints: "Open this link: https://agent.cs.ac.cn/codex-auth/codex/device
+#                Enter code: XXXX-XXXX"
+# Open URL on phone/laptop, enter code, click Approve.
+ls ~/.codex/auth.json
+
+export CODEX_REFRESH_TOKEN_URL_OVERRIDE='https://agent.cs.ac.cn/codex-auth/oauth/token'
+codex exec-server --remote 'https://codex-exec.agent.cs.ac.cn' \
+       --executor-id 'exe_test_device' --name 'jetson-test-device'
+```
+
+Expected: same success message; WS connected.
+
+- [ ] **Step 3: Agent Identity flow**
+
+On jetson-805:
+
+```bash
+# In the Connectors page, click "Add connector" → name "jetson-805-ai" →
+# copy the Agent Identity command block, paste in jetson terminal:
+
+export CODEX_ACCESS_TOKEN='eyJhbGc…(the JWT)'
+export CODEX_AGENT_IDENTITY_AUTHAPI_BASE_URL='https://agent.cs.ac.cn/codex-auth'
+codex -c chatgpt.base_url='https://agent.cs.ac.cn/codex-auth' \
+      exec-server --remote 'https://codex-exec.agent.cs.ac.cn' \
+      --executor-id 'exe_…' --name 'jetson-805-ai' \
+      --use-agent-identity-auth
+```
+
+Expected: registered successfully.
+
+- [ ] **Step 4: From Jupyter, verify env appears**
+
+```python
+envs = await ctx.envs()
+print(envs)
+# Should include any of the three test executors registered above.
+```
+
+---
+
+## Self-review
+
+**Spec coverage (every section → at least one task):**
+
+| Spec section | Covered by |
+|---|---|
+| Problem / Non-goals | (intro context) |
+| How codex 0.132 calls us | (informs all tasks) |
+| Architecture / Why not Hydra | B7 (wiring), D5 (chart values) |
+| ChatGPT mode — login (PKCE) | B2 (authorize), B3 (token) |
+| ChatGPT mode — refresh URL override | B4 + UI in D3 |
+| Device flow | B5 (endpoints), B6 (browser page) |
+| Agent Identity — mint | C1 |
+| Agent Identity — JWKS | C2 |
+| Agent Identity — task/register | C1 |
+| /cloud/executor validation (Bearer + AgentAssertion + legacy bcrypt) | D1 (validator), D2 (delegation) |
+| Database schema additions (incl. device codes) | A1 |
+| Connect-command UI changes | D3 (server), D4 (web) |
+| Backward compat | D2 (legacy bcrypt path retained) |
+| Testing | B7 (smoke), C3 (integration test) |
+| Rollout | Phase E |
+
+**Type consistency check:**
+- `*codexauth.Server` referenced consistently across cmd/serve.go, internal/server/server.go, codex_executors.go.
+- `MintAgentIdentityArgs` / `MintAgentIdentityResult` defined in C1, used in D3.
+- `AgentserverValidator` defined in D2, used in cloud_register.
+- `HashToken([]byte)` returns `[]byte` consistently in A4 + A6.
+- `ConnectCommands` JSON shape matches between D3 (Go) and D4 (TS).
+
+**No placeholder scan:** all steps show actual code or commands. Bash steps have exact env vars and expected output.
+
+---
+
+## Execution
+
+**Plan complete and saved to `docs/superpowers/plans/2026-05-20-codex-0.132-auth.md`. Two execution options:**
+
+**1. Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration. Best for this plan because there are 27 self-contained tasks with clear test gates.
+
+**2. Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints. Better if you want to watch each task land in real time.
+
+**Which approach?**

--- a/docs/superpowers/plans/2026-05-20-codex-0.132-auth.md
+++ b/docs/superpowers/plans/2026-05-20-codex-0.132-auth.md
@@ -1197,6 +1197,31 @@ func TestBuildIDToken_CarriesOpenAIClaim(t *testing.T) {
 	}
 }
 
+func TestBuildAccessToken_HasExpClaim(t *testing.T) {
+	kid, kp, _ := GenerateRSAKey()
+	exp := time.Now().Add(1 * time.Hour)
+	jwt, err := BuildAccessToken(kp.PrivateKey, kid, IDTokenClaims{
+		Issuer:    "https://example/codex-auth",
+		Subject:   "user-abc",
+		ExpiresAt: exp,
+	})
+	if err != nil {
+		t.Fatalf("BuildAccessToken: %v", err)
+	}
+	parts := strings.Split(jwt, ".")
+	payload, _ := base64.RawURLEncoding.DecodeString(parts[1])
+	var claims map[string]any
+	json.Unmarshal(payload, &claims)
+	// Codex's parse_jwt_expiration reads `exp` and triggers refresh
+	// when exp <= now — so we must mint this value.
+	if claims["exp"] == nil {
+		t.Errorf("exp claim missing: %v", claims)
+	}
+	if claims["sub"] != "user-abc" {
+		t.Errorf("sub = %v", claims["sub"])
+	}
+}
+
 func TestBuildAgentIdentityJWT_IsCodexParseable(t *testing.T) {
 	kid, kp, _ := GenerateRSAKey()
 	_, pub, _ := GenerateEd25519Key()
@@ -1283,6 +1308,24 @@ func BuildIDToken(key *rsa.PrivateKey, kid string, c IDTokenClaims) (string, err
 			"completed_platform_onboarding":   true,
 			"is_org_owner":                    true,
 		},
+	}
+	return signRS256(key, kid, payload)
+}
+
+// BuildAccessToken mints the access_token as an RS256 JWT carrying just
+// `{iss, sub, iat, exp}`. Codex never validates the signature (it treats
+// access_token as an opaque bearer), but it *does* parse `exp` to drive
+// proactive refresh (login/src/auth/manager.rs:1793-1812 —
+// is_stale_for_proactive_refresh calls parse_jwt_expiration on
+// access_token). Minting the access_token as a JWT means codex refreshes
+// cleanly at the real expiry instead of waiting for a 401 retry.
+func BuildAccessToken(key *rsa.PrivateKey, kid string, c IDTokenClaims) (string, error) {
+	payload := map[string]any{
+		"iss": c.Issuer,
+		"sub": c.Subject,
+		"aud": "app_EMoamEEZ73f0CkXaXp7hrann",
+		"iat": time.Now().Unix(),
+		"exp": c.ExpiresAt.Unix(),
 	}
 	return signRS256(key, kid, payload)
 }
@@ -1936,12 +1979,29 @@ func (s *Server) handleTokenAuthorizationCode(w http.ResponseWriter, r *http.Req
 // mintTokensFor mints access + refresh + id_token and writes the codex-
 // shaped response. Shared by authorization_code, refresh_token, and the
 // device-flow exchange path.
+//
+// access_token is minted as a signed JWT with `{sub, exp}` so codex's
+// proactive refresh logic (parse_jwt_expiration) works correctly.
+// We still store its sha256 hash in codex_access_tokens for server-side
+// revocation and the hash is what /internal/codex-auth/validate looks
+// up — the JWT body is opaque to us.
 func (s *Server) mintTokensFor(w http.ResponseWriter, r *http.Request, userID string) {
 	ctx := r.Context()
-	access := mustRandomHex(32)
+	accessExp := time.Now().Add(accessTokenTTL)
+	email := s.lookupEmail(ctx, userID)
+	access, err := BuildAccessToken(s.SigningKey, s.SigningKid, IDTokenClaims{
+		Issuer:    s.IssuerURL,
+		Subject:   userID,
+		Email:     email,
+		ExpiresAt: accessExp,
+	})
+	if err != nil {
+		writeOauthError(w, http.StatusInternalServerError, "server_error",
+			"build access_token: "+err.Error())
+		return
+	}
 	refresh := mustRandomHex(32)
 
-	accessExp := time.Now().Add(accessTokenTTL)
 	if err := s.Store.InsertAccessToken(ctx, HashToken(access), userID, accessExp); err != nil {
 		writeOauthError(w, http.StatusInternalServerError, "server_error", err.Error())
 		return
@@ -1953,7 +2013,6 @@ func (s *Server) mintTokensFor(w http.ResponseWriter, r *http.Request, userID st
 		return
 	}
 
-	email := s.lookupEmail(ctx, userID)
 	idTok, err := BuildIDToken(s.SigningKey, s.SigningKid, IDTokenClaims{
 		Issuer:    s.IssuerURL,
 		Subject:   userID,
@@ -2105,14 +2164,24 @@ func (s *Server) handleTokenRefresh(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	access := mustRandomHex(32)
 	accessExp := time.Now().Add(accessTokenTTL)
+	email := s.lookupEmail(r.Context(), userID)
+	access, err := BuildAccessToken(s.SigningKey, s.SigningKid, IDTokenClaims{
+		Issuer:    s.IssuerURL,
+		Subject:   userID,
+		Email:     email,
+		ExpiresAt: accessExp,
+	})
+	if err != nil {
+		writeOauthError(w, http.StatusInternalServerError, "server_error",
+			"build access_token: "+err.Error())
+		return
+	}
 	if err := s.Store.InsertAccessToken(r.Context(), HashToken(access), userID, accessExp); err != nil {
 		writeOauthError(w, http.StatusInternalServerError, "server_error", err.Error())
 		return
 	}
 
-	email := s.lookupEmail(r.Context(), userID)
 	idTok, err := BuildIDToken(s.SigningKey, s.SigningKid, IDTokenClaims{
 		Issuer:    s.IssuerURL,
 		Subject:   userID,
@@ -3337,6 +3406,37 @@ func TestValidate_BearerExpiredReturns401(t *testing.T) {
 	}
 }
 
+func TestValidate_BearerWithAccountIDMismatch_401(t *testing.T) {
+	srv := newTestServer(t, "")
+	uid := mustCreateTestUser(t, srv.Store.db)
+	srv.Store.InsertAccessToken(context.Background(), HashToken("crosscheck"), uid,
+		time.Now().Add(1*time.Hour))
+
+	body, _ := json.Marshal(map[string]string{
+		"scheme": "bearer", "token": "crosscheck",
+		"account_id": "different-user-id",
+	})
+	rr := callValidate(t, srv, body)
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 for account_id mismatch", rr.Code)
+	}
+}
+
+func TestValidate_BearerWithAccountIDMatch_200(t *testing.T) {
+	srv := newTestServer(t, "")
+	uid := mustCreateTestUser(t, srv.Store.db)
+	srv.Store.InsertAccessToken(context.Background(), HashToken("matchcheck"), uid,
+		time.Now().Add(1*time.Hour))
+
+	body, _ := json.Marshal(map[string]string{
+		"scheme": "bearer", "token": "matchcheck", "account_id": uid,
+	})
+	rr := callValidate(t, srv, body)
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 for account_id match", rr.Code)
+	}
+}
+
 func TestValidate_AgentAssertionHappyPath(t *testing.T) {
 	srv := newTestServer(t, "")
 	ctx := context.Background()
@@ -3442,6 +3542,14 @@ func (s *Server) validate(ctx context.Context, req validateRequest) (string, err
 		}
 		if uid == "" {
 			return "", fmt.Errorf("bearer token unknown or expired")
+		}
+		// Defense-in-depth: ChatGPT-mode bearer requests always carry
+		// the ChatGPT-Account-ID header (BearerAuthProvider adds it
+		// unconditionally — model-provider/src/bearer_auth_provider.rs).
+		// We mint id_token with chatgpt_account_id == user_id, so codex
+		// will echo our user_id back. Reject mismatches.
+		if req.AccountID != "" && req.AccountID != uid {
+			return "", fmt.Errorf("ChatGPT-Account-ID header does not match token owner")
 		}
 		return uid, nil
 	case "agent_assertion":
@@ -3677,11 +3785,14 @@ func CloudRegister(store CloudRegisterStore, publicWSBaseURL string, validator A
 func classifyAndValidate(ctx context.Context, v AgentserverValidator, authHeader, accountID string) (string, bool) {
 	if strings.HasPrefix(authHeader, "Bearer ") {
 		token := strings.TrimPrefix(authHeader, "Bearer ")
-		// 32-byte hex matches our new codex_access_tokens; legacy bcrypt
-		// tokens have similar shape so we always try delegating first,
-		// fall back to bcrypt path on 401.
+		// ChatGPT-mode bearer requests always come with the
+		// ChatGPT-Account-ID header (BearerAuthProvider in codex always
+		// adds it). Forward it so agentserver can cross-check the
+		// header against the token's owner.
+		// Legacy bcrypt tokens have similar shape; we always try
+		// delegating first and fall back to the bcrypt path on 401.
 		uid, err := v.Validate(ctx, map[string]string{
-			"scheme": "bearer", "token": token,
+			"scheme": "bearer", "token": token, "account_id": accountID,
 		})
 		if err == nil && uid != "" {
 			return uid, true

--- a/docs/superpowers/specs/2026-05-20-codex-0.132-auth.md
+++ b/docs/superpowers/specs/2026-05-20-codex-0.132-auth.md
@@ -1,0 +1,583 @@
+# codex 0.132+ auth integration design
+
+**Status:** draft, awaiting user approval
+**Author:** mryao
+**Date:** 2026-05-20
+
+## Problem
+
+Codex 0.132 removed `CODEX_EXEC_SERVER_REMOTE_BEARER_TOKEN`
+([release notes #22769](https://github.com/openai/codex/releases/tag/rust-v0.132.0)).
+`codex exec-server --remote …` now refuses to register with our gateway
+unless the user has either:
+
+1. **ChatGPT auth** in `~/.codex/auth.json` (produced by `codex login`
+   against the OpenAI OAuth issuer), or
+2. **Agent Identity JWT** in `$CODEX_ACCESS_TOKEN` (produced by — well,
+   by us, if we implement it).
+
+For self-hosted deployments like `agent.cs.ac.cn` neither exists. The
+current Windows / jetson `codex exec-server --remote` flow returns
+`Error: remote exec-server registration requires ChatGPT authentication;
+run \`codex login\` first` and dies.
+
+We need to support **both** modes against our own infrastructure, so
+users can `codex login` with their agentserver identity OR use a
+pre-minted Agent Identity token, and `exec-server --remote` Just Works.
+
+## Non-goals
+
+- Replacing `chatgpt.com` for the **model turn path** (the actual LLM
+  call still hits whatever `model_providers.openai.base_url` points at —
+  out of scope here, separately addressable via config override and
+  llmproxy).
+- Supporting `codex` TUI's full feature set (workspace browser, plan
+  inspection, etc.) — those endpoints can no-op or 404.
+- Replacing `app-server --remote-control` flow (the `/wham/…` endpoints).
+  Different subcommand, different auth, will revisit if needed.
+- Wire-compatible OpenAI auth.json — we mint shaped-like-OpenAI claims
+  but with our identifiers; we do not pretend to be openai.com.
+
+## How codex 0.132 actually calls us
+
+Verified from `git show rust-v0.132.0:codex-rs/exec-server/src/remote.rs`
+and `cli/src/main.rs`:
+
+```
+codex exec-server --remote $BASE_URL --executor-id $EXE_ID --name $NAME
+                  [--use-agent-identity-auth]
+
+→ load_exec_server_remote_auth_provider(...)
+    if --use-agent-identity-auth:
+       JWT  := getenv("CODEX_ACCESS_TOKEN")
+       _    := CodexAuth::from_agent_identity_jwt(JWT, chatgpt.base_url)
+                 ↳ AgentIdentityAuthRecord::from_agent_identity_jwt(JWT)   // parse only
+                 ↳ fetch_agent_identity_jwks({chatgpt.base_url}/agent-identities/jwks)
+                 ↳ decode_agent_identity_jwt(JWT, &jwks)                   // verify RS256
+                 ↳ register_agent_task(POST {authapi}/v1/agent/{rid}/task/register
+                                       body {timestamp, signature_ed25519})
+                                       expects {task_id}
+    else:
+       Auth := read ~/.codex/auth.json — REQUIRES auth_mode == "chatgpt"
+
+→ POST $BASE_URL/cloud/executor/$EXE_ID/register
+    headers := auth_provider.to_auth_headers()
+        ChatGPT mode:        Authorization: Bearer <openai-shaped access_token>
+        AgentIdentity mode:  Authorization: AgentAssertion <base64url-json>
+                             ChatGPT-Account-ID: <claims.account_id>
+    response := {executor_id, url}
+
+→ connect_async(url)   // WS — url contains the cap-token in its query
+```
+
+So the wire surface we must implement falls into two unrelated buckets,
+plus a shared third bucket:
+
+| Bucket | ChatGPT mode | Agent Identity mode |
+|---|---|---|
+| **Mint credentials** | `/oauth/authorize`, `/oauth/token` (PKCE / refresh) | mint JWT at "add connector" time + serve `/agent-identities/jwks` + accept `/v1/agent/{rid}/task/register` |
+| **Codex-side validation** | none (signature not checked) | RS256 against our JWKS |
+| **Our `/cloud/executor/{id}/register`** | validate `Authorization: Bearer` | validate `Authorization: AgentAssertion` + cross-check `ChatGPT-Account-ID` |
+
+The model-turn endpoint is **not** on this surface — codex still POSTs
+to `https://chatgpt.com/backend-api/codex/responses` unless the user
+also overrides `model_providers.openai.base_url`. That is a separate
+config concern.
+
+## Architecture
+
+One new package, `internal/codexauth/`, on agentserver itself (NOT on
+codex-exec-gateway — auth is a user-identity concern and agentserver
+already owns user identity / sessions). The package exposes:
+
+```
+internal/codexauth/
+├── server.go            # chi.Router with all routes mounted
+├── pkce.go              # PKCE flow handlers (authorize, token, refresh)
+├── claims.go            # OpenAI-shaped id_token claims builder
+├── jwks.go              # /agent-identities/jwks handler + key rotation
+├── agent_identity.go    # mint JWT, /v1/agent/{rid}/task/register, store agent pubkey
+├── validate.go          # Bearer + AgentAssertion validators for /cloud/executor
+└── store.go             # postgres-backed: refresh tokens, agent records
+```
+
+The `/cloud/executor/{id}/register` handler stays on **codex-exec-gateway**
+but delegates validation to a shared `codexauth.Validate(ctx, headers)`
+call (HTTP, internal endpoint on agentserver). One auth subsystem, one
+place to test.
+
+```
+                        ┌────────────────────────────────────────────────┐
+  user-facing TLS:      │ https://agent.cs.ac.cn                          │
+                        │   /codex-auth/oauth/authorize  ── PKCE start    │
+                        │   /codex-auth/oauth/token      ── PKCE exchange │
+                        │                                  + refresh      │
+                        │   /codex-auth/agent-identities/jwks             │
+                        │   /codex-auth/v1/agent/{rid}/task/register      │
+                        └─────────────────────┬──────────────────────────┘
+                                              │ (mux to agentserver:8080)
+                                              ▼
+                        ┌────────────────────────────────────────────────┐
+  internal:             │ agentserver (Go)                                │
+                        │   internal/codexauth — all of the above         │
+                        │   internal/auth      — session ↔ user_id        │
+                        │   /internal/codex-auth/validate  (called by     │
+                        │     codex-exec-gateway over X-Internal-Secret)  │
+                        └────────────────────────────────────────────────┘
+
+                        ┌────────────────────────────────────────────────┐
+  user-facing TLS:      │ https://codex-exec.agent.cs.ac.cn               │
+                        │   /cloud/executor/{exe_id}/register   ←  codex  │
+                        │     → calls agentserver validate                │
+                        └────────────────────────────────────────────────┘
+```
+
+### Why not Hydra
+
+Hydra can serve OAuth2 PKCE — that part is uncontroversial. But:
+
+1. **Hydra's `id_token` shape is standard OIDC**, while codex parses a
+   nested OpenAI claim (`https://api.openai.com/auth` → object with
+   `chatgpt_account_id`, `chatgpt_plan_type`, etc.). We'd need a
+   token-rewriting proxy in front of Hydra to repackage claims —
+   complexity equal to just minting our own tokens directly.
+2. **Codex never verifies the access_token signature** (`server.rs`
+   parses it but `access_token` is opaque; the id_token claim object is
+   base64-decoded without sig check). So there is no value in Hydra's
+   real OAuth2 enforcement — we just need claim-shape-compatible blobs.
+3. **Hydra refresh token URL** is hardcoded inside codex
+   (`https://auth.openai.com/oauth/token`) — only overridable via env
+   `CODEX_REFRESH_TOKEN_URL_OVERRIDE`. Either way it points at us, not
+   Hydra directly. So Hydra is at best one indirection away from the
+   wire and adds no security we can't get inline.
+4. We already have agentserver session + user_id state in postgres.
+   Building PKCE → user_id directly is ~200 lines of Go and reuses our
+   existing session table. Bouncing through Hydra costs us another
+   storage layer and an OAuth client per environment to manage.
+
+**Decision: implement PKCE + token endpoints directly in
+`internal/codexauth`. Hydra continues to serve its existing
+Device-Flow-for-third-party-agents role; codex auth does not depend on
+it.** If we ever expose codex login to third parties as a federated
+client, revisit then.
+
+## ChatGPT mode — design
+
+### Login (PKCE)
+
+User runs (once per machine):
+
+```
+codex login --issuer https://agent.cs.ac.cn/codex-auth
+```
+
+The `--issuer` flag controls where codex's PKCE flow goes. Default is
+`https://auth.openai.com`; we substitute ours.
+
+#### `GET /codex-auth/oauth/authorize`
+
+Query params codex sends:
+- `response_type=code`
+- `client_id=app_EMoamEEZ73f0CkXaXp7hrann` — codex's hardcoded id; we
+  ignore it (single-client universe)
+- `redirect_uri=http://localhost:1455/auth/callback`
+- `scope=openid profile email offline_access api.connectors.read api.connectors.invoke`
+  — we ignore; everything is implicit
+- `code_challenge=…&code_challenge_method=S256` — PKCE; we store and
+  verify on token exchange
+- `state=…` — opaque; round-trip back
+- `id_token_add_organizations=true`, `codex_cli_simplified_flow=true`,
+  `originator=…` — ignore
+
+Handler behavior:
+1. If request has no agentserver session cookie → 302 to
+   `/login?next={original_url}` (existing agentserver login). After
+   login the user lands back here with a session.
+2. With session: insert a row into `codex_pkce_requests` with
+   `(code, code_challenge, state, user_id, expires_at = now+10min)`,
+   where `code` is a freshly generated 32-byte hex.
+3. 302 to `redirect_uri?code={code}&state={state}` (back to
+   `localhost:1455` on the user's machine).
+
+#### `POST /codex-auth/oauth/token`
+
+Two grant types codex uses; we handle both. Both return JSON.
+
+**`grant_type=authorization_code`**
+Body (form-urlencoded): `code`, `code_verifier`, `redirect_uri`,
+`client_id`.
+1. Look up `codex_pkce_requests` by `code`. 400 if missing/expired.
+2. Verify `code_challenge == base64url_no_pad(sha256(code_verifier))`.
+   400 if not.
+3. Delete the row (single-use).
+4. Mint:
+   - `access_token` = opaque 32-byte hex, stored in
+     `codex_access_tokens` table with `(token_hash, user_id, expires_at)`.
+   - `refresh_token` = opaque 32-byte hex, stored in
+     `codex_refresh_tokens` table with `(token_hash, user_id, family_id,
+     expires_at = 1y)`. Rotation on use (issue new + invalidate old).
+   - `id_token` = RS256 JWT signed with the same RSA key we use for
+     Agent Identity JWKS (header `{"alg":"RS256","kid":"<active-kid>"}`).
+     Codex does not verify the signature today, but signing is
+     defense-in-depth against future codex versions and lets us
+     introspect tokens from our own logs without trusting bearers.
+     Claims per `internal/codexauth/claims.go`:
+     ```jsonc
+     {
+       "iss": "https://agent.cs.ac.cn/codex-auth",
+       "sub": "<user_id>",
+       "aud": "app_EMoamEEZ73f0CkXaXp7hrann",
+       "iat": <now>, "exp": <now+1h>,
+       "email": "<user.email>",
+       "https://api.openai.com/auth": {
+         "chatgpt_account_id": "<user_id>",
+         "chatgpt_plan_type":  "pro",          // pick the one that satisfies plan checks
+         "organization_id":    "org_agentserver",
+         "project_id":         "proj_default",
+         "completed_platform_onboarding": true,
+         "is_org_owner":       true
+       }
+     }
+     ```
+   - **Codex does not signature-check `access_token` or `id_token`**
+     (verified by reading `manager.rs:806-918` + `server.rs:878-907`).
+     So unsigned alg=none on id_token is fine — codex parses claims and
+     trusts them. Our `/cloud/executor` validator does the real check
+     by looking up `access_token` in postgres.
+5. Response (per `server.rs:711-782`):
+   ```json
+   { "id_token": "…", "access_token": "…", "refresh_token": "…",
+     "token_type": "Bearer", "expires_in": 3600 }
+   ```
+
+**`grant_type=refresh_token`**
+Body: `refresh_token`, `client_id`.
+1. Look up `codex_refresh_tokens` by hash. 401 with
+   `{"error":"refresh_token_expired"}` if missing/expired/invalidated —
+   codex treats this as terminal and prompts re-login.
+2. Mint new `access_token` + new `refresh_token` (rotate); invalidate
+   the old refresh row (`revoked_at = now`).
+3. Same response shape as above.
+
+**`grant_type=urn:ietf:params:oauth:grant-type:token-exchange`**
+Codex optionally calls this with `requested_token=openai-api-key` to
+obtain a `sk-…` to put in `OPENAI_API_KEY`. Failure is non-fatal
+(`server.rs:352-354`). **Return 400** — we don't have an OpenAI API
+key to give back, and codex will continue without it.
+
+### Refresh URL override
+
+Codex's refresh URL is hardcoded but overridable. We tell users to set:
+
+```
+export CODEX_REFRESH_TOKEN_URL_OVERRIDE='https://agent.cs.ac.cn/codex-auth/oauth/token'
+```
+
+OR ship a default `~/.codex/config.toml` snippet:
+
+```toml
+chatgpt_base_url = "https://agent.cs.ac.cn/codex-auth"
+```
+
+(The chatgpt_base_url is read for Agent Identity JWKS path; the refresh
+URL is independent and **only env-overridable**. Document both.)
+
+### `/cloud/executor/{id}/register` validation — ChatGPT side
+
+The handler peels `Authorization: Bearer <token>` and asks agentserver:
+
+```
+POST /internal/codex-auth/validate    (X-Internal-Secret required)
+Body: { "scheme": "bearer", "token": "<access_token>" }
+Resp: { "user_id": "<uuid>" } on 200, { "error": "..." } on 401
+```
+
+agentserver hashes the token and looks it up in `codex_access_tokens`;
+on hit + not expired, returns the user_id. Then the existing
+register handler matches `(user_id, exe_id)` against
+`executors.user_id` (already enforced today) and proceeds.
+
+## Agent Identity mode — design
+
+### Mint
+
+When user clicks "Add connector" in the Connectors page, instead of
+returning the legacy bearer token, we:
+
+1. Generate an Ed25519 keypair. Encode private key as base64(PKCS#8 DER).
+2. Build an RS256 JWT with our RSA signing key. Header
+   `{"alg":"RS256","kid":"<active-kid>"}`. Claims (per
+   `agent-identity/src/lib.rs:65-78`):
+   ```jsonc
+   {
+     "iss": "https://chatgpt.com/codex-backend/agent-identity",  // codex enforces literal
+     "aud": "codex-app-server",                                  // codex enforces literal
+     "iat": <now>, "exp": <now + 30d>,
+     "agent_runtime_id":           "<exe_id>",       // reuse exe_id
+     "agent_private_key":          "<b64-pkcs8>",    // from step 1
+     "account_id":                 "<user_id>",      // opaque
+     "chatgpt_user_id":            "<user_id>",      // opaque
+     "email":                      "<user.email>",
+     "plan_type":                  "pro",
+     "chatgpt_account_is_fedramp": false
+   }
+   ```
+3. Store `(exe_id, ed25519_public_key, expires_at, user_id)` in a new
+   `codex_agent_identities` table.
+4. Return to UI:
+   ```
+   export CODEX_ACCESS_TOKEN='<the JWT>'
+   codex -c chatgpt.base_url='https://agent.cs.ac.cn/codex-auth' \
+         exec-server --remote 'https://codex-exec.agent.cs.ac.cn' \
+         --executor-id '<exe_id>' --name '<name>' \
+         --use-agent-identity-auth
+   ```
+   (Plus `CODEX_AGENT_IDENTITY_AUTHAPI_BASE_URL=https://agent.cs.ac.cn/codex-auth`
+   for the task-register call; document both env vars.)
+
+### JWKS
+
+`GET /codex-auth/agent-identities/jwks`
+
+Returns the standard JwkSet codex expects:
+```json
+{ "keys": [
+   {"kty":"RSA","kid":"key-2026-05","use":"sig","alg":"RS256",
+    "n":"<base64url-modulus>","e":"AQAB"},
+   ...older keys retained during rotation grace window...
+]}
+```
+
+Keys live in `codex_jwks_keys` table with `(kid, public_n, public_e,
+private_pkcs8, created_at, active)`. Active key signs new JWTs; old
+keys stay in JWKS until all JWTs they signed have expired.
+
+Rotation: cron generates new key monthly, marks old as inactive (but
+keeps in JWKS until +30d).
+
+### `/v1/agent/{agent_runtime_id}/task/register`
+
+Codex calls this once per JWT load to obtain a `task_id` used in every
+subsequent `AgentAssertion`.
+
+`POST /codex-auth/v1/agent/{rid}/task/register`
+Body: `{"timestamp": "<RFC3339-Z>", "signature": "<base64>"}`
+
+1. Look up `codex_agent_identities` by `rid` (== exe_id). 404 if missing.
+2. Verify `Ed25519.verify(public_key, "{rid}:{timestamp}", signature)`.
+   401 on failure.
+3. Check `timestamp` within ±5min of now. 401 on stale.
+4. Mint `task_id` = freshly generated 32-byte hex. Store in
+   `codex_agent_tasks` `(task_id, rid, user_id, issued_at, expires_at = +24h)`.
+5. Return `{"task_id": "<hex>"}`.
+
+### `/cloud/executor/{id}/register` validation — Agent Identity side
+
+The handler sees `Authorization: AgentAssertion <base64url-json>` +
+`ChatGPT-Account-ID: <opaque>`. The base64url-json decodes to:
+```json
+{ "agent_runtime_id":"<rid>", "task_id":"<hex>",
+  "timestamp":"<RFC3339-Z>",   "signature":"<b64>" }
+```
+
+(Per `codex-api/src/auth.rs:21-50`, signature is over
+`"{rid}:{task_id}:{timestamp}"` with the agent's Ed25519 private key.)
+
+agentserver validates:
+
+```
+POST /internal/codex-auth/validate
+Body: { "scheme": "agent_assertion",
+        "assertion": "<the base64url-json string>",
+        "account_id": "<ChatGPT-Account-ID header>" }
+```
+
+1. Decode assertion JSON.
+2. Look up `codex_agent_identities` by `agent_runtime_id`. 401 if missing.
+3. Look up `codex_agent_tasks` by `task_id`. 401 if missing/expired.
+4. Cross-check the row's `user_id` == account_id header.
+5. Verify Ed25519 signature against the stored public key.
+6. Reject if `timestamp` is more than ±5min off (replay window).
+7. Return `{ "user_id": "<uuid>" }`.
+
+Note: the same `codex_agent_identities` row holds the public key for
+both `/v1/agent/.../task/register` and the per-request assertion check.
+
+## Database schema additions
+
+```sql
+-- ChatGPT mode --------------------------------------------------------
+CREATE TABLE codex_pkce_requests (
+    code            TEXT PRIMARY KEY,
+    code_challenge  TEXT NOT NULL,
+    state           TEXT NOT NULL,
+    user_id         UUID NOT NULL REFERENCES users(id),
+    expires_at      TIMESTAMPTZ NOT NULL
+);
+CREATE INDEX ON codex_pkce_requests (expires_at);
+
+CREATE TABLE codex_access_tokens (
+    token_hash      BYTEA PRIMARY KEY,           -- sha256(raw)
+    user_id         UUID NOT NULL REFERENCES users(id),
+    expires_at      TIMESTAMPTZ NOT NULL,
+    revoked_at      TIMESTAMPTZ
+);
+CREATE INDEX ON codex_access_tokens (user_id);
+CREATE INDEX ON codex_access_tokens (expires_at);
+
+CREATE TABLE codex_refresh_tokens (
+    token_hash      BYTEA PRIMARY KEY,
+    family_id       UUID NOT NULL,               -- for refresh-token rotation chains
+    user_id         UUID NOT NULL REFERENCES users(id),
+    expires_at      TIMESTAMPTZ NOT NULL,
+    revoked_at      TIMESTAMPTZ
+);
+CREATE INDEX ON codex_refresh_tokens (family_id);
+
+-- Agent Identity mode -------------------------------------------------
+CREATE TABLE codex_jwks_keys (
+    kid             TEXT PRIMARY KEY,
+    public_n        TEXT NOT NULL,               -- base64url
+    public_e        TEXT NOT NULL,               -- base64url
+    private_pkcs8   BYTEA NOT NULL,              -- encrypted at rest via app secret
+    created_at      TIMESTAMPTZ NOT NULL,
+    active          BOOL NOT NULL                -- only one active at a time
+);
+
+CREATE TABLE codex_agent_identities (
+    agent_runtime_id  TEXT PRIMARY KEY,          -- == exe_id
+    user_id           UUID NOT NULL REFERENCES users(id),
+    public_key        BYTEA NOT NULL,            -- Ed25519 32-byte pub
+    jwt_signed_with   TEXT NOT NULL REFERENCES codex_jwks_keys(kid),
+    issued_at         TIMESTAMPTZ NOT NULL,
+    expires_at        TIMESTAMPTZ NOT NULL,
+    revoked_at        TIMESTAMPTZ
+);
+
+CREATE TABLE codex_agent_tasks (
+    task_id           TEXT PRIMARY KEY,
+    agent_runtime_id  TEXT NOT NULL REFERENCES codex_agent_identities(agent_runtime_id),
+    user_id           UUID NOT NULL,             -- denormalized for fast lookup
+    issued_at         TIMESTAMPTZ NOT NULL,
+    expires_at        TIMESTAMPTZ NOT NULL
+);
+```
+
+All tables go in agentserver's existing postgres DB. Migration in
+`internal/codexauth/migrations/`.
+
+## Connect-command UI changes
+
+`internal/server/codex_executors.go:107-117` currently emits the
+legacy bearer command. We change it to emit the Agent Identity command
+by default (and offer the ChatGPT-login command as a secondary option).
+
+Two commands shown side by side on "Add connector" success page:
+
+**Recommended (Agent Identity):**
+```bash
+export CODEX_ACCESS_TOKEN='eyJhbGc…'
+export CODEX_AGENT_IDENTITY_AUTHAPI_BASE_URL='https://agent.cs.ac.cn/codex-auth'
+codex -c chatgpt.base_url='https://agent.cs.ac.cn/codex-auth' \
+      exec-server --remote 'https://codex-exec.agent.cs.ac.cn' \
+      --executor-id 'exe_…' --name 'jetson-805' \
+      --use-agent-identity-auth
+```
+
+**Alternative (ChatGPT login, interactive):**
+```bash
+codex login --issuer https://agent.cs.ac.cn/codex-auth
+export CODEX_REFRESH_TOKEN_URL_OVERRIDE='https://agent.cs.ac.cn/codex-auth/oauth/token'
+codex exec-server --remote 'https://codex-exec.agent.cs.ac.cn' \
+      --executor-id 'exe_…' --name 'jetson-805'
+```
+
+The ChatGPT-login path is the one to use for shared / multi-user
+machines (no JWT to leak); Agent Identity is for headless / unattended
+machines (no browser needed).
+
+## Backward compat
+
+- `CODEX_EXEC_SERVER_REMOTE_BEARER_TOKEN` is gone from codex 0.132.
+  Codex < 0.132 users keep working: our `/cloud/executor/{id}/register`
+  handler retains the old bcrypt-bearer path as a third validator.
+  Users running 0.131 see no change.
+- After this lands, the connect-command UI shows the **new** commands.
+  Users who minted bearer tokens in the old UI keep them working until
+  the executor row is deleted.
+
+## Testing
+
+- `internal/codexauth/...` get tested against an httptest stub of
+  codex's expected flows. We can replay actual codex 0.132 binary calls
+  by `cargo build` then invoking it against `httptest.NewServer`.
+- End-to-end test: `cmd/codex-auth-smoketest` spins up agentserver +
+  codex-exec-gateway in-process, runs an actual `codex login` (using
+  `--with-access-token` to skip browser) and `codex exec-server --remote`,
+  asserts the WS connects.
+- Integration test in CI: a tiny mock Ubuntu container with `codex`
+  binary pinned to 0.132, run the full registration in CI.
+
+## Open questions / risks
+
+1. **Hydra device flow** — the existing `codex login --device` path
+   uses the issuer's `/deviceauth/usercode` + `/deviceauth/token`
+   endpoints. Out of scope for v1; add later if a user asks. (Browser
+   PKCE works on headless machines via `--issuer ... --device-auth`
+   too — TBD if codex 0.132 still supports.)
+2. **Per-request signature on `/cloud/executor/{id}/register`** — Agent
+   Identity assertions include a fresh per-request signature; the
+   handler is currently single-thread per workspace and lookup-heavy.
+   At today's traffic this is fine; if we ever hit >100 registers/sec
+   the Ed25519 verify + DB lookup chain may need batching.
+3. **JWKS rotation** — old JWTs valid up to 30d. If we rotate keys
+   faster, we orphan in-flight executors. Document that key rotation
+   should match the longest issued JWT TTL.
+4. **`/v1/agent/{rid}/task/register` is called every JWT load** —
+   codex calls this from `exec-server --remote` startup, and on the
+   model-turn path too. We must keep latency low (<200ms) because
+   codex blocks on it. Postgres roundtrip is enough budget.
+5. **Refresh-token URL override is env-only.** Users who forget the env
+   var will eventually fail when their access_token expires. UI should
+   show a warning, or — better — we ship a `~/.codex/config.toml`
+   fragment via `agent connect` that sets it in a more durable place.
+   (Investigate if config.toml has an equivalent.)
+6. **Connect-command leaks JWT in shell history.** Mitigation: print
+   token to stdout only, never log it server-side; document `unset
+   HISTCONTROL` workaround.
+
+## Rollout
+
+1. **PR 1** — `internal/codexauth/` scaffolding: schema migrations,
+   JWKS key generator script, claims builder, store layer. No HTTP
+   wired yet. Tests on store + claims.
+2. **PR 2** — PKCE + token endpoints (`codex login` path). UI: surface
+   the secondary connect-command. Test: invoke real `codex login
+   --issuer ...` against ephemeral server, assert auth.json shape.
+3. **PR 3** — JWKS + JWT mint + `/v1/agent/.../task/register` + UI
+   connect-command. Test: invoke real `codex exec-server --remote
+   --use-agent-identity-auth` against ephemeral server, assert
+   registration completes.
+4. **PR 4** — `/cloud/executor/{id}/register` accepts both new auth
+   schemes via `codexauth.Validate(...)`. Retain legacy bcrypt-bearer
+   path for codex < 0.132 users.
+5. **PR 5** — `pulumi up` + production rollout. Update Connectors UI
+   to default to Agent Identity command.
+
+Each PR independently mergeable. Order matters: 1 → (2 ∥ 3) → 4 → 5.
+
+## Open: should `/v1/agent/{rid}/task/register` be on codex-exec-gateway instead?
+
+Argument for agentserver: user identity lives there; we already proxy
+admin secrets across the namespace.
+
+Argument for codex-exec-gateway: codex calls it directly on the URL we
+hand back in the connect-command (the same host as
+`--remote https://codex-exec.agent.cs.ac.cn`). Adding another host to
+the connect-command worsens UX.
+
+**Decision: serve both `/codex-auth/...` and `/v1/agent/...` on
+agentserver, accessed via the same `agent.cs.ac.cn` ingress.
+codex-exec-gateway only exposes `/cloud/executor/...` and `/bridge/...`
+as today; it calls into agentserver over the cluster-internal URL for
+validation.** Two hosts, no overlap, clean.

--- a/docs/superpowers/specs/2026-05-20-codex-0.132-auth.md
+++ b/docs/superpowers/specs/2026-05-20-codex-0.132-auth.md
@@ -282,6 +282,103 @@ chatgpt_base_url = "https://agent.cs.ac.cn/codex-auth"
 (The chatgpt_base_url is read for Agent Identity JWKS path; the refresh
 URL is independent and **only env-overridable**. Document both.)
 
+### Device flow (for headless ChatGPT-account users)
+
+PKCE requires a browser on the same machine. For headless executors
+(jetson, server boxes) where the user wants ChatGPT-account semantics
+rather than Agent Identity, `codex login --device-auth --issuer
+https://agent.cs.ac.cn/codex-auth` is the answer.
+
+Codex 0.132 device flow (verified against
+`codex-rs/login/src/device_code_auth.rs` at rust-v0.132.0):
+
+```
+codex login --device-auth --issuer $ISSUER
+  → POST $ISSUER/api/accounts/deviceauth/usercode
+       body  {"client_id": "app_EMoam…"}
+       resp  {"device_auth_id": …, "user_code": …, "interval": <s>}
+  → print verification URL = $ISSUER/codex/device
+                 user_code  = (e.g. "BDWD-HQPK")
+  → poll POST $ISSUER/api/accounts/deviceauth/token
+            body  {"device_auth_id": …, "user_code": …}
+            403/404 → keep polling at interval
+            200 →  {"authorization_code": …,
+                    "code_challenge": …, "code_verifier": …}
+  → POST $ISSUER/oauth/token grant_type=authorization_code
+                              code=…, code_verifier=…,
+                              redirect_uri=$ISSUER/deviceauth/callback
+       (reuses the same /oauth/token handler from PKCE — codex generated
+        the code_challenge/verifier on the device server side, so we
+        treat this as a normal PKCE exchange.)
+```
+
+#### Endpoints we add
+
+**`POST /codex-auth/api/accounts/deviceauth/usercode`**
+
+1. Generate `device_auth_id` (32-byte hex), `user_code` (8-char `XXXX-XXXX`
+   uppercase alphanum, easy to read aloud), `code_verifier` (43-128
+   char URL-safe random), `code_challenge` = `base64url_no_pad(sha256(code_verifier))`,
+   `authorization_code` (32-byte hex; will only be revealed AFTER approval).
+2. Insert into `codex_device_codes` with `status='pending'`, `expires_at=now+15min`.
+3. Respond `{ "device_auth_id": …, "user_code": …, "interval": 5 }`.
+
+**`POST /codex-auth/api/accounts/deviceauth/token`**
+
+1. Look up by `device_auth_id` + `user_code`. 404 if either missing.
+2. If `status='pending'` → 403 (codex keeps polling).
+3. If `status='approved'` → return the stored
+   `{authorization_code, code_challenge, code_verifier}` and mark
+   `status='exchanged'` (single-use).
+4. If `status='exchanged'` → 403 (don't replay).
+5. If `expires_at < now` → 404.
+
+**`GET /codex-auth/codex/device`** — browser-facing approval page
+
+1. If no agentserver session cookie → 302 to `/login?next={here}`.
+2. Render HTML form with input field for `user_code` + Approve / Deny
+   buttons. Show the username so the user knows what account they're
+   authorising.
+
+**`POST /codex-auth/codex/device`** — form submit
+
+1. Parse `user_code` + `action` (approve|deny). Session required.
+2. Look up `codex_device_codes` by `user_code` (only rows with
+   `status='pending'`, `expires_at > now`).
+3. If approve: set `status='approved'`, `user_id=<session.user_id>`.
+4. If deny: set `status='denied'`.
+5. Show confirmation page ("You may now return to your terminal.").
+
+**`POST /codex-auth/oauth/token` `grant_type=authorization_code`** —
+no change required: it already validates code_challenge against
+code_verifier and mints the token bundle.
+
+#### New table
+
+```sql
+CREATE TABLE codex_device_codes (
+    device_auth_id      TEXT PRIMARY KEY,
+    user_code           TEXT NOT NULL UNIQUE,
+    code_challenge      TEXT NOT NULL,       -- pre-generated server-side
+    code_verifier       TEXT NOT NULL,       -- pre-generated server-side
+    authorization_code  TEXT NOT NULL,
+    status              TEXT NOT NULL,       -- pending|approved|exchanged|denied
+    user_id             UUID REFERENCES users(id),  -- nullable until approved
+    expires_at          TIMESTAMPTZ NOT NULL,
+    approved_at         TIMESTAMPTZ
+);
+CREATE INDEX ON codex_device_codes (user_code);
+CREATE INDEX ON codex_device_codes (expires_at);
+```
+
+Authorization codes minted via device flow share the existing
+`codex_pkce_requests` lifecycle once exchanged, so the same
+`/oauth/token` `grant_type=authorization_code` handler validates them.
+Implementation detail: when device approval flips status to 'approved',
+we also insert a `codex_pkce_requests` row with the stored
+`(authorization_code, code_challenge, user_id)` so the token endpoint
+sees it as if it had come from a normal browser PKCE flow.
+
 ### `/cloud/executor/{id}/register` validation — ChatGPT side
 
 The handler peels `Authorization: Bearer <token>` and asks agentserver:
@@ -484,7 +581,7 @@ codex -c chatgpt.base_url='https://agent.cs.ac.cn/codex-auth' \
       --use-agent-identity-auth
 ```
 
-**Alternative (ChatGPT login, interactive):**
+**Alternative (ChatGPT login, browser available):**
 ```bash
 codex login --issuer https://agent.cs.ac.cn/codex-auth
 export CODEX_REFRESH_TOKEN_URL_OVERRIDE='https://agent.cs.ac.cn/codex-auth/oauth/token'
@@ -492,9 +589,23 @@ codex exec-server --remote 'https://codex-exec.agent.cs.ac.cn' \
       --executor-id 'exe_…' --name 'jetson-805'
 ```
 
-The ChatGPT-login path is the one to use for shared / multi-user
-machines (no JWT to leak); Agent Identity is for headless / unattended
-machines (no browser needed).
+**Alternative (ChatGPT login, headless / no browser):**
+```bash
+codex login --device-auth --issuer https://agent.cs.ac.cn/codex-auth
+# (prints a URL + short code; user opens URL on any device, enters code)
+export CODEX_REFRESH_TOKEN_URL_OVERRIDE='https://agent.cs.ac.cn/codex-auth/oauth/token'
+codex exec-server --remote 'https://codex-exec.agent.cs.ac.cn' \
+      --executor-id 'exe_…' --name 'jetson-805'
+```
+
+Choose:
+- **Agent Identity** — best for unattended machines that never need a
+  ChatGPT account context. One token, one paste, done.
+- **ChatGPT login (browser)** — best when the machine has a desktop
+  and the user wants single-sign-on against their agentserver session.
+- **ChatGPT login (device-auth)** — when the machine is headless but
+  the user still prefers ChatGPT-account semantics over a long-lived
+  JWT (e.g. SSO with org policy, easier revocation through the web UI).
 
 ## Backward compat
 
@@ -520,11 +631,13 @@ machines (no browser needed).
 
 ## Open questions / risks
 
-1. **Hydra device flow** — the existing `codex login --device` path
-   uses the issuer's `/deviceauth/usercode` + `/deviceauth/token`
-   endpoints. Out of scope for v1; add later if a user asks. (Browser
-   PKCE works on headless machines via `--issuer ... --device-auth`
-   too — TBD if codex 0.132 still supports.)
+1. **Workspace selection at login** — not needed. `exec-server --remote`
+   commands carry `--executor-id`, which is bound to a workspace at
+   "Add connector" time. Auth tokens (PKCE / device flow / Agent
+   Identity) only encode user identity; workspace context is implicit
+   in the executor_id. If we ever expose the codex TUI's full
+   workspace-scoped operations against our backend (out of scope here),
+   revisit then.
 2. **Per-request signature on `/cloud/executor/{id}/register`** — Agent
    Identity assertions include a fresh per-request signature; the
    handler is currently single-thread per workspace and lookup-heavy.
@@ -548,21 +661,25 @@ machines (no browser needed).
 
 ## Rollout
 
-1. **PR 1** — `internal/codexauth/` scaffolding: schema migrations,
-   JWKS key generator script, claims builder, store layer. No HTTP
-   wired yet. Tests on store + claims.
-2. **PR 2** — PKCE + token endpoints (`codex login` path). UI: surface
-   the secondary connect-command. Test: invoke real `codex login
-   --issuer ...` against ephemeral server, assert auth.json shape.
-3. **PR 3** — JWKS + JWT mint + `/v1/agent/.../task/register` + UI
-   connect-command. Test: invoke real `codex exec-server --remote
-   --use-agent-identity-auth` against ephemeral server, assert
-   registration completes.
+1. **PR 1** — `internal/codexauth/` scaffolding: schema migrations
+   (all 7 tables including device codes), JWKS key generator script,
+   claims builder, store layer. No HTTP wired yet. Tests on store +
+   claims.
+2. **PR 2** — PKCE + device-flow + token endpoints (full `codex login`
+   path, both browser and `--device-auth` variants). Browser approval
+   page for device flow. Test: invoke real `codex login --issuer ...`
+   AND `codex login --device-auth --issuer ...` against ephemeral
+   server, assert auth.json shape in both cases.
+3. **PR 3** — JWKS + JWT mint + `/v1/agent/.../task/register`. Test:
+   invoke real `codex exec-server --remote --use-agent-identity-auth`
+   against ephemeral server, assert registration completes.
 4. **PR 4** — `/cloud/executor/{id}/register` accepts both new auth
    schemes via `codexauth.Validate(...)`. Retain legacy bcrypt-bearer
-   path for codex < 0.132 users.
-5. **PR 5** — `pulumi up` + production rollout. Update Connectors UI
-   to default to Agent Identity command.
+   path for codex < 0.132 users. Update Connectors UI: surface all
+   three connect-command variants (Agent Identity primary, ChatGPT
+   browser, ChatGPT device-auth).
+5. **PR 5** — `pulumi up` + production rollout. Verify all three paths
+   end-to-end against the live cluster.
 
 Each PR independently mergeable. Order matters: 1 → (2 ∥ 3) → 4 → 5.
 


### PR DESCRIPTION
Self-hosted shim for the two auth modes 0.132's `exec-server --remote` requires:

- **ChatGPT mode**: `codex login --issuer` against our PKCE endpoint
- **Agent Identity mode**: `CODEX_ACCESS_TOKEN` JWT we mint, served via our JWKS

**Decision summary:**
- New package `internal/codexauth/` on agentserver
- Hydra **not** used (id_token claim-shape mismatch with codex's OpenAI-nested expectations; refresh URL is env-only overridable; codex doesn't verify access_token signatures so Hydra adds no real security)
- PKCE + token endpoints in Go directly
- Agent Identity JWT signed with our RSA key, served via `/agent-identities/jwks`
- `/cloud/executor/{id}/register` validation moves to a shared agentserver internal validator (codex-exec-gateway delegates over X-Internal-Secret)
- 5-PR rollout plan, scaffolding → PKCE → JWKS/JWT → validator → production
- 6 open questions captured

**Read the full spec at** `docs/superpowers/specs/2026-05-20-codex-0.132-auth.md`.

After this lands, the implementation plan goes at `docs/superpowers/plans/2026-05-20-codex-0.132-auth.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)