### PR TITLE
feat(codexauth): PR 4 — /cloud/executor validator + 3-way UI + chart 0.62.0

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -259,6 +259,7 @@ var serveCmd = &cobra.Command{
 				},
 				LoginRedirectURL: "/login",
 			}
+			srv.CodexAuthIssuerURL = issuer
 			log.Printf("codexauth: enabled (issuer=%s, kid=%s)", issuer, activeKey.Kid)
 		}
 

--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.61.12
-appVersion: "0.61.12"
+version: 0.62.0
+appVersion: "0.62.0"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/internal/codexauth/validate.go
+++ b/internal/codexauth/validate.go
@@ -1,0 +1,118 @@
+package codexauth
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type validateRequest struct {
+	Scheme    string `json:"scheme"`
+	Token     string `json:"token,omitempty"`
+	Assertion string `json:"assertion,omitempty"`
+	AccountID string `json:"account_id,omitempty"`
+}
+
+// HandleValidate is the internal endpoint codex-exec-gateway calls
+// over X-Internal-Secret to verify a Bearer / AgentAssertion token.
+// Returns 200 with {user_id} or 401 with {error}.
+func (s *Server) HandleValidate(w http.ResponseWriter, r *http.Request) {
+	var req validateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "bad body", http.StatusBadRequest)
+		return
+	}
+	uid, err := s.validate(r.Context(), req)
+	if err != nil {
+		writeJSON(w, http.StatusUnauthorized, map[string]string{"error": err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"user_id": uid})
+}
+
+func (s *Server) validate(ctx context.Context, req validateRequest) (string, error) {
+	switch req.Scheme {
+	case "bearer":
+		uid, err := s.Store.LookupAccessToken(ctx, req.Token)
+		if err != nil {
+			return "", err
+		}
+		if uid == "" {
+			return "", fmt.Errorf("bearer token unknown or expired")
+		}
+		// Defense-in-depth: ChatGPT-mode bearer requests always carry
+		// the ChatGPT-Account-ID header (codex's BearerAuthProvider adds it
+		// unconditionally — model-provider/src/bearer_auth_provider.rs).
+		// We mint id_token with chatgpt_account_id == user_id (see
+		// BuildIDToken in claims.go), so codex will echo our user_id back.
+		// Reject mismatches.
+		if req.AccountID != "" && req.AccountID != uid {
+			return "", fmt.Errorf("ChatGPT-Account-ID header does not match token owner")
+		}
+		return uid, nil
+	case "agent_assertion":
+		return s.validateAgentAssertion(ctx, req)
+	default:
+		return "", fmt.Errorf("unknown scheme %q", req.Scheme)
+	}
+}
+
+func (s *Server) validateAgentAssertion(ctx context.Context, req validateRequest) (string, error) {
+	raw, err := base64.RawURLEncoding.DecodeString(req.Assertion)
+	if err != nil {
+		return "", fmt.Errorf("base64url decode: %w", err)
+	}
+	var a struct {
+		AgentRuntimeID string `json:"agent_runtime_id"`
+		TaskID         string `json:"task_id"`
+		Timestamp      string `json:"timestamp"`
+		Signature      string `json:"signature"`
+	}
+	if err := json.Unmarshal(raw, &a); err != nil {
+		return "", fmt.Errorf("assertion json: %w", err)
+	}
+	if a.AgentRuntimeID == "" || a.TaskID == "" || a.Timestamp == "" || a.Signature == "" {
+		return "", fmt.Errorf("assertion missing fields")
+	}
+
+	identity, err := s.Store.GetAgentIdentity(ctx, a.AgentRuntimeID)
+	if err != nil {
+		return "", err
+	}
+	if identity == nil {
+		return "", fmt.Errorf("unknown agent")
+	}
+	if req.AccountID != "" && req.AccountID != identity.UserID {
+		return "", fmt.Errorf("account_id header does not match identity owner")
+	}
+
+	task, err := s.Store.GetAgentTask(ctx, a.TaskID)
+	if err != nil {
+		return "", err
+	}
+	if task == nil || task.AgentRuntimeID != a.AgentRuntimeID {
+		return "", fmt.Errorf("task_id unknown or mismatched")
+	}
+
+	ts, err := time.Parse(time.RFC3339, a.Timestamp)
+	if err != nil {
+		return "", fmt.Errorf("bad timestamp")
+	}
+	if d := time.Since(ts); d > taskRegisterClockSkew || d < -taskRegisterClockSkew {
+		return "", fmt.Errorf("timestamp outside replay window")
+	}
+
+	sig, err := base64.StdEncoding.DecodeString(a.Signature)
+	if err != nil {
+		return "", fmt.Errorf("signature base64: %w", err)
+	}
+	msg := []byte(a.AgentRuntimeID + ":" + a.TaskID + ":" + a.Timestamp)
+	if !ed25519.Verify(ed25519.PublicKey(identity.PublicKey), msg, sig) {
+		return "", fmt.Errorf("signature invalid")
+	}
+	return identity.UserID, nil
+}

--- a/internal/codexauth/validate_test.go
+++ b/internal/codexauth/validate_test.go
@@ -1,0 +1,151 @@
+package codexauth
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+func TestValidate_BearerHappyPath(t *testing.T) {
+	srv := newAuthTestServer(t, "")
+	uid := mustCreateTestUser(t, srv.Store.db)
+	if err := srv.Store.InsertAccessToken(context.Background(), HashToken("good-bearer"), uid,
+		time.Now().Add(1*time.Hour)); err != nil {
+		t.Fatalf("InsertAccessToken: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]string{"scheme": "bearer", "token": "good-bearer"})
+	rr := callValidate(t, srv, body)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		UserID string `json:"user_id"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.UserID != uid {
+		t.Errorf("user_id = %q, want %q", resp.UserID, uid)
+	}
+}
+
+func TestValidate_BearerExpiredReturns401(t *testing.T) {
+	srv := newAuthTestServer(t, "")
+	uid := mustCreateTestUser(t, srv.Store.db)
+	if err := srv.Store.InsertAccessToken(context.Background(), HashToken("expired"), uid,
+		time.Now().Add(-1*time.Hour)); err != nil {
+		t.Fatalf("InsertAccessToken: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]string{"scheme": "bearer", "token": "expired"})
+	rr := callValidate(t, srv, body)
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401", rr.Code)
+	}
+}
+
+func TestValidate_BearerWithAccountIDMismatch_401(t *testing.T) {
+	srv := newAuthTestServer(t, "")
+	uid := mustCreateTestUser(t, srv.Store.db)
+	if err := srv.Store.InsertAccessToken(context.Background(), HashToken("crosscheck"), uid,
+		time.Now().Add(1*time.Hour)); err != nil {
+		t.Fatalf("InsertAccessToken: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]string{
+		"scheme":     "bearer",
+		"token":      "crosscheck",
+		"account_id": "different-user-id",
+	})
+	rr := callValidate(t, srv, body)
+	if rr.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 for account_id mismatch", rr.Code)
+	}
+}
+
+func TestValidate_BearerWithAccountIDMatch_200(t *testing.T) {
+	srv := newAuthTestServer(t, "")
+	uid := mustCreateTestUser(t, srv.Store.db)
+	if err := srv.Store.InsertAccessToken(context.Background(), HashToken("matchcheck"), uid,
+		time.Now().Add(1*time.Hour)); err != nil {
+		t.Fatalf("InsertAccessToken: %v", err)
+	}
+
+	body, _ := json.Marshal(map[string]string{
+		"scheme":     "bearer",
+		"token":      "matchcheck",
+		"account_id": uid,
+	})
+	rr := callValidate(t, srv, body)
+	if rr.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 for account_id match", rr.Code)
+	}
+}
+
+func TestValidate_AgentAssertionHappyPath(t *testing.T) {
+	srv := newAuthTestServer(t, "")
+	ctx := context.Background()
+	uid := mustCreateTestUser(t, srv.Store.db)
+
+	mint, err := srv.MintAgentIdentity(ctx, MintAgentIdentityArgs{
+		AgentRuntimeID: "exe_v_test", UserID: uid, Email: "u@test",
+	})
+	if err != nil {
+		t.Fatalf("MintAgentIdentity: %v", err)
+	}
+	// Issue a task_id (simulating codex's prior task/register call).
+	if err := srv.Store.InsertAgentTask(ctx, "task_v_test", "exe_v_test", uid,
+		time.Now().Add(24*time.Hour)); err != nil {
+		t.Fatalf("InsertAgentTask: %v", err)
+	}
+
+	ts := time.Now().UTC().Format(time.RFC3339)
+	sig := ed25519.Sign(mint.privKey, []byte("exe_v_test:task_v_test:"+ts))
+	assertion := map[string]string{
+		"agent_runtime_id": "exe_v_test",
+		"task_id":          "task_v_test",
+		"timestamp":        ts,
+		"signature":        base64.StdEncoding.EncodeToString(sig),
+	}
+	assBytes, _ := json.Marshal(assertion)
+	assB64 := base64.RawURLEncoding.EncodeToString(assBytes)
+
+	body, _ := json.Marshal(map[string]string{
+		"scheme":     "agent_assertion",
+		"assertion":  assB64,
+		"account_id": uid,
+	})
+	rr := callValidate(t, srv, body)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		UserID string `json:"user_id"`
+	}
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.UserID != uid {
+		t.Errorf("user_id = %q, want %q", resp.UserID, uid)
+	}
+}
+
+func callValidate(t *testing.T, srv *Server, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	r := chi.NewRouter()
+	r.Post("/internal/codex-auth/validate", srv.HandleValidate)
+	req := httptest.NewRequest(http.MethodPost, "/internal/codex-auth/validate", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	r.ServeHTTP(rr, req)
+	return rr
+}

--- a/internal/codexexecgateway/handlers/cloud_register.go
+++ b/internal/codexexecgateway/handlers/cloud_register.go
@@ -1,10 +1,14 @@
 package handlers
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 	"golang.org/x/crypto/bcrypt"
@@ -27,12 +31,50 @@ type cloudRegisterResponse struct {
 	URL        string `json:"url"`
 }
 
-// CloudRegister is the upstream-compatibility shim for
-// `codex exec-server --remote <base_url> --executor-id <id>`. Upstream
-// codex first POSTs to `<base_url>/cloud/executor/{id}/register` with
-// `Authorization: Bearer <token>` (token from
-// CODEX_EXEC_SERVER_REMOTE_BEARER_TOKEN env), then connects to the
-// returned URL with no further auth (the URL itself is the credential).
+// AgentserverValidator calls agentserver's /internal/codex-auth/validate
+// to verify codex 0.132 Bearer / AgentAssertion auth on cloud register.
+type AgentserverValidator struct {
+	BaseURL        string // e.g. "http://agentserver.agentserver.svc:8080"
+	InternalSecret string
+	HTTPClient     *http.Client // optional; nil → default with 5s timeout
+}
+
+// Validate POSTs the request body to agentserver and returns the
+// resolved user_id, or an error if validation fails.
+func (v *AgentserverValidator) Validate(ctx context.Context, req map[string]string) (userID string, err error) {
+	if v.BaseURL == "" {
+		return "", fmt.Errorf("validator not configured")
+	}
+	body, _ := json.Marshal(req)
+	httpReq, _ := http.NewRequestWithContext(ctx, http.MethodPost,
+		v.BaseURL+"/internal/codex-auth/validate", bytes.NewReader(body))
+	httpReq.Header.Set("Content-Type", "application/json")
+	httpReq.Header.Set("X-Internal-Secret", v.InternalSecret)
+	client := v.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Second}
+	}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return "", fmt.Errorf("validate: %w", err)
+	}
+	defer resp.Body.Close()
+	var rb struct {
+		UserID string `json:"user_id"`
+		Error  string `json:"error"`
+	}
+	json.NewDecoder(resp.Body).Decode(&rb)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("validate: %s (status %d)", rb.Error, resp.StatusCode)
+	}
+	return rb.UserID, nil
+}
+
+// CloudRegister handles POST /cloud/executor/{exe_id}/register.
+//
+// Auth: prefers codex 0.132+ schemes (Bearer access_token or
+// AgentAssertion) validated via agentserver. Falls back to legacy
+// bcrypt bearer token (codex < 0.132) for backward compat.
 //
 // Our existing inbound handler at `/codex-exec/{exe_id}?token=...` is
 // the actual ws endpoint; this handler verifies the bearer once and
@@ -42,46 +84,114 @@ type cloudRegisterResponse struct {
 // "wss://codex-exec.agent.cs.ac.cn:443"). When empty, the response URL
 // is synthesised from r.Host with wss scheme — best-effort fallback for
 // dev / direct in-cluster use.
-func CloudRegister(store CloudRegisterStore, publicWSBaseURL string) http.HandlerFunc {
+func CloudRegister(store CloudRegisterStore, publicWSBaseURL string, validator AgentserverValidator) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		exeID := chi.URLParam(r, "exe_id")
 		if exeID == "" {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "exe_id required"})
 			return
 		}
+
+		// 1. New codex 0.132+ path: try Bearer (ChatGPT) or
+		//    AgentAssertion (Agent Identity) via agentserver.
+		authHeader := r.Header.Get("Authorization")
+		if userID, ok := classifyAndValidate(r.Context(), validator,
+			authHeader, r.Header.Get("ChatGPT-Account-ID")); ok {
+			if err := assertExeOwnedByUser(r.Context(), store, exeID, userID); err != nil {
+				writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+				return
+			}
+			respondWithWSURL(w, r, exeID, authHeader, publicWSBaseURL)
+			return
+		}
+
+		// 2. Legacy bcrypt bearer path for codex < 0.132 — kept until
+		//    we drop support, then this block goes away.
 		bearer, ok := extractBearer(r)
 		if !ok || bearer == "" {
 			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "missing bearer"})
 			return
 		}
-
 		hash, err := store.GetRegistrationTokenHash(r.Context(), exeID)
 		if err != nil {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal"})
 			return
 		}
-		if hash == "" {
-			// Don't distinguish unknown-id from bad-token to upstream.
+		if hash == "" || bcrypt.CompareHashAndPassword([]byte(hash), []byte(bearer)) != nil {
 			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
 			return
 		}
-		if err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(bearer)); err != nil {
-			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
-			return
-		}
-
-		base := publicWSBaseURL
-		if base == "" {
-			base = synthBaseURL(r)
-		}
-		wsURL := base + "/codex-exec/" + url.PathEscape(exeID) + "?token=" + url.QueryEscape(bearer)
-
-		writeJSON(w, http.StatusOK, cloudRegisterResponse{
-			ID:         exeID,
-			ExecutorID: exeID,
-			URL:        wsURL,
-		})
+		respondWithWSURL(w, r, exeID, "Bearer "+bearer, publicWSBaseURL)
 	}
+}
+
+// classifyAndValidate inspects the auth header and calls agentserver
+// with the appropriate scheme. Returns userID + ok=true on match.
+// Returns ok=false on any failure (legacy bcrypt path will then be tried).
+func classifyAndValidate(ctx context.Context, v AgentserverValidator, authHeader, accountID string) (string, bool) {
+	if strings.HasPrefix(authHeader, "Bearer ") {
+		token := strings.TrimPrefix(authHeader, "Bearer ")
+		// ChatGPT-mode bearer requests always come with the
+		// ChatGPT-Account-ID header (codex's BearerAuthProvider always
+		// adds it). Forward it so agentserver can cross-check the
+		// header against the token's owner.
+		// Legacy bcrypt tokens have similar shape; we always try
+		// delegating first and fall back to the bcrypt path on 401.
+		uid, err := v.Validate(ctx, map[string]string{
+			"scheme": "bearer", "token": token, "account_id": accountID,
+		})
+		if err == nil && uid != "" {
+			return uid, true
+		}
+		return "", false
+	}
+	if strings.HasPrefix(authHeader, "AgentAssertion ") {
+		assertion := strings.TrimPrefix(authHeader, "AgentAssertion ")
+		uid, err := v.Validate(ctx, map[string]string{
+			"scheme": "agent_assertion", "assertion": assertion, "account_id": accountID,
+		})
+		if err == nil && uid != "" {
+			return uid, true
+		}
+		return "", false
+	}
+	return "", false
+}
+
+func assertExeOwnedByUser(ctx context.Context, store CloudRegisterStore, exeID, userID string) error {
+	type ownerStore interface {
+		UserIDForExecutor(ctx context.Context, exeID string) (string, error)
+	}
+	os, ok := store.(ownerStore)
+	if !ok {
+		return fmt.Errorf("store does not implement UserIDForExecutor")
+	}
+	owner, err := os.UserIDForExecutor(ctx, exeID)
+	if err != nil {
+		return fmt.Errorf("lookup owner: %w", err)
+	}
+	if owner == "" {
+		return fmt.Errorf("executor %s not registered", exeID)
+	}
+	if owner != userID {
+		return fmt.Errorf("executor %s not owned by user %s", exeID, userID)
+	}
+	return nil
+}
+
+func respondWithWSURL(w http.ResponseWriter, r *http.Request, exeID, authHeader, publicWSBaseURL string) {
+	base := publicWSBaseURL
+	if base == "" {
+		base = synthBaseURL(r)
+	}
+	// The WS URL has its own bearer cap-token in the query string; the
+	// auth header above only authorized the register call itself.
+	tokenForWS := strings.TrimPrefix(strings.TrimPrefix(authHeader, "Bearer "), "AgentAssertion ")
+	wsURL := base + "/codex-exec/" + url.PathEscape(exeID) + "?token=" +
+		url.QueryEscape(tokenForWS)
+	writeJSON(w, http.StatusOK, cloudRegisterResponse{
+		ID: exeID, ExecutorID: exeID, URL: wsURL,
+	})
 }
 
 // extractBearer returns the Authorization: Bearer <token> value.
@@ -103,4 +213,3 @@ func synthBaseURL(r *http.Request) string {
 	}
 	return scheme + "://" + r.Host
 }
-

--- a/internal/codexexecgateway/handlers/cloud_register_test.go
+++ b/internal/codexexecgateway/handlers/cloud_register_test.go
@@ -1,0 +1,148 @@
+package handlers
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi/v5"
+	"golang.org/x/crypto/bcrypt"
+)
+
+func bcryptHash(plain string) (string, error) {
+	h, err := bcrypt.GenerateFromPassword([]byte(plain), bcrypt.MinCost)
+	return string(h), err
+}
+
+// mockCloudRegisterStore implements CloudRegisterStore and also exposes
+// UserIDForExecutor (matched by assertExeOwnedByUser's ad-hoc interface
+// assertion). Lets us exercise CloudRegister without a real DB.
+type mockCloudRegisterStore struct {
+	hash       string
+	hashErr    error
+	owner      string
+	ownerErr   error
+	registered bool // false → UserIDForExecutor returns "" (unknown executor)
+}
+
+func (m *mockCloudRegisterStore) GetRegistrationTokenHash(ctx context.Context, exeID string) (string, error) {
+	return m.hash, m.hashErr
+}
+
+func (m *mockCloudRegisterStore) UserIDForExecutor(ctx context.Context, exeID string) (string, error) {
+	if !m.registered {
+		return "", m.ownerErr
+	}
+	return m.owner, m.ownerErr
+}
+
+// newStoreWithExecutor returns a mock store that "knows" an executor
+// row exists for exeID owned by userID.
+func newStoreWithExecutor(t *testing.T, exeID, userID string) *mockCloudRegisterStore {
+	t.Helper()
+	return &mockCloudRegisterStore{owner: userID, registered: true}
+}
+
+func TestCloudRegister_BearerScheme_DelegatesToAgentserver(t *testing.T) {
+	// Stub agentserver: any call to /internal/codex-auth/validate with
+	// scheme=bearer + matching token returns user-id "u-1".
+	agentSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/internal/codex-auth/validate" {
+			http.Error(w, "wrong path", 404)
+			return
+		}
+		var req struct {
+			Scheme string `json:"scheme"`
+			Token  string `json:"token"`
+		}
+		json.NewDecoder(r.Body).Decode(&req)
+		w.Header().Set("Content-Type", "application/json")
+		if req.Scheme == "bearer" && req.Token == "valid-bearer" {
+			json.NewEncoder(w).Encode(map[string]string{"user_id": "u-1"})
+			return
+		}
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{"error": "no"})
+	}))
+	defer agentSrv.Close()
+
+	store := newStoreWithExecutor(t, "exe_x", "u-1")
+	h := CloudRegister(store, "wss://test", AgentserverValidator{
+		BaseURL:        agentSrv.URL,
+		InternalSecret: "shh",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/cloud/executor/exe_x/register", nil)
+	req.Header.Set("Authorization", "Bearer valid-bearer")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("exe_id", "exe_x")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rr := httptest.NewRecorder()
+	h(rr, req)
+	if rr.Code != http.StatusOK {
+		body, _ := io.ReadAll(rr.Body)
+		t.Fatalf("status = %d body = %s", rr.Code, body)
+	}
+	var resp cloudRegisterResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ExecutorID != "exe_x" {
+		t.Fatalf("executor_id = %q", resp.ExecutorID)
+	}
+	if resp.URL == "" || resp.URL[:5] != "wss:/" {
+		t.Fatalf("url = %q", resp.URL)
+	}
+}
+
+// Wrong-owner: agentserver validates token (returns u-2) but executor
+// is owned by u-1 → 403.
+func TestCloudRegister_BearerScheme_WrongOwner(t *testing.T) {
+	agentSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"user_id": "u-2"})
+	}))
+	defer agentSrv.Close()
+
+	store := newStoreWithExecutor(t, "exe_x", "u-1")
+	h := CloudRegister(store, "wss://test", AgentserverValidator{
+		BaseURL:        agentSrv.URL,
+		InternalSecret: "shh",
+	})
+	req := httptest.NewRequest(http.MethodPost, "/cloud/executor/exe_x/register", nil)
+	req.Header.Set("Authorization", "Bearer some-token")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("exe_id", "exe_x")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rr := httptest.NewRecorder()
+	h(rr, req)
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}
+
+// When the validator is unconfigured (BaseURL=""), the legacy bcrypt
+// fallback path must still authenticate codex < 0.132 clients.
+func TestCloudRegister_LegacyBcryptFallback(t *testing.T) {
+	// bcrypt of "legacy-token" (cost 4 to keep test snappy).
+	// Generated via: bcrypt.GenerateFromPassword([]byte("legacy-token"), 4).
+	// We compute it at test time to avoid a hardcoded constant.
+	hash, err := bcryptHash("legacy-token")
+	if err != nil {
+		t.Fatalf("bcryptHash: %v", err)
+	}
+	store := &mockCloudRegisterStore{hash: hash}
+	h := CloudRegister(store, "wss://test", AgentserverValidator{})
+
+	req := httptest.NewRequest(http.MethodPost, "/cloud/executor/exe_x/register", nil)
+	req.Header.Set("Authorization", "Bearer legacy-token")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("exe_id", "exe_x")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rr := httptest.NewRecorder()
+	h(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/codexexecgateway/server.go
+++ b/internal/codexexecgateway/server.go
@@ -167,7 +167,12 @@ func (s *Server) Routes() http.Handler {
 
 	// Upstream codex `exec-server --remote` compat: clients POST here
 	// with bearer auth, get back the ws URL above.
-	r.Post("/cloud/executor/{exe_id}/register", handlers.CloudRegister(s.store, s.config.PublicWSBaseURL))
+	r.Post("/cloud/executor/{exe_id}/register",
+		handlers.CloudRegister(s.store, s.config.PublicWSBaseURL,
+			handlers.AgentserverValidator{
+				BaseURL:        s.config.AgentserverInternalURL,
+				InternalSecret: s.config.AgentserverInternalSecret,
+			}))
 
 	// *Store satisfies handlers.Store, handlers.BindingStore, and
 	// handlers.InternalConnectedStore directly — no adapter needed because

--- a/internal/codexexecgateway/store.go
+++ b/internal/codexexecgateway/store.go
@@ -249,6 +249,19 @@ func (s *Store) truncateForTest() {
 	s.db.Exec(`DELETE FROM executors`)           //nolint:errcheck
 }
 
+// UserIDForExecutor returns the owner user_id of an executor row.
+// Used by /cloud/executor/{id}/register to confirm the token holder
+// owns the executor they're trying to register as.
+func (s *Store) UserIDForExecutor(ctx context.Context, exeID string) (string, error) {
+	var uid string
+	err := s.db.QueryRowContext(ctx,
+		`SELECT user_id FROM executors WHERE exe_id = $1`, exeID).Scan(&uid)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	return uid, err
+}
+
 // ConnectedExecutorsForWorkspace returns the intersection of (workspace's bound
 // executors) ∩ (the connected exe_id list passed in). Used by the internal
 // `/api/exec-gateway/connected` endpoint.

--- a/internal/server/codex_executors.go
+++ b/internal/server/codex_executors.go
@@ -7,6 +7,7 @@ import (
 	"regexp"
 
 	"github.com/agentserver/agentserver/internal/auth"
+	"github.com/agentserver/agentserver/internal/codexauth"
 
 	"github.com/go-chi/chi/v5"
 )
@@ -34,7 +35,28 @@ type registerExecutorResp struct {
 	// ConnectCommand is the one-liner the user pastes on the machine
 	// they want to expose as an executor. Empty when the gateway public
 	// host isn't configured — the UI falls back to a generic template.
+	// Kept for backward compatibility with UI clients predating the
+	// 3-variant bundle (set to the Agent Identity command when codexAuth
+	// is enabled so old clients still get a working command).
 	ConnectCommand string `json:"connect_command,omitempty"`
+	// AgentIdentityJWT is the codex Agent Identity JWT minted alongside
+	// the bcrypt registration token. Present only when codexAuth is
+	// enabled (CODEX_AUTH_ISSUER_URL set).
+	AgentIdentityJWT string `json:"agent_identity_jwt,omitempty"`
+	// ConnectCommands is the 3-variant bundle surfaced by the Add
+	// Connector UI. Empty when codexAuth is disabled.
+	ConnectCommands ConnectCommands `json:"connect_commands,omitempty"`
+}
+
+// ConnectCommands is the 3-variant connect-command bundle returned by
+// the Add Connector API. Agent Identity is the recommended path for
+// unattended machines; ChatGPT browser is the recommended path for
+// developer laptops; ChatGPT device-auth covers the headless +
+// ChatGPT-account case.
+type ConnectCommands struct {
+	AgentIdentity     string `json:"agent_identity"`
+	ChatgptBrowser    string `json:"chatgpt_browser"`
+	ChatgptDeviceAuth string `json:"chatgpt_device_auth"`
 }
 
 // handleRegisterExecutor mints a new executor owned by the calling user
@@ -100,9 +122,34 @@ func (s *Server) handleRegisterExecutor(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
+	// Mint Agent Identity JWT alongside the legacy bearer registration.
+	// The exe_id is the agent_runtime_id (1-to-1 mapping). Best-effort
+	// email lookup — empty email is OK, JWT just won't carry it.
+	var aiResult *codexauth.MintAgentIdentityResult
+	if s.CodexAuth != nil {
+		var email string
+		if user, uerr := s.Auth.GetUserByID(userID); uerr == nil && user != nil {
+			email = user.Email
+		}
+		var mintErr error
+		aiResult, mintErr = s.CodexAuth.MintAgentIdentity(r.Context(),
+			codexauth.MintAgentIdentityArgs{
+				AgentRuntimeID: reg.ExeID,
+				UserID:         userID,
+				Email:          email,
+			})
+		if mintErr != nil {
+			http.Error(w, "mint agent identity: "+mintErr.Error(), http.StatusInternalServerError)
+			return
+		}
+	}
+
 	resp := registerExecutorResp{
 		ExeID:             reg.ExeID,
 		RegistrationToken: reg.RegistrationToken,
+	}
+	if aiResult != nil {
+		resp.AgentIdentityJWT = aiResult.JWT
 	}
 	if s.CodexExecGatewayPublicHost != "" {
 		// Upstream codex `exec-server --remote` contract:
@@ -110,10 +157,31 @@ func (s *Server) handleRegisterExecutor(w http.ResponseWriter, r *http.Request) 
 		//   2. Server returns {executor_id, url}, codex then ws-dials url.
 		// Surface the user's `name` as codex's --name (visible in their
 		// shell + tracing) so it lines up with what the LLM sees.
-		resp.ConnectCommand = fmt.Sprintf(
-			"export CODEX_EXEC_SERVER_REMOTE_BEARER_TOKEN='%s' && \\\ncodex exec-server --remote 'https://%s' --executor-id '%s' --name '%s'",
-			reg.RegistrationToken, s.CodexExecGatewayPublicHost, reg.ExeID, req.Name,
-		)
+		gatewayURL := "https://" + s.CodexExecGatewayPublicHost
+		issuer := s.CodexAuthIssuerURL
+		if issuer == "" {
+			// codexAuth disabled — legacy bearer-only command (no Agent
+			// Identity, no ChatGPT login). Preserves pre-D3 behaviour.
+			resp.ConnectCommand = fmt.Sprintf(
+				"export CODEX_EXEC_SERVER_REMOTE_BEARER_TOKEN='%s'\ncodex exec-server --remote '%s' --executor-id '%s' --name '%s'",
+				reg.RegistrationToken, gatewayURL, reg.ExeID, req.Name)
+		} else {
+			// codexAuth enabled — surface all 3 variants. Keep the legacy
+			// single-string field populated with the Agent Identity
+			// command so unrevised UI clients still get a working paste.
+			resp.ConnectCommands = ConnectCommands{
+				AgentIdentity: fmt.Sprintf(
+					"export CODEX_ACCESS_TOKEN='%s'\nexport CODEX_AGENT_IDENTITY_AUTHAPI_BASE_URL='%s'\ncodex -c chatgpt.base_url='%s' exec-server --remote '%s' --executor-id '%s' --name '%s' --use-agent-identity-auth",
+					aiResult.JWT, issuer, issuer, gatewayURL, reg.ExeID, req.Name),
+				ChatgptBrowser: fmt.Sprintf(
+					"codex login --issuer %s\nexport CODEX_REFRESH_TOKEN_URL_OVERRIDE='%s/oauth/token'\ncodex exec-server --remote '%s' --executor-id '%s' --name '%s'",
+					issuer, issuer, gatewayURL, reg.ExeID, req.Name),
+				ChatgptDeviceAuth: fmt.Sprintf(
+					"codex login --device-auth --issuer %s\nexport CODEX_REFRESH_TOKEN_URL_OVERRIDE='%s/oauth/token'\ncodex exec-server --remote '%s' --executor-id '%s' --name '%s'",
+					issuer, issuer, gatewayURL, reg.ExeID, req.Name),
+			}
+			resp.ConnectCommand = resp.ConnectCommands.AgentIdentity
+		}
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -321,6 +321,18 @@ func (s *Server) Router() http.Handler {
 		r.Route("/codex-auth", func(r chi.Router) {
 			s.CodexAuth.Mount(r)
 		})
+		// Internal cross-scheme validator called by codex-exec-gateway.
+		// Auth: X-Internal-Secret matching INTERNAL_API_SECRET.
+		r.Post("/internal/codex-auth/validate", func(w http.ResponseWriter, r *http.Request) {
+			secret := os.Getenv("INTERNAL_API_SECRET")
+			if secret != "" {
+				if r.Header.Get("X-Internal-Secret") != secret {
+					http.Error(w, "unauthorized", http.StatusUnauthorized)
+					return
+				}
+			}
+			s.CodexAuth.HandleValidate(w, r)
+		})
 	}
 
 	// Hydra login/consent provider endpoints (no auth required — Hydra redirects here).

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -92,6 +92,13 @@ type Server struct {
 	// flow / JWKS / Agent Identity). Mounted under /codex-auth/* when set.
 	CodexAuth *codexauth.Server
 
+	// CodexAuthIssuerURL is the public-facing issuer URL for the codex
+	// auth shim, e.g. "https://agent.cs.ac.cn/codex-auth". Mirrors the
+	// value used to construct CodexAuth.IssuerURL; surfaced separately so
+	// register-executor can build connect commands that point clients at
+	// the right `codex login --issuer` / token-refresh endpoints.
+	CodexAuthIssuerURL string
+
 	// OperationsRetention is the TTL for rows in the operations table.
 	// 0 disables the background retention loop. Configurable via
 	// AGENTSERVER_OPERATIONS_RETENTION_DAYS (default 90).

--- a/web/src/components/RemoteExecutorsPanel.tsx
+++ b/web/src/components/RemoteExecutorsPanel.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { Plus, Trash2, Copy, Check, X, Server, Circle } from 'lucide-react'
 import {
-  type RemoteExecutor, type RegisterExecutorResponse,
+  type RemoteExecutor, type RegisterExecutorResponse, type ConnectCommands,
   listRemoteExecutors, registerRemoteExecutor, unbindRemoteExecutor,
 } from '../lib/api'
 import { ConfirmModal } from './Modals'
@@ -23,7 +23,6 @@ export default function RemoteExecutorsPanel({ workspaceId }: Props) {
   const [newName, setNewName] = useState('')
   const [newDesc, setNewDesc] = useState('')
   const [generated, setGenerated] = useState<RegisterExecutorResponse | null>(null)
-  const [copied, setCopied] = useState(false)
   const [unbindTarget, setUnbindTarget] = useState<RemoteExecutor | null>(null)
 
   const refresh = useCallback(async () => {
@@ -70,13 +69,6 @@ export default function RemoteExecutorsPanel({ workspaceId }: Props) {
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e))
     }
-  }
-
-  const copyCommand = async () => {
-    if (!generated?.connect_command) return
-    await navigator.clipboard.writeText(generated.connect_command)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 1500)
   }
 
   const isOnline = (r: RemoteExecutor): boolean => {
@@ -241,17 +233,13 @@ export default function RemoteExecutorsPanel({ workspaceId }: Props) {
             <p className="mb-3 text-sm text-[var(--muted-foreground)]">
               Run this on the machine you want to expose. The token won't be shown again — copy it now.
             </p>
-            {generated.connect_command ? (
-              <div className="mb-4 flex items-center gap-2">
-                <pre className="flex-1 overflow-x-auto rounded-md border border-[var(--border)] bg-[var(--background)] p-3 font-mono text-xs text-[var(--foreground)] whitespace-pre-wrap break-all">{generated.connect_command}</pre>
-                <button
-                  onClick={copyCommand}
-                  className="rounded-md border border-[var(--border)] p-2 text-[var(--foreground)] hover:bg-[var(--secondary)]"
-                  aria-label="Copy command"
-                  title="Copy"
-                >
-                  {copied ? <Check size={14} /> : <Copy size={14} />}
-                </button>
+            {generated.connect_commands ? (
+              <div className="mb-4">
+                <ConnectCommandsPanel cmds={generated.connect_commands} />
+              </div>
+            ) : generated.connect_command ? (
+              <div className="mb-4">
+                <SingleCommandBlock cmd={generated.connect_command} />
               </div>
             ) : (
               <div className="mb-4 rounded-md border border-[var(--border)] bg-[var(--background)] p-3 font-mono text-xs text-[var(--foreground)]">
@@ -284,6 +272,112 @@ export default function RemoteExecutorsPanel({ workspaceId }: Props) {
           onCancel={() => setUnbindTarget(null)}
         />
       )}
+    </div>
+  )
+}
+
+// --- Connect-command rendering helpers ---
+
+function SingleCommandBlock({ cmd }: { cmd: string }) {
+  const [copied, setCopied] = useState(false)
+  const onCopy = async () => {
+    await navigator.clipboard.writeText(cmd)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1500)
+  }
+  return (
+    <div className="flex items-center gap-2">
+      <pre className="flex-1 overflow-x-auto rounded-md border border-[var(--border)] bg-[var(--background)] p-3 font-mono text-xs text-[var(--foreground)] whitespace-pre-wrap break-all">{cmd}</pre>
+      <button
+        onClick={onCopy}
+        className="rounded-md border border-[var(--border)] p-2 text-[var(--foreground)] hover:bg-[var(--secondary)]"
+        aria-label="Copy command"
+        title="Copy"
+      >
+        {copied ? <Check size={14} /> : <Copy size={14} />}
+      </button>
+    </div>
+  )
+}
+
+type ConnectTabKey = keyof ConnectCommands
+
+const CONNECT_TABS: { key: ConnectTabKey; label: string; hint: string }[] = [
+  {
+    key: 'agent_identity',
+    label: 'Agent Identity (headless)',
+    hint: 'Best for unattended machines. One paste, done.',
+  },
+  {
+    key: 'chatgpt_browser',
+    label: 'codex login (browser)',
+    hint: 'For desktops. SSO with your agentserver session.',
+  },
+  {
+    key: 'chatgpt_device_auth',
+    label: 'codex login --device-auth',
+    hint: 'Headless + ChatGPT-account semantics. Enter a code in a browser.',
+  },
+]
+
+function ConnectCommandsPanel({ cmds }: { cmds: ConnectCommands }) {
+  // Default to the first tab whose command is actually populated, falling
+  // back to agent_identity if none are (so the panel still renders something).
+  const firstAvailable = CONNECT_TABS.find((t) => cmds[t.key])?.key ?? 'agent_identity'
+  const [tab, setTab] = useState<ConnectTabKey>(firstAvailable)
+  const [copied, setCopied] = useState(false)
+  const current = cmds[tab] || ''
+
+  const onCopy = async () => {
+    if (!current) return
+    await navigator.clipboard.writeText(current)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 1500)
+  }
+
+  return (
+    <div>
+      <div className="mb-3 flex flex-wrap gap-2">
+        {CONNECT_TABS.map(({ key, label }) => {
+          const active = tab === key
+          const disabled = !cmds[key]
+          return (
+            <button
+              key={key}
+              type="button"
+              disabled={disabled}
+              onClick={() => setTab(key)}
+              className={[
+                'rounded-md border px-3 py-1 text-xs font-medium transition-colors',
+                active
+                  ? 'border-[var(--primary)] bg-[var(--primary)] text-[var(--primary-foreground)]'
+                  : 'border-[var(--border)] bg-[var(--card)] text-[var(--foreground)] hover:bg-[var(--secondary)]',
+                disabled ? 'cursor-not-allowed opacity-40' : '',
+              ].join(' ')}
+              title={disabled ? 'Not available for this connector' : undefined}
+            >
+              {label}
+            </button>
+          )
+        })}
+      </div>
+      <p className="mb-2 text-[11px] text-[var(--muted-foreground)]">
+        {CONNECT_TABS.find((t) => t.key === tab)!.hint}
+      </p>
+      <div className="flex items-center gap-2">
+        <pre className="flex-1 overflow-x-auto rounded-md border border-[var(--border)] bg-[var(--background)] p-3 font-mono text-xs text-[var(--foreground)] whitespace-pre-wrap break-all">
+          {current || <span className="italic opacity-60">(not available)</span>}
+        </pre>
+        <button
+          onClick={onCopy}
+          disabled={!current}
+          className="rounded-md border border-[var(--border)] p-2 text-[var(--foreground)] hover:bg-[var(--secondary)] disabled:cursor-not-allowed disabled:opacity-40"
+          aria-label="Copy command"
+          title="Copy"
+        >
+          {copied ? <Check size={14} /> : <Copy size={14} />}
+        </button>
+      </div>
     </div>
   )
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1046,10 +1046,24 @@ export interface RegisterExecutorRequest {
   description?: string
 }
 
+export interface ConnectCommands {
+  agent_identity?: string
+  chatgpt_browser?: string
+  chatgpt_device_auth?: string
+}
+
 export interface RegisterExecutorResponse {
   exe_id: string
   registration_token: string
+  // Legacy single-string command, still populated for backwards compat
+  // (Agent Identity command when codexAuth is enabled, bearer-token
+  // command otherwise).
   connect_command?: string
+  // Optional JWT minted for the executor's Agent Identity bundle.
+  agent_identity_jwt?: string
+  // New: 3-flavor command bundle (agent_identity / chatgpt_browser /
+  // chatgpt_device_auth). Present only when codexAuth is enabled.
+  connect_commands?: ConnectCommands
 }
 
 export async function listRemoteExecutors(workspaceId: string): Promise<RemoteExecutor[]> {


### PR DESCRIPTION
Phase D of the codex 0.132+ auth spec. Builds on PRs #125 (A), #126 (B), #127 (C).

## What this lands

5 commits:

1. \`5a72d61\` /internal/codex-auth/validate endpoint (bearer + agent_assertion + account_id cross-check, 5min replay window)
2. \`183cb4c\` codex-exec-gateway /cloud/executor delegates to agentserver validator (legacy bcrypt fallback retained)
3. \`0da35be\` handleRegisterExecutor mints Agent Identity JWT + returns 3 connect-commands
4. \`0b94a2c\` Web UI: 3-tab connect-command panel on Add Connector success modal
5. \`b568a22\` Chart bump 0.61.12 → 0.62.0

## After this lands users can

1. Click "Add Connector" → choose tab → copy the right command:
   - Agent Identity (headless)
   - codex login (browser)
   - codex login --device-auth
2. On the executor host, paste + run. Token validates via agentserver.
3. /cloud/executor/.../register confirms exe_id is owned by the resolved user.

## Backwards compat

- Legacy bcrypt registration tokens (codex < 0.132) still work — the new validator runs first, bcrypt only on its 401 fallback.
- Legacy \`connect_command\` field still populated for stale UI clients.

## Tests

- 6 new tests: 5 in validate_test.go (bearer happy/expired/mismatch/match + agent_assertion happy) + 3 in cloud_register_test.go (bearer delegation, wrong-owner 403, legacy bcrypt fallback).
- \`go build ./...\` + all package tests clean. Web \`npm run build\` clean.
- Helm renders \`CODEX_AUTH_ISSUER_URL\` + \`CXG_AGENTSERVER_INTERNAL_URL/SECRET\` when toggles enabled.

## What this does NOT do yet

- Production rollout — Phase E (PR 5) covers pulumi 0.62.0 + e2e smoke test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)