### PR TITLE
feat(codexauth): PR 1 — scaffolding (schema, store, keys, claims)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/docker/docker v28.5.2+incompatible
 	github.com/go-chi/chi/v5 v5.2.5
 	github.com/google/uuid v1.6.0
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/hashicorp/yamux v0.1.2
 	github.com/lib/pq v1.11.2
 	github.com/mdp/qrterminal/v3 v3.2.1
@@ -56,7 +57,6 @@ require (
 	github.com/clipperhouse/stringish v0.1.1 // indirect
 	github.com/clipperhouse/uax29/v2 v2.5.0 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
-	github.com/hashicorp/golang-lru/v2 v2.0.7 // indirect
 	github.com/lucasb-eyer/go-colorful v1.3.0 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect
 	github.com/mattn/go-runewidth v0.0.19 // indirect
@@ -85,7 +85,7 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect

--- a/internal/codexauth/claims.go
+++ b/internal/codexauth/claims.go
@@ -1,0 +1,112 @@
+package codexauth
+
+import (
+	"crypto/rsa"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/go-jose/go-jose/v4"
+)
+
+// IDTokenClaims is the subset of fields we populate for the OpenAI-shaped
+// id_token. Codex never verifies the signature, but it base64-decodes
+// the payload and looks for the nested OpenAI claim.
+type IDTokenClaims struct {
+	Issuer    string
+	Subject   string
+	Email     string
+	ExpiresAt time.Time
+}
+
+// BuildIDToken returns a signed RS256 JWT with the OpenAI-nested claim
+// that codex's `compose_success_url` and `jwt_auth_claims` paths expect
+// (login/src/server.rs:821-907).
+func BuildIDToken(key *rsa.PrivateKey, kid string, c IDTokenClaims) (string, error) {
+	payload := map[string]any{
+		"iss":   c.Issuer,
+		"sub":   c.Subject,
+		"aud":   "app_EMoamEEZ73f0CkXaXp7hrann",
+		"iat":   time.Now().Unix(),
+		"exp":   c.ExpiresAt.Unix(),
+		"email": c.Email,
+		"https://api.openai.com/auth": map[string]any{
+			"chatgpt_account_id":            c.Subject,
+			"chatgpt_plan_type":             "pro",
+			"organization_id":               "org_agentserver",
+			"project_id":                    "proj_default",
+			"completed_platform_onboarding": true,
+			"is_org_owner":                  true,
+		},
+	}
+	return signRS256(key, kid, payload)
+}
+
+// BuildAccessToken mints the access_token as an RS256 JWT carrying just
+// `{iss, sub, iat, exp}`. Codex never validates the signature (it treats
+// access_token as an opaque bearer), but it *does* parse `exp` to drive
+// proactive refresh (login/src/auth/manager.rs:1793-1812 —
+// is_stale_for_proactive_refresh calls parse_jwt_expiration on
+// access_token). Minting the access_token as a JWT means codex refreshes
+// cleanly at the real expiry instead of waiting for a 401 retry.
+func BuildAccessToken(key *rsa.PrivateKey, kid string, c IDTokenClaims) (string, error) {
+	payload := map[string]any{
+		"iss": c.Issuer,
+		"sub": c.Subject,
+		"aud": "app_EMoamEEZ73f0CkXaXp7hrann",
+		"iat": time.Now().Unix(),
+		"exp": c.ExpiresAt.Unix(),
+	}
+	return signRS256(key, kid, payload)
+}
+
+// AgentIdentityClaims is the JWT codex's exec-server --remote
+// --use-agent-identity-auth requires (agent-identity/src/lib.rs:65-78).
+type AgentIdentityClaims struct {
+	AgentRuntimeID       string
+	AgentPrivateKeyPKCS8 []byte
+	AccountID            string
+	ChatgptUserID        string
+	Email                string
+	PlanType             string
+	ExpiresAt            time.Time
+}
+
+// BuildAgentIdentityJWT returns an RS256 JWT whose claims pass codex's
+// strict aud="codex-app-server" + iss=".../agent-identity" check.
+func BuildAgentIdentityJWT(key *rsa.PrivateKey, kid string, c AgentIdentityClaims) (string, error) {
+	payload := map[string]any{
+		"iss":                        "https://chatgpt.com/codex-backend/agent-identity",
+		"aud":                        "codex-app-server",
+		"iat":                        time.Now().Unix(),
+		"exp":                        c.ExpiresAt.Unix(),
+		"agent_runtime_id":           c.AgentRuntimeID,
+		"agent_private_key":          base64.StdEncoding.EncodeToString(c.AgentPrivateKeyPKCS8),
+		"account_id":                 c.AccountID,
+		"chatgpt_user_id":            c.ChatgptUserID,
+		"email":                      c.Email,
+		"plan_type":                  c.PlanType,
+		"chatgpt_account_is_fedramp": false,
+	}
+	return signRS256(key, kid, payload)
+}
+
+func signRS256(key *rsa.PrivateKey, kid string, payload map[string]any) (string, error) {
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal payload: %w", err)
+	}
+	signer, err := jose.NewSigner(
+		jose.SigningKey{Algorithm: jose.RS256, Key: key},
+		(&jose.SignerOptions{}).WithType("JWT").WithHeader("kid", kid),
+	)
+	if err != nil {
+		return "", fmt.Errorf("new signer: %w", err)
+	}
+	jws, err := signer.Sign(body)
+	if err != nil {
+		return "", fmt.Errorf("sign: %w", err)
+	}
+	return jws.CompactSerialize()
+}

--- a/internal/codexauth/claims_test.go
+++ b/internal/codexauth/claims_test.go
@@ -1,0 +1,106 @@
+package codexauth
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestBuildIDToken_CarriesOpenAIClaim(t *testing.T) {
+	kid, kp, _ := GenerateRSAKey()
+	issuer := "https://example/codex-auth"
+	jwt, err := BuildIDToken(kp.PrivateKey, kid, IDTokenClaims{
+		Issuer:    issuer,
+		Subject:   "user-abc",
+		Email:     "u@test",
+		ExpiresAt: time.Now().Add(1 * time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("BuildIDToken: %v", err)
+	}
+	parts := strings.Split(jwt, ".")
+	if len(parts) != 3 {
+		t.Fatalf("not 3-part JWT: %d parts", len(parts))
+	}
+	payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+	if err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	var claims map[string]any
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// The nested OpenAI claim is critical — codex parses it.
+	oai, ok := claims["https://api.openai.com/auth"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing https://api.openai.com/auth claim: %v", claims)
+	}
+	if oai["chatgpt_account_id"] != "user-abc" {
+		t.Errorf("chatgpt_account_id = %v", oai["chatgpt_account_id"])
+	}
+	if oai["chatgpt_plan_type"] != "pro" {
+		t.Errorf("chatgpt_plan_type = %v", oai["chatgpt_plan_type"])
+	}
+}
+
+func TestBuildAccessToken_HasExpClaim(t *testing.T) {
+	kid, kp, _ := GenerateRSAKey()
+	exp := time.Now().Add(1 * time.Hour)
+	jwt, err := BuildAccessToken(kp.PrivateKey, kid, IDTokenClaims{
+		Issuer:    "https://example/codex-auth",
+		Subject:   "user-abc",
+		ExpiresAt: exp,
+	})
+	if err != nil {
+		t.Fatalf("BuildAccessToken: %v", err)
+	}
+	parts := strings.Split(jwt, ".")
+	payload, _ := base64.RawURLEncoding.DecodeString(parts[1])
+	var claims map[string]any
+	json.Unmarshal(payload, &claims)
+	// Codex's parse_jwt_expiration reads `exp` and triggers refresh
+	// when exp <= now — so we must mint this value.
+	if claims["exp"] == nil {
+		t.Errorf("exp claim missing: %v", claims)
+	}
+	if claims["sub"] != "user-abc" {
+		t.Errorf("sub = %v", claims["sub"])
+	}
+}
+
+func TestBuildAgentIdentityJWT_IsCodexParseable(t *testing.T) {
+	kid, kp, _ := GenerateRSAKey()
+	_, pub, _ := GenerateEd25519Key()
+	priv, _, _ := GenerateEd25519Key()
+	jwt, err := BuildAgentIdentityJWT(kp.PrivateKey, kid, AgentIdentityClaims{
+		AgentRuntimeID:       "exe_xyz",
+		AgentPrivateKeyPKCS8: priv,
+		AccountID:            "u-1",
+		ChatgptUserID:        "u-1",
+		Email:                "u@test",
+		PlanType:             "pro",
+		ExpiresAt:            time.Now().Add(30 * 24 * time.Hour),
+	})
+	if err != nil {
+		t.Fatalf("BuildAgentIdentityJWT: %v", err)
+	}
+	parts := strings.Split(jwt, ".")
+	payload, _ := base64.RawURLEncoding.DecodeString(parts[1])
+	var claims map[string]any
+	json.Unmarshal(payload, &claims)
+	// Codex enforces these literals (agent-identity/src/lib.rs:163-166).
+	if claims["iss"] != "https://chatgpt.com/codex-backend/agent-identity" {
+		t.Errorf("iss = %v", claims["iss"])
+	}
+	if claims["aud"] != "codex-app-server" {
+		t.Errorf("aud = %v", claims["aud"])
+	}
+	// agent_private_key is base64(PKCS#8 DER) of an Ed25519 key.
+	apk, _ := claims["agent_private_key"].(string)
+	if apk == "" {
+		t.Error("agent_private_key missing")
+	}
+	_ = pub // referenced for future tests; not asserted here
+}

--- a/internal/codexauth/keys.go
+++ b/internal/codexauth/keys.go
@@ -1,0 +1,63 @@
+package codexauth
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"fmt"
+	"math/big"
+)
+
+// RSAKeyPair is an RSA-2048 keypair ready for JWKS exposure (public)
+// and JWT signing (private). PublicN/PublicE are base64url-no-pad
+// encoded for direct JWKS serialization; PrivatePKCS8 is the DER blob
+// stored encrypted at rest.
+type RSAKeyPair struct {
+	PrivateKey   *rsa.PrivateKey
+	PrivatePKCS8 []byte
+	PublicN      string
+	PublicE      string
+}
+
+// GenerateRSAKey mints a fresh RSA-2048 keypair and a deterministic kid
+// derived from the public modulus prefix. kid stability matters because
+// it's embedded in JWT headers and used to look up the verification key
+// in JWKS; a random kid forces full JWKS scans.
+func GenerateRSAKey() (kid string, kp *RSAKeyPair, err error) {
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return "", nil, fmt.Errorf("rsa.GenerateKey: %w", err)
+	}
+	pkcs8, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return "", nil, fmt.Errorf("MarshalPKCS8PrivateKey: %w", err)
+	}
+	pubN := base64.RawURLEncoding.EncodeToString(priv.N.Bytes())
+	pubE := base64.RawURLEncoding.EncodeToString(big.NewInt(int64(priv.E)).Bytes())
+	// kid: first 16 chars of the modulus, deterministic and grep-friendly
+	kid = "rsa-" + pubN[:16]
+	return kid, &RSAKeyPair{
+		PrivateKey:   priv,
+		PrivatePKCS8: pkcs8,
+		PublicN:      pubN,
+		PublicE:      pubE,
+	}, nil
+}
+
+// GenerateEd25519Key produces an Ed25519 keypair used per-agent for
+// AgentAssertion signing. PrivatePKCS8 is stored on the client (inside
+// the Agent Identity JWT's agent_private_key claim); the public key
+// stays server-side for verification.
+func GenerateEd25519Key() (privatePKCS8 []byte, public []byte, err error) {
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("ed25519.GenerateKey: %w", err)
+	}
+	pkcs8, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return nil, nil, fmt.Errorf("MarshalPKCS8PrivateKey: %w", err)
+	}
+	return pkcs8, pub, nil
+}

--- a/internal/codexauth/keys_test.go
+++ b/internal/codexauth/keys_test.go
@@ -1,0 +1,62 @@
+package codexauth
+
+import (
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"testing"
+)
+
+func TestGenerateRSAKey_ReturnsUsableKeyMaterial(t *testing.T) {
+	kid, kp, err := GenerateRSAKey()
+	if err != nil {
+		t.Fatalf("GenerateRSAKey: %v", err)
+	}
+	if kid == "" {
+		t.Fatal("kid should not be empty")
+	}
+	if kp.PrivateKey.N.BitLen() < 2048 {
+		t.Errorf("key too small: %d bits", kp.PrivateKey.N.BitLen())
+	}
+	// Public modulus & exponent serialize round-trippably.
+	if _, err := base64.RawURLEncoding.DecodeString(kp.PublicN); err != nil {
+		t.Errorf("PublicN not base64url: %v", err)
+	}
+	if _, err := base64.RawURLEncoding.DecodeString(kp.PublicE); err != nil {
+		t.Errorf("PublicE not base64url: %v", err)
+	}
+	// Private key encoded as PKCS#8 DER.
+	parsed, err := x509.ParsePKCS8PrivateKey(kp.PrivatePKCS8)
+	if err != nil {
+		t.Fatalf("ParsePKCS8PrivateKey: %v", err)
+	}
+	if _, ok := parsed.(*rsa.PrivateKey); !ok {
+		t.Errorf("parsed key is not *rsa.PrivateKey: %T", parsed)
+	}
+}
+
+func TestGenerateEd25519Key_ReturnsKeypair(t *testing.T) {
+	priv, pub, err := GenerateEd25519Key()
+	if err != nil {
+		t.Fatalf("GenerateEd25519Key: %v", err)
+	}
+	if len(pub) != 32 {
+		t.Errorf("pub len = %d, want 32", len(pub))
+	}
+	// PKCS#8 DER round-trip.
+	parsed, err := x509.ParsePKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("ParsePKCS8PrivateKey: %v", err)
+	}
+	// crypto/x509.ParsePKCS8PrivateKey returns ed25519.PrivateKey whose
+	// Public() returns crypto.PublicKey (a defined type alias for any).
+	signer, ok := parsed.(crypto.Signer)
+	if !ok {
+		t.Fatalf("parsed key is not crypto.Signer: %T", parsed)
+	}
+	if _, ok := signer.Public().(ed25519.PublicKey); !ok {
+		t.Errorf("parsed key's Public() is not ed25519.PublicKey: %T", signer.Public())
+	}
+}

--- a/internal/codexauth/store.go
+++ b/internal/codexauth/store.go
@@ -2,11 +2,20 @@ package codexauth
 
 import (
 	"context"
+	"crypto/sha256"
 	"database/sql"
+	"errors"
 	"fmt"
+	"time"
 
 	"github.com/agentserver/agentserver/internal/db"
 )
+
+// ErrRefreshTokenReuse is returned by RotateRefreshToken when the
+// presented token is unknown OR has already been revoked. Callers
+// (the /oauth/token refresh handler) should map this to a 401 with
+// OAuth error `refresh_token_expired` or `refresh_token_reused`.
+var ErrRefreshTokenReuse = errors.New("refresh token unknown or revoked")
 
 // Store is a thin DB facade over all codex_* tables. Each method takes
 // a context and returns a typed value or error; no business logic lives
@@ -72,4 +81,152 @@ func (s *Store) ListAllJwksKeys(ctx context.Context) ([]JwksKey, error) {
 		out = append(out, k)
 	}
 	return out, nil
+}
+
+// ----- PKCE -----
+
+type PkceRequest struct {
+	Code          string
+	CodeChallenge string
+	State         string
+	UserID        string
+	ExpiresAt     time.Time
+}
+
+func (s *Store) InsertPkceRequest(ctx context.Context, r PkceRequest) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO codex_pkce_requests (code, code_challenge, state, user_id, expires_at)
+		VALUES ($1, $2, $3, $4, $5)`,
+		r.Code, r.CodeChallenge, r.State, r.UserID, r.ExpiresAt)
+	if err != nil {
+		return fmt.Errorf("insert pkce request: %w", err)
+	}
+	return nil
+}
+
+// ConsumePkceRequest atomically deletes and returns the row.
+// Returns nil if the code is missing or expired.
+func (s *Store) ConsumePkceRequest(ctx context.Context, code string) (*PkceRequest, error) {
+	var r PkceRequest
+	err := s.db.QueryRowContext(ctx, `
+		DELETE FROM codex_pkce_requests
+		WHERE code = $1 AND expires_at > NOW()
+		RETURNING code, code_challenge, state, user_id, expires_at`,
+		code).Scan(&r.Code, &r.CodeChallenge, &r.State, &r.UserID, &r.ExpiresAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("consume pkce request: %w", err)
+	}
+	return &r, nil
+}
+
+// ----- Tokens -----
+
+// HashToken returns sha256(raw) suitable for DB primary key.
+// Tokens are never stored plaintext.
+func HashToken(raw string) []byte {
+	h := sha256.Sum256([]byte(raw))
+	return h[:]
+}
+
+func (s *Store) InsertAccessToken(ctx context.Context, tokenHash []byte, userID string, expiresAt time.Time) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO codex_access_tokens (token_hash, user_id, expires_at)
+		VALUES ($1, $2, $3)`,
+		tokenHash, userID, expiresAt)
+	if err != nil {
+		return fmt.Errorf("insert access token: %w", err)
+	}
+	return nil
+}
+
+// LookupAccessToken returns the user_id if the token is valid (exists,
+// not expired, not revoked); empty string otherwise.
+func (s *Store) LookupAccessToken(ctx context.Context, rawToken string) (string, error) {
+	var userID string
+	err := s.db.QueryRowContext(ctx, `
+		SELECT user_id FROM codex_access_tokens
+		WHERE token_hash = $1
+		  AND expires_at > NOW()
+		  AND revoked_at IS NULL`,
+		HashToken(rawToken)).Scan(&userID)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("lookup access token: %w", err)
+	}
+	return userID, nil
+}
+
+func (s *Store) InsertRefreshToken(ctx context.Context, tokenHash []byte, familyID, userID string, expiresAt time.Time) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO codex_refresh_tokens (token_hash, family_id, user_id, expires_at)
+		VALUES ($1, $2, $3, $4)`,
+		tokenHash, familyID, userID, expiresAt)
+	if err != nil {
+		return fmt.Errorf("insert refresh token: %w", err)
+	}
+	return nil
+}
+
+// RotateRefreshToken revokes the old refresh token and inserts a new
+// one in the same family. Returns the user_id; errors if the old token
+// is missing or already revoked.
+func (s *Store) RotateRefreshToken(ctx context.Context, oldRaw string, newHash []byte, newExpiry time.Time) (string, error) {
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return "", fmt.Errorf("begin tx: %w", err)
+	}
+	defer tx.Rollback()
+
+	oldHash := HashToken(oldRaw)
+	var userID, familyID string
+	err = tx.QueryRowContext(ctx, `
+		UPDATE codex_refresh_tokens
+		SET revoked_at = NOW()
+		WHERE token_hash = $1 AND revoked_at IS NULL AND expires_at > NOW()
+		RETURNING user_id, family_id::text`,
+		oldHash).Scan(&userID, &familyID)
+	if err == sql.ErrNoRows {
+		// Reuse detection (OAuth 2.1 §6.1): the token is either unknown
+		// or already revoked. If it EXISTS but is revoked, assume the
+		// family is compromised and burn every sibling token.
+		var existingFamily string
+		lookupErr := tx.QueryRowContext(ctx, `
+			SELECT family_id::text FROM codex_refresh_tokens
+			WHERE token_hash = $1`, oldHash).Scan(&existingFamily)
+		if lookupErr == nil {
+			if _, revokeErr := tx.ExecContext(ctx, `
+				UPDATE codex_refresh_tokens
+				SET revoked_at = NOW()
+				WHERE family_id = $1::uuid AND revoked_at IS NULL`,
+				existingFamily); revokeErr != nil {
+				return "", fmt.Errorf("revoke family: %w", revokeErr)
+			}
+			if commitErr := tx.Commit(); commitErr != nil {
+				return "", fmt.Errorf("commit family revoke: %w", commitErr)
+			}
+		} else if !errors.Is(lookupErr, sql.ErrNoRows) {
+			return "", fmt.Errorf("lookup revoked refresh: %w", lookupErr)
+		}
+		return "", fmt.Errorf("refresh token expired or revoked: %w", ErrRefreshTokenReuse)
+	}
+	if err != nil {
+		return "", fmt.Errorf("revoke old refresh: %w", err)
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO codex_refresh_tokens (token_hash, family_id, user_id, expires_at)
+		VALUES ($1, $2, $3, $4)`,
+		newHash, familyID, userID, newExpiry); err != nil {
+		return "", fmt.Errorf("insert new refresh: %w", err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return "", fmt.Errorf("commit: %w", err)
+	}
+	return userID, nil
 }

--- a/internal/codexauth/store.go
+++ b/internal/codexauth/store.go
@@ -230,3 +230,79 @@ func (s *Store) RotateRefreshToken(ctx context.Context, oldRaw string, newHash [
 	}
 	return userID, nil
 }
+
+// ----- Agent Identity -----
+
+type AgentIdentity struct {
+	AgentRuntimeID string
+	UserID         string
+	PublicKey      []byte
+	JWTSignedWith  string
+	IssuedAt       time.Time
+	ExpiresAt      time.Time
+}
+
+func (s *Store) InsertAgentIdentity(ctx context.Context, a AgentIdentity) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO codex_agent_identities
+			(agent_runtime_id, user_id, public_key, jwt_signed_with, issued_at, expires_at)
+		VALUES ($1, $2, $3, $4, $5, $6)`,
+		a.AgentRuntimeID, a.UserID, a.PublicKey, a.JWTSignedWith, a.IssuedAt, a.ExpiresAt)
+	if err != nil {
+		return fmt.Errorf("insert agent identity: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) GetAgentIdentity(ctx context.Context, rid string) (*AgentIdentity, error) {
+	var a AgentIdentity
+	err := s.db.QueryRowContext(ctx, `
+		SELECT agent_runtime_id, user_id, public_key, jwt_signed_with, issued_at, expires_at
+		FROM codex_agent_identities
+		WHERE agent_runtime_id = $1 AND revoked_at IS NULL AND expires_at > NOW()`,
+		rid).Scan(&a.AgentRuntimeID, &a.UserID, &a.PublicKey, &a.JWTSignedWith, &a.IssuedAt, &a.ExpiresAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get agent identity: %w", err)
+	}
+	return &a, nil
+}
+
+// ----- Agent Tasks -----
+
+type AgentTask struct {
+	TaskID         string
+	AgentRuntimeID string
+	UserID         string
+	IssuedAt       time.Time
+	ExpiresAt      time.Time
+}
+
+func (s *Store) InsertAgentTask(ctx context.Context, taskID, rid, userID string, expiresAt time.Time) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO codex_agent_tasks (task_id, agent_runtime_id, user_id, issued_at, expires_at)
+		VALUES ($1, $2, $3, NOW(), $4)`,
+		taskID, rid, userID, expiresAt)
+	if err != nil {
+		return fmt.Errorf("insert agent task: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) GetAgentTask(ctx context.Context, taskID string) (*AgentTask, error) {
+	var t AgentTask
+	err := s.db.QueryRowContext(ctx, `
+		SELECT task_id, agent_runtime_id, user_id, issued_at, expires_at
+		FROM codex_agent_tasks
+		WHERE task_id = $1 AND expires_at > NOW()`,
+		taskID).Scan(&t.TaskID, &t.AgentRuntimeID, &t.UserID, &t.IssuedAt, &t.ExpiresAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get agent task: %w", err)
+	}
+	return &t, nil
+}

--- a/internal/codexauth/store.go
+++ b/internal/codexauth/store.go
@@ -1,0 +1,75 @@
+package codexauth
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/agentserver/agentserver/internal/db"
+)
+
+// Store is a thin DB facade over all codex_* tables. Each method takes
+// a context and returns a typed value or error; no business logic lives
+// here (compose in pkce.go, agent_identity.go, etc.).
+type Store struct {
+	db *db.DB
+}
+
+func NewStore(d *db.DB) *Store {
+	return &Store{db: d}
+}
+
+// ----- JWKS keys -----
+
+type JwksKey struct {
+	Kid          string
+	PublicN      string
+	PublicE      string
+	PrivatePKCS8 []byte
+	Active       bool
+}
+
+func (s *Store) InsertJwksKey(ctx context.Context, kid string, kp *RSAKeyPair, active bool) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO codex_jwks_keys (kid, public_n, public_e, private_pkcs8, active)
+		VALUES ($1, $2, $3, $4, $5)`,
+		kid, kp.PublicN, kp.PublicE, kp.PrivatePKCS8, active)
+	if err != nil {
+		return fmt.Errorf("insert jwks key: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) GetActiveJwksKey(ctx context.Context) (*JwksKey, error) {
+	var k JwksKey
+	err := s.db.QueryRowContext(ctx, `
+		SELECT kid, public_n, public_e, private_pkcs8, active
+		FROM codex_jwks_keys WHERE active = TRUE`).
+		Scan(&k.Kid, &k.PublicN, &k.PublicE, &k.PrivatePKCS8, &k.Active)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get active jwks key: %w", err)
+	}
+	return &k, nil
+}
+
+func (s *Store) ListAllJwksKeys(ctx context.Context) ([]JwksKey, error) {
+	rows, err := s.db.QueryContext(ctx, `
+		SELECT kid, public_n, public_e, private_pkcs8, active
+		FROM codex_jwks_keys ORDER BY created_at DESC`)
+	if err != nil {
+		return nil, fmt.Errorf("list jwks keys: %w", err)
+	}
+	defer rows.Close()
+	var out []JwksKey
+	for rows.Next() {
+		var k JwksKey
+		if err := rows.Scan(&k.Kid, &k.PublicN, &k.PublicE, &k.PrivatePKCS8, &k.Active); err != nil {
+			return nil, fmt.Errorf("scan jwks key: %w", err)
+		}
+		out = append(out, k)
+	}
+	return out, nil
+}

--- a/internal/codexauth/store.go
+++ b/internal/codexauth/store.go
@@ -306,3 +306,94 @@ func (s *Store) GetAgentTask(ctx context.Context, taskID string) (*AgentTask, er
 	}
 	return &t, nil
 }
+
+// ----- Device Codes -----
+
+type DeviceCode struct {
+	DeviceAuthID      string
+	UserCode          string
+	CodeChallenge     string
+	CodeVerifier      string
+	AuthorizationCode string
+	Status            string
+	UserID            string
+	ExpiresAt         time.Time
+	ApprovedAt        *time.Time
+}
+
+func (s *Store) InsertDeviceCode(ctx context.Context, dc DeviceCode) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO codex_device_codes
+			(device_auth_id, user_code, code_challenge, code_verifier,
+			 authorization_code, status, expires_at)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+		dc.DeviceAuthID, dc.UserCode, dc.CodeChallenge, dc.CodeVerifier,
+		dc.AuthorizationCode, dc.Status, dc.ExpiresAt)
+	if err != nil {
+		return fmt.Errorf("insert device code: %w", err)
+	}
+	return nil
+}
+
+func (s *Store) GetDeviceCodeByUserCode(ctx context.Context, userCode string) (*DeviceCode, error) {
+	var dc DeviceCode
+	var uid sql.NullString
+	err := s.db.QueryRowContext(ctx, `
+		SELECT device_auth_id, user_code, code_challenge, code_verifier,
+		       authorization_code, status, COALESCE(user_id, ''), expires_at
+		FROM codex_device_codes
+		WHERE user_code = $1 AND expires_at > NOW()`,
+		userCode).Scan(&dc.DeviceAuthID, &dc.UserCode, &dc.CodeChallenge,
+		&dc.CodeVerifier, &dc.AuthorizationCode, &dc.Status, &uid, &dc.ExpiresAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("get device code: %w", err)
+	}
+	if uid.Valid {
+		dc.UserID = uid.String
+	}
+	return &dc, nil
+}
+
+func (s *Store) ApproveDeviceCode(ctx context.Context, userCode, userID string) error {
+	res, err := s.db.ExecContext(ctx, `
+		UPDATE codex_device_codes
+		SET status = 'approved', user_id = $2, approved_at = NOW()
+		WHERE user_code = $1 AND status = 'pending' AND expires_at > NOW()`,
+		userCode, userID)
+	if err != nil {
+		return fmt.Errorf("approve device code: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("user_code not found or not pending")
+	}
+	return nil
+}
+
+// ExchangeDeviceCode atomically returns the row and marks it 'exchanged'.
+// Only approved rows are returned; subsequent calls return nil.
+func (s *Store) ExchangeDeviceCode(ctx context.Context, deviceAuthID, userCode string) (*DeviceCode, error) {
+	var dc DeviceCode
+	var uid sql.NullString
+	err := s.db.QueryRowContext(ctx, `
+		UPDATE codex_device_codes
+		SET status = 'exchanged'
+		WHERE device_auth_id = $1 AND user_code = $2 AND status = 'approved' AND expires_at > NOW()
+		RETURNING device_auth_id, user_code, code_challenge, code_verifier,
+		          authorization_code, status, COALESCE(user_id, ''), expires_at`,
+		deviceAuthID, userCode).Scan(&dc.DeviceAuthID, &dc.UserCode, &dc.CodeChallenge,
+		&dc.CodeVerifier, &dc.AuthorizationCode, &dc.Status, &uid, &dc.ExpiresAt)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("exchange device code: %w", err)
+	}
+	if uid.Valid {
+		dc.UserID = uid.String
+	}
+	return &dc, nil
+}

--- a/internal/codexauth/store_test.go
+++ b/internal/codexauth/store_test.go
@@ -2,8 +2,10 @@ package codexauth
 
 import (
 	"context"
+	"errors"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/agentserver/agentserver/internal/db"
 )
@@ -84,4 +86,177 @@ func TestStore_ListAllJwksKeys(t *testing.T) {
 	if len(keys) != 2 {
 		t.Errorf("keys count = %d, want 2", len(keys))
 	}
+}
+
+func TestStore_PkceRequest_RoundTrip(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+	uid := mustCreateTestUser(t, s.db)
+
+	err := s.InsertPkceRequest(ctx, PkceRequest{
+		Code:          "code-abc",
+		CodeChallenge: "chall-123",
+		State:         "state-xyz",
+		UserID:        uid,
+		ExpiresAt:     time.Now().Add(10 * time.Minute),
+	})
+	if err != nil {
+		t.Fatalf("InsertPkceRequest: %v", err)
+	}
+	got, err := s.ConsumePkceRequest(ctx, "code-abc")
+	if err != nil || got == nil {
+		t.Fatalf("ConsumePkceRequest: %v %+v", err, got)
+	}
+	if got.CodeChallenge != "chall-123" {
+		t.Errorf("CodeChallenge = %q", got.CodeChallenge)
+	}
+	// ConsumePkceRequest deletes — second call returns nil.
+	got2, _ := s.ConsumePkceRequest(ctx, "code-abc")
+	if got2 != nil {
+		t.Error("second consume should return nil")
+	}
+}
+
+func TestStore_AccessToken_HashLookup(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+	uid := mustCreateTestUser(t, s.db)
+
+	hash := HashToken("raw-access-token")
+	exp := time.Now().Add(1 * time.Hour).UTC()
+	if err := s.InsertAccessToken(ctx, hash, uid, exp); err != nil {
+		t.Fatalf("InsertAccessToken: %v", err)
+	}
+	gotUID, err := s.LookupAccessToken(ctx, "raw-access-token")
+	if err != nil {
+		t.Fatalf("LookupAccessToken: %v", err)
+	}
+	if gotUID != uid {
+		t.Errorf("uid = %q, want %q", gotUID, uid)
+	}
+}
+
+func TestStore_AccessToken_ExpiredReturnsEmpty(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+	uid := mustCreateTestUser(t, s.db)
+
+	hash := HashToken("raw-expired-token")
+	if err := s.InsertAccessToken(ctx, hash, uid, time.Now().Add(-1*time.Hour)); err != nil {
+		t.Fatalf("InsertAccessToken: %v", err)
+	}
+	gotUID, _ := s.LookupAccessToken(ctx, "raw-expired-token")
+	if gotUID != "" {
+		t.Errorf("uid = %q, expected empty for expired token", gotUID)
+	}
+}
+
+func TestStore_RefreshToken_RotateInvalidatesOld(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+	uid := mustCreateTestUser(t, s.db)
+
+	family := mustNewUUID(t, s.db)
+	oldHash := HashToken("refresh-old")
+	if err := s.InsertRefreshToken(ctx, oldHash, family, uid, time.Now().Add(24*time.Hour)); err != nil {
+		t.Fatalf("InsertRefreshToken: %v", err)
+	}
+
+	// Look up + revoke old, insert new, all in one call.
+	newHash := HashToken("refresh-new")
+	gotUID, err := s.RotateRefreshToken(ctx, "refresh-old", newHash, time.Now().Add(24*time.Hour))
+	if err != nil {
+		t.Fatalf("RotateRefreshToken: %v", err)
+	}
+	if gotUID != uid {
+		t.Errorf("uid = %q, want %q", gotUID, uid)
+	}
+	// Old is now revoked.
+	if _, err := s.RotateRefreshToken(ctx, "refresh-old", newHash, time.Now().Add(24*time.Hour)); err == nil {
+		t.Error("rotating revoked token should error")
+	}
+}
+
+func TestStore_RefreshToken_FamilyIDPreserved(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+	uid := mustCreateTestUser(t, s.db)
+
+	family := mustNewUUID(t, s.db)
+	s.InsertRefreshToken(ctx, HashToken("rt-1"), family, uid, time.Now().Add(24*time.Hour))
+	s.RotateRefreshToken(ctx, "rt-1", HashToken("rt-2"), time.Now().Add(24*time.Hour))
+
+	var got string
+	if err := s.db.QueryRow(
+		`SELECT family_id::text FROM codex_refresh_tokens WHERE token_hash = $1`,
+		HashToken("rt-2"),
+	).Scan(&got); err != nil {
+		t.Fatalf("scan: %v", err)
+	}
+	if got != family {
+		t.Errorf("family_id = %q, want %q", got, family)
+	}
+}
+
+func TestStore_RefreshToken_ReuseRevokesFamily(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+	uid := mustCreateTestUser(t, s.db)
+
+	family := mustNewUUID(t, s.db)
+	// Insert two siblings in the same family.
+	s.InsertRefreshToken(ctx, HashToken("rt-a"), family, uid, time.Now().Add(24*time.Hour))
+	s.InsertRefreshToken(ctx, HashToken("rt-b"), family, uid, time.Now().Add(24*time.Hour))
+
+	// Rotate rt-a → rt-c (legitimate use, succeeds).
+	if _, err := s.RotateRefreshToken(ctx, "rt-a", HashToken("rt-c"), time.Now().Add(24*time.Hour)); err != nil {
+		t.Fatalf("first rotate: %v", err)
+	}
+
+	// Attempted reuse of revoked rt-a — must error with ErrRefreshTokenReuse
+	// AND revoke the entire family (so rt-b and rt-c are now unusable).
+	_, err := s.RotateRefreshToken(ctx, "rt-a", HashToken("rt-d"), time.Now().Add(24*time.Hour))
+	if !errors.Is(err, ErrRefreshTokenReuse) {
+		t.Errorf("err = %v, want ErrRefreshTokenReuse", err)
+	}
+
+	// rt-b should now be revoked too (family burned).
+	_, err = s.RotateRefreshToken(ctx, "rt-b", HashToken("rt-e"), time.Now().Add(24*time.Hour))
+	if !errors.Is(err, ErrRefreshTokenReuse) {
+		t.Errorf("rt-b rotate after family burn: err = %v, want ErrRefreshTokenReuse", err)
+	}
+	// rt-c (the legitimate post-rotation token) should also be burned.
+	_, err = s.RotateRefreshToken(ctx, "rt-c", HashToken("rt-f"), time.Now().Add(24*time.Hour))
+	if !errors.Is(err, ErrRefreshTokenReuse) {
+		t.Errorf("rt-c rotate after family burn: err = %v, want ErrRefreshTokenReuse", err)
+	}
+}
+
+// --- helpers ---
+
+func mustCreateTestUser(t *testing.T, d *db.DB) string {
+	t.Helper()
+	id := mustNewUUID(t, d)
+	_, err := d.Exec(`INSERT INTO users (id, username, email, created_at)
+		VALUES ($1, $2, $3, NOW())
+		ON CONFLICT (id) DO NOTHING`, id, "test-"+id[:8], id+"@test.local")
+	if err != nil {
+		t.Fatalf("create test user: %v", err)
+	}
+	return id
+}
+
+func mustNewUUID(t *testing.T, d *db.DB) string {
+	t.Helper()
+	var s string
+	if err := d.QueryRow("SELECT gen_random_uuid()::text").Scan(&s); err != nil {
+		t.Fatalf("gen_random_uuid: %v", err)
+	}
+	return s
 }

--- a/internal/codexauth/store_test.go
+++ b/internal/codexauth/store_test.go
@@ -260,3 +260,64 @@ func mustNewUUID(t *testing.T, d *db.DB) string {
 	}
 	return s
 }
+
+func TestStore_AgentIdentity_RoundTrip(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+	uid := mustCreateTestUser(t, s.db)
+
+	kid, kp, _ := GenerateRSAKey()
+	s.InsertJwksKey(ctx, kid, kp, true)
+
+	_, pub, _ := GenerateEd25519Key()
+	rid := "exe_test_" + mustNewUUID(t, s.db)
+	if err := s.InsertAgentIdentity(ctx, AgentIdentity{
+		AgentRuntimeID: rid,
+		UserID:         uid,
+		PublicKey:      pub,
+		JWTSignedWith:  kid,
+		IssuedAt:       time.Now(),
+		ExpiresAt:      time.Now().Add(30 * 24 * time.Hour),
+	}); err != nil {
+		t.Fatalf("InsertAgentIdentity: %v", err)
+	}
+
+	got, err := s.GetAgentIdentity(ctx, rid)
+	if err != nil || got == nil {
+		t.Fatalf("GetAgentIdentity: %v %+v", err, got)
+	}
+	if got.UserID != uid || string(got.PublicKey) != string(pub) {
+		t.Errorf("got = %+v", got)
+	}
+}
+
+func TestStore_AgentTask_RoundTrip(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+	uid := mustCreateTestUser(t, s.db)
+
+	kid, kp, _ := GenerateRSAKey()
+	s.InsertJwksKey(ctx, kid, kp, true)
+	_, pub, _ := GenerateEd25519Key()
+	rid := "exe_task_" + mustNewUUID(t, s.db)
+	s.InsertAgentIdentity(ctx, AgentIdentity{
+		AgentRuntimeID: rid, UserID: uid, PublicKey: pub,
+		JWTSignedWith: kid, IssuedAt: time.Now(),
+		ExpiresAt: time.Now().Add(30 * 24 * time.Hour),
+	})
+
+	tid := "task_" + mustNewUUID(t, s.db)
+	if err := s.InsertAgentTask(ctx, tid, rid, uid, time.Now().Add(24*time.Hour)); err != nil {
+		t.Fatalf("InsertAgentTask: %v", err)
+	}
+
+	got, err := s.GetAgentTask(ctx, tid)
+	if err != nil || got == nil {
+		t.Fatalf("GetAgentTask: %v %+v", err, got)
+	}
+	if got.AgentRuntimeID != rid || got.UserID != uid {
+		t.Errorf("got = %+v", got)
+	}
+}

--- a/internal/codexauth/store_test.go
+++ b/internal/codexauth/store_test.go
@@ -1,0 +1,87 @@
+package codexauth
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/agentserver/agentserver/internal/db"
+)
+
+func newTestStore(t *testing.T) (*Store, func()) {
+	t.Helper()
+	url := os.Getenv("TEST_DATABASE_URL")
+	if url == "" {
+		t.Skip("TEST_DATABASE_URL not set")
+	}
+	d, err := db.Open(url)
+	if err != nil {
+		t.Fatalf("db.Open: %v", err)
+	}
+	// Wipe codex_* tables for a clean slate.
+	d.Exec(`DELETE FROM codex_agent_tasks`)
+	d.Exec(`DELETE FROM codex_agent_identities`)
+	d.Exec(`DELETE FROM codex_jwks_keys`)
+	d.Exec(`DELETE FROM codex_device_codes`)
+	d.Exec(`DELETE FROM codex_refresh_tokens`)
+	d.Exec(`DELETE FROM codex_access_tokens`)
+	d.Exec(`DELETE FROM codex_pkce_requests`)
+	return NewStore(d), func() { d.Close() }
+}
+
+func TestStore_InsertJwksKey_RoundTrip(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	kid, kp, err := GenerateRSAKey()
+	if err != nil {
+		t.Fatalf("GenerateRSAKey: %v", err)
+	}
+	if err := s.InsertJwksKey(ctx, kid, kp, true); err != nil {
+		t.Fatalf("InsertJwksKey: %v", err)
+	}
+
+	got, err := s.GetActiveJwksKey(ctx)
+	if err != nil || got == nil {
+		t.Fatalf("GetActiveJwksKey: %v %+v", err, got)
+	}
+	if got.Kid != kid {
+		t.Errorf("kid = %q, want %q", got.Kid, kid)
+	}
+}
+
+func TestStore_OnlyOneActiveKey(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	kid1, kp1, _ := GenerateRSAKey()
+	kid2, kp2, _ := GenerateRSAKey()
+	if err := s.InsertJwksKey(ctx, kid1, kp1, true); err != nil {
+		t.Fatalf("InsertJwksKey #1: %v", err)
+	}
+	err := s.InsertJwksKey(ctx, kid2, kp2, true)
+	if err == nil {
+		t.Fatal("InsertJwksKey #2 should fail uniq_codex_jwks_keys_one_active")
+	}
+}
+
+func TestStore_ListAllJwksKeys(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+
+	kid1, kp1, _ := GenerateRSAKey()
+	kid2, kp2, _ := GenerateRSAKey()
+	s.InsertJwksKey(ctx, kid1, kp1, true)
+	s.InsertJwksKey(ctx, kid2, kp2, false)
+
+	keys, err := s.ListAllJwksKeys(ctx)
+	if err != nil {
+		t.Fatalf("ListAllJwksKeys: %v", err)
+	}
+	if len(keys) != 2 {
+		t.Errorf("keys count = %d, want 2", len(keys))
+	}
+}

--- a/internal/codexauth/store_test.go
+++ b/internal/codexauth/store_test.go
@@ -321,3 +321,63 @@ func TestStore_AgentTask_RoundTrip(t *testing.T) {
 		t.Errorf("got = %+v", got)
 	}
 }
+
+func TestStore_DeviceCode_PendingToApproved(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+	uid := mustCreateTestUser(t, s.db)
+
+	dc := DeviceCode{
+		DeviceAuthID:      "dev-abc",
+		UserCode:          "BDWD-HQPK",
+		CodeChallenge:     "chall",
+		CodeVerifier:      "ver",
+		AuthorizationCode: "authcode-xyz",
+		Status:            "pending",
+		ExpiresAt:         time.Now().Add(15 * time.Minute),
+	}
+	if err := s.InsertDeviceCode(ctx, dc); err != nil {
+		t.Fatalf("InsertDeviceCode: %v", err)
+	}
+	// Initially pending.
+	got, _ := s.GetDeviceCodeByUserCode(ctx, "BDWD-HQPK")
+	if got == nil || got.Status != "pending" {
+		t.Fatalf("got = %+v", got)
+	}
+	// Approve.
+	if err := s.ApproveDeviceCode(ctx, "BDWD-HQPK", uid); err != nil {
+		t.Fatalf("ApproveDeviceCode: %v", err)
+	}
+	got2, _ := s.GetDeviceCodeByUserCode(ctx, "BDWD-HQPK")
+	if got2.Status != "approved" || got2.UserID != uid {
+		t.Errorf("after approve: %+v", got2)
+	}
+}
+
+func TestStore_DeviceCode_ExchangeOnceOnly(t *testing.T) {
+	s, cleanup := newTestStore(t)
+	defer cleanup()
+	ctx := context.Background()
+	uid := mustCreateTestUser(t, s.db)
+
+	dc := DeviceCode{
+		DeviceAuthID:      "dev-only-once",
+		UserCode:          "ABCD-EFGH",
+		CodeChallenge:     "chall",
+		CodeVerifier:      "ver",
+		AuthorizationCode: "authcode-xyz",
+		Status:            "pending",
+		ExpiresAt:         time.Now().Add(15 * time.Minute),
+	}
+	s.InsertDeviceCode(ctx, dc)
+	s.ApproveDeviceCode(ctx, "ABCD-EFGH", uid)
+	got, err := s.ExchangeDeviceCode(ctx, "dev-only-once", "ABCD-EFGH")
+	if err != nil || got == nil {
+		t.Fatalf("first exchange: %v %+v", err, got)
+	}
+	got2, _ := s.ExchangeDeviceCode(ctx, "dev-only-once", "ABCD-EFGH")
+	if got2 != nil {
+		t.Error("second exchange should return nil (single-use)")
+	}
+}

--- a/internal/db/migrations/025_codex_auth.sql
+++ b/internal/db/migrations/025_codex_auth.sql
@@ -1,0 +1,77 @@
+-- 025_codex_auth.sql
+-- Self-hosted codex auth: PKCE + device flow + Agent Identity JWT minting.
+-- Spec: docs/superpowers/specs/2026-05-20-codex-0.132-auth.md
+
+-- ChatGPT mode --------------------------------------------------------
+CREATE TABLE codex_pkce_requests (
+    code            TEXT PRIMARY KEY,
+    code_challenge  TEXT NOT NULL,
+    state           TEXT NOT NULL,
+    user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    expires_at      TIMESTAMPTZ NOT NULL
+);
+CREATE INDEX idx_codex_pkce_requests_expires_at ON codex_pkce_requests (expires_at);
+
+CREATE TABLE codex_access_tokens (
+    token_hash      BYTEA PRIMARY KEY,
+    user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    expires_at      TIMESTAMPTZ NOT NULL,
+    revoked_at      TIMESTAMPTZ
+);
+CREATE INDEX idx_codex_access_tokens_user_id  ON codex_access_tokens (user_id);
+CREATE INDEX idx_codex_access_tokens_expires  ON codex_access_tokens (expires_at);
+
+CREATE TABLE codex_refresh_tokens (
+    token_hash      BYTEA PRIMARY KEY,
+    family_id       UUID NOT NULL,
+    user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    expires_at      TIMESTAMPTZ NOT NULL,
+    revoked_at      TIMESTAMPTZ
+);
+CREATE INDEX idx_codex_refresh_tokens_family ON codex_refresh_tokens (family_id);
+
+CREATE TABLE codex_device_codes (
+    device_auth_id      TEXT PRIMARY KEY,
+    user_code           TEXT NOT NULL UNIQUE,
+    code_challenge      TEXT NOT NULL,
+    code_verifier       TEXT NOT NULL,
+    authorization_code  TEXT NOT NULL,
+    status              TEXT NOT NULL,  -- pending|approved|exchanged|denied
+    user_id             UUID REFERENCES users(id) ON DELETE CASCADE,
+    expires_at          TIMESTAMPTZ NOT NULL,
+    approved_at         TIMESTAMPTZ
+);
+CREATE INDEX idx_codex_device_codes_user_code ON codex_device_codes (user_code);
+CREATE INDEX idx_codex_device_codes_expires   ON codex_device_codes (expires_at);
+
+-- Agent Identity mode -------------------------------------------------
+CREATE TABLE codex_jwks_keys (
+    kid             TEXT PRIMARY KEY,
+    public_n        TEXT NOT NULL,
+    public_e        TEXT NOT NULL,
+    private_pkcs8   BYTEA NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    active          BOOL NOT NULL
+);
+CREATE UNIQUE INDEX uniq_codex_jwks_keys_one_active
+    ON codex_jwks_keys (active)
+    WHERE active;
+
+CREATE TABLE codex_agent_identities (
+    agent_runtime_id  TEXT PRIMARY KEY,
+    user_id           UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    public_key        BYTEA NOT NULL,
+    jwt_signed_with   TEXT NOT NULL REFERENCES codex_jwks_keys(kid),
+    issued_at         TIMESTAMPTZ NOT NULL,
+    expires_at        TIMESTAMPTZ NOT NULL,
+    revoked_at        TIMESTAMPTZ
+);
+
+CREATE TABLE codex_agent_tasks (
+    task_id           TEXT PRIMARY KEY,
+    agent_runtime_id  TEXT NOT NULL REFERENCES codex_agent_identities(agent_runtime_id) ON DELETE CASCADE,
+    user_id           UUID NOT NULL,
+    issued_at         TIMESTAMPTZ NOT NULL,
+    expires_at        TIMESTAMPTZ NOT NULL
+);
+CREATE INDEX idx_codex_agent_tasks_expires ON codex_agent_tasks (expires_at);

--- a/internal/db/migrations/025_codex_auth.sql
+++ b/internal/db/migrations/025_codex_auth.sql
@@ -3,49 +3,49 @@
 -- Spec: docs/superpowers/specs/2026-05-20-codex-0.132-auth.md
 
 -- ChatGPT mode --------------------------------------------------------
-CREATE TABLE codex_pkce_requests (
+CREATE TABLE IF NOT EXISTS codex_pkce_requests (
     code            TEXT PRIMARY KEY,
     code_challenge  TEXT NOT NULL,
     state           TEXT NOT NULL,
-    user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     expires_at      TIMESTAMPTZ NOT NULL
 );
-CREATE INDEX idx_codex_pkce_requests_expires_at ON codex_pkce_requests (expires_at);
+CREATE INDEX IF NOT EXISTS idx_codex_pkce_requests_expires_at ON codex_pkce_requests (expires_at);
 
-CREATE TABLE codex_access_tokens (
+CREATE TABLE IF NOT EXISTS codex_access_tokens (
     token_hash      BYTEA PRIMARY KEY,
-    user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     expires_at      TIMESTAMPTZ NOT NULL,
     revoked_at      TIMESTAMPTZ
 );
-CREATE INDEX idx_codex_access_tokens_user_id  ON codex_access_tokens (user_id);
-CREATE INDEX idx_codex_access_tokens_expires  ON codex_access_tokens (expires_at);
+CREATE INDEX IF NOT EXISTS idx_codex_access_tokens_user_id    ON codex_access_tokens (user_id);
+CREATE INDEX IF NOT EXISTS idx_codex_access_tokens_expires_at ON codex_access_tokens (expires_at);
 
-CREATE TABLE codex_refresh_tokens (
+CREATE TABLE IF NOT EXISTS codex_refresh_tokens (
     token_hash      BYTEA PRIMARY KEY,
     family_id       UUID NOT NULL,
-    user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    user_id         TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     expires_at      TIMESTAMPTZ NOT NULL,
     revoked_at      TIMESTAMPTZ
 );
-CREATE INDEX idx_codex_refresh_tokens_family ON codex_refresh_tokens (family_id);
+CREATE INDEX IF NOT EXISTS idx_codex_refresh_tokens_family_id ON codex_refresh_tokens (family_id);
 
-CREATE TABLE codex_device_codes (
+CREATE TABLE IF NOT EXISTS codex_device_codes (
     device_auth_id      TEXT PRIMARY KEY,
     user_code           TEXT NOT NULL UNIQUE,
     code_challenge      TEXT NOT NULL,
     code_verifier       TEXT NOT NULL,
     authorization_code  TEXT NOT NULL,
     status              TEXT NOT NULL,  -- pending|approved|exchanged|denied
-    user_id             UUID REFERENCES users(id) ON DELETE CASCADE,
+    user_id             TEXT REFERENCES users(id) ON DELETE CASCADE,
     expires_at          TIMESTAMPTZ NOT NULL,
     approved_at         TIMESTAMPTZ
 );
-CREATE INDEX idx_codex_device_codes_user_code ON codex_device_codes (user_code);
-CREATE INDEX idx_codex_device_codes_expires   ON codex_device_codes (expires_at);
+CREATE INDEX IF NOT EXISTS idx_codex_device_codes_user_code  ON codex_device_codes (user_code);
+CREATE INDEX IF NOT EXISTS idx_codex_device_codes_expires_at ON codex_device_codes (expires_at);
 
 -- Agent Identity mode -------------------------------------------------
-CREATE TABLE codex_jwks_keys (
+CREATE TABLE IF NOT EXISTS codex_jwks_keys (
     kid             TEXT PRIMARY KEY,
     public_n        TEXT NOT NULL,
     public_e        TEXT NOT NULL,
@@ -53,13 +53,13 @@ CREATE TABLE codex_jwks_keys (
     created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     active          BOOL NOT NULL
 );
-CREATE UNIQUE INDEX uniq_codex_jwks_keys_one_active
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_codex_jwks_keys_one_active
     ON codex_jwks_keys (active)
     WHERE active;
 
-CREATE TABLE codex_agent_identities (
+CREATE TABLE IF NOT EXISTS codex_agent_identities (
     agent_runtime_id  TEXT PRIMARY KEY,
-    user_id           UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    user_id           TEXT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     public_key        BYTEA NOT NULL,
     jwt_signed_with   TEXT NOT NULL REFERENCES codex_jwks_keys(kid),
     issued_at         TIMESTAMPTZ NOT NULL,
@@ -67,11 +67,11 @@ CREATE TABLE codex_agent_identities (
     revoked_at        TIMESTAMPTZ
 );
 
-CREATE TABLE codex_agent_tasks (
+CREATE TABLE IF NOT EXISTS codex_agent_tasks (
     task_id           TEXT PRIMARY KEY,
     agent_runtime_id  TEXT NOT NULL REFERENCES codex_agent_identities(agent_runtime_id) ON DELETE CASCADE,
-    user_id           UUID NOT NULL,
+    user_id           TEXT NOT NULL,
     issued_at         TIMESTAMPTZ NOT NULL,
     expires_at        TIMESTAMPTZ NOT NULL
 );
-CREATE INDEX idx_codex_agent_tasks_expires ON codex_agent_tasks (expires_at);
+CREATE INDEX IF NOT EXISTS idx_codex_agent_tasks_expires_at ON codex_agent_tasks (expires_at);


### PR DESCRIPTION
Phase A of the codex 0.132+ auth spec (`docs/superpowers/specs/2026-05-20-codex-0.132-auth.md` on branch \`docs/codex-0.132-auth-spec\`, PR #122).

## What this lands

8 commits, all in `internal/codexauth/` + one DB migration:

1. `d9b491d` migration 025 (7 tables: codex_pkce_requests, codex_access_tokens, codex_refresh_tokens, codex_device_codes, codex_jwks_keys, codex_agent_identities, codex_agent_tasks)
2. `829b8cc` migration fix — TEXT user_id (matches actual users.id), consistent index names, IF NOT EXISTS
3. `3067c90` RSA-2048 + Ed25519 key generation
4. `50a4bbd` Store layer: JWKS keys (Insert/GetActive/ListAll + partial-unique-index test)
5. `47dd355` Store layer: PKCE + access/refresh tokens (with OAuth 2.1 family-burn reuse detection, sentinel error)
6. `4ed2889` Store layer: agent identities + tasks
7. `85d31db` Store layer: device codes (atomic single-use ExchangeDeviceCode)
8. `e056faa` Claims builders: BuildIDToken (OpenAI-nested claim), BuildAccessToken (exp for codex proactive refresh), BuildAgentIdentityJWT (RS256, kid header, strict iss/aud literals matching codex 0.132 expectations)

## What this does NOT do yet

- No HTTP routes wired (Phase B will add PKCE/device flow handlers)
- No agentserver bootstrap (Phase B Task B7 wires it via CODEX_AUTH_ISSUER_URL env)
- No JWKS endpoint (Phase C)

## Tests

13 store tests + 3 claims tests + 2 key tests = 18 tests, all PASS or SKIP cleanly (skip when TEST_DATABASE_URL unset). \`go vet ./internal/codexauth/...\` clean.

## Notes

- Each task went through TDD (failing test → impl → pass → commit) and 2-stage review (spec compliance + code quality) per superpowers:subagent-driven-development.
- A4 added OAuth 2.1 §6.1 refresh-token reuse detection (family revocation + ErrRefreshTokenReuse sentinel) on top of the basic rotation in the spec — recommended by code reviewer, accepted.
- Migration originally declared user_id as UUID but users.id is TEXT — caught + fixed before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)