### PR TITLE
feat(codexauth): PR 2 — ChatGPT login (PKCE + device flow)

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -21,6 +21,7 @@ import (
 	"encoding/hex"
 
 	"github.com/agentserver/agentserver/internal/auth"
+	"github.com/agentserver/agentserver/internal/codexauth"
 	"github.com/agentserver/agentserver/internal/crypto"
 	_ "github.com/agentserver/agentserver/internal/credentialproxy/k8s" // register k8s credential provider
 	"github.com/agentserver/agentserver/internal/bridge"
@@ -233,6 +234,33 @@ var serveCmd = &cobra.Command{
 			srv.ExecutorsClient = server.NewExecutorsClient(u, os.Getenv("INTERNAL_API_SECRET"))
 		}
 		srv.CodexExecGatewayPublicHost = os.Getenv("CODEX_EXEC_GATEWAY_PUBLIC_HOST")
+
+		// Self-hosted codex 0.132+ auth shim. When CODEX_AUTH_ISSUER_URL is
+		// set, agentserver exposes PKCE / device flow / JWKS / Agent Identity
+		// endpoints under /codex-auth/* so `codex login --issuer
+		// <CODEX_AUTH_ISSUER_URL>` works against this deployment.
+		if issuer := os.Getenv("CODEX_AUTH_ISSUER_URL"); issuer != "" {
+			caStore := codexauth.NewStore(database)
+			activeKey, err := codexauth.EnsureActiveKey(context.Background(), caStore)
+			if err != nil {
+				log.Fatalf("codexauth EnsureActiveKey: %v", err)
+			}
+			priv, err := codexauth.LoadRSAPrivate(activeKey.PrivatePKCS8)
+			if err != nil {
+				log.Fatalf("codexauth LoadRSAPrivate: %v", err)
+			}
+			srv.CodexAuth = &codexauth.Server{
+				Store:      caStore,
+				IssuerURL:  issuer,
+				SigningKey: priv,
+				SigningKid: activeKey.Kid,
+				SessionResolve: func(r *http.Request) string {
+					return auth.UserIDFromContext(r.Context())
+				},
+				LoginRedirectURL: "/login",
+			}
+			log.Printf("codexauth: enabled (issuer=%s, kid=%s)", issuer, activeKey.Kid)
+		}
 
 		// Operations retention TTL — 90 days default, 0 disables. Env var
 		// AGENTSERVER_OPERATIONS_RETENTION_DAYS overrides.

--- a/deploy/helm/agentserver/templates/deployment.yaml
+++ b/deploy/helm/agentserver/templates/deployment.yaml
@@ -227,6 +227,10 @@ spec:
             - name: CODEX_EXEC_GATEWAY_PUBLIC_HOST
               value: {{ .Values.codexExecGateway.publicHost | quote }}
             {{- end }}
+            {{- if .Values.codexAuth.enabled }}
+            - name: CODEX_AUTH_ISSUER_URL
+              value: {{ printf "https://%s/codex-auth" .Values.platform.domain | quote }}
+            {{- end }}
             - name: OPENCODE_SUBDOMAIN_PREFIX
               value: {{ .Values.sandbox.opencode.subdomainPrefix | default "code" | quote }}
             - name: OPENCLAW_SUBDOMAIN_PREFIX

--- a/deploy/helm/agentserver/values.yaml
+++ b/deploy/helm/agentserver/values.yaml
@@ -126,6 +126,13 @@ agentSandbox:
   install: true
   controllerImage: registry.k8s.io/agent-sandbox/agent-sandbox-controller:v0.1.1
 
+codexAuth:
+  # Self-hosted codex 0.132+ auth shim. When enabled, agentserver
+  # serves PKCE / device flow / JWKS / agent-identity endpoints under
+  # /codex-auth/* so `codex login --issuer https://<platform.domain>/codex-auth`
+  # works against this deployment.
+  enabled: false
+
 hydra:
   # Ory Hydra OAuth2 server for agent Device Flow registration.
   # When enabled, deploys Hydra alongside agentserver and configures

--- a/internal/codexauth/device.go
+++ b/internal/codexauth/device.go
@@ -1,0 +1,115 @@
+package codexauth
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	deviceCodeTTL      = 15 * time.Minute
+	devicePollInterval = 5
+)
+
+// userCodeAlphabet excludes I, O, 0, 1 to reduce read-aloud confusion.
+const userCodeAlphabet = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+
+func (s *Server) handleDeviceUserCode(w http.ResponseWriter, r *http.Request) {
+	deviceAuthID := mustRandomHex(32)
+	userCode := mustRandomUserCode()
+	verifier := mustRandomHex(32) // 64 chars hex, fits 43-128 URL-safe
+	challenge := base64URLNoPad(sha256Sum([]byte(verifier)))
+	authorizationCode := mustRandomHex(32)
+
+	if err := s.Store.InsertDeviceCode(r.Context(), DeviceCode{
+		DeviceAuthID:      deviceAuthID,
+		UserCode:          userCode,
+		CodeChallenge:     challenge,
+		CodeVerifier:      verifier,
+		AuthorizationCode: authorizationCode,
+		Status:            "pending",
+		ExpiresAt:         time.Now().Add(deviceCodeTTL),
+	}); err != nil {
+		http.Error(w, "store: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"device_auth_id": deviceAuthID,
+		"user_code":      userCode,
+		"interval":       devicePollInterval,
+	})
+}
+
+func (s *Server) handleDeviceToken(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		DeviceAuthID string `json:"device_auth_id"`
+		UserCode     string `json:"user_code"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad body", http.StatusBadRequest)
+		return
+	}
+	if req.DeviceAuthID == "" || req.UserCode == "" {
+		http.Error(w, "device_auth_id and user_code required", http.StatusBadRequest)
+		return
+	}
+	row, err := s.Store.GetDeviceCodeByUserCode(r.Context(), req.UserCode)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if row == nil || row.DeviceAuthID != req.DeviceAuthID {
+		// 404 keeps codex polling until expiry.
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	switch row.Status {
+	case "pending":
+		// 403 keeps codex polling (device_code_auth.rs:128-138).
+		http.Error(w, "authorization pending", http.StatusForbidden)
+		return
+	case "denied", "exchanged":
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	case "approved":
+		// fall through
+	}
+
+	dc, err := s.Store.ExchangeDeviceCode(r.Context(), req.DeviceAuthID, req.UserCode)
+	if err != nil || dc == nil {
+		http.Error(w, "not found", http.StatusNotFound)
+		return
+	}
+	// Insert a matching codex_pkce_requests row so the subsequent
+	// /oauth/token call (grant_type=authorization_code) succeeds.
+	if err := s.Store.InsertPkceRequest(r.Context(), PkceRequest{
+		Code:          dc.AuthorizationCode,
+		CodeChallenge: dc.CodeChallenge,
+		State:         "device-flow",
+		UserID:        dc.UserID,
+		ExpiresAt:     time.Now().Add(pkceCodeTTL),
+	}); err != nil {
+		http.Error(w, "store: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]string{
+		"authorization_code": dc.AuthorizationCode,
+		"code_challenge":     dc.CodeChallenge,
+		"code_verifier":      dc.CodeVerifier,
+	})
+}
+
+func mustRandomUserCode() string {
+	// 8 chars in "XXXX-XXXX" form.
+	b := make([]byte, 8)
+	if _, err := rand.Read(b); err != nil {
+		panic("rand: " + err.Error())
+	}
+	pick := func(i byte) byte { return userCodeAlphabet[int(i)%len(userCodeAlphabet)] }
+	return fmt.Sprintf("%c%c%c%c-%c%c%c%c",
+		pick(b[0]), pick(b[1]), pick(b[2]), pick(b[3]),
+		pick(b[4]), pick(b[5]), pick(b[6]), pick(b[7]))
+}

--- a/internal/codexauth/device.go
+++ b/internal/codexauth/device.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 )
 
@@ -100,6 +102,87 @@ func (s *Server) handleDeviceToken(w http.ResponseWriter, r *http.Request) {
 		"code_challenge":     dc.CodeChallenge,
 		"code_verifier":      dc.CodeVerifier,
 	})
+}
+
+const verifyFormHTML = `<!doctype html>
+<html><head><meta charset="utf-8"><title>Codex device login</title>
+<style>
+  body { font-family: -apple-system, sans-serif; max-width: 480px; margin: 4em auto; padding: 0 1em; }
+  input[name=user_code] { font-family: monospace; font-size: 1.4em; letter-spacing: 0.1em;
+                          text-transform: uppercase; padding: 0.5em; width: 100%%; }
+  button { padding: 0.6em 1.2em; margin-right: 1em; font-size: 1em; }
+  .deny { background: #fee; }
+</style></head><body>
+<h1>Codex device login</h1>
+<p>Signed in as <code>%s</code>.</p>
+<form method="POST" action="/codex/device">
+  <p><label>Enter the code shown by <code>codex login --device-auth</code>:</label></p>
+  <p><input name="user_code" autocomplete="off" autofocus required pattern="[A-Z0-9]{4}-[A-Z0-9]{4}"></p>
+  <p><button name="action" value="approve">Approve</button>
+     <button name="action" value="deny" class="deny">Deny</button></p>
+</form>
+</body></html>`
+
+const verifyResultHTML = `<!doctype html>
+<html><head><meta charset="utf-8"><title>Codex device login</title>
+<style>body{font-family:-apple-system,sans-serif;max-width:480px;margin:4em auto;padding:0 1em;}</style>
+</head><body><h1>%s</h1><p>You may now return to your terminal.</p></body></html>`
+
+func (s *Server) handleDeviceVerifyPage(w http.ResponseWriter, r *http.Request) {
+	if s.SessionResolve == nil {
+		http.Error(w, "session resolver not configured", http.StatusInternalServerError)
+		return
+	}
+	uid := s.SessionResolve(r)
+	if uid == "" {
+		next := url.QueryEscape(r.URL.RequestURI())
+		http.Redirect(w, r, s.LoginRedirectURL+"?next="+next, http.StatusFound)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	fmt.Fprintf(w, verifyFormHTML, htmlEscape(s.lookupEmail(r.Context(), uid)))
+}
+
+func (s *Server) handleDeviceVerifySubmit(w http.ResponseWriter, r *http.Request) {
+	if s.SessionResolve == nil {
+		http.Error(w, "session resolver not configured", http.StatusInternalServerError)
+		return
+	}
+	uid := s.SessionResolve(r)
+	if uid == "" {
+		http.Error(w, "session required", http.StatusUnauthorized)
+		return
+	}
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, "parse form", http.StatusBadRequest)
+		return
+	}
+	userCode := strings.ToUpper(strings.TrimSpace(r.PostForm.Get("user_code")))
+	action := r.PostForm.Get("action")
+
+	switch action {
+	case "approve":
+		if err := s.Store.ApproveDeviceCode(r.Context(), userCode, uid); err != nil {
+			http.Error(w, "code not found or already used: "+err.Error(), http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprintf(w, verifyResultHTML, "Approved ✓")
+	case "deny":
+		_, _ = s.Store.db.ExecContext(r.Context(),
+			`UPDATE codex_device_codes SET status = 'denied'
+			 WHERE user_code = $1 AND status = 'pending'`, userCode)
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		fmt.Fprintf(w, verifyResultHTML, "Denied ✗")
+	default:
+		http.Error(w, "action must be approve|deny", http.StatusBadRequest)
+	}
+}
+
+func htmlEscape(s string) string {
+	// Minimal — only the email displayed in the form.
+	r := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", `"`, "&quot;")
+	return r.Replace(s)
 }
 
 func mustRandomUserCode() string {

--- a/internal/codexauth/device_test.go
+++ b/internal/codexauth/device_test.go
@@ -1,0 +1,111 @@
+package codexauth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestDeviceUserCode_ReturnsPendingRow(t *testing.T) {
+	srv := newAuthTestServer(t, "")
+	r := chi.NewRouter()
+	srv.Mount(r)
+
+	body := bytes.NewReader([]byte(`{"client_id":"app_EMoamEEZ73f0CkXaXp7hrann"}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/accounts/deviceauth/usercode", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		DeviceAuthID string `json:"device_auth_id"`
+		UserCode     string `json:"user_code"`
+		Interval     int    `json:"interval"`
+	}
+	json.NewDecoder(rr.Body).Decode(&resp)
+	if resp.DeviceAuthID == "" || resp.UserCode == "" || resp.Interval == 0 {
+		t.Errorf("missing fields: %+v", resp)
+	}
+}
+
+func TestDeviceToken_PendingReturns403(t *testing.T) {
+	srv := newAuthTestServer(t, "")
+	ctx := context.Background()
+	srv.Store.InsertDeviceCode(ctx, DeviceCode{
+		DeviceAuthID:      "dev-pending",
+		UserCode:          "PEND-PEND",
+		CodeChallenge:     "c",
+		CodeVerifier:      "v",
+		AuthorizationCode: "a",
+		Status:            "pending",
+		ExpiresAt:         time.Now().Add(15 * time.Minute),
+	})
+
+	body, _ := json.Marshal(map[string]string{"device_auth_id": "dev-pending", "user_code": "PEND-PEND"})
+	req := httptest.NewRequest(http.MethodPost, "/api/accounts/deviceauth/token", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r := chi.NewRouter()
+	srv.Mount(r)
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Errorf("status = %d, want 403", rr.Code)
+	}
+}
+
+func TestDeviceToken_ApprovedReturnsAuthCode(t *testing.T) {
+	srv := newAuthTestServer(t, "")
+	ctx := context.Background()
+	uid := mustCreateTestUser(t, srv.Store.db)
+	srv.Store.InsertDeviceCode(ctx, DeviceCode{
+		DeviceAuthID:      "dev-ok",
+		UserCode:          "GOOD-CODE",
+		CodeChallenge:     "ch-1",
+		CodeVerifier:      "ver-1",
+		AuthorizationCode: "ac-1",
+		Status:            "pending",
+		ExpiresAt:         time.Now().Add(15 * time.Minute),
+	})
+	srv.Store.ApproveDeviceCode(ctx, "GOOD-CODE", uid)
+
+	body, _ := json.Marshal(map[string]string{"device_auth_id": "dev-ok", "user_code": "GOOD-CODE"})
+	req := httptest.NewRequest(http.MethodPost, "/api/accounts/deviceauth/token", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r := chi.NewRouter()
+	srv.Mount(r)
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		AuthorizationCode string `json:"authorization_code"`
+		CodeChallenge     string `json:"code_challenge"`
+		CodeVerifier      string `json:"code_verifier"`
+	}
+	json.NewDecoder(rr.Body).Decode(&resp)
+	if resp.AuthorizationCode != "ac-1" || resp.CodeChallenge != "ch-1" || resp.CodeVerifier != "ver-1" {
+		t.Errorf("got = %+v", resp)
+	}
+
+	// AND the device row should now have a matching pkce_requests row,
+	// so the subsequent /oauth/token call works.
+	var n int
+	srv.Store.db.QueryRow(`SELECT COUNT(*) FROM codex_pkce_requests WHERE code = 'ac-1'`).Scan(&n)
+	if n != 1 {
+		t.Errorf("expected 1 codex_pkce_requests row, got %d", n)
+	}
+	_ = strings.TrimSpace // keep "strings" import quiet if unused elsewhere
+}

--- a/internal/codexauth/device_test.go
+++ b/internal/codexauth/device_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 	"time"
@@ -108,4 +109,61 @@ func TestDeviceToken_ApprovedReturnsAuthCode(t *testing.T) {
 		t.Errorf("expected 1 codex_pkce_requests row, got %d", n)
 	}
 	_ = strings.TrimSpace // keep "strings" import quiet if unused elsewhere
+}
+
+func TestDeviceVerify_UnauthRedirectsToLogin(t *testing.T) {
+	srv := newAuthTestServer(t, "")
+	r := chi.NewRouter()
+	srv.Mount(r)
+	req := httptest.NewRequest(http.MethodGet, "/codex/device", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	if rr.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302", rr.Code)
+	}
+}
+
+func TestDeviceVerify_AuthedRendersForm(t *testing.T) {
+	srv := newAuthTestServer(t, "user-abc")
+	r := chi.NewRouter()
+	srv.Mount(r)
+	req := httptest.NewRequest(http.MethodGet, "/codex/device", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	body := rr.Body.String()
+	if !strings.Contains(body, `name="user_code"`) {
+		t.Errorf("page missing user_code input")
+	}
+	if !strings.Contains(body, `name="action"`) {
+		t.Errorf("page missing action buttons")
+	}
+}
+
+func TestDeviceVerify_SubmitApproveFlipsStatus(t *testing.T) {
+	srv := newAuthTestServer(t, "user-approver")
+	ctx := context.Background()
+	srv.Store.InsertDeviceCode(ctx, DeviceCode{
+		DeviceAuthID: "dev-form-1", UserCode: "FORM-CODE",
+		CodeChallenge: "c", CodeVerifier: "v", AuthorizationCode: "a",
+		Status: "pending", ExpiresAt: time.Now().Add(15 * time.Minute),
+	})
+	form := url.Values{}
+	form.Set("user_code", "FORM-CODE")
+	form.Set("action", "approve")
+	req := httptest.NewRequest(http.MethodPost, "/codex/device", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	r := chi.NewRouter()
+	srv.Mount(r)
+	r.ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rr.Code, rr.Body.String())
+	}
+	row, _ := srv.Store.GetDeviceCodeByUserCode(ctx, "FORM-CODE")
+	if row == nil || row.Status != "approved" || row.UserID != "user-approver" {
+		t.Errorf("row = %+v", row)
+	}
 }

--- a/internal/codexauth/internal_helpers.go
+++ b/internal/codexauth/internal_helpers.go
@@ -1,0 +1,15 @@
+package codexauth
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+)
+
+func sha256Sum(b []byte) []byte {
+	h := sha256.Sum256(b)
+	return h[:]
+}
+
+func base64URLNoPad(b []byte) string {
+	return base64.RawURLEncoding.EncodeToString(b)
+}

--- a/internal/codexauth/keys.go
+++ b/internal/codexauth/keys.go
@@ -1,6 +1,7 @@
 package codexauth
 
 import (
+	"context"
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/rsa"
@@ -60,4 +61,39 @@ func GenerateEd25519Key() (privatePKCS8 []byte, public []byte, err error) {
 		return nil, nil, fmt.Errorf("MarshalPKCS8PrivateKey: %w", err)
 	}
 	return pkcs8, pub, nil
+}
+
+// EnsureActiveKey returns the active JWKS key, generating a fresh one
+// and inserting it into the store if none exists. Idempotent — safe to
+// call at every server startup.
+func EnsureActiveKey(ctx context.Context, s *Store) (*JwksKey, error) {
+	got, err := s.GetActiveJwksKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if got != nil {
+		return got, nil
+	}
+	kid, kp, err := GenerateRSAKey()
+	if err != nil {
+		return nil, err
+	}
+	if err := s.InsertJwksKey(ctx, kid, kp, true); err != nil {
+		return nil, err
+	}
+	return s.GetActiveJwksKey(ctx)
+}
+
+// LoadRSAPrivate parses a PKCS#8 DER blob (as stored in
+// codex_jwks_keys.private_pkcs8) back into an *rsa.PrivateKey for signing.
+func LoadRSAPrivate(pkcs8 []byte) (*rsa.PrivateKey, error) {
+	k, err := x509.ParsePKCS8PrivateKey(pkcs8)
+	if err != nil {
+		return nil, fmt.Errorf("parse pkcs8: %w", err)
+	}
+	priv, ok := k.(*rsa.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("not an RSA key: %T", k)
+	}
+	return priv, nil
 }

--- a/internal/codexauth/pkce.go
+++ b/internal/codexauth/pkce.go
@@ -1,16 +1,22 @@
 package codexauth
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
 	"time"
 )
 
-const pkceCodeTTL = 10 * time.Minute
+const (
+	pkceCodeTTL     = 10 * time.Minute
+	accessTokenTTL  = 1 * time.Hour
+	refreshTokenTTL = 365 * 24 * time.Hour
+)
 
 func (s *Server) handleAuthorize(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query()
@@ -82,4 +88,135 @@ func pkceVerifierMatches(verifier, challenge string) bool {
 	sum := sha256Sum([]byte(verifier))
 	expected := base64URLNoPad(sum)
 	return expected == strings.TrimRight(challenge, "=")
+}
+
+func (s *Server) handleToken(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		writeOauthError(w, http.StatusBadRequest, "invalid_request", "parse form: "+err.Error())
+		return
+	}
+	switch r.PostForm.Get("grant_type") {
+	case "authorization_code":
+		s.handleTokenAuthorizationCode(w, r)
+	case "refresh_token":
+		// Implemented in B4 — stub for now.
+		writeOauthError(w, http.StatusBadRequest, "unsupported_grant_type",
+			"refresh_token grant not yet implemented")
+	case "urn:ietf:params:oauth:grant-type:token-exchange":
+		// We don't have an OpenAI sk-... to give back. Codex tolerates the
+		// failure (login/src/server.rs:352-354).
+		writeOauthError(w, http.StatusBadRequest, "unsupported_grant_type",
+			"token-exchange to OpenAI API key is not supported on this issuer")
+	default:
+		writeOauthError(w, http.StatusBadRequest, "unsupported_grant_type",
+			r.PostForm.Get("grant_type"))
+	}
+}
+
+func (s *Server) handleTokenAuthorizationCode(w http.ResponseWriter, r *http.Request) {
+	code := r.PostForm.Get("code")
+	verifier := r.PostForm.Get("code_verifier")
+	if code == "" || verifier == "" {
+		writeOauthError(w, http.StatusBadRequest, "invalid_request",
+			"code and code_verifier required")
+		return
+	}
+
+	req, err := s.Store.ConsumePkceRequest(r.Context(), code)
+	if err != nil {
+		writeOauthError(w, http.StatusInternalServerError, "server_error", err.Error())
+		return
+	}
+	if req == nil {
+		writeOauthError(w, http.StatusBadRequest, "invalid_grant",
+			"code unknown or expired")
+		return
+	}
+	if !pkceVerifierMatches(verifier, req.CodeChallenge) {
+		writeOauthError(w, http.StatusBadRequest, "invalid_grant",
+			"code_verifier does not match code_challenge")
+		return
+	}
+
+	s.mintTokensFor(w, r, req.UserID)
+}
+
+// mintTokensFor mints access + refresh + id_token and writes the codex-
+// shaped response. Shared by authorization_code, refresh_token (B4), and
+// the device-flow exchange path (B5).
+//
+// access_token is minted as a signed JWT with `{sub, exp}` so codex's
+// proactive refresh logic (parse_jwt_expiration) works correctly.
+// We still store its sha256 hash in codex_access_tokens for server-side
+// revocation; the hash is what /internal/codex-auth/validate looks
+// up (Phase D) — the JWT body is opaque to us.
+func (s *Server) mintTokensFor(w http.ResponseWriter, r *http.Request, userID string) {
+	ctx := r.Context()
+	accessExp := time.Now().Add(accessTokenTTL)
+	email := s.lookupEmail(ctx, userID)
+	access, err := BuildAccessToken(s.SigningKey, s.SigningKid, IDTokenClaims{
+		Issuer:    s.IssuerURL,
+		Subject:   userID,
+		Email:     email,
+		ExpiresAt: accessExp,
+	})
+	if err != nil {
+		writeOauthError(w, http.StatusInternalServerError, "server_error",
+			"build access_token: "+err.Error())
+		return
+	}
+	refresh := mustRandomHex(32)
+
+	if err := s.Store.InsertAccessToken(ctx, HashToken(access), userID, accessExp); err != nil {
+		writeOauthError(w, http.StatusInternalServerError, "server_error", err.Error())
+		return
+	}
+	familyID := mustNewUUIDString()
+	if err := s.Store.InsertRefreshToken(ctx, HashToken(refresh), familyID, userID,
+		time.Now().Add(refreshTokenTTL)); err != nil {
+		writeOauthError(w, http.StatusInternalServerError, "server_error", err.Error())
+		return
+	}
+
+	idTok, err := BuildIDToken(s.SigningKey, s.SigningKid, IDTokenClaims{
+		Issuer:    s.IssuerURL,
+		Subject:   userID,
+		Email:     email,
+		ExpiresAt: accessExp,
+	})
+	if err != nil {
+		writeOauthError(w, http.StatusInternalServerError, "server_error",
+			"build id_token: "+err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"id_token":      idTok,
+		"access_token":  access,
+		"refresh_token": refresh,
+		"token_type":    "Bearer",
+		"expires_in":    int(accessTokenTTL.Seconds()),
+	})
+}
+
+func (s *Server) lookupEmail(ctx context.Context, userID string) string {
+	var email string
+	_ = s.Store.db.QueryRowContext(ctx,
+		`SELECT email FROM users WHERE id = $1`, userID).Scan(&email)
+	if email == "" {
+		email = userID + "@agent.cs.ac.cn"
+	}
+	return email
+}
+
+// mustNewUUIDString generates a UUIDv4 via crypto/rand without pulling
+// in a new dep (matches the rest of the codebase, e.g. process/spawn.go).
+func mustNewUUIDString() string {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		panic("rand: " + err.Error())
+	}
+	b[6] = (b[6] & 0x0f) | 0x40
+	b[8] = (b[8] & 0x3f) | 0x80
+	return fmt.Sprintf("%x-%x-%x-%x-%x", b[0:4], b[4:6], b[6:8], b[8:10], b[10:16])
 }

--- a/internal/codexauth/pkce.go
+++ b/internal/codexauth/pkce.go
@@ -99,9 +99,7 @@ func (s *Server) handleToken(w http.ResponseWriter, r *http.Request) {
 	case "authorization_code":
 		s.handleTokenAuthorizationCode(w, r)
 	case "refresh_token":
-		// Implemented in B4 — stub for now.
-		writeOauthError(w, http.StatusBadRequest, "unsupported_grant_type",
-			"refresh_token grant not yet implemented")
+		s.handleTokenRefresh(w, r)
 	case "urn:ietf:params:oauth:grant-type:token-exchange":
 		// We don't have an OpenAI sk-... to give back. Codex tolerates the
 		// failure (login/src/server.rs:352-354).
@@ -194,6 +192,61 @@ func (s *Server) mintTokensFor(w http.ResponseWriter, r *http.Request, userID st
 		"id_token":      idTok,
 		"access_token":  access,
 		"refresh_token": refresh,
+		"token_type":    "Bearer",
+		"expires_in":    int(accessTokenTTL.Seconds()),
+	})
+}
+
+func (s *Server) handleTokenRefresh(w http.ResponseWriter, r *http.Request) {
+	raw := r.PostForm.Get("refresh_token")
+	if raw == "" {
+		writeOauthError(w, http.StatusBadRequest, "invalid_request",
+			"refresh_token required")
+		return
+	}
+	newRefresh := mustRandomHex(32)
+	userID, err := s.Store.RotateRefreshToken(r.Context(), raw,
+		HashToken(newRefresh), time.Now().Add(refreshTokenTTL))
+	if err != nil {
+		// Both "unknown token" and "already revoked (reuse)" surface as
+		// ErrRefreshTokenReuse from the store; codex treats the
+		// reuse/expired/invalidated codes as terminal (manager.rs:1050+).
+		writeOauthError(w, http.StatusUnauthorized, "refresh_token_expired", err.Error())
+		return
+	}
+
+	accessExp := time.Now().Add(accessTokenTTL)
+	email := s.lookupEmail(r.Context(), userID)
+	access, err := BuildAccessToken(s.SigningKey, s.SigningKid, IDTokenClaims{
+		Issuer:    s.IssuerURL,
+		Subject:   userID,
+		Email:     email,
+		ExpiresAt: accessExp,
+	})
+	if err != nil {
+		writeOauthError(w, http.StatusInternalServerError, "server_error",
+			"build access_token: "+err.Error())
+		return
+	}
+	if err := s.Store.InsertAccessToken(r.Context(), HashToken(access), userID, accessExp); err != nil {
+		writeOauthError(w, http.StatusInternalServerError, "server_error", err.Error())
+		return
+	}
+
+	idTok, err := BuildIDToken(s.SigningKey, s.SigningKid, IDTokenClaims{
+		Issuer:    s.IssuerURL,
+		Subject:   userID,
+		Email:     email,
+		ExpiresAt: accessExp,
+	})
+	if err != nil {
+		writeOauthError(w, http.StatusInternalServerError, "server_error", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"id_token":      idTok,
+		"access_token":  access,
+		"refresh_token": newRefresh,
 		"token_type":    "Bearer",
 		"expires_in":    int(accessTokenTTL.Seconds()),
 	})

--- a/internal/codexauth/pkce.go
+++ b/internal/codexauth/pkce.go
@@ -1,0 +1,85 @@
+package codexauth
+
+import (
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const pkceCodeTTL = 10 * time.Minute
+
+func (s *Server) handleAuthorize(w http.ResponseWriter, r *http.Request) {
+	q := r.URL.Query()
+	state := q.Get("state")
+	challenge := q.Get("code_challenge")
+	redirectURI := q.Get("redirect_uri")
+	if state == "" || challenge == "" || redirectURI == "" {
+		http.Error(w, "missing required oauth params (state, code_challenge, redirect_uri)",
+			http.StatusBadRequest)
+		return
+	}
+
+	userID := s.SessionResolve(r)
+	if userID == "" {
+		next := url.QueryEscape(r.URL.RequestURI())
+		http.Redirect(w, r, s.LoginRedirectURL+"?next="+next, http.StatusFound)
+		return
+	}
+
+	code := mustRandomHex(32)
+	if err := s.Store.InsertPkceRequest(r.Context(), PkceRequest{
+		Code:          code,
+		CodeChallenge: challenge,
+		State:         state,
+		UserID:        userID,
+		ExpiresAt:     time.Now().Add(pkceCodeTTL),
+	}); err != nil {
+		http.Error(w, "store: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	// Redirect back to the codex local callback server with code + state.
+	dest, err := url.Parse(redirectURI)
+	if err != nil {
+		http.Error(w, "bad redirect_uri", http.StatusBadRequest)
+		return
+	}
+	dq := dest.Query()
+	dq.Set("code", code)
+	dq.Set("state", state)
+	dest.RawQuery = dq.Encode()
+	http.Redirect(w, r, dest.String(), http.StatusFound)
+}
+
+func mustRandomHex(n int) string {
+	b := make([]byte, n)
+	if _, err := rand.Read(b); err != nil {
+		panic("rand: " + err.Error())
+	}
+	return hex.EncodeToString(b)
+}
+
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	json.NewEncoder(w).Encode(v) //nolint:errcheck
+}
+
+func writeOauthError(w http.ResponseWriter, status int, code, desc string) {
+	writeJSON(w, status, map[string]string{
+		"error":             code,
+		"error_description": desc,
+	})
+}
+
+// pkceVerifierMatches implements RFC 7636 S256:
+// base64url_no_pad(sha256(code_verifier)) == code_challenge.
+func pkceVerifierMatches(verifier, challenge string) bool {
+	sum := sha256Sum([]byte(verifier))
+	expected := base64URLNoPad(sum)
+	return expected == strings.TrimRight(challenge, "=")
+}

--- a/internal/codexauth/pkce_test.go
+++ b/internal/codexauth/pkce_test.go
@@ -2,10 +2,14 @@ package codexauth
 
 import (
 	"context"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/agentserver/agentserver/internal/db"
 	"github.com/go-chi/chi/v5"
@@ -99,4 +103,99 @@ func minInt(a, b int) int {
 		return a
 	}
 	return b
+}
+
+func TestToken_AuthorizationCode_ReturnsTriplet(t *testing.T) {
+	srv := newAuthTestServer(t, "")
+	ctx := context.Background()
+
+	// Pre-seed an authorize row.
+	uid := mustCreateTestUser(t, srv.Store.db)
+	verifier := strings.Repeat("a", 48)
+	challenge := base64URLNoPad(sha256Sum([]byte(verifier)))
+	srv.Store.InsertPkceRequest(ctx, PkceRequest{
+		Code:          "code-xyz",
+		CodeChallenge: challenge,
+		State:         "irrelevant",
+		UserID:        uid,
+		ExpiresAt:     time.Now().Add(5 * time.Minute),
+	})
+
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", "code-xyz")
+	form.Set("code_verifier", verifier)
+	form.Set("redirect_uri", "http://localhost:1455/auth/callback")
+	form.Set("client_id", "app_EMoamEEZ73f0CkXaXp7hrann")
+
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	r := chi.NewRouter()
+	srv.Mount(r)
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		body, _ := io.ReadAll(rr.Body)
+		t.Fatalf("status = %d, body = %s", rr.Code, body)
+	}
+	var resp struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		IDToken      string `json:"id_token"`
+		TokenType    string `json:"token_type"`
+		ExpiresIn    int    `json:"expires_in"`
+	}
+	json.NewDecoder(rr.Body).Decode(&resp)
+	if resp.AccessToken == "" || resp.RefreshToken == "" || resp.IDToken == "" {
+		t.Fatalf("missing fields: %+v", resp)
+	}
+	if resp.TokenType != "Bearer" {
+		t.Errorf("token_type = %q", resp.TokenType)
+	}
+}
+
+func TestToken_AuthorizationCode_BadVerifierRejected(t *testing.T) {
+	srv := newAuthTestServer(t, "")
+	ctx := context.Background()
+	uid := mustCreateTestUser(t, srv.Store.db)
+	srv.Store.InsertPkceRequest(ctx, PkceRequest{
+		Code:          "code-bad",
+		CodeChallenge: "different-challenge",
+		State:         "x",
+		UserID:        uid,
+		ExpiresAt:     time.Now().Add(5 * time.Minute),
+	})
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", "code-bad")
+	form.Set("code_verifier", "wrong-verifier")
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	r := chi.NewRouter()
+	srv.Mount(r)
+	r.ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rr.Code)
+	}
+}
+
+func TestToken_TokenExchange_ReturnsBadRequest(t *testing.T) {
+	srv := newAuthTestServer(t, "")
+	form := url.Values{}
+	form.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
+	form.Set("requested_token", "openai-api-key")
+	form.Set("subject_token", "irrelevant")
+	form.Set("subject_token_type", "urn:ietf:params:oauth:token-type:id_token")
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	r := chi.NewRouter()
+	srv.Mount(r)
+	r.ServeHTTP(rr, req)
+	// Codex tolerates failure (server.rs:352-354) — return 400 to opt out.
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", rr.Code)
+	}
 }

--- a/internal/codexauth/pkce_test.go
+++ b/internal/codexauth/pkce_test.go
@@ -1,0 +1,102 @@
+package codexauth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/agentserver/agentserver/internal/db"
+	"github.com/go-chi/chi/v5"
+)
+
+func TestAuthorize_RedirectsUnauthToLogin(t *testing.T) {
+	srv := newAuthTestServer(t, "")
+	r := chi.NewRouter()
+	srv.Mount(r)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/oauth/authorize?state=xyz&code_challenge=abc&redirect_uri=http://localhost:1455/auth/callback", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302", rr.Code)
+	}
+	loc, _ := url.Parse(rr.Header().Get("Location"))
+	if loc.Path != "/login" {
+		t.Errorf("redirect path = %q, want /login", loc.Path)
+	}
+	if loc.Query().Get("next") == "" {
+		t.Error("missing next param on login redirect")
+	}
+}
+
+func TestAuthorize_AuthedRedirectsToRedirectURIWithCode(t *testing.T) {
+	srv := newAuthTestServer(t, "user-abc")
+	r := chi.NewRouter()
+	srv.Mount(r)
+
+	req := httptest.NewRequest(http.MethodGet,
+		"/oauth/authorize?state=st-1&code_challenge=ch-1&redirect_uri=http://localhost:1455/auth/callback", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusFound {
+		t.Fatalf("status = %d, want 302", rr.Code)
+	}
+	loc, _ := url.Parse(rr.Header().Get("Location"))
+	if loc.Host != "localhost:1455" || loc.Path != "/auth/callback" {
+		t.Errorf("redirect = %s", loc.String())
+	}
+	q := loc.Query()
+	if q.Get("state") != "st-1" {
+		t.Errorf("state = %q", q.Get("state"))
+	}
+	if q.Get("code") == "" {
+		t.Error("missing code")
+	}
+}
+
+// newAuthTestServer builds a Server backed by the real test DB (skips
+// when TEST_DATABASE_URL unset) with a fixed session user.
+func newAuthTestServer(t *testing.T, sessionUserID string) *Server {
+	t.Helper()
+	store, cleanup := newTestStore(t)
+	t.Cleanup(cleanup)
+	kid, kp, _ := GenerateRSAKey()
+	ctx := context.Background()
+	store.InsertJwksKey(ctx, kid, kp, true)
+	// Pre-create the user if the test wants an authed session.
+	if sessionUserID != "" {
+		mustCreateTestUserWithID(t, store.db, sessionUserID)
+	}
+	return &Server{
+		Store:            store,
+		IssuerURL:        "https://test/codex-auth",
+		SigningKey:       kp.PrivateKey,
+		SigningKid:       kid,
+		SessionResolve:   func(r *http.Request) string { return sessionUserID },
+		LoginRedirectURL: "/login",
+	}
+}
+
+// mustCreateTestUserWithID inserts a user with the exact id we want.
+// Helper used by tests that need a specific session user id.
+func mustCreateTestUserWithID(t *testing.T, d *db.DB, uid string) {
+	t.Helper()
+	_, err := d.Exec(`INSERT INTO users (id, username, email, created_at)
+		VALUES ($1, $2, $3, NOW()) ON CONFLICT (id) DO NOTHING`,
+		uid, "test-"+uid[:minInt(8, len(uid))], uid+"@test.local")
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/codexauth/pkce_test.go
+++ b/internal/codexauth/pkce_test.go
@@ -181,6 +181,66 @@ func TestToken_AuthorizationCode_BadVerifierRejected(t *testing.T) {
 	}
 }
 
+func TestToken_Refresh_RotatesTokens(t *testing.T) {
+	srv := newAuthTestServer(t, "")
+	ctx := context.Background()
+	uid := mustCreateTestUser(t, srv.Store.db)
+
+	// Issue an initial refresh token directly.
+	srv.Store.InsertRefreshToken(ctx, HashToken("old-refresh"), mustNewUUIDString(), uid,
+		time.Now().Add(7*24*time.Hour))
+
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", "old-refresh")
+	form.Set("client_id", "app_EMoamEEZ73f0CkXaXp7hrann")
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	r := chi.NewRouter()
+	srv.Mount(r)
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+	}
+	json.NewDecoder(rr.Body).Decode(&resp)
+	if resp.AccessToken == "" || resp.RefreshToken == "" || resp.RefreshToken == "old-refresh" {
+		t.Errorf("bad rotated tokens: %+v", resp)
+	}
+}
+
+func TestToken_Refresh_ExpiredReturnsTerminalError(t *testing.T) {
+	srv := newAuthTestServer(t, "")
+	form := url.Values{}
+	form.Set("grant_type", "refresh_token")
+	form.Set("refresh_token", "never-issued")
+	req := httptest.NewRequest(http.MethodPost, "/oauth/token", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	rr := httptest.NewRecorder()
+	r := chi.NewRouter()
+	srv.Mount(r)
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d, want 401", rr.Code)
+	}
+	var resp map[string]string
+	json.NewDecoder(rr.Body).Decode(&resp)
+	// Codex treats these specific error codes as terminal (manager.rs:1050+).
+	switch resp["error"] {
+	case "refresh_token_expired", "refresh_token_reused", "refresh_token_invalidated":
+		// OK
+	default:
+		t.Errorf("error = %q; expected one of refresh_token_{expired,reused,invalidated}",
+			resp["error"])
+	}
+}
+
 func TestToken_TokenExchange_ReturnsBadRequest(t *testing.T) {
 	srv := newAuthTestServer(t, "")
 	form := url.Values{}

--- a/internal/codexauth/server.go
+++ b/internal/codexauth/server.go
@@ -41,10 +41,7 @@ func (s *Server) Mount(r chi.Router) {
 
 // All handlers are stubs initially; subsequent tasks fill them in.
 // Returning a clear "not implemented" so tests can detect missing wiring.
-// handleAuthorize is implemented in pkce.go.
-func (s *Server) handleToken(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "token: not implemented", http.StatusNotImplemented)
-}
+// handleAuthorize and handleToken are implemented in pkce.go.
 func (s *Server) handleJWKS(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, "jwks: not implemented", http.StatusNotImplemented)
 }

--- a/internal/codexauth/server.go
+++ b/internal/codexauth/server.go
@@ -48,12 +48,6 @@ func (s *Server) handleJWKS(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleTaskRegister(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, "task register: not implemented", http.StatusNotImplemented)
 }
-func (s *Server) handleDeviceUserCode(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "device usercode: not implemented", http.StatusNotImplemented)
-}
-func (s *Server) handleDeviceToken(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "device token: not implemented", http.StatusNotImplemented)
-}
 func (s *Server) handleDeviceVerifyPage(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, "device verify page: not implemented", http.StatusNotImplemented)
 }

--- a/internal/codexauth/server.go
+++ b/internal/codexauth/server.go
@@ -1,0 +1,67 @@
+package codexauth
+
+import (
+	"crypto/rsa"
+	"net/http"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// SessionResolver returns the user_id for the request's session cookie,
+// or empty string if unauthenticated. agentserver supplies its existing
+// session middleware here.
+type SessionResolver func(r *http.Request) string
+
+// Server is the user-facing codex-auth HTTP surface (PKCE / device flow /
+// JWKS / agent-identity), all mounted under a single chi subrouter.
+type Server struct {
+	Store            *Store
+	IssuerURL        string          // e.g. "https://agent.cs.ac.cn/codex-auth"
+	SigningKey       *rsa.PrivateKey // active RSA key for id_token + Agent Identity JWT
+	SigningKid       string
+	SessionResolve   SessionResolver
+	LoginRedirectURL string // where /oauth/authorize sends unauth users
+}
+
+// Mount registers all codex-auth routes onto r. Routes are mounted
+// without a prefix; the caller decides where this subtree lives
+// (typically /codex-auth/* on agentserver's outermost router).
+func (s *Server) Mount(r chi.Router) {
+	r.Get("/oauth/authorize", s.handleAuthorize)
+	r.Post("/oauth/token", s.handleToken)
+
+	r.Get("/agent-identities/jwks", s.handleJWKS)
+	r.Post("/v1/agent/{rid}/task/register", s.handleTaskRegister)
+
+	r.Post("/api/accounts/deviceauth/usercode", s.handleDeviceUserCode)
+	r.Post("/api/accounts/deviceauth/token", s.handleDeviceToken)
+	r.Get("/codex/device", s.handleDeviceVerifyPage)
+	r.Post("/codex/device", s.handleDeviceVerifySubmit)
+}
+
+// All handlers are stubs initially; subsequent tasks fill them in.
+// Returning a clear "not implemented" so tests can detect missing wiring.
+func (s *Server) handleAuthorize(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "authorize: not implemented", http.StatusNotImplemented)
+}
+func (s *Server) handleToken(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "token: not implemented", http.StatusNotImplemented)
+}
+func (s *Server) handleJWKS(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "jwks: not implemented", http.StatusNotImplemented)
+}
+func (s *Server) handleTaskRegister(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "task register: not implemented", http.StatusNotImplemented)
+}
+func (s *Server) handleDeviceUserCode(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "device usercode: not implemented", http.StatusNotImplemented)
+}
+func (s *Server) handleDeviceToken(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "device token: not implemented", http.StatusNotImplemented)
+}
+func (s *Server) handleDeviceVerifyPage(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "device verify page: not implemented", http.StatusNotImplemented)
+}
+func (s *Server) handleDeviceVerifySubmit(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "device verify submit: not implemented", http.StatusNotImplemented)
+}

--- a/internal/codexauth/server.go
+++ b/internal/codexauth/server.go
@@ -41,9 +41,7 @@ func (s *Server) Mount(r chi.Router) {
 
 // All handlers are stubs initially; subsequent tasks fill them in.
 // Returning a clear "not implemented" so tests can detect missing wiring.
-func (s *Server) handleAuthorize(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "authorize: not implemented", http.StatusNotImplemented)
-}
+// handleAuthorize is implemented in pkce.go.
 func (s *Server) handleToken(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, "token: not implemented", http.StatusNotImplemented)
 }

--- a/internal/codexauth/server.go
+++ b/internal/codexauth/server.go
@@ -48,9 +48,3 @@ func (s *Server) handleJWKS(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleTaskRegister(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, "task register: not implemented", http.StatusNotImplemented)
 }
-func (s *Server) handleDeviceVerifyPage(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "device verify page: not implemented", http.StatusNotImplemented)
-}
-func (s *Server) handleDeviceVerifySubmit(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "device verify submit: not implemented", http.StatusNotImplemented)
-}

--- a/internal/codexauth/server_test.go
+++ b/internal/codexauth/server_test.go
@@ -1,0 +1,34 @@
+package codexauth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestServer_MountRegistersAllRoutes(t *testing.T) {
+	s := &Server{IssuerURL: "https://example/codex-auth"}
+	r := chi.NewRouter()
+	s.Mount(r)
+
+	// Assert each route at least returns non-404 (will return 4xx/405 for
+	// missing handlers/wrong methods, but the route must be registered).
+	want := []string{
+		"/oauth/authorize",
+		"/oauth/token",
+		"/agent-identities/jwks",
+		"/codex/device",
+		"/api/accounts/deviceauth/usercode",
+		"/api/accounts/deviceauth/token",
+	}
+	for _, path := range want {
+		req := httptest.NewRequest(http.MethodGet, path, nil)
+		rr := httptest.NewRecorder()
+		r.ServeHTTP(rr, req)
+		if rr.Code == http.StatusNotFound {
+			t.Errorf("route %s not registered (404)", path)
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/agentserver/agentserver/internal/auth"
 	"github.com/agentserver/agentserver/internal/bridge"
+	"github.com/agentserver/agentserver/internal/codexauth"
 	"github.com/agentserver/agentserver/internal/db"
 	"github.com/agentserver/agentserver/internal/namespace"
 	"github.com/agentserver/agentserver/internal/process"
@@ -86,6 +87,10 @@ type Server struct {
 	// Codex exec gateway
 	ExecutorsClient            *ExecutorsClient
 	CodexExecGatewayPublicHost string // e.g. "codex-exec.example.com" — used to compose connect commands
+
+	// CodexAuth is the self-hosted codex 0.132+ auth shim (PKCE / device
+	// flow / JWKS / Agent Identity). Mounted under /codex-auth/* when set.
+	CodexAuth *codexauth.Server
 
 	// OperationsRetention is the TTL for rows in the operations table.
 	// 0 disables the background retention loop. Configurable via
@@ -308,6 +313,15 @@ func (s *Server) Router() http.Handler {
 
 	// Agent registration (auth via OAuth Bearer token).
 	r.Post("/api/agent/register", s.handleAgentRegister)
+
+	// Self-hosted codex 0.132+ auth shim under /codex-auth/*.
+	// All sub-routes are public — each handler resolves session itself
+	// via the SessionResolve callback wired in cmd/serve.go.
+	if s.CodexAuth != nil {
+		r.Route("/codex-auth", func(r chi.Router) {
+			s.CodexAuth.Mount(r)
+		})
+	}
 
 	// Hydra login/consent provider endpoints (no auth required — Hydra redirects here).
 	if s.HydraClient != nil {


### PR DESCRIPTION
Phase B of the codex 0.132+ auth spec. Builds on PR #125 (Phase A scaffolding).

## What this lands

7 commits, all in \`internal/codexauth/\` plus cmd/serve.go + server.go + chart toggle:

1. \`886e7e6\` Server struct + Mount(8 route stubs returning 501)
2. \`49c9ffc\` GET /oauth/authorize (PKCE init: persist code, redirect to localhost:1455)
3. \`1b979d5\` POST /oauth/token grant_type=authorization_code (mint RS256 access + refresh + id_token)
4. \`5d80a3c\` POST /oauth/token grant_type=refresh_token (rotate via OAuth 2.1 family-burn)
5. \`c51a3e6\` Device flow /api/accounts/deviceauth/{usercode,token} (polling endpoints)
6. \`02aacbb\` Device flow /codex/device browser approval page (HTML form)
7. \`178aab1\` Wire into agentserver (cmd/serve.go bootstrap + server.go mount + chart toggle)

## How users enable it

After this PR + chart 0.62.x:

\`\`\`yaml
# values.yaml
codexAuth:
  enabled: true
\`\`\`

\`\`\`bash
# user shell — browser PKCE
codex login --issuer https://agent.cs.ac.cn/codex-auth
# OR headless device flow
codex login --device-auth --issuer https://agent.cs.ac.cn/codex-auth
\`\`\`

## Tests

- 5 new test files in internal/codexauth (server, pkce, device).
- All tests PASS when TEST_DATABASE_URL set; SKIP cleanly otherwise.
- \`go vet ./...\` and \`go build ./...\` clean.
- Helm renders \`CODEX_AUTH_ISSUER_URL\` when toggle on, omitted when off.

## What this does NOT do yet

- No Agent Identity JWT mint / JWKS endpoint (Phase C / PR 3)
- /cloud/executor validator on codex-exec-gateway not updated (Phase D / PR 4)
- Connectors UI still shows legacy bearer command (Phase D / PR 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)