### PR TITLE
feat(codexauth): PR 3 — Agent Identity (JWT mint + JWKS + task/register)

### DIFF
--- a/internal/codexauth/agent_identity.go
+++ b/internal/codexauth/agent_identity.go
@@ -1,0 +1,138 @@
+package codexauth
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+const (
+	agentIdentityJWTTTL   = 30 * 24 * time.Hour
+	agentTaskTTL          = 24 * time.Hour
+	taskRegisterClockSkew = 5 * time.Minute
+)
+
+// MintAgentIdentityArgs is the input shape used by the UI's "Add
+// connector" path and the test bench.
+type MintAgentIdentityArgs struct {
+	AgentRuntimeID string // == exe_id
+	UserID         string
+	Email          string
+}
+
+// MintAgentIdentityResult is what the UI shows the user (JWT) and what
+// tests use (privKey) to assert downstream signature checks pass.
+type MintAgentIdentityResult struct {
+	JWT     string
+	privKey ed25519.PrivateKey // not exported; tests in same package read it
+}
+
+// MintAgentIdentity generates an Ed25519 keypair for the new agent,
+// signs the Agent Identity JWT with the active RSA key, and persists
+// (public key, jwt_signed_with) so subsequent AgentAssertion signatures
+// can be verified.
+func (s *Server) MintAgentIdentity(ctx context.Context, args MintAgentIdentityArgs) (*MintAgentIdentityResult, error) {
+	if args.AgentRuntimeID == "" || args.UserID == "" {
+		return nil, fmt.Errorf("AgentRuntimeID and UserID required")
+	}
+
+	pkcs8, pub, err := GenerateEd25519Key()
+	if err != nil {
+		return nil, fmt.Errorf("ed25519 generate: %w", err)
+	}
+
+	expires := time.Now().Add(agentIdentityJWTTTL)
+	jwt, err := BuildAgentIdentityJWT(s.SigningKey, s.SigningKid, AgentIdentityClaims{
+		AgentRuntimeID:       args.AgentRuntimeID,
+		AgentPrivateKeyPKCS8: pkcs8,
+		AccountID:            args.UserID,
+		ChatgptUserID:        args.UserID,
+		Email:                args.Email,
+		PlanType:             "pro",
+		ExpiresAt:            expires,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("build jwt: %w", err)
+	}
+
+	if err := s.Store.InsertAgentIdentity(ctx, AgentIdentity{
+		AgentRuntimeID: args.AgentRuntimeID,
+		UserID:         args.UserID,
+		PublicKey:      pub,
+		JWTSignedWith:  s.SigningKid,
+		IssuedAt:       time.Now(),
+		ExpiresAt:      expires,
+	}); err != nil {
+		return nil, err
+	}
+
+	// Recover the ed25519 private key for in-process tests / debug.
+	parsed, _ := x509.ParsePKCS8PrivateKey(pkcs8)
+	priv, _ := parsed.(ed25519.PrivateKey)
+	return &MintAgentIdentityResult{JWT: jwt, privKey: priv}, nil
+}
+
+// handleTaskRegister handles POST /v1/agent/{rid}/task/register —
+// called once per JWT load by codex. We verify the Ed25519 signature,
+// issue a task_id, and persist it.
+func (s *Server) handleTaskRegister(w http.ResponseWriter, r *http.Request) {
+	rid := chi.URLParam(r, "rid")
+	if rid == "" {
+		http.Error(w, "rid required", http.StatusBadRequest)
+		return
+	}
+
+	var req struct {
+		Timestamp string `json:"timestamp"`
+		Signature string `json:"signature"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad body", http.StatusBadRequest)
+		return
+	}
+	ts, err := time.Parse(time.RFC3339, req.Timestamp)
+	if err != nil {
+		http.Error(w, "bad timestamp", http.StatusBadRequest)
+		return
+	}
+	if d := time.Since(ts); d > taskRegisterClockSkew || d < -taskRegisterClockSkew {
+		http.Error(w, "timestamp stale", http.StatusUnauthorized)
+		return
+	}
+
+	identity, err := s.Store.GetAgentIdentity(r.Context(), rid)
+	if err != nil {
+		http.Error(w, "store: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	if identity == nil {
+		http.Error(w, "unknown agent", http.StatusNotFound)
+		return
+	}
+
+	sig, err := base64.StdEncoding.DecodeString(req.Signature)
+	if err != nil {
+		http.Error(w, "bad signature base64", http.StatusBadRequest)
+		return
+	}
+	message := []byte(rid + ":" + req.Timestamp)
+	if !ed25519.Verify(ed25519.PublicKey(identity.PublicKey), message, sig) {
+		http.Error(w, "signature invalid", http.StatusUnauthorized)
+		return
+	}
+
+	taskID := "task_" + mustRandomHex(24)
+	if err := s.Store.InsertAgentTask(r.Context(), taskID, rid, identity.UserID,
+		time.Now().Add(agentTaskTTL)); err != nil {
+		http.Error(w, "store: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"task_id": taskID})
+}

--- a/internal/codexauth/agent_identity_test.go
+++ b/internal/codexauth/agent_identity_test.go
@@ -1,0 +1,99 @@
+package codexauth
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestMintAgentIdentity_PersistsRow(t *testing.T) {
+	srv := newAuthTestServer(t, "")
+	uid := mustCreateTestUser(t, srv.Store.db)
+
+	res, err := srv.MintAgentIdentity(context.Background(), MintAgentIdentityArgs{
+		AgentRuntimeID: "exe_test_mint",
+		UserID:         uid,
+		Email:          "u@test",
+	})
+	if err != nil {
+		t.Fatalf("MintAgentIdentity: %v", err)
+	}
+	if !strings.HasPrefix(res.JWT, "eyJ") {
+		t.Errorf("JWT looks bogus: %.30s...", res.JWT)
+	}
+	got, _ := srv.Store.GetAgentIdentity(context.Background(), "exe_test_mint")
+	if got == nil || len(got.PublicKey) != 32 {
+		t.Errorf("agent identity row missing or bad pubkey: %+v", got)
+	}
+}
+
+func TestTaskRegister_VerifiesEd25519AndIssuesTaskID(t *testing.T) {
+	srv := newAuthTestServer(t, "")
+	r := chi.NewRouter()
+	srv.Mount(r)
+	uid := mustCreateTestUser(t, srv.Store.db)
+
+	mint, err := srv.MintAgentIdentity(context.Background(), MintAgentIdentityArgs{
+		AgentRuntimeID: "exe_task_reg",
+		UserID:         uid,
+		Email:          "u@test",
+	})
+	if err != nil {
+		t.Fatalf("MintAgentIdentity: %v", err)
+	}
+
+	ts := time.Now().UTC().Format(time.RFC3339)
+	sig := ed25519.Sign(mint.privKey, []byte("exe_task_reg:"+ts))
+	body, _ := json.Marshal(map[string]string{
+		"timestamp": ts,
+		"signature": base64.StdEncoding.EncodeToString(sig),
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/agent/exe_task_reg/task/register", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		TaskID string `json:"task_id"`
+	}
+	json.NewDecoder(rr.Body).Decode(&resp)
+	if resp.TaskID == "" {
+		t.Error("missing task_id")
+	}
+}
+
+func TestTaskRegister_BadSignatureRejected(t *testing.T) {
+	srv := newAuthTestServer(t, "")
+	r := chi.NewRouter()
+	srv.Mount(r)
+	uid := mustCreateTestUser(t, srv.Store.db)
+	if _, err := srv.MintAgentIdentity(context.Background(), MintAgentIdentityArgs{
+		AgentRuntimeID: "exe_bad_sig", UserID: uid, Email: "u@test",
+	}); err != nil {
+		t.Fatalf("MintAgentIdentity: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]string{
+		"timestamp": time.Now().UTC().Format(time.RFC3339),
+		"signature": base64.StdEncoding.EncodeToString(bytes.Repeat([]byte{0}, 64)),
+	})
+	req := httptest.NewRequest(http.MethodPost, "/v1/agent/exe_bad_sig/task/register", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rr.Code)
+	}
+}

--- a/internal/codexauth/integration_test.go
+++ b/internal/codexauth/integration_test.go
@@ -1,0 +1,122 @@
+//go:build integration
+// +build integration
+
+package codexauth
+
+import (
+	"context"
+	"io"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// TestIntegration_AgentIdentityWithRealCodex spins up the codexauth
+// Server in-process behind httptest, mints an Agent Identity JWT, then
+// invokes the real `codex exec-server --remote --use-agent-identity-auth`
+// binary and confirms it gets past JWKS fetch + task/register (i.e.
+// reaches the /cloud/executor/.../register call, which isn't mounted
+// on our test server, so codex will see a 404 and bail — but that's
+// AFTER our auth checks have passed).
+//
+// Requires `codex` >= 0.132 on PATH and TEST_DATABASE_URL set. Skips
+// cleanly otherwise.
+func TestIntegration_AgentIdentityWithRealCodex(t *testing.T) {
+	if _, err := exec.LookPath("codex"); err != nil {
+		t.Skip("codex binary not on PATH")
+	}
+	if os.Getenv("TEST_DATABASE_URL") == "" {
+		t.Skip("TEST_DATABASE_URL not set")
+	}
+
+	srv := newAuthTestServer(t, "")
+	uid := mustCreateTestUser(t, srv.Store.db)
+
+	r := chi.NewRouter()
+	srv.Mount(r)
+	httpSrv := httptest.NewServer(r)
+	defer httpSrv.Close()
+
+	mint, err := srv.MintAgentIdentity(context.Background(), MintAgentIdentityArgs{
+		AgentRuntimeID: "exe_integration_real",
+		UserID:         uid,
+		Email:          "u@test",
+	})
+	if err != nil {
+		t.Fatalf("MintAgentIdentity: %v", err)
+	}
+
+	// codex exec-server --remote $URL --executor-id $EXE --use-agent-identity-auth
+	//   1. reads CODEX_ACCESS_TOKEN
+	//   2. fetches {chatgpt.base_url}/agent-identities/jwks → verifies JWT
+	//   3. POSTs {CODEX_AGENT_IDENTITY_AUTHAPI_BASE_URL}/v1/agent/{rid}/task/register
+	//   4. POSTs $URL/cloud/executor/{rid}/register   ← we don't mount this; codex hits 404 here
+	//
+	// Reaching step 4 means our auth-side wiring (JWKS + task/register)
+	// worked end-to-end. The 404 at step 4 is expected.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "codex",
+		"-c", "chatgpt.base_url="+httpSrv.URL,
+		"exec-server", "--remote", httpSrv.URL,
+		"--executor-id", "exe_integration_real",
+		"--name", "test-agent",
+		"--use-agent-identity-auth",
+	)
+	cmd.Env = append(os.Environ(),
+		"CODEX_ACCESS_TOKEN="+mint.JWT,
+		"CODEX_AGENT_IDENTITY_AUTHAPI_BASE_URL="+httpSrv.URL,
+	)
+	stderrPipe, _ := cmd.StderrPipe()
+	stdoutPipe, _ := cmd.StdoutPipe()
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start codex: %v", err)
+	}
+
+	// Collect output until codex exits (it will, because step 4 returns
+	// 404 and codex retries with backoff — context timeout will cut it
+	// short).
+	var combined strings.Builder
+	go func() {
+		b, _ := io.ReadAll(stderrPipe)
+		combined.Write(b)
+	}()
+	go func() {
+		b, _ := io.ReadAll(stdoutPipe)
+		combined.Write(b)
+	}()
+	_ = cmd.Wait()
+	out := combined.String()
+
+	// Auth-side success indicators (each appears in codex's stderr on
+	// successful JWKS+task/register):
+	//   - we should NOT see "requires ChatGPT authentication"
+	//   - we should NOT see "failed to verify agent identity JWT" (JWKS works)
+	//   - we should NOT see "failed to register agent task" (task/register works)
+	for _, bad := range []string{
+		"requires ChatGPT authentication",
+		"failed to verify agent identity JWT",
+		"failed to register agent task",
+	} {
+		if strings.Contains(out, bad) {
+			t.Errorf("codex stderr contains %q (auth setup failed):\n%s", bad, out)
+		}
+	}
+
+	// Positive signal: the cloud-executor POST is the last step codex
+	// makes. If we see SOMETHING resembling a registration attempt or
+	// the 404 from our test server, JWKS+task/register made it through.
+	// (codex's exact log lines change between versions; permissive check.)
+	if !strings.Contains(out, "registered") && !strings.Contains(out, "404") &&
+		!strings.Contains(out, "cloud/executor") {
+		t.Logf("codex output (for diagnostic):\n%s", out)
+		// Don't t.Errorf here — codex versions differ in stderr format,
+		// and the negative checks above are the real assertion.
+	}
+}

--- a/internal/codexauth/jwks.go
+++ b/internal/codexauth/jwks.go
@@ -1,0 +1,38 @@
+package codexauth
+
+import "net/http"
+
+// handleJWKS serves GET /agent-identities/jwks — the JSON Web Key Set
+// codex fetches to verify Agent Identity JWTs (codex-rs/agent-identity/
+// src/lib.rs:147-171 at rust-v0.132.0).
+//
+// Returns every key in codex_jwks_keys (active and inactive). Inactive
+// keys are retained during a rotation grace window so JWTs issued by
+// the previous active key still validate.
+func (s *Server) handleJWKS(w http.ResponseWriter, r *http.Request) {
+	if s.Store == nil {
+		http.Error(w, "store not configured", http.StatusInternalServerError)
+		return
+	}
+	keys, err := s.Store.ListAllJwksKeys(r.Context())
+	if err != nil {
+		http.Error(w, "store: "+err.Error(), http.StatusInternalServerError)
+		return
+	}
+	jwks := make([]map[string]string, 0, len(keys))
+	for _, k := range keys {
+		jwks = append(jwks, map[string]string{
+			"kty": "RSA",
+			"alg": "RS256",
+			"use": "sig",
+			"kid": k.Kid,
+			"n":   k.PublicN,
+			"e":   k.PublicE,
+		})
+	}
+	// 5min cache — codex has no JWKS cache of its own (lib.rs:147-171
+	// fetches fresh every JWT load), so this only helps if a CDN is in
+	// front. Harmless either way.
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	writeJSON(w, http.StatusOK, map[string]any{"keys": jwks})
+}

--- a/internal/codexauth/jwks_test.go
+++ b/internal/codexauth/jwks_test.go
@@ -1,0 +1,46 @@
+package codexauth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestJWKS_ReturnsActiveKeys(t *testing.T) {
+	srv := newAuthTestServer(t, "")
+	r := chi.NewRouter()
+	srv.Mount(r)
+
+	// Add one more inactive key to cover the rotation case.
+	kid2, kp2, _ := GenerateRSAKey()
+	srv.Store.InsertJwksKey(context.Background(), kid2, kp2, false)
+
+	req := httptest.NewRequest(http.MethodGet, "/agent-identities/jwks", nil)
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	var doc struct {
+		Keys []map[string]string `json:"keys"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&doc); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(doc.Keys) != 2 {
+		t.Errorf("got %d keys, want 2 (one active + one inactive)", len(doc.Keys))
+	}
+	for _, k := range doc.Keys {
+		if k["kty"] != "RSA" || k["alg"] != "RS256" || k["use"] != "sig" {
+			t.Errorf("bad key shape: %+v", k)
+		}
+		if k["kid"] == "" || k["n"] == "" || k["e"] == "" {
+			t.Errorf("missing required field: %+v", k)
+		}
+	}
+}

--- a/internal/codexauth/server.go
+++ b/internal/codexauth/server.go
@@ -39,9 +39,5 @@ func (s *Server) Mount(r chi.Router) {
 	r.Post("/codex/device", s.handleDeviceVerifySubmit)
 }
 
-// All handlers are stubs initially; subsequent tasks fill them in.
-// Returning a clear "not implemented" so tests can detect missing wiring.
-// handleAuthorize and handleToken are implemented in pkce.go.
-func (s *Server) handleJWKS(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "jwks: not implemented", http.StatusNotImplemented)
-}
+// All route handlers are implemented in dedicated files:
+// pkce.go, device.go, agent_identity.go, jwks.go.

--- a/internal/codexauth/server.go
+++ b/internal/codexauth/server.go
@@ -45,6 +45,3 @@ func (s *Server) Mount(r chi.Router) {
 func (s *Server) handleJWKS(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, "jwks: not implemented", http.StatusNotImplemented)
 }
-func (s *Server) handleTaskRegister(w http.ResponseWriter, r *http.Request) {
-	http.Error(w, "task register: not implemented", http.StatusNotImplemented)
-}


### PR DESCRIPTION
Phase C of the codex 0.132+ auth spec. Builds on PR #126 (Phase B ChatGPT login).

## What this lands

3 commits in \`internal/codexauth/\`:

1. \`1e641c2\` MintAgentIdentity + POST /v1/agent/{rid}/task/register
2. \`96457f8\` GET /agent-identities/jwks (RFC 7517 JwkSet)
3. \`eda957f\` Integration test with real codex 0.132 binary (build-tag \`integration\`)

## Wire contract verified against codex rust-v0.132.0

- JWT claims: \`iss=https://chatgpt.com/codex-backend/agent-identity\`, \`aud=codex-app-server\` (codex enforces literals at agent-identity/src/lib.rs:163-166)
- JWKS path: \`/agent-identities/jwks\` (no /backend-api prefix)
- task/register payload: Ed25519 signature over \`{rid}:{timestamp}\` (RFC3339); body \`{timestamp, signature}\`; response \`{task_id}\`
- ±5min clock skew window
- 24h task TTL, 30d JWT TTL

## Tests

- 4 new tests (mint persists row, task/register happy/badsig, JWKS shape)
- 1 build-tagged integration test that drives real \`codex exec-server --remote --use-agent-identity-auth\` end-to-end through JWKS+task/register
- All non-integration tests PASS with TEST_DATABASE_URL, SKIP cleanly otherwise

## What this does NOT do yet

- /cloud/executor validator on codex-exec-gateway still uses legacy bcrypt-only (Phase D / PR 4)
- Connectors UI doesn't yet mint Agent Identity JWTs (Phase D / PR 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)