### PR TITLE
fix(envtools): always send env={} on process/start

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.61.10
-appVersion: "0.61.10"
+version: 0.61.11
+appVersion: "0.61.11"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/docs/superpowers/specs/2026-05-20-codex-0.132-auth.md
+++ b/docs/superpowers/specs/2026-05-20-codex-0.132-auth.md
@@ -1,0 +1,583 @@
+# codex 0.132+ auth integration design
+
+**Status:** draft, awaiting user approval
+**Author:** mryao
+**Date:** 2026-05-20
+
+## Problem
+
+Codex 0.132 removed `CODEX_EXEC_SERVER_REMOTE_BEARER_TOKEN`
+([release notes #22769](https://github.com/openai/codex/releases/tag/rust-v0.132.0)).
+`codex exec-server --remote …` now refuses to register with our gateway
+unless the user has either:
+
+1. **ChatGPT auth** in `~/.codex/auth.json` (produced by `codex login`
+   against the OpenAI OAuth issuer), or
+2. **Agent Identity JWT** in `$CODEX_ACCESS_TOKEN` (produced by — well,
+   by us, if we implement it).
+
+For self-hosted deployments like `agent.cs.ac.cn` neither exists. The
+current Windows / jetson `codex exec-server --remote` flow returns
+`Error: remote exec-server registration requires ChatGPT authentication;
+run \`codex login\` first` and dies.
+
+We need to support **both** modes against our own infrastructure, so
+users can `codex login` with their agentserver identity OR use a
+pre-minted Agent Identity token, and `exec-server --remote` Just Works.
+
+## Non-goals
+
+- Replacing `chatgpt.com` for the **model turn path** (the actual LLM
+  call still hits whatever `model_providers.openai.base_url` points at —
+  out of scope here, separately addressable via config override and
+  llmproxy).
+- Supporting `codex` TUI's full feature set (workspace browser, plan
+  inspection, etc.) — those endpoints can no-op or 404.
+- Replacing `app-server --remote-control` flow (the `/wham/…` endpoints).
+  Different subcommand, different auth, will revisit if needed.
+- Wire-compatible OpenAI auth.json — we mint shaped-like-OpenAI claims
+  but with our identifiers; we do not pretend to be openai.com.
+
+## How codex 0.132 actually calls us
+
+Verified from `git show rust-v0.132.0:codex-rs/exec-server/src/remote.rs`
+and `cli/src/main.rs`:
+
+```
+codex exec-server --remote $BASE_URL --executor-id $EXE_ID --name $NAME
+                  [--use-agent-identity-auth]
+
+→ load_exec_server_remote_auth_provider(...)
+    if --use-agent-identity-auth:
+       JWT  := getenv("CODEX_ACCESS_TOKEN")
+       _    := CodexAuth::from_agent_identity_jwt(JWT, chatgpt.base_url)
+                 ↳ AgentIdentityAuthRecord::from_agent_identity_jwt(JWT)   // parse only
+                 ↳ fetch_agent_identity_jwks({chatgpt.base_url}/agent-identities/jwks)
+                 ↳ decode_agent_identity_jwt(JWT, &jwks)                   // verify RS256
+                 ↳ register_agent_task(POST {authapi}/v1/agent/{rid}/task/register
+                                       body {timestamp, signature_ed25519})
+                                       expects {task_id}
+    else:
+       Auth := read ~/.codex/auth.json — REQUIRES auth_mode == "chatgpt"
+
+→ POST $BASE_URL/cloud/executor/$EXE_ID/register
+    headers := auth_provider.to_auth_headers()
+        ChatGPT mode:        Authorization: Bearer <openai-shaped access_token>
+        AgentIdentity mode:  Authorization: AgentAssertion <base64url-json>
+                             ChatGPT-Account-ID: <claims.account_id>
+    response := {executor_id, url}
+
+→ connect_async(url)   // WS — url contains the cap-token in its query
+```
+
+So the wire surface we must implement falls into two unrelated buckets,
+plus a shared third bucket:
+
+| Bucket | ChatGPT mode | Agent Identity mode |
+|---|---|---|
+| **Mint credentials** | `/oauth/authorize`, `/oauth/token` (PKCE / refresh) | mint JWT at "add connector" time + serve `/agent-identities/jwks` + accept `/v1/agent/{rid}/task/register` |
+| **Codex-side validation** | none (signature not checked) | RS256 against our JWKS |
+| **Our `/cloud/executor/{id}/register`** | validate `Authorization: Bearer` | validate `Authorization: AgentAssertion` + cross-check `ChatGPT-Account-ID` |
+
+The model-turn endpoint is **not** on this surface — codex still POSTs
+to `https://chatgpt.com/backend-api/codex/responses` unless the user
+also overrides `model_providers.openai.base_url`. That is a separate
+config concern.
+
+## Architecture
+
+One new package, `internal/codexauth/`, on agentserver itself (NOT on
+codex-exec-gateway — auth is a user-identity concern and agentserver
+already owns user identity / sessions). The package exposes:
+
+```
+internal/codexauth/
+├── server.go            # chi.Router with all routes mounted
+├── pkce.go              # PKCE flow handlers (authorize, token, refresh)
+├── claims.go            # OpenAI-shaped id_token claims builder
+├── jwks.go              # /agent-identities/jwks handler + key rotation
+├── agent_identity.go    # mint JWT, /v1/agent/{rid}/task/register, store agent pubkey
+├── validate.go          # Bearer + AgentAssertion validators for /cloud/executor
+└── store.go             # postgres-backed: refresh tokens, agent records
+```
+
+The `/cloud/executor/{id}/register` handler stays on **codex-exec-gateway**
+but delegates validation to a shared `codexauth.Validate(ctx, headers)`
+call (HTTP, internal endpoint on agentserver). One auth subsystem, one
+place to test.
+
+```
+                        ┌────────────────────────────────────────────────┐
+  user-facing TLS:      │ https://agent.cs.ac.cn                          │
+                        │   /codex-auth/oauth/authorize  ── PKCE start    │
+                        │   /codex-auth/oauth/token      ── PKCE exchange │
+                        │                                  + refresh      │
+                        │   /codex-auth/agent-identities/jwks             │
+                        │   /codex-auth/v1/agent/{rid}/task/register      │
+                        └─────────────────────┬──────────────────────────┘
+                                              │ (mux to agentserver:8080)
+                                              ▼
+                        ┌────────────────────────────────────────────────┐
+  internal:             │ agentserver (Go)                                │
+                        │   internal/codexauth — all of the above         │
+                        │   internal/auth      — session ↔ user_id        │
+                        │   /internal/codex-auth/validate  (called by     │
+                        │     codex-exec-gateway over X-Internal-Secret)  │
+                        └────────────────────────────────────────────────┘
+
+                        ┌────────────────────────────────────────────────┐
+  user-facing TLS:      │ https://codex-exec.agent.cs.ac.cn               │
+                        │   /cloud/executor/{exe_id}/register   ←  codex  │
+                        │     → calls agentserver validate                │
+                        └────────────────────────────────────────────────┘
+```
+
+### Why not Hydra
+
+Hydra can serve OAuth2 PKCE — that part is uncontroversial. But:
+
+1. **Hydra's `id_token` shape is standard OIDC**, while codex parses a
+   nested OpenAI claim (`https://api.openai.com/auth` → object with
+   `chatgpt_account_id`, `chatgpt_plan_type`, etc.). We'd need a
+   token-rewriting proxy in front of Hydra to repackage claims —
+   complexity equal to just minting our own tokens directly.
+2. **Codex never verifies the access_token signature** (`server.rs`
+   parses it but `access_token` is opaque; the id_token claim object is
+   base64-decoded without sig check). So there is no value in Hydra's
+   real OAuth2 enforcement — we just need claim-shape-compatible blobs.
+3. **Hydra refresh token URL** is hardcoded inside codex
+   (`https://auth.openai.com/oauth/token`) — only overridable via env
+   `CODEX_REFRESH_TOKEN_URL_OVERRIDE`. Either way it points at us, not
+   Hydra directly. So Hydra is at best one indirection away from the
+   wire and adds no security we can't get inline.
+4. We already have agentserver session + user_id state in postgres.
+   Building PKCE → user_id directly is ~200 lines of Go and reuses our
+   existing session table. Bouncing through Hydra costs us another
+   storage layer and an OAuth client per environment to manage.
+
+**Decision: implement PKCE + token endpoints directly in
+`internal/codexauth`. Hydra continues to serve its existing
+Device-Flow-for-third-party-agents role; codex auth does not depend on
+it.** If we ever expose codex login to third parties as a federated
+client, revisit then.
+
+## ChatGPT mode — design
+
+### Login (PKCE)
+
+User runs (once per machine):
+
+```
+codex login --issuer https://agent.cs.ac.cn/codex-auth
+```
+
+The `--issuer` flag controls where codex's PKCE flow goes. Default is
+`https://auth.openai.com`; we substitute ours.
+
+#### `GET /codex-auth/oauth/authorize`
+
+Query params codex sends:
+- `response_type=code`
+- `client_id=app_EMoamEEZ73f0CkXaXp7hrann` — codex's hardcoded id; we
+  ignore it (single-client universe)
+- `redirect_uri=http://localhost:1455/auth/callback`
+- `scope=openid profile email offline_access api.connectors.read api.connectors.invoke`
+  — we ignore; everything is implicit
+- `code_challenge=…&code_challenge_method=S256` — PKCE; we store and
+  verify on token exchange
+- `state=…` — opaque; round-trip back
+- `id_token_add_organizations=true`, `codex_cli_simplified_flow=true`,
+  `originator=…` — ignore
+
+Handler behavior:
+1. If request has no agentserver session cookie → 302 to
+   `/login?next={original_url}` (existing agentserver login). After
+   login the user lands back here with a session.
+2. With session: insert a row into `codex_pkce_requests` with
+   `(code, code_challenge, state, user_id, expires_at = now+10min)`,
+   where `code` is a freshly generated 32-byte hex.
+3. 302 to `redirect_uri?code={code}&state={state}` (back to
+   `localhost:1455` on the user's machine).
+
+#### `POST /codex-auth/oauth/token`
+
+Two grant types codex uses; we handle both. Both return JSON.
+
+**`grant_type=authorization_code`**
+Body (form-urlencoded): `code`, `code_verifier`, `redirect_uri`,
+`client_id`.
+1. Look up `codex_pkce_requests` by `code`. 400 if missing/expired.
+2. Verify `code_challenge == base64url_no_pad(sha256(code_verifier))`.
+   400 if not.
+3. Delete the row (single-use).
+4. Mint:
+   - `access_token` = opaque 32-byte hex, stored in
+     `codex_access_tokens` table with `(token_hash, user_id, expires_at)`.
+   - `refresh_token` = opaque 32-byte hex, stored in
+     `codex_refresh_tokens` table with `(token_hash, user_id, family_id,
+     expires_at = 1y)`. Rotation on use (issue new + invalidate old).
+   - `id_token` = RS256 JWT signed with the same RSA key we use for
+     Agent Identity JWKS (header `{"alg":"RS256","kid":"<active-kid>"}`).
+     Codex does not verify the signature today, but signing is
+     defense-in-depth against future codex versions and lets us
+     introspect tokens from our own logs without trusting bearers.
+     Claims per `internal/codexauth/claims.go`:
+     ```jsonc
+     {
+       "iss": "https://agent.cs.ac.cn/codex-auth",
+       "sub": "<user_id>",
+       "aud": "app_EMoamEEZ73f0CkXaXp7hrann",
+       "iat": <now>, "exp": <now+1h>,
+       "email": "<user.email>",
+       "https://api.openai.com/auth": {
+         "chatgpt_account_id": "<user_id>",
+         "chatgpt_plan_type":  "pro",          // pick the one that satisfies plan checks
+         "organization_id":    "org_agentserver",
+         "project_id":         "proj_default",
+         "completed_platform_onboarding": true,
+         "is_org_owner":       true
+       }
+     }
+     ```
+   - **Codex does not signature-check `access_token` or `id_token`**
+     (verified by reading `manager.rs:806-918` + `server.rs:878-907`).
+     So unsigned alg=none on id_token is fine — codex parses claims and
+     trusts them. Our `/cloud/executor` validator does the real check
+     by looking up `access_token` in postgres.
+5. Response (per `server.rs:711-782`):
+   ```json
+   { "id_token": "…", "access_token": "…", "refresh_token": "…",
+     "token_type": "Bearer", "expires_in": 3600 }
+   ```
+
+**`grant_type=refresh_token`**
+Body: `refresh_token`, `client_id`.
+1. Look up `codex_refresh_tokens` by hash. 401 with
+   `{"error":"refresh_token_expired"}` if missing/expired/invalidated —
+   codex treats this as terminal and prompts re-login.
+2. Mint new `access_token` + new `refresh_token` (rotate); invalidate
+   the old refresh row (`revoked_at = now`).
+3. Same response shape as above.
+
+**`grant_type=urn:ietf:params:oauth:grant-type:token-exchange`**
+Codex optionally calls this with `requested_token=openai-api-key` to
+obtain a `sk-…` to put in `OPENAI_API_KEY`. Failure is non-fatal
+(`server.rs:352-354`). **Return 400** — we don't have an OpenAI API
+key to give back, and codex will continue without it.
+
+### Refresh URL override
+
+Codex's refresh URL is hardcoded but overridable. We tell users to set:
+
+```
+export CODEX_REFRESH_TOKEN_URL_OVERRIDE='https://agent.cs.ac.cn/codex-auth/oauth/token'
+```
+
+OR ship a default `~/.codex/config.toml` snippet:
+
+```toml
+chatgpt_base_url = "https://agent.cs.ac.cn/codex-auth"
+```
+
+(The chatgpt_base_url is read for Agent Identity JWKS path; the refresh
+URL is independent and **only env-overridable**. Document both.)
+
+### `/cloud/executor/{id}/register` validation — ChatGPT side
+
+The handler peels `Authorization: Bearer <token>` and asks agentserver:
+
+```
+POST /internal/codex-auth/validate    (X-Internal-Secret required)
+Body: { "scheme": "bearer", "token": "<access_token>" }
+Resp: { "user_id": "<uuid>" } on 200, { "error": "..." } on 401
+```
+
+agentserver hashes the token and looks it up in `codex_access_tokens`;
+on hit + not expired, returns the user_id. Then the existing
+register handler matches `(user_id, exe_id)` against
+`executors.user_id` (already enforced today) and proceeds.
+
+## Agent Identity mode — design
+
+### Mint
+
+When user clicks "Add connector" in the Connectors page, instead of
+returning the legacy bearer token, we:
+
+1. Generate an Ed25519 keypair. Encode private key as base64(PKCS#8 DER).
+2. Build an RS256 JWT with our RSA signing key. Header
+   `{"alg":"RS256","kid":"<active-kid>"}`. Claims (per
+   `agent-identity/src/lib.rs:65-78`):
+   ```jsonc
+   {
+     "iss": "https://chatgpt.com/codex-backend/agent-identity",  // codex enforces literal
+     "aud": "codex-app-server",                                  // codex enforces literal
+     "iat": <now>, "exp": <now + 30d>,
+     "agent_runtime_id":           "<exe_id>",       // reuse exe_id
+     "agent_private_key":          "<b64-pkcs8>",    // from step 1
+     "account_id":                 "<user_id>",      // opaque
+     "chatgpt_user_id":            "<user_id>",      // opaque
+     "email":                      "<user.email>",
+     "plan_type":                  "pro",
+     "chatgpt_account_is_fedramp": false
+   }
+   ```
+3. Store `(exe_id, ed25519_public_key, expires_at, user_id)` in a new
+   `codex_agent_identities` table.
+4. Return to UI:
+   ```
+   export CODEX_ACCESS_TOKEN='<the JWT>'
+   codex -c chatgpt.base_url='https://agent.cs.ac.cn/codex-auth' \
+         exec-server --remote 'https://codex-exec.agent.cs.ac.cn' \
+         --executor-id '<exe_id>' --name '<name>' \
+         --use-agent-identity-auth
+   ```
+   (Plus `CODEX_AGENT_IDENTITY_AUTHAPI_BASE_URL=https://agent.cs.ac.cn/codex-auth`
+   for the task-register call; document both env vars.)
+
+### JWKS
+
+`GET /codex-auth/agent-identities/jwks`
+
+Returns the standard JwkSet codex expects:
+```json
+{ "keys": [
+   {"kty":"RSA","kid":"key-2026-05","use":"sig","alg":"RS256",
+    "n":"<base64url-modulus>","e":"AQAB"},
+   ...older keys retained during rotation grace window...
+]}
+```
+
+Keys live in `codex_jwks_keys` table with `(kid, public_n, public_e,
+private_pkcs8, created_at, active)`. Active key signs new JWTs; old
+keys stay in JWKS until all JWTs they signed have expired.
+
+Rotation: cron generates new key monthly, marks old as inactive (but
+keeps in JWKS until +30d).
+
+### `/v1/agent/{agent_runtime_id}/task/register`
+
+Codex calls this once per JWT load to obtain a `task_id` used in every
+subsequent `AgentAssertion`.
+
+`POST /codex-auth/v1/agent/{rid}/task/register`
+Body: `{"timestamp": "<RFC3339-Z>", "signature": "<base64>"}`
+
+1. Look up `codex_agent_identities` by `rid` (== exe_id). 404 if missing.
+2. Verify `Ed25519.verify(public_key, "{rid}:{timestamp}", signature)`.
+   401 on failure.
+3. Check `timestamp` within ±5min of now. 401 on stale.
+4. Mint `task_id` = freshly generated 32-byte hex. Store in
+   `codex_agent_tasks` `(task_id, rid, user_id, issued_at, expires_at = +24h)`.
+5. Return `{"task_id": "<hex>"}`.
+
+### `/cloud/executor/{id}/register` validation — Agent Identity side
+
+The handler sees `Authorization: AgentAssertion <base64url-json>` +
+`ChatGPT-Account-ID: <opaque>`. The base64url-json decodes to:
+```json
+{ "agent_runtime_id":"<rid>", "task_id":"<hex>",
+  "timestamp":"<RFC3339-Z>",   "signature":"<b64>" }
+```
+
+(Per `codex-api/src/auth.rs:21-50`, signature is over
+`"{rid}:{task_id}:{timestamp}"` with the agent's Ed25519 private key.)
+
+agentserver validates:
+
+```
+POST /internal/codex-auth/validate
+Body: { "scheme": "agent_assertion",
+        "assertion": "<the base64url-json string>",
+        "account_id": "<ChatGPT-Account-ID header>" }
+```
+
+1. Decode assertion JSON.
+2. Look up `codex_agent_identities` by `agent_runtime_id`. 401 if missing.
+3. Look up `codex_agent_tasks` by `task_id`. 401 if missing/expired.
+4. Cross-check the row's `user_id` == account_id header.
+5. Verify Ed25519 signature against the stored public key.
+6. Reject if `timestamp` is more than ±5min off (replay window).
+7. Return `{ "user_id": "<uuid>" }`.
+
+Note: the same `codex_agent_identities` row holds the public key for
+both `/v1/agent/.../task/register` and the per-request assertion check.
+
+## Database schema additions
+
+```sql
+-- ChatGPT mode --------------------------------------------------------
+CREATE TABLE codex_pkce_requests (
+    code            TEXT PRIMARY KEY,
+    code_challenge  TEXT NOT NULL,
+    state           TEXT NOT NULL,
+    user_id         UUID NOT NULL REFERENCES users(id),
+    expires_at      TIMESTAMPTZ NOT NULL
+);
+CREATE INDEX ON codex_pkce_requests (expires_at);
+
+CREATE TABLE codex_access_tokens (
+    token_hash      BYTEA PRIMARY KEY,           -- sha256(raw)
+    user_id         UUID NOT NULL REFERENCES users(id),
+    expires_at      TIMESTAMPTZ NOT NULL,
+    revoked_at      TIMESTAMPTZ
+);
+CREATE INDEX ON codex_access_tokens (user_id);
+CREATE INDEX ON codex_access_tokens (expires_at);
+
+CREATE TABLE codex_refresh_tokens (
+    token_hash      BYTEA PRIMARY KEY,
+    family_id       UUID NOT NULL,               -- for refresh-token rotation chains
+    user_id         UUID NOT NULL REFERENCES users(id),
+    expires_at      TIMESTAMPTZ NOT NULL,
+    revoked_at      TIMESTAMPTZ
+);
+CREATE INDEX ON codex_refresh_tokens (family_id);
+
+-- Agent Identity mode -------------------------------------------------
+CREATE TABLE codex_jwks_keys (
+    kid             TEXT PRIMARY KEY,
+    public_n        TEXT NOT NULL,               -- base64url
+    public_e        TEXT NOT NULL,               -- base64url
+    private_pkcs8   BYTEA NOT NULL,              -- encrypted at rest via app secret
+    created_at      TIMESTAMPTZ NOT NULL,
+    active          BOOL NOT NULL                -- only one active at a time
+);
+
+CREATE TABLE codex_agent_identities (
+    agent_runtime_id  TEXT PRIMARY KEY,          -- == exe_id
+    user_id           UUID NOT NULL REFERENCES users(id),
+    public_key        BYTEA NOT NULL,            -- Ed25519 32-byte pub
+    jwt_signed_with   TEXT NOT NULL REFERENCES codex_jwks_keys(kid),
+    issued_at         TIMESTAMPTZ NOT NULL,
+    expires_at        TIMESTAMPTZ NOT NULL,
+    revoked_at        TIMESTAMPTZ
+);
+
+CREATE TABLE codex_agent_tasks (
+    task_id           TEXT PRIMARY KEY,
+    agent_runtime_id  TEXT NOT NULL REFERENCES codex_agent_identities(agent_runtime_id),
+    user_id           UUID NOT NULL,             -- denormalized for fast lookup
+    issued_at         TIMESTAMPTZ NOT NULL,
+    expires_at        TIMESTAMPTZ NOT NULL
+);
+```
+
+All tables go in agentserver's existing postgres DB. Migration in
+`internal/codexauth/migrations/`.
+
+## Connect-command UI changes
+
+`internal/server/codex_executors.go:107-117` currently emits the
+legacy bearer command. We change it to emit the Agent Identity command
+by default (and offer the ChatGPT-login command as a secondary option).
+
+Two commands shown side by side on "Add connector" success page:
+
+**Recommended (Agent Identity):**
+```bash
+export CODEX_ACCESS_TOKEN='eyJhbGc…'
+export CODEX_AGENT_IDENTITY_AUTHAPI_BASE_URL='https://agent.cs.ac.cn/codex-auth'
+codex -c chatgpt.base_url='https://agent.cs.ac.cn/codex-auth' \
+      exec-server --remote 'https://codex-exec.agent.cs.ac.cn' \
+      --executor-id 'exe_…' --name 'jetson-805' \
+      --use-agent-identity-auth
+```
+
+**Alternative (ChatGPT login, interactive):**
+```bash
+codex login --issuer https://agent.cs.ac.cn/codex-auth
+export CODEX_REFRESH_TOKEN_URL_OVERRIDE='https://agent.cs.ac.cn/codex-auth/oauth/token'
+codex exec-server --remote 'https://codex-exec.agent.cs.ac.cn' \
+      --executor-id 'exe_…' --name 'jetson-805'
+```
+
+The ChatGPT-login path is the one to use for shared / multi-user
+machines (no JWT to leak); Agent Identity is for headless / unattended
+machines (no browser needed).
+
+## Backward compat
+
+- `CODEX_EXEC_SERVER_REMOTE_BEARER_TOKEN` is gone from codex 0.132.
+  Codex < 0.132 users keep working: our `/cloud/executor/{id}/register`
+  handler retains the old bcrypt-bearer path as a third validator.
+  Users running 0.131 see no change.
+- After this lands, the connect-command UI shows the **new** commands.
+  Users who minted bearer tokens in the old UI keep them working until
+  the executor row is deleted.
+
+## Testing
+
+- `internal/codexauth/...` get tested against an httptest stub of
+  codex's expected flows. We can replay actual codex 0.132 binary calls
+  by `cargo build` then invoking it against `httptest.NewServer`.
+- End-to-end test: `cmd/codex-auth-smoketest` spins up agentserver +
+  codex-exec-gateway in-process, runs an actual `codex login` (using
+  `--with-access-token` to skip browser) and `codex exec-server --remote`,
+  asserts the WS connects.
+- Integration test in CI: a tiny mock Ubuntu container with `codex`
+  binary pinned to 0.132, run the full registration in CI.
+
+## Open questions / risks
+
+1. **Hydra device flow** — the existing `codex login --device` path
+   uses the issuer's `/deviceauth/usercode` + `/deviceauth/token`
+   endpoints. Out of scope for v1; add later if a user asks. (Browser
+   PKCE works on headless machines via `--issuer ... --device-auth`
+   too — TBD if codex 0.132 still supports.)
+2. **Per-request signature on `/cloud/executor/{id}/register`** — Agent
+   Identity assertions include a fresh per-request signature; the
+   handler is currently single-thread per workspace and lookup-heavy.
+   At today's traffic this is fine; if we ever hit >100 registers/sec
+   the Ed25519 verify + DB lookup chain may need batching.
+3. **JWKS rotation** — old JWTs valid up to 30d. If we rotate keys
+   faster, we orphan in-flight executors. Document that key rotation
+   should match the longest issued JWT TTL.
+4. **`/v1/agent/{rid}/task/register` is called every JWT load** —
+   codex calls this from `exec-server --remote` startup, and on the
+   model-turn path too. We must keep latency low (<200ms) because
+   codex blocks on it. Postgres roundtrip is enough budget.
+5. **Refresh-token URL override is env-only.** Users who forget the env
+   var will eventually fail when their access_token expires. UI should
+   show a warning, or — better — we ship a `~/.codex/config.toml`
+   fragment via `agent connect` that sets it in a more durable place.
+   (Investigate if config.toml has an equivalent.)
+6. **Connect-command leaks JWT in shell history.** Mitigation: print
+   token to stdout only, never log it server-side; document `unset
+   HISTCONTROL` workaround.
+
+## Rollout
+
+1. **PR 1** — `internal/codexauth/` scaffolding: schema migrations,
+   JWKS key generator script, claims builder, store layer. No HTTP
+   wired yet. Tests on store + claims.
+2. **PR 2** — PKCE + token endpoints (`codex login` path). UI: surface
+   the secondary connect-command. Test: invoke real `codex login
+   --issuer ...` against ephemeral server, assert auth.json shape.
+3. **PR 3** — JWKS + JWT mint + `/v1/agent/.../task/register` + UI
+   connect-command. Test: invoke real `codex exec-server --remote
+   --use-agent-identity-auth` against ephemeral server, assert
+   registration completes.
+4. **PR 4** — `/cloud/executor/{id}/register` accepts both new auth
+   schemes via `codexauth.Validate(...)`. Retain legacy bcrypt-bearer
+   path for codex < 0.132 users.
+5. **PR 5** — `pulumi up` + production rollout. Update Connectors UI
+   to default to Agent Identity command.
+
+Each PR independently mergeable. Order matters: 1 → (2 ∥ 3) → 4 → 5.
+
+## Open: should `/v1/agent/{rid}/task/register` be on codex-exec-gateway instead?
+
+Argument for agentserver: user identity lives there; we already proxy
+admin secrets across the namespace.
+
+Argument for codex-exec-gateway: codex calls it directly on the URL we
+hand back in the connect-command (the same host as
+`--remote https://codex-exec.agent.cs.ac.cn`). Adding another host to
+the connect-command worsens UX.
+
+**Decision: serve both `/codex-auth/...` and `/v1/agent/...` on
+agentserver, accessed via the same `agent.cs.ac.cn` ingress.
+codex-exec-gateway only exposes `/cloud/executor/...` and `/bridge/...`
+as today; it calls into agentserver over the cluster-internal URL for
+validation.** Two hosts, no overlap, clean.

--- a/internal/envtools/bridge/bridge_test.go
+++ b/internal/envtools/bridge/bridge_test.go
@@ -278,3 +278,30 @@ func TestBridgeClient_Close_Idempotent(t *testing.T) {
 	bc.Close()
 	bc.Close() // must not panic, must not block
 }
+
+// TestProcessStartParamsMarshalEnv pins the wire shape: even when the
+// Go-side Env is nil, the marshaled JSON must contain `"env":{}` —
+// exec-server's serde rejects `null` / omitted env with
+// "missing field `env`".
+func TestProcessStartParamsMarshalEnv(t *testing.T) {
+	cases := []struct {
+		name string
+		env  map[string]string
+		want string
+	}{
+		{"nil", nil, `"env":{}`},
+		{"empty", map[string]string{}, `"env":{}`},
+		{"populated", map[string]string{"K": "v"}, `"env":{"K":"v"}`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			b, err := json.Marshal(ProcessStartParams{ProcessID: "p", Argv: []string{"sh"}, Env: tc.env})
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			if !strings.Contains(string(b), tc.want) {
+				t.Errorf("missing %q in %s", tc.want, b)
+			}
+		})
+	}
+}

--- a/internal/envtools/bridge/types.go
+++ b/internal/envtools/bridge/types.go
@@ -55,11 +55,26 @@ type ProcessStartParams struct {
 	// own working directory. Sending "" was treated by Windows
 	// exec-server as a literal (invalid) path → os error 267
 	// "目录名称无效".
-	Cwd       string            `json:"cwd,omitempty"`
-	Env       map[string]string `json:"env,omitempty"`
+	Cwd string `json:"cwd,omitempty"`
+	// Env is REQUIRED on the wire (exec-server's ExecParams.env is
+	// HashMap<String,String>, not Option<...>). Nil/omitted → serde
+	// "missing field `env`". MarshalJSON below normalizes nil → {}.
+	Env       map[string]string `json:"env"`
 	TTY       bool              `json:"tty"`
 	PipeStdin bool              `json:"pipeStdin"`
 	Arg0      *string           `json:"arg0,omitempty"`
+}
+
+// MarshalJSON ensures Env is always emitted as an object, even when nil.
+// A nil map serializes to `null` by default, which exec-server's serde
+// rejects with "missing field `env`".
+func (p ProcessStartParams) MarshalJSON() ([]byte, error) {
+	type alias ProcessStartParams
+	a := alias(p)
+	if a.Env == nil {
+		a.Env = map[string]string{}
+	}
+	return json.Marshal(a)
 }
 
 type ProcessStartResult struct {


### PR DESCRIPTION
## Summary
Calls to remote executors failed with \`process/start: missing field env\`. Codex's exec-server defines \`ExecParams.env\` as a required \`HashMap<String, String>\` (not \`Option<...>\`); when our Go side passed nil, \`json.Marshal\` emitted \`"env":null\` (or omitted the field with the old \`omitempty\` tag), and serde rejected the request.

Drop \`omitempty\` on Env and add a custom \`MarshalJSON\` that normalizes nil → empty map. Callers can keep passing nil to mean "no extra env", which now correctly serializes as \`"env":{}\` and exec-server inherits its own environment.

Pin the wire shape with a regression test (nil, empty, populated).

Bump chart to 0.61.11.

## Test plan
- [x] new TestProcessStartParamsMarshalEnv passes
- [ ] After rollout, codex env tools (shell, copy, terminate) succeed against \`windows-ggl\` and \`jetson-805\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)