### PR TITLE
feat(devices): unify Browsers + Connectors panels, fix online detection

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.62.0
-appVersion: "0.62.0"
+version: 0.62.2
+appVersion: "0.62.2"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/internal/clientmeta/clientmeta.go
+++ b/internal/clientmeta/clientmeta.go
@@ -1,0 +1,66 @@
+// Package clientmeta extracts originating-client metadata (IP, codex
+// version, OS) from inbound HTTP requests. Used by both codex-exec-gateway
+// (executors connecting from user laptops) and codex-app-gateway (codex
+// --remote CLI sessions) so the Browsers + Connectors UI columns derive
+// from identical logic.
+package clientmeta
+
+import (
+	"net"
+	"net/http"
+	"regexp"
+	"strings"
+)
+
+// ClientIP returns the best-effort originating client IP for an inbound
+// HTTP request. The kube ingress chain prepends entries to
+// X-Forwarded-For ("client, proxy1, proxy2"); the first non-empty hop is
+// the real client. Falls back to X-Real-IP, then r.RemoteAddr (host:port)
+// with the port stripped.
+func ClientIP(r *http.Request) string {
+	if xff := r.Header.Get("X-Forwarded-For"); xff != "" {
+		for _, hop := range strings.Split(xff, ",") {
+			hop = strings.TrimSpace(hop)
+			if hop != "" {
+				return hop
+			}
+		}
+	}
+	if xri := r.Header.Get("X-Real-IP"); xri != "" {
+		return strings.TrimSpace(xri)
+	}
+	if r.RemoteAddr != "" {
+		if host, _, err := net.SplitHostPort(r.RemoteAddr); err == nil {
+			return host
+		}
+		return r.RemoteAddr
+	}
+	return ""
+}
+
+// ParseCodexUA extracts the codex CLI version and host OS from the
+// User-Agent string of a codex client (exec-server inbound or `codex
+// --remote` ws). Upstream codex's reqwest client sends UAs shaped like:
+//
+//	codex_cli_rs/0.130.0 (Darwin 24.4.0; arm64)
+//	codex_cli_rs/0.128.0 (Linux 6.5.0-15-generic; x86_64)
+//
+// We pattern-match conservatively and return ("", "") on anything we
+// don't recognise so callers can store NULL and the UI shows "—".
+func ParseCodexUA(ua string) (version, osStr string) {
+	if ua == "" {
+		return "", ""
+	}
+	if m := codexUAVersionRE.FindStringSubmatch(ua); m != nil {
+		version = m[1]
+	}
+	if m := codexUAOSRE.FindStringSubmatch(ua); m != nil {
+		osStr = m[1]
+	}
+	return version, osStr
+}
+
+var (
+	codexUAVersionRE = regexp.MustCompile(`(?i)\bcodex(?:_cli_rs|_cli|)\s*/\s*([0-9][\w.\-+]*)`)
+	codexUAOSRE      = regexp.MustCompile(`\(\s*([A-Za-z][A-Za-z0-9_-]*)`)
+)

--- a/internal/clientmeta/clientmeta_test.go
+++ b/internal/clientmeta/clientmeta_test.go
@@ -1,0 +1,67 @@
+package clientmeta
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClientIP_XForwardedForWins(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "10.0.0.1:5555"
+	r.Header.Set("X-Forwarded-For", "203.0.113.7, 10.0.0.1")
+	if got := ClientIP(r); got != "203.0.113.7" {
+		t.Fatalf("want 203.0.113.7, got %q", got)
+	}
+}
+
+func TestClientIP_XRealIPFallback(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "10.0.0.1:5555"
+	r.Header.Set("X-Real-IP", "203.0.113.8")
+	if got := ClientIP(r); got != "203.0.113.8" {
+		t.Fatalf("want 203.0.113.8, got %q", got)
+	}
+}
+
+func TestClientIP_RemoteAddrStripsPort(t *testing.T) {
+	r := httptest.NewRequest("GET", "/", nil)
+	r.RemoteAddr = "10.0.0.1:5555"
+	if got := ClientIP(r); got != "10.0.0.1" {
+		t.Fatalf("want 10.0.0.1, got %q", got)
+	}
+}
+
+func TestParseCodexUA(t *testing.T) {
+	cases := []struct {
+		ua          string
+		wantVersion string
+		wantOS      string
+	}{
+		{"codex_cli_rs/0.130.0 (Darwin 24.4.0; arm64)", "0.130.0", "Darwin"},
+		{"codex_cli_rs/0.128.0 (Linux 6.5.0-15-generic; x86_64)", "0.128.0", "Linux"},
+		{"codex/0.131.1 (Windows NT 10.0; x64)", "0.131.1", "Windows"},
+		{"curl/7.88.1", "", ""},
+		{"", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.ua, func(t *testing.T) {
+			v, o := ParseCodexUA(tc.ua)
+			if v != tc.wantVersion {
+				t.Errorf("version: got %q want %q", v, tc.wantVersion)
+			}
+			if o != tc.wantOS {
+				t.Errorf("os: got %q want %q", o, tc.wantOS)
+			}
+		})
+	}
+}
+
+// Sanity: ClientIP with a totally empty request never panics.
+func TestClientIP_EmptyRequest(t *testing.T) {
+	r, _ := http.NewRequest("GET", "/", nil)
+	r.RemoteAddr = ""
+	if got := ClientIP(r); got != "" {
+		t.Errorf("want empty, got %q", got)
+	}
+}

--- a/internal/codexappgateway/auth/auth.go
+++ b/internal/codexappgateway/auth/auth.go
@@ -32,6 +32,15 @@ type Authenticator interface {
 	Verify(ctx context.Context, token string) (Identity, error)
 }
 
+// SessionTracker is an optional capability for Authenticator implementations
+// that also record per-connection sessions (RemoteVerifier does, HMAC does
+// not). The handler in CXG type-asserts and prefers OpenSession when
+// available so the Browsers panel can show live online state + client info.
+type SessionTracker interface {
+	OpenSession(ctx context.Context, token, clientIP, clientUA, codexVersion, osStr string) (Identity, string, error)
+	CloseSession(ctx context.Context, sessionID string) error
+}
+
 // HMAC is the phase-1 Authenticator.
 type HMAC struct{ secret []byte }
 

--- a/internal/codexappgateway/auth/remote_verifier.go
+++ b/internal/codexappgateway/auth/remote_verifier.go
@@ -82,3 +82,75 @@ func (v *RemoteVerifier) Verify(ctx context.Context, token string) (Identity, er
 	}
 	return Identity{UserID: out.UserID, WorkspaceID: out.WorkspaceID}, nil
 }
+
+// OpenSession verifies the token AND inserts a browser-session row in
+// codex_browser_sessions, returning the session id so the caller can close
+// it on ws disconnect. Implements auth.SessionTracker.
+func (v *RemoteVerifier) OpenSession(ctx context.Context, token, clientIP, clientUA, codexVersion, osStr string) (Identity, string, error) {
+	body, err := json.Marshal(map[string]string{
+		"token":         token,
+		"client_ip":     clientIP,
+		"client_ua":     clientUA,
+		"codex_version": codexVersion,
+		"os":            osStr,
+	})
+	if err != nil {
+		return Identity{}, "", fmt.Errorf("marshal session-open body: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, v.baseURL+"/api/internal/codex/tokens/session-open", bytes.NewReader(body))
+	if err != nil {
+		return Identity{}, "", fmt.Errorf("build session-open request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Internal-Secret", v.bearer)
+	resp, err := v.httpClient.Do(req)
+	if err != nil {
+		return Identity{}, "", fmt.Errorf("session-open call: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusUnauthorized {
+		return Identity{}, "", ErrUnauthorized
+	}
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return Identity{}, "", fmt.Errorf("session-open call: status=%d body=%q", resp.StatusCode, b)
+	}
+	var out struct {
+		UserID      string `json:"user_id"`
+		WorkspaceID string `json:"workspace_id"`
+		SessionID   string `json:"session_id"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return Identity{}, "", fmt.Errorf("decode session-open response: %w", err)
+	}
+	return Identity{UserID: out.UserID, WorkspaceID: out.WorkspaceID}, out.SessionID, nil
+}
+
+// CloseSession stamps disconnected_at on the row. Best-effort — callers
+// invoke from a deferred goroutine with a short bg ctx so the ws close
+// path is never blocked on it. Implements auth.SessionTracker.
+func (v *RemoteVerifier) CloseSession(ctx context.Context, sessionID string) error {
+	if sessionID == "" {
+		return nil
+	}
+	body, err := json.Marshal(map[string]string{"session_id": sessionID})
+	if err != nil {
+		return fmt.Errorf("marshal session-close body: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, v.baseURL+"/api/internal/codex/tokens/session-close", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build session-close request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Internal-Secret", v.bearer)
+	resp, err := v.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("session-close call: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNoContent && resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("session-close call: status=%d body=%q", resp.StatusCode, b)
+	}
+	return nil
+}

--- a/internal/codexappgateway/server.go
+++ b/internal/codexappgateway/server.go
@@ -16,6 +16,7 @@ import (
 	"github.com/agentserver/agentserver/internal/codexappgateway/oplog"
 	"github.com/agentserver/agentserver/internal/codexappgateway/supervisor"
 	"github.com/agentserver/agentserver/internal/codexexecgateway/execmodel"
+	"github.com/agentserver/agentserver/internal/clientmeta"
 	"github.com/agentserver/agentserver/internal/shortid"
 	"github.com/agentserver/agentserver/internal/wsbridge"
 
@@ -287,11 +288,42 @@ func (s *Server) handleCodexAppWS(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "missing Bearer", http.StatusUnauthorized)
 		return
 	}
-	id, err := s.auth.Verify(r.Context(), tok)
+
+	// Prefer OpenSession when the authenticator supports it (RemoteVerifier
+	// in production). HMAC (local-test only) falls through to plain Verify
+	// and leaves sessionID empty so the deferred close is a no-op.
+	clientIP := clientmeta.ClientIP(r)
+	clientUA := r.Header.Get("User-Agent")
+	codexVersion, osStr := clientmeta.ParseCodexUA(clientUA)
+	var (
+		id        auth.Identity
+		sessionID string
+		err       error
+	)
+	if tracker, ok := s.auth.(auth.SessionTracker); ok {
+		id, sessionID, err = tracker.OpenSession(r.Context(), tok, clientIP, clientUA, codexVersion, osStr)
+	} else {
+		id, err = s.auth.Verify(r.Context(), tok)
+	}
 	if err != nil {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
+	if sessionID != "" {
+		// Close session in the background — must not block ws shutdown.
+		defer func() {
+			go func(sid string) {
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				if tracker, ok := s.auth.(auth.SessionTracker); ok {
+					if cerr := tracker.CloseSession(ctx, sid); cerr != nil {
+						s.logger.Warn("close session", "err", cerr, "session", sid)
+					}
+				}
+			}(sessionID)
+		}()
+	}
+
 	userWS, err := websocket.Accept(w, r, nil)
 	if err != nil {
 		s.logger.Warn("ws accept failed", "err", err)

--- a/internal/codexexecgateway/execmodel/types.go
+++ b/internal/codexexecgateway/execmodel/types.go
@@ -7,14 +7,27 @@ package execmodel
 import "time"
 
 // Executor is the persistent identity of a codex-exec node.
+//
+// IsOnline reflects in-memory ConnRegistry membership at the moment the row
+// was assembled — it is NOT a column. ClientIP/UA/CodexVersion/OS and the
+// connected_at/disconnected_at pair are overwritten on each new inbound
+// connect; LastSeenAt is kept for back-compat callers but is no longer
+// touched on disconnect (use DisconnectedAt instead).
 type Executor struct {
-	ExeID        string     `json:"exe_id"`
-	UserID       string     `json:"user_id"`
-	DisplayName  string     `json:"display_name,omitempty"`
-	Description  string     `json:"description,omitempty"`
-	DefaultCwd   string     `json:"default_cwd,omitempty"`
-	RegisteredAt time.Time  `json:"registered_at"`
-	LastSeenAt   *time.Time `json:"last_seen_at,omitempty"`
+	ExeID          string     `json:"exe_id"`
+	UserID         string     `json:"user_id"`
+	DisplayName    string     `json:"display_name,omitempty"`
+	Description    string     `json:"description,omitempty"`
+	DefaultCwd     string     `json:"default_cwd,omitempty"`
+	RegisteredAt   time.Time  `json:"registered_at"`
+	LastSeenAt     *time.Time `json:"last_seen_at,omitempty"`
+	ClientIP       string     `json:"client_ip,omitempty"`
+	ClientUA       string     `json:"client_ua,omitempty"`
+	CodexVersion   string     `json:"codex_version,omitempty"`
+	OS             string     `json:"os,omitempty"`
+	ConnectedAt    *time.Time `json:"connected_at,omitempty"`
+	DisconnectedAt *time.Time `json:"disconnected_at,omitempty"`
+	IsOnline       bool       `json:"is_online"`
 }
 
 // WorkspaceExecutor is a row in workspace_executors. Name is the
@@ -34,10 +47,21 @@ type WorkspaceExecutor struct {
 // and /api/exec-gateway/connected endpoints. ExeID is still present
 // (env-mcp uses it to dial /bridge and our internal routing keys by
 // it) but LLM-facing payloads omit it.
+//
+// The client-info fields mirror Executor and let the workspace UI render
+// IP / OS / codex version without a second roundtrip. IsOnline is set by
+// the SDK adapter from the live ConnRegistry, not the DB.
 type ConnectedExecutor struct {
-	ExeID       string     `json:"exe_id"`
-	Name        string     `json:"name"`
-	Description string     `json:"description"`
-	IsDefault   bool       `json:"is_default"`
-	LastSeenAt  *time.Time `json:"last_seen_at,omitempty"`
+	ExeID          string     `json:"exe_id"`
+	Name           string     `json:"name"`
+	Description    string     `json:"description"`
+	IsDefault      bool       `json:"is_default"`
+	LastSeenAt     *time.Time `json:"last_seen_at,omitempty"`
+	ClientIP       string     `json:"client_ip,omitempty"`
+	ClientUA       string     `json:"client_ua,omitempty"`
+	CodexVersion   string     `json:"codex_version,omitempty"`
+	OS             string     `json:"os,omitempty"`
+	ConnectedAt    *time.Time `json:"connected_at,omitempty"`
+	DisconnectedAt *time.Time `json:"disconnected_at,omitempty"`
+	IsOnline       bool       `json:"is_online"`
 }

--- a/internal/codexexecgateway/handlers/workspace_binding.go
+++ b/internal/codexexecgateway/handlers/workspace_binding.go
@@ -16,6 +16,11 @@ type BindingStore interface {
 	ListWorkspaceExecutors(ctx context.Context, workspaceID string) ([]execmodel.ConnectedExecutor, error)
 }
 
+// OnlineSet reports whether an exe_id has a live inbound ws right now. The
+// gateway's ConnRegistry satisfies this via a tiny adapter in server.go.
+// Defined here as a func type so the handler stays loosely coupled.
+type OnlineSet func() map[string]struct{}
+
 type bindRequest struct {
 	ExeID       string `json:"exe_id"`
 	Name        string `json:"name"`
@@ -63,8 +68,10 @@ func DeleteBinding(store BindingStore) http.HandlerFunc {
 	}
 }
 
-// ListBinding returns an http.HandlerFunc that lists all executors bound to a workspace.
-func ListBinding(store BindingStore) http.HandlerFunc {
+// ListBinding returns an http.HandlerFunc that lists all executors bound to a
+// workspace, annotated with IsOnline from the live registry so the UI doesn't
+// have to guess from last_seen_at.
+func ListBinding(store BindingStore, online OnlineSet) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		wid := chi.URLParam(r, "wid")
 		rows, err := store.ListWorkspaceExecutors(r.Context(), wid)
@@ -74,6 +81,16 @@ func ListBinding(store BindingStore) http.HandlerFunc {
 		}
 		if rows == nil {
 			rows = []execmodel.ConnectedExecutor{}
+		}
+		var onlineIDs map[string]struct{}
+		if online != nil {
+			onlineIDs = online()
+		}
+		for i := range rows {
+			if onlineIDs != nil {
+				_, ok := onlineIDs[rows[i].ExeID]
+				rows[i].IsOnline = ok
+			}
 		}
 		writeJSON(w, http.StatusOK, rows)
 	}

--- a/internal/codexexecgateway/inbound.go
+++ b/internal/codexexecgateway/inbound.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/agentserver/agentserver/internal/clientmeta"
 	"github.com/agentserver/agentserver/internal/relaypb"
 	"github.com/agentserver/agentserver/internal/wsbridge"
 	"github.com/go-chi/chi/v5"
@@ -58,10 +59,13 @@ func (s *Server) handleInbound(w http.ResponseWriter, r *http.Request) {
 		s.logger.Info("inbound: evicted prior conn", "exe_id", exeID)
 		evicted.close(nil)
 	}
-	if err := s.store.UpdateLastSeen(r.Context(), exeID); err != nil {
-		s.logger.Warn("inbound: update last_seen", "exe_id", exeID, "error", err)
+	clientIP := clientmeta.ClientIP(r)
+	clientUA := r.Header.Get("User-Agent")
+	codexVersion, osStr := clientmeta.ParseCodexUA(clientUA)
+	if err := s.store.MarkConnected(r.Context(), exeID, clientIP, clientUA, codexVersion, osStr); err != nil {
+		s.logger.Warn("inbound: mark connected", "exe_id", exeID, "error", err)
 	}
-	s.logger.Info("inbound: connected", "exe_id", exeID)
+	s.logger.Info("inbound: connected", "exe_id", exeID, "ip", clientIP, "ua", clientUA)
 
 	// 30s ws PING (control frame) is layered on TCP keepalive (15s) for
 	// middlebox idle-kill resistance.
@@ -78,8 +82,8 @@ func (s *Server) handleInbound(w http.ResponseWriter, r *http.Request) {
 	s.registry.Unregister(exeID, ic)
 	ic.close(nil)
 	bg := context.Background()
-	if err := s.store.UpdateLastSeen(bg, exeID); err != nil {
-		s.logger.Warn("inbound: final last_seen", "exe_id", exeID, "error", err)
+	if err := s.store.MarkDisconnected(bg, exeID); err != nil {
+		s.logger.Warn("inbound: mark disconnected", "exe_id", exeID, "error", err)
 	}
 	s.logger.Info("inbound: disconnected", "exe_id", exeID)
 }

--- a/internal/codexexecgateway/migrations/003_executor_client_info.sql
+++ b/internal/codexexecgateway/migrations/003_executor_client_info.sql
@@ -1,0 +1,14 @@
+-- Add client-info columns captured on each inbound /inbound/{exe_id} connect.
+-- These power the Connectors UI's IP / OS / codex-version / online-status columns
+-- and replace the old "last_seen_at < 90s" frontend heuristic.
+--
+-- last_seen_at is kept for back-compat but no longer touched on disconnect; the
+-- new connected_at / disconnected_at pair is the source of truth for "currently
+-- online" + "when did this last fall offline".
+ALTER TABLE executors
+    ADD COLUMN IF NOT EXISTS client_ip       TEXT,
+    ADD COLUMN IF NOT EXISTS client_ua       TEXT,
+    ADD COLUMN IF NOT EXISTS codex_version   TEXT,
+    ADD COLUMN IF NOT EXISTS os              TEXT,
+    ADD COLUMN IF NOT EXISTS connected_at    TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS disconnected_at TIMESTAMPTZ;

--- a/internal/codexexecgateway/sdk_adapter.go
+++ b/internal/codexexecgateway/sdk_adapter.go
@@ -42,3 +42,25 @@ func (a sdkConnectedAdapter) Connected(ctx context.Context, wsID string) ([]sdkp
 	}
 	return out, nil
 }
+
+// ListWorkspaceWithLive returns every executor bound to wsID with IsOnline
+// set from the live in-memory ConnRegistry — distinct from the SDK adapter
+// above, which only returns the intersection (codex env-mcp callers want
+// online-only). The /workspaces/{wsID}/executors UI endpoint uses this so
+// offline executors stay visible in the Connectors table with their last
+// disconnect time.
+func (a sdkConnectedAdapter) ListWorkspaceWithLive(ctx context.Context, wsID string) ([]ConnectedExecutor, error) {
+	rows, err := a.store.ListWorkspaceExecutors(ctx, wsID)
+	if err != nil {
+		return nil, err
+	}
+	connSet := make(map[string]struct{})
+	for _, id := range a.registry.ConnectedIDs() {
+		connSet[id] = struct{}{}
+	}
+	for i := range rows {
+		_, ok := connSet[rows[i].ExeID]
+		rows[i].IsOnline = ok
+	}
+	return rows, nil
+}

--- a/internal/codexexecgateway/server.go
+++ b/internal/codexexecgateway/server.go
@@ -187,7 +187,14 @@ func (s *Server) Routes() http.Handler {
 		r.Delete("/executors/{exe_id}", handlers.DeleteExecutor(s.store))
 		r.Route("/workspaces/{wid}/executors", func(r chi.Router) {
 			r.Post("/", handlers.PostBinding(s.store))
-			r.Get("/", handlers.ListBinding(s.store))
+			r.Get("/", handlers.ListBinding(s.store, func() map[string]struct{} {
+				ids := s.registry.ConnectedIDs()
+				set := make(map[string]struct{}, len(ids))
+				for _, id := range ids {
+					set[id] = struct{}{}
+				}
+				return set
+			}))
 			r.Delete("/{exe_id}", handlers.DeleteBinding(s.store))
 		})
 	})

--- a/internal/codexexecgateway/store.go
+++ b/internal/codexexecgateway/store.go
@@ -105,12 +105,19 @@ func (s *Store) GetExecutor(ctx context.Context, exeID string) (*Executor, error
 		       COALESCE(display_name, ''),
 		       COALESCE(description, ''),
 		       COALESCE(default_cwd, ''),
-		       registered_at, last_seen_at
+		       registered_at, last_seen_at,
+		       COALESCE(client_ip, ''),
+		       COALESCE(client_ua, ''),
+		       COALESCE(codex_version, ''),
+		       COALESCE(os, ''),
+		       connected_at, disconnected_at
 		FROM executors WHERE exe_id=$1`, exeID)
 	var e Executor
-	var lastSeen sql.NullTime
+	var lastSeen, connectedAt, disconnectedAt sql.NullTime
 	err := row.Scan(&e.ExeID, &e.UserID, &e.DisplayName, &e.Description, &e.DefaultCwd,
-		&e.RegisteredAt, &lastSeen)
+		&e.RegisteredAt, &lastSeen,
+		&e.ClientIP, &e.ClientUA, &e.CodexVersion, &e.OS,
+		&connectedAt, &disconnectedAt)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -120,6 +127,14 @@ func (s *Store) GetExecutor(ctx context.Context, exeID string) (*Executor, error
 	if lastSeen.Valid {
 		t := lastSeen.Time
 		e.LastSeenAt = &t
+	}
+	if connectedAt.Valid {
+		t := connectedAt.Time
+		e.ConnectedAt = &t
+	}
+	if disconnectedAt.Valid {
+		t := disconnectedAt.Time
+		e.DisconnectedAt = &t
 	}
 	return &e, nil
 }
@@ -139,10 +154,49 @@ func (s *Store) GetRegistrationTokenHash(ctx context.Context, exeID string) (str
 }
 
 // UpdateLastSeen sets the last_seen_at timestamp to NOW().
+//
+// Kept for callers that just want to register liveness without metadata.
+// Inbound connect/disconnect now use MarkConnected / MarkDisconnected so
+// the UI can distinguish "currently online" from "last seen at".
 func (s *Store) UpdateLastSeen(ctx context.Context, exeID string) error {
 	_, err := s.db.ExecContext(ctx, `UPDATE executors SET last_seen_at=NOW() WHERE exe_id=$1`, exeID)
 	if err != nil {
 		return fmt.Errorf("update last_seen: %w", err)
+	}
+	return nil
+}
+
+// MarkConnected records a new inbound ws connect: bumps last_seen_at and
+// connected_at to NOW(), clears disconnected_at, and overwrites the
+// client-info columns. Empty strings for codexVersion / os are stored as
+// NULL so the UI can render "—" without further mapping.
+func (s *Store) MarkConnected(ctx context.Context, exeID, clientIP, clientUA, codexVersion, osStr string) error {
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE executors
+		   SET last_seen_at    = NOW(),
+		       connected_at    = NOW(),
+		       disconnected_at = NULL,
+		       client_ip       = NULLIF($2, ''),
+		       client_ua       = NULLIF($3, ''),
+		       codex_version   = NULLIF($4, ''),
+		       os              = NULLIF($5, '')
+		 WHERE exe_id = $1`,
+		exeID, clientIP, clientUA, codexVersion, osStr)
+	if err != nil {
+		return fmt.Errorf("mark connected: %w", err)
+	}
+	return nil
+}
+
+// MarkDisconnected records ws close: sets disconnected_at to NOW() but does
+// NOT bump last_seen_at — that field's job is "last evidence of life from
+// the executor", and the disconnect event isn't evidence. Without this fix
+// the frontend's old `last_seen_at < 90s` heuristic kept freshly-offline
+// executors as Online for 90s.
+func (s *Store) MarkDisconnected(ctx context.Context, exeID string) error {
+	_, err := s.db.ExecContext(ctx, `UPDATE executors SET disconnected_at=NOW() WHERE exe_id=$1`, exeID)
+	if err != nil {
+		return fmt.Errorf("mark disconnected: %w", err)
 	}
 	return nil
 }
@@ -217,7 +271,13 @@ func (s *Store) ListWorkspaceExecutors(ctx context.Context, workspaceID string) 
 		       we.name,
 		       COALESCE(we.description, ''),
 		       we.is_default,
-		       e.last_seen_at
+		       e.last_seen_at,
+		       COALESCE(e.client_ip, ''),
+		       COALESCE(e.client_ua, ''),
+		       COALESCE(e.codex_version, ''),
+		       COALESCE(e.os, ''),
+		       e.connected_at,
+		       e.disconnected_at
 		FROM workspace_executors we
 		JOIN executors e ON e.exe_id = we.exe_id
 		WHERE we.workspace_id = $1
@@ -229,13 +289,23 @@ func (s *Store) ListWorkspaceExecutors(ctx context.Context, workspaceID string) 
 	var out []ConnectedExecutor
 	for rows.Next() {
 		var c ConnectedExecutor
-		var lastSeen sql.NullTime
-		if err := rows.Scan(&c.ExeID, &c.Name, &c.Description, &c.IsDefault, &lastSeen); err != nil {
+		var lastSeen, connectedAt, disconnectedAt sql.NullTime
+		if err := rows.Scan(&c.ExeID, &c.Name, &c.Description, &c.IsDefault, &lastSeen,
+			&c.ClientIP, &c.ClientUA, &c.CodexVersion, &c.OS,
+			&connectedAt, &disconnectedAt); err != nil {
 			return nil, err
 		}
 		if lastSeen.Valid {
 			t := lastSeen.Time
 			c.LastSeenAt = &t
+		}
+		if connectedAt.Valid {
+			t := connectedAt.Time
+			c.ConnectedAt = &t
+		}
+		if disconnectedAt.Valid {
+			t := disconnectedAt.Time
+			c.DisconnectedAt = &t
 		}
 		out = append(out, c)
 	}

--- a/internal/db/codex_browser_sessions.go
+++ b/internal/db/codex_browser_sessions.go
@@ -1,0 +1,109 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// CodexBrowserSession is a single live (or historical) `codex --remote` ws
+// connection. The row is inserted by CXG on ws accept and stamped with
+// disconnected_at on ws close. Multiple concurrent rows per token_id are
+// supported — a token can be used from N machines simultaneously.
+type CodexBrowserSession struct {
+	ID             string
+	TokenID        string
+	ClientIP       string
+	ClientUA       string
+	CodexVersion   string
+	OS             string
+	ConnectedAt    time.Time
+	DisconnectedAt *time.Time
+}
+
+// CreateCodexBrowserSession inserts a new session row. The caller supplies
+// the id (cryptographic random, namespaced separately from token ids so a
+// leaked session id can't be confused with a token).
+func (db *DB) CreateCodexBrowserSession(ctx context.Context, s CodexBrowserSession) error {
+	_, err := db.ExecContext(ctx, `
+		INSERT INTO codex_browser_sessions
+		    (id, token_id, client_ip, client_ua, codex_version, os, connected_at)
+		VALUES ($1, $2, NULLIF($3,''), NULLIF($4,''), NULLIF($5,''), NULLIF($6,''), NOW())`,
+		s.ID, s.TokenID, s.ClientIP, s.ClientUA, s.CodexVersion, s.OS)
+	if err != nil {
+		return fmt.Errorf("insert codex_browser_sessions: %w", err)
+	}
+	return nil
+}
+
+// CloseCodexBrowserSession stamps disconnected_at. Idempotent: a missing or
+// already-closed row is a no-op.
+func (db *DB) CloseCodexBrowserSession(ctx context.Context, id string) error {
+	_, err := db.ExecContext(ctx, `
+		UPDATE codex_browser_sessions
+		   SET disconnected_at = NOW()
+		 WHERE id = $1 AND disconnected_at IS NULL`, id)
+	if err != nil {
+		return fmt.Errorf("close codex_browser_sessions: %w", err)
+	}
+	return nil
+}
+
+// SweepStaleCodexBrowserSessions marks any session connected before olderThan
+// and not yet closed as disconnected. Called from CXG startup so rows from
+// a crashed previous CXG pod don't leak forever as "online".
+func (db *DB) SweepStaleCodexBrowserSessions(ctx context.Context, olderThan time.Time) (int64, error) {
+	res, err := db.ExecContext(ctx, `
+		UPDATE codex_browser_sessions
+		   SET disconnected_at = NOW()
+		 WHERE disconnected_at IS NULL AND connected_at < $1`, olderThan)
+	if err != nil {
+		return 0, fmt.Errorf("sweep codex_browser_sessions: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	return n, nil
+}
+
+// LatestCodexBrowserSession returns the most recent session for a token (open
+// if any, otherwise the latest historical one), or (nil, nil) if the token
+// has never been used.
+func (db *DB) LatestCodexBrowserSession(ctx context.Context, tokenID string) (*CodexBrowserSession, error) {
+	row := db.QueryRowContext(ctx, `
+		SELECT id, token_id,
+		       COALESCE(client_ip, ''), COALESCE(client_ua, ''),
+		       COALESCE(codex_version, ''), COALESCE(os, ''),
+		       connected_at, disconnected_at
+		  FROM codex_browser_sessions
+		 WHERE token_id = $1
+		 ORDER BY (disconnected_at IS NULL) DESC, connected_at DESC
+		 LIMIT 1`, tokenID)
+	var s CodexBrowserSession
+	var disconnected sql.NullTime
+	if err := row.Scan(&s.ID, &s.TokenID, &s.ClientIP, &s.ClientUA,
+		&s.CodexVersion, &s.OS, &s.ConnectedAt, &disconnected); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("scan codex_browser_sessions: %w", err)
+	}
+	if disconnected.Valid {
+		t := disconnected.Time
+		s.DisconnectedAt = &t
+	}
+	return &s, nil
+}
+
+// CountOpenCodexBrowserSessions returns the number of open (disconnected_at IS
+// NULL) sessions for a token. Used by the Browsers list endpoint to set
+// is_online without iterating all rows.
+func (db *DB) CountOpenCodexBrowserSessions(ctx context.Context, tokenID string) (int, error) {
+	var n int
+	err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM codex_browser_sessions WHERE token_id = $1 AND disconnected_at IS NULL`,
+		tokenID).Scan(&n)
+	if err != nil {
+		return 0, fmt.Errorf("count codex_browser_sessions: %w", err)
+	}
+	return n, nil
+}

--- a/internal/db/migrations/026_codex_browser_sessions.sql
+++ b/internal/db/migrations/026_codex_browser_sessions.sql
@@ -1,0 +1,25 @@
+-- Per-connection record for each `codex --remote` ws session against
+-- codex-app-gateway. One token can be used by many machines concurrently;
+-- each ws open inserts a row, ws close stamps disconnected_at, and the
+-- workspace UI's Browsers panel joins these to render IP / OS / codex
+-- version / online status per token.
+CREATE TABLE IF NOT EXISTS codex_browser_sessions (
+    id              TEXT PRIMARY KEY,
+    token_id        TEXT NOT NULL REFERENCES codex_remote_tokens(id) ON DELETE CASCADE,
+    client_ip       TEXT,
+    client_ua       TEXT,
+    codex_version   TEXT,
+    os              TEXT,
+    connected_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    disconnected_at TIMESTAMPTZ
+);
+
+-- Hot index: list-open-sessions-for-token. Partial so it doesn't bloat
+-- with the long historical tail of disconnected sessions.
+CREATE INDEX IF NOT EXISTS idx_codex_browser_sessions_token_open
+    ON codex_browser_sessions(token_id)
+    WHERE disconnected_at IS NULL;
+
+-- Lookup index for the "latest session for token" join (online or recent).
+CREATE INDEX IF NOT EXISTS idx_codex_browser_sessions_token_connected
+    ON codex_browser_sessions(token_id, connected_at DESC);

--- a/internal/server/codex_browser_sessions_internal.go
+++ b/internal/server/codex_browser_sessions_internal.go
@@ -1,0 +1,130 @@
+package server
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"encoding/json"
+	"log"
+	"net/http"
+	"time"
+
+	"golang.org/x/crypto/bcrypt"
+
+	"github.com/agentserver/agentserver/internal/db"
+)
+
+// sessionOpenReq is what CXG POSTs to /api/internal/codex/tokens/session-open
+// when a `codex --remote` ws connection is accepted. The bearer token is
+// re-verified (same bcrypt + expiry + revocation checks as Verify) so a
+// malicious or buggy CXG can't fabricate sessions for arbitrary token ids.
+type sessionOpenReq struct {
+	Token        string `json:"token"`
+	ClientIP     string `json:"client_ip,omitempty"`
+	ClientUA     string `json:"client_ua,omitempty"`
+	CodexVersion string `json:"codex_version,omitempty"`
+	OS           string `json:"os,omitempty"`
+}
+
+type sessionOpenResp struct {
+	UserID      string `json:"user_id"`
+	WorkspaceID string `json:"workspace_id"`
+	SessionID   string `json:"session_id"`
+}
+
+// handleCodexSessionOpen verifies the token, inserts a new browser-session
+// row, and returns the session id so CXG can call session-close on ws
+// disconnect.
+func (s *Server) handleCodexSessionOpen(w http.ResponseWriter, r *http.Request) {
+	var req sessionOpenReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeVerifyUnauthorized(w)
+		return
+	}
+	id, secret, err := parseCodexToken(req.Token)
+	if err != nil {
+		writeVerifyUnauthorized(w)
+		return
+	}
+	row, err := s.DB.GetCodexToken(r.Context(), id)
+	if err != nil || row == nil {
+		writeVerifyUnauthorized(w)
+		return
+	}
+	if err := bcrypt.CompareHashAndPassword([]byte(row.TokenHash), []byte(secret)); err != nil {
+		writeVerifyUnauthorized(w)
+		return
+	}
+	if row.RevokedAt != nil || time.Now().UTC().After(row.ExpiresAt) {
+		writeVerifyUnauthorized(w)
+		return
+	}
+
+	sessionID, err := newSessionID()
+	if err != nil {
+		log.Printf("session-open: gen id: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	if err := s.DB.CreateCodexBrowserSession(r.Context(), db.CodexBrowserSession{
+		ID:           sessionID,
+		TokenID:      row.ID,
+		ClientIP:     req.ClientIP,
+		ClientUA:     req.ClientUA,
+		CodexVersion: req.CodexVersion,
+		OS:           req.OS,
+	}); err != nil {
+		log.Printf("session-open: insert: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+
+	// Best-effort touch on the parent token row so existing UI keeps showing
+	// "last used" updates.
+	go func(tid string) {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		if err := s.DB.TouchCodexToken(ctx, tid); err != nil {
+			log.Printf("session-open: touch %s: %v", tid, err)
+		}
+	}(row.ID)
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(sessionOpenResp{
+		UserID:      row.UserID,
+		WorkspaceID: row.WorkspaceID,
+		SessionID:   sessionID,
+	})
+}
+
+type sessionCloseReq struct {
+	SessionID string `json:"session_id"`
+}
+
+// handleCodexSessionClose stamps disconnected_at on the row. Idempotent.
+// Auth: X-Internal-Secret (same as the other internal endpoints) so any
+// agentserver-pod-local caller can close — no per-session capability is
+// needed, the session_id itself is unguessable.
+func (s *Server) handleCodexSessionClose(w http.ResponseWriter, r *http.Request) {
+	var req sessionCloseReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.SessionID == "" {
+		http.Error(w, "session_id required", http.StatusBadRequest)
+		return
+	}
+	if err := s.DB.CloseCodexBrowserSession(r.Context(), req.SessionID); err != nil {
+		log.Printf("session-close: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// newSessionID returns an unguessable 128-bit hex id, prefixed so a leak
+// can't be mistaken for a codex token (which start with "cxt_").
+func newSessionID() (string, error) {
+	var b [16]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return "cbs_" + hex.EncodeToString(b[:]), nil
+}

--- a/internal/server/codex_browser_sessions_internal_test.go
+++ b/internal/server/codex_browser_sessions_internal_test.go
@@ -1,0 +1,102 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// Integration test: requires TEST_DATABASE_URL (skipped otherwise).
+// Verifies session-open returns a valid session id, sets metadata on
+// the row, and session-close marks it disconnected.
+func TestHandleCodexSession_OpenThenClose(t *testing.T) {
+	srv, d := newCodexTokensTestServer(t)
+	mintRow(t, d, "abc12345", "supersecret", "u1", "ws_a", time.Now().Add(time.Hour), nil)
+
+	body := bytes.NewReader([]byte(`{
+        "token": "ast_abc12345_supersecret",
+        "client_ip": "203.0.113.7",
+        "client_ua": "codex_cli_rs/0.130.0 (Darwin 24.4.0; arm64)",
+        "codex_version": "0.130.0",
+        "os": "Darwin"
+    }`))
+	req := httptest.NewRequest(http.MethodPost, "/api/internal/codex/tokens/session-open", body)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	srv.handleCodexSessionOpen(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("open status = %d body=%s", rr.Code, rr.Body.String())
+	}
+	var openResp sessionOpenResp
+	if err := json.Unmarshal(rr.Body.Bytes(), &openResp); err != nil {
+		t.Fatalf("decode open: %v", err)
+	}
+	if openResp.SessionID == "" || openResp.UserID != "u1" || openResp.WorkspaceID != "ws_a" {
+		t.Fatalf("open resp = %+v", openResp)
+	}
+
+	// Row exists with metadata + no disconnected_at.
+	latest, err := d.LatestCodexBrowserSession(context.Background(), "abc12345")
+	if err != nil {
+		t.Fatalf("latest: %v", err)
+	}
+	if latest == nil || latest.DisconnectedAt != nil {
+		t.Fatalf("expected open session, got %+v", latest)
+	}
+	if latest.ClientIP != "203.0.113.7" || latest.CodexVersion != "0.130.0" || latest.OS != "Darwin" {
+		t.Fatalf("metadata not stored: %+v", latest)
+	}
+	openCount, _ := d.CountOpenCodexBrowserSessions(context.Background(), "abc12345")
+	if openCount != 1 {
+		t.Fatalf("open count = %d want 1", openCount)
+	}
+
+	// Close it.
+	closeBody := bytes.NewReader([]byte(`{"session_id":"` + openResp.SessionID + `"}`))
+	closeReq := httptest.NewRequest(http.MethodPost, "/api/internal/codex/tokens/session-close", closeBody)
+	closeReq.Header.Set("Content-Type", "application/json")
+	closeRR := httptest.NewRecorder()
+	srv.handleCodexSessionClose(closeRR, closeReq)
+	if closeRR.Code != http.StatusNoContent {
+		t.Fatalf("close status = %d body=%s", closeRR.Code, closeRR.Body.String())
+	}
+
+	openCount, _ = d.CountOpenCodexBrowserSessions(context.Background(), "abc12345")
+	if openCount != 0 {
+		t.Fatalf("open count after close = %d want 0", openCount)
+	}
+}
+
+// Session-open with bad secret must 401 — guards against a malicious or
+// buggy CXG forging sessions for token ids it doesn't actually hold.
+func TestHandleCodexSessionOpen_BadSecret_401(t *testing.T) {
+	srv, d := newCodexTokensTestServer(t)
+	mintRow(t, d, "abc12345", "rightsecret", "u1", "ws_a", time.Now().Add(time.Hour), nil)
+	body := bytes.NewReader([]byte(`{"token":"ast_abc12345_wrongsecret"}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/internal/codex/tokens/session-open", body)
+	rr := httptest.NewRecorder()
+	srv.handleCodexSessionOpen(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	openCount, _ := d.CountOpenCodexBrowserSessions(context.Background(), "abc12345")
+	if openCount != 0 {
+		t.Fatalf("session leaked on bad secret: count=%d", openCount)
+	}
+}
+
+// Closing an unknown session id must be a clean no-op (idempotent).
+func TestHandleCodexSessionClose_MissingIsNoOp(t *testing.T) {
+	srv, _ := newCodexTokensTestServer(t)
+	body := bytes.NewReader([]byte(`{"session_id":"cbs_nonexistent"}`))
+	req := httptest.NewRequest(http.MethodPost, "/api/internal/codex/tokens/session-close", body)
+	rr := httptest.NewRecorder()
+	srv.handleCodexSessionClose(rr, req)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d body=%s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/server/codex_browsers.go
+++ b/internal/server/codex_browsers.go
@@ -1,0 +1,73 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/go-chi/chi/v5"
+)
+
+// codexBrowser is the per-row payload of GET /api/workspaces/{wid}/browsers.
+// Shape mirrors RemoteExecutor (the Connectors panel) so the frontend can
+// render both with the same DeviceListPanel component.
+//
+// IsOnline = there is at least one open codex_browser_session for this token.
+// ClientIP / ClientUA / CodexVersion / OS / ConnectedAt / DisconnectedAt all
+// come from the latest session (open if any, otherwise the most recent
+// historical row).
+type codexBrowser struct {
+	ID             string     `json:"id"`
+	Name           string     `json:"name"`
+	WorkspaceID    string     `json:"workspace_id"`
+	CreatedAt      time.Time  `json:"created_at"`
+	ExpiresAt      time.Time  `json:"expires_at"`
+	LastUsedAt     *time.Time `json:"last_used_at,omitempty"`
+	IsOnline       bool       `json:"is_online"`
+	ClientIP       string     `json:"client_ip,omitempty"`
+	ClientUA       string     `json:"client_ua,omitempty"`
+	CodexVersion   string     `json:"codex_version,omitempty"`
+	OS             string     `json:"os,omitempty"`
+	ConnectedAt    *time.Time `json:"connected_at,omitempty"`
+	DisconnectedAt *time.Time `json:"disconnected_at,omitempty"`
+}
+
+// handleListCodexBrowsers returns one row per non-revoked codex token for
+// the workspace, annotated with live session info from
+// codex_browser_sessions. Auth: any workspace member.
+func (s *Server) handleListCodexBrowsers(w http.ResponseWriter, r *http.Request) {
+	wid := chi.URLParam(r, "wid")
+	if _, ok := s.requireWorkspaceMember(w, r, wid); !ok {
+		return
+	}
+	tokens, err := s.DB.ListCodexTokensForWorkspace(r.Context(), wid, false)
+	if err != nil {
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	out := make([]codexBrowser, 0, len(tokens))
+	for _, t := range tokens {
+		row := codexBrowser{
+			ID: t.ID, Name: t.Name, WorkspaceID: t.WorkspaceID,
+			CreatedAt: t.CreatedAt, ExpiresAt: t.ExpiresAt, LastUsedAt: t.LastUsedAt,
+		}
+		// One row + one count per token. Browsers panels are small (single
+		// digit tokens per workspace typically); N+1 here is acceptable and
+		// keeps the query trivial. If this becomes hot, fold into a single
+		// JOIN+LEFT-LATERAL query.
+		openCount, _ := s.DB.CountOpenCodexBrowserSessions(r.Context(), t.ID)
+		row.IsOnline = openCount > 0
+		if latest, _ := s.DB.LatestCodexBrowserSession(r.Context(), t.ID); latest != nil {
+			row.ClientIP = latest.ClientIP
+			row.ClientUA = latest.ClientUA
+			row.CodexVersion = latest.CodexVersion
+			row.OS = latest.OS
+			ca := latest.ConnectedAt
+			row.ConnectedAt = &ca
+			row.DisconnectedAt = latest.DisconnectedAt
+		}
+		out = append(out, row)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(out)
+}

--- a/internal/server/codex_executors_client.go
+++ b/internal/server/codex_executors_client.go
@@ -53,11 +53,18 @@ type RegisterExecutorResponse struct {
 // Per v0.54.0, surfaced fields are binding-level (name + description)
 // from workspace_executors, not the executor row.
 type ListedExecutor struct {
-	ExeID       string     `json:"exe_id"`
-	Name        string     `json:"name"`
-	Description string     `json:"description"`
-	IsDefault   bool       `json:"is_default"`
-	LastSeenAt  *time.Time `json:"last_seen_at,omitempty"`
+	ExeID          string     `json:"exe_id"`
+	Name           string     `json:"name"`
+	Description    string     `json:"description"`
+	IsDefault      bool       `json:"is_default"`
+	LastSeenAt     *time.Time `json:"last_seen_at,omitempty"`
+	ClientIP       string     `json:"client_ip,omitempty"`
+	ClientUA       string     `json:"client_ua,omitempty"`
+	CodexVersion   string     `json:"codex_version,omitempty"`
+	OS             string     `json:"os,omitempty"`
+	ConnectedAt    *time.Time `json:"connected_at,omitempty"`
+	DisconnectedAt *time.Time `json:"disconnected_at,omitempty"`
+	IsOnline       bool       `json:"is_online"`
 }
 
 // Register creates a new executor owned by userID and returns the raw

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -239,6 +239,25 @@ func (s *Server) Router() http.Handler {
 		}
 		s.handleVerifyCodexToken(w, r)
 	})
+	// Browser-session lifecycle (PR #N): CXG calls open on ws accept and
+	// close on ws disconnect so the Browsers panel can render online state
+	// + client metadata per token.
+	r.Post("/api/internal/codex/tokens/session-open", func(w http.ResponseWriter, r *http.Request) {
+		secret := os.Getenv("INTERNAL_API_SECRET")
+		if secret != "" && r.Header.Get("X-Internal-Secret") != secret {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		s.handleCodexSessionOpen(w, r)
+	})
+	r.Post("/api/internal/codex/tokens/session-close", func(w http.ResponseWriter, r *http.Request) {
+		secret := os.Getenv("INTERNAL_API_SECRET")
+		if secret != "" && r.Header.Get("X-Internal-Secret") != secret {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		s.handleCodexSessionClose(w, r)
+	})
 
 	// Internal API for ModelServer token retrieval (no cookie auth).
 	r.Get("/internal/workspaces/{id}/modelserver-token", s.handleInternalModelserverToken)
@@ -520,6 +539,12 @@ func (s *Server) Router() http.Handler {
 		r.Post("/api/workspaces/{wid}/executors", s.handleRegisterExecutor)
 		r.Get("/api/workspaces/{wid}/executors", s.handleListExecutors)
 		r.Delete("/api/workspaces/{wid}/executors/{exe_id}", s.handleUnbindExecutor)
+
+		// Browsers: same per-workspace listing shape as Connectors above,
+		// but rows are codex_remote_tokens annotated with live session info
+		// (IsOnline / ClientIP / OS / CodexVersion) so the Browsers panel
+		// can render with the same DeviceListPanel component.
+		r.Get("/api/workspaces/{wid}/browsers", s.handleListCodexBrowsers)
 
 		// Admin routes
 		r.Route("/api/admin", func(r chi.Router) {

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>agentserver</title>
-    <script type="module" crossorigin src="/assets/index-BConCck3.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-DBHJUdt6.css">
+    <script type="module" crossorigin src="/assets/index-BQ3dNF7v.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-DYwLjhrL.css">
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/components/CodexTokensPanel.tsx
+++ b/web/src/components/CodexTokensPanel.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect, useCallback } from 'react'
 import { Plus, Trash2, Copy, Check, X, Key } from 'lucide-react'
 import {
-  type CodexToken, type MintCodexTokenResponse,
-  listCodexTokens, mintCodexToken, revokeCodexToken,
+  type CodexBrowser, type MintCodexTokenResponse,
+  listCodexBrowsers, mintCodexToken, revokeCodexToken,
 } from '../lib/api'
 import { ConfirmModal } from './Modals'
+import { DeviceListPanel, type DeviceRow } from './DeviceListPanel'
 
 interface Props {
   workspaceId: string
@@ -13,7 +14,7 @@ interface Props {
 const TTL_OPTIONS = [1, 7, 30, 90, 180, 365] as const
 
 export default function CodexTokensPanel({ workspaceId }: Props) {
-  const [tokens, setTokens] = useState<CodexToken[]>([])
+  const [browsers, setBrowsers] = useState<CodexBrowser[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [showMint, setShowMint] = useState(false)
@@ -21,13 +22,12 @@ export default function CodexTokensPanel({ workspaceId }: Props) {
   const [newTTL, setNewTTL] = useState<number>(90)
   const [generated, setGenerated] = useState<MintCodexTokenResponse | null>(null)
   const [copied, setCopied] = useState(false)
-  const [revokeTarget, setRevokeTarget] = useState<CodexToken | null>(null)
+  const [revokeTarget, setRevokeTarget] = useState<CodexBrowser | null>(null)
 
   const refresh = useCallback(async () => {
-    setLoading(true)
     try {
-      const rows = await listCodexTokens(workspaceId)
-      setTokens(rows)
+      const rows = await listCodexBrowsers(workspaceId)
+      setBrowsers(rows)
       setError(null)
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e))
@@ -36,7 +36,13 @@ export default function CodexTokensPanel({ workspaceId }: Props) {
     }
   }, [workspaceId])
 
-  useEffect(() => { void refresh() }, [refresh])
+  // Initial load + 10s poll so online state stays fresh while the user
+  // watches a codex --remote session connect / disconnect.
+  useEffect(() => {
+    void refresh()
+    const id = window.setInterval(() => { void refresh() }, 10_000)
+    return () => window.clearInterval(id)
+  }, [refresh])
 
   const onMint = async () => {
     if (!newName.trim()) return
@@ -73,94 +79,58 @@ export default function CodexTokensPanel({ workspaceId }: Props) {
     setTimeout(() => setCopied(false), 1500)
   }
 
+  const deviceRows: DeviceRow[] = browsers.map((b) => ({
+    id: b.id,
+    name: b.name,
+    is_online: b.is_online,
+    client_ip: b.client_ip,
+    os: b.os,
+    codex_version: b.codex_version,
+    connected_at: b.connected_at,
+    disconnected_at: b.disconnected_at,
+    lastSeenFallback: b.last_used_at,
+  }))
+
+  const findBrowser = (id: string) => browsers.find((b) => b.id === id)
+
   return (
-    <div className="mt-6 rounded-lg border border-[var(--border)] bg-[var(--card)]">
-      <div className="flex items-center justify-between border-b border-[var(--border)] px-5 py-3">
-        <div className="flex items-center gap-2">
-          <Key size={14} className="text-blue-400" />
-          <span className="text-sm font-medium text-[var(--foreground)]">Codex Remote Access</span>
-          {!loading && tokens.length > 0 && (
-            <span className="rounded-full bg-[var(--secondary)] px-2 py-0.5 text-[10px] text-[var(--muted-foreground)]">
-              {tokens.length}
-            </span>
-          )}
-        </div>
-        <button
-          onClick={() => setShowMint(true)}
-          className="inline-flex items-center gap-1.5 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-1 text-xs font-medium text-[var(--foreground)] hover:bg-[var(--secondary)] transition-colors"
-        >
-          <Plus size={12} />
-          Generate token
-        </button>
-      </div>
-
-      <div className="px-5 py-4">
-        <p className="mb-3 text-xs text-[var(--muted-foreground)]">
-          Use these tokens with{' '}
-          <code className="rounded bg-[var(--background)] px-1 py-0.5 font-mono text-[11px] text-[var(--foreground)]">
-            codex --remote wss://codex-app.&lt;host&gt;:443 --remote-auth-token-env &lt;ENV_VAR&gt;
-          </code>
-        </p>
-
-        {error && (
-          <div className="mb-3 rounded-md border border-[var(--destructive)]/30 bg-[var(--destructive)]/10 px-3 py-2 text-xs text-[var(--destructive)]">
-            {error}
-          </div>
+    <>
+      <DeviceListPanel
+        title="Browsers"
+        icon={Key}
+        iconClassName="text-blue-400"
+        rows={deviceRows}
+        loading={loading}
+        error={error}
+        emptyMessage="No browsers yet — generate a token to enable a remote codex CLI."
+        description={
+          <>
+            Each browser is a <code className="rounded bg-[var(--background)] px-1 py-0.5 font-mono text-[11px] text-[var(--foreground)]">codex --remote wss://codex-app.&lt;host&gt;:443</code> client using this workspace's token. Online / OS / IP / codex version come from the live ws connection — they auto-update when a CLI connects or disconnects.
+          </>
+        }
+        headerAction={
+          <button
+            onClick={() => setShowMint(true)}
+            className="inline-flex items-center gap-1.5 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-1 text-xs font-medium text-[var(--foreground)] hover:bg-[var(--secondary)] transition-colors"
+          >
+            <Plus size={12} />
+            Generate token
+          </button>
+        }
+        actions={(row) => (
+          <button
+            onClick={() => {
+              const b = findBrowser(row.id)
+              if (b) setRevokeTarget(b)
+            }}
+            className="rounded p-1 text-[var(--muted-foreground)] hover:bg-[var(--secondary)] hover:text-[var(--destructive)]"
+            aria-label="Revoke token"
+            title="Revoke token"
+          >
+            <Trash2 size={14} />
+          </button>
         )}
-
-        {loading ? (
-          <div className="text-xs text-[var(--muted-foreground)]">Loading…</div>
-        ) : tokens.length === 0 ? (
-          <div className="rounded-md border border-dashed border-[var(--border)] py-8 text-center text-xs italic text-[var(--muted-foreground)]">
-            No tokens yet — generate one to enable a remote codex CLI.
-          </div>
-        ) : (
-          <div className="overflow-hidden rounded-md border border-[var(--border)]">
-            <table className="w-full table-fixed border-collapse text-xs">
-              <thead className="bg-[var(--secondary)] text-[var(--muted-foreground)]">
-                <tr>
-                  <th className="px-3 py-2 text-left font-medium">Name</th>
-                  <th className="w-32 px-3 py-2 text-left font-medium">Created</th>
-                  <th className="w-32 px-3 py-2 text-left font-medium">Expires</th>
-                  <th className="w-44 px-3 py-2 text-left font-medium">Last used</th>
-                  <th className="w-16 px-3 py-2 text-right font-medium">Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {tokens.map((t, i) => (
-                  <tr
-                    key={t.id}
-                    className={`border-t border-[var(--border)] ${i % 2 === 1 ? 'bg-[var(--background)]/40' : ''}`}
-                  >
-                    <td className="truncate px-3 py-2 font-medium text-[var(--foreground)]">{t.name}</td>
-                    <td className="px-3 py-2 text-[11px] text-[var(--muted-foreground)]">
-                      {new Date(t.created_at).toLocaleDateString()}
-                    </td>
-                    <td className="px-3 py-2 text-[11px] text-[var(--muted-foreground)]">
-                      {new Date(t.expires_at).toLocaleDateString()}
-                    </td>
-                    <td className="px-3 py-2 text-[11px] text-[var(--muted-foreground)]">
-                      {t.last_used_at
-                        ? new Date(t.last_used_at).toLocaleString()
-                        : <span className="italic opacity-60">never</span>}
-                    </td>
-                    <td className="px-3 py-2 text-right">
-                      <button
-                        onClick={() => setRevokeTarget(t)}
-                        className="rounded p-1 text-[var(--muted-foreground)] hover:bg-[var(--secondary)] hover:text-[var(--destructive)]"
-                        aria-label="Revoke token"
-                        title="Revoke token"
-                      >
-                        <Trash2 size={14} />
-                      </button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </div>
+      />
 
       {showMint && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={() => setShowMint(false)}>
@@ -273,6 +243,6 @@ codex --remote wss://codex-app.${typeof window !== 'undefined' ? window.location
           onCancel={() => setRevokeTarget(null)}
         />
       )}
-    </div>
+    </>
   )
 }

--- a/web/src/components/DeviceListPanel.tsx
+++ b/web/src/components/DeviceListPanel.tsx
@@ -1,0 +1,143 @@
+import { Circle, type LucideIcon } from 'lucide-react'
+import { type ReactNode } from 'react'
+
+// DeviceRow is the unified shape consumed by both the Connectors
+// (RemoteExecutorsPanel) and Browsers (CodexTokensPanel) tabs. Caller
+// adapts its native type to this shape and supplies an `actions` cell
+// renderer for row-level controls (unbind / revoke / etc).
+export interface DeviceRow {
+  id: string
+  name: string
+  description?: string
+  is_online: boolean
+  client_ip?: string
+  os?: string
+  codex_version?: string
+  // ISO timestamps. Last-seen prefers disconnected_at then connected_at
+  // then the fallback the caller can provide via lastSeenFallback (e.g.
+  // last_used_at on Browsers, registered_at on Connectors).
+  connected_at?: string
+  disconnected_at?: string
+  lastSeenFallback?: string
+}
+
+interface Props {
+  title: string
+  icon: LucideIcon
+  iconClassName?: string
+  rows: DeviceRow[]
+  loading: boolean
+  error: string | null
+  emptyMessage: string
+  headerAction?: ReactNode
+  description?: ReactNode
+  actions: (row: DeviceRow) => ReactNode
+}
+
+// DeviceListPanel renders a uniform Status / Name / OS / Codex / IP /
+// Connected / Last seen / Actions table. Both the Connectors and Browsers
+// tabs use this so they stay visually identical.
+export function DeviceListPanel({
+  title, icon: Icon, iconClassName,
+  rows, loading, error, emptyMessage,
+  headerAction, description, actions,
+}: Props) {
+  return (
+    <div className="mt-6 rounded-lg border border-[var(--border)] bg-[var(--card)]">
+      <div className="flex items-center justify-between border-b border-[var(--border)] px-5 py-3">
+        <div className="flex items-center gap-2">
+          <Icon size={14} className={iconClassName ?? 'text-emerald-400'} />
+          <span className="text-sm font-medium text-[var(--foreground)]">{title}</span>
+          {!loading && rows.length > 0 && (
+            <span className="rounded-full bg-[var(--secondary)] px-2 py-0.5 text-[10px] text-[var(--muted-foreground)]">
+              {rows.length}
+            </span>
+          )}
+        </div>
+        {headerAction}
+      </div>
+
+      <div className="px-5 py-4">
+        {description && (
+          <div className="mb-3 text-xs text-[var(--muted-foreground)]">{description}</div>
+        )}
+        {error && (
+          <div className="mb-3 rounded-md border border-[var(--destructive)]/30 bg-[var(--destructive)]/10 px-3 py-2 text-xs text-[var(--destructive)]">
+            {error}
+          </div>
+        )}
+        {loading ? (
+          <div className="text-xs text-[var(--muted-foreground)]">Loading…</div>
+        ) : rows.length === 0 ? (
+          <div className="rounded-md border border-dashed border-[var(--border)] py-8 text-center text-xs italic text-[var(--muted-foreground)]">
+            {emptyMessage}
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-md border border-[var(--border)]">
+            <table className="w-full table-fixed border-collapse text-xs">
+              <thead className="bg-[var(--secondary)] text-[var(--muted-foreground)]">
+                <tr>
+                  <th className="w-20 px-3 py-2 text-left font-medium">Status</th>
+                  <th className="px-3 py-2 text-left font-medium">Name</th>
+                  <th className="w-24 px-3 py-2 text-left font-medium">OS</th>
+                  <th className="w-24 px-3 py-2 text-left font-medium">Codex</th>
+                  <th className="w-36 px-3 py-2 text-left font-medium">IP</th>
+                  <th className="w-40 px-3 py-2 text-left font-medium">Last seen</th>
+                  <th className="w-16 px-3 py-2 text-right font-medium">Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((r, i) => (
+                  <tr
+                    key={r.id}
+                    className={`border-t border-[var(--border)] ${i % 2 === 1 ? 'bg-[var(--background)]/40' : ''}`}
+                  >
+                    <td className="px-3 py-2">
+                      <span className="inline-flex items-center gap-1.5">
+                        <Circle
+                          size={8}
+                          className={r.is_online ? 'fill-emerald-500 text-emerald-500' : 'fill-gray-400 text-gray-400'}
+                        />
+                        <span className="text-[11px] text-[var(--muted-foreground)]">
+                          {r.is_online ? 'Online' : 'Offline'}
+                        </span>
+                      </span>
+                    </td>
+                    <td className="px-3 py-2">
+                      <div className="truncate font-medium text-[var(--foreground)]">{r.name}</div>
+                      {r.description && (
+                        <div className="truncate text-[11px] text-[var(--muted-foreground)]">{r.description}</div>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-[var(--muted-foreground)]">
+                      {r.os || <span className="italic opacity-60">—</span>}
+                    </td>
+                    <td className="px-3 py-2 text-[var(--muted-foreground)]">
+                      {r.codex_version || <span className="italic opacity-60">—</span>}
+                    </td>
+                    <td className="px-3 py-2 font-mono text-[11px] text-[var(--muted-foreground)]">
+                      {r.client_ip || <span className="font-sans italic opacity-60">—</span>}
+                    </td>
+                    <td className="px-3 py-2 text-[11px] text-[var(--muted-foreground)]">
+                      {formatLastSeen(r)}
+                    </td>
+                    <td className="px-3 py-2 text-right">{actions(r)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// formatLastSeen picks the best timestamp to show: while online,
+// `connected_at`; once offline, `disconnected_at`; otherwise the caller's
+// fallback (e.g. token's last_used_at). Empty → "never".
+function formatLastSeen(r: DeviceRow): ReactNode {
+  const ts = r.is_online ? r.connected_at : (r.disconnected_at ?? r.connected_at ?? r.lastSeenFallback)
+  if (!ts) return <span className="italic opacity-60">never</span>
+  return new Date(ts).toLocaleString()
+}

--- a/web/src/components/RemoteExecutorsPanel.tsx
+++ b/web/src/components/RemoteExecutorsPanel.tsx
@@ -1,19 +1,15 @@
 import { useState, useEffect, useCallback } from 'react'
-import { Plus, Trash2, Copy, Check, X, Server, Circle } from 'lucide-react'
+import { Plus, Trash2, Copy, Check, X, Server } from 'lucide-react'
 import {
   type RemoteExecutor, type RegisterExecutorResponse, type ConnectCommands,
   listRemoteExecutors, registerRemoteExecutor, unbindRemoteExecutor,
 } from '../lib/api'
 import { ConfirmModal } from './Modals'
+import { DeviceListPanel, type DeviceRow } from './DeviceListPanel'
 
 interface Props {
   workspaceId: string
 }
-
-// Online threshold: gateway updates last_seen_at on every connection event.
-// "Online" if seen within the last 90s (allowing some clock skew + a slow
-// ping cycle on the executor side).
-const ONLINE_THRESHOLD_MS = 90 * 1000
 
 export default function RemoteExecutorsPanel({ workspaceId }: Props) {
   const [rows, setRows] = useState<RemoteExecutor[]>([])
@@ -37,7 +33,9 @@ export default function RemoteExecutorsPanel({ workspaceId }: Props) {
     }
   }, [workspaceId])
 
-  // Initial load + 10s poll for online status freshness.
+  // Initial load + 10s poll. Online state is authoritative from the API
+  // (is_online from the gateway's live registry); the poll just refreshes
+  // it on a reasonable cadence.
   useEffect(() => {
     void refresh()
     const id = window.setInterval(() => { void refresh() }, 10_000)
@@ -71,105 +69,60 @@ export default function RemoteExecutorsPanel({ workspaceId }: Props) {
     }
   }
 
-  const isOnline = (r: RemoteExecutor): boolean => {
-    if (!r.last_seen_at) return false
-    return Date.now() - new Date(r.last_seen_at).getTime() < ONLINE_THRESHOLD_MS
-  }
+  const deviceRows: DeviceRow[] = rows.map((r) => ({
+    id: r.exe_id,
+    name: r.name,
+    description: r.description,
+    is_online: r.is_online,
+    client_ip: r.client_ip,
+    os: r.os,
+    codex_version: r.codex_version,
+    connected_at: r.connected_at,
+    disconnected_at: r.disconnected_at,
+    lastSeenFallback: r.last_seen_at,
+  }))
+
+  const findRow = (id: string) => rows.find((r) => r.exe_id === id)
 
   return (
-    <div className="mt-6 rounded-lg border border-[var(--border)] bg-[var(--card)]">
-      <div className="flex items-center justify-between border-b border-[var(--border)] px-5 py-3">
-        <div className="flex items-center gap-2">
-          <Server size={14} className="text-emerald-400" />
-          <span className="text-sm font-medium text-[var(--foreground)]">Connectors</span>
-          {!loading && rows.length > 0 && (
-            <span className="rounded-full bg-[var(--secondary)] px-2 py-0.5 text-[10px] text-[var(--muted-foreground)]">
-              {rows.length}
-            </span>
-          )}
-        </div>
-        <button
-          onClick={() => setShowRegister(true)}
-          className="inline-flex items-center gap-1.5 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-1 text-xs font-medium text-[var(--foreground)] hover:bg-[var(--secondary)] transition-colors"
-        >
-          <Plus size={12} />
-          Register connector
-        </button>
-      </div>
-
-      <div className="px-5 py-4">
-        <p className="mb-3 text-xs text-[var(--muted-foreground)]">
-          Register a machine to expose its shell to codex sessions in this workspace.
-          Run the printed <code className="rounded bg-[var(--background)] px-1 py-0.5 font-mono text-[11px] text-[var(--foreground)]">codex exec-server --remote ...</code> command on that machine to bring it online.
-        </p>
-
-        {error && (
-          <div className="mb-3 rounded-md border border-[var(--destructive)]/30 bg-[var(--destructive)]/10 px-3 py-2 text-xs text-[var(--destructive)]">
-            {error}
-          </div>
+    <>
+      <DeviceListPanel
+        title="Connectors"
+        icon={Server}
+        iconClassName="text-emerald-400"
+        rows={deviceRows}
+        loading={loading}
+        error={error}
+        emptyMessage="No connectors yet — register one to expose a machine to this workspace."
+        description={
+          <>
+            Register a machine to expose its shell to codex sessions in this workspace.
+            Run the printed <code className="rounded bg-[var(--background)] px-1 py-0.5 font-mono text-[11px] text-[var(--foreground)]">codex exec-server --remote ...</code> command on that machine to bring it online.
+          </>
+        }
+        headerAction={
+          <button
+            onClick={() => setShowRegister(true)}
+            className="inline-flex items-center gap-1.5 rounded-md border border-[var(--border)] bg-[var(--card)] px-3 py-1 text-xs font-medium text-[var(--foreground)] hover:bg-[var(--secondary)] transition-colors"
+          >
+            <Plus size={12} />
+            Register connector
+          </button>
+        }
+        actions={(row) => (
+          <button
+            onClick={() => {
+              const r = findRow(row.id)
+              if (r) setUnbindTarget(r)
+            }}
+            className="rounded p-1 text-[var(--muted-foreground)] hover:bg-[var(--secondary)] hover:text-[var(--destructive)]"
+            aria-label="Unbind connector"
+            title="Unbind from workspace"
+          >
+            <Trash2 size={14} />
+          </button>
         )}
-
-        {loading ? (
-          <div className="text-xs text-[var(--muted-foreground)]">Loading…</div>
-        ) : rows.length === 0 ? (
-          <div className="rounded-md border border-dashed border-[var(--border)] py-8 text-center text-xs italic text-[var(--muted-foreground)]">
-            No connectors yet — register one to expose a machine to this workspace.
-          </div>
-        ) : (
-          <div className="overflow-hidden rounded-md border border-[var(--border)]">
-            <table className="w-full table-fixed border-collapse text-xs">
-              <thead className="bg-[var(--secondary)] text-[var(--muted-foreground)]">
-                <tr>
-                  <th className="w-16 px-3 py-2 text-left font-medium">Status</th>
-                  <th className="px-3 py-2 text-left font-medium">Name</th>
-                  <th className="px-3 py-2 text-left font-medium">Description</th>
-                  <th className="w-44 px-3 py-2 text-left font-medium">Last seen</th>
-                  <th className="w-16 px-3 py-2 text-right font-medium">Actions</th>
-                </tr>
-              </thead>
-              <tbody>
-                {rows.map((r, i) => (
-                  <tr
-                    key={r.exe_id}
-                    className={`border-t border-[var(--border)] ${i % 2 === 1 ? 'bg-[var(--background)]/40' : ''}`}
-                  >
-                    <td className="px-3 py-2">
-                      <span className="inline-flex items-center gap-1.5">
-                        <Circle
-                          size={8}
-                          className={isOnline(r) ? 'fill-emerald-500 text-emerald-500' : 'fill-gray-400 text-gray-400'}
-                        />
-                        <span className="text-[11px] text-[var(--muted-foreground)]">
-                          {isOnline(r) ? 'Online' : 'Offline'}
-                        </span>
-                      </span>
-                    </td>
-                    <td className="truncate px-3 py-2 font-medium text-[var(--foreground)]">{r.name}</td>
-                    <td className="truncate px-3 py-2 text-[var(--muted-foreground)]">
-                      {r.description || <span className="italic opacity-60">—</span>}
-                    </td>
-                    <td className="px-3 py-2 text-[11px] text-[var(--muted-foreground)]">
-                      {r.last_seen_at
-                        ? new Date(r.last_seen_at).toLocaleString()
-                        : <span className="italic opacity-60">never</span>}
-                    </td>
-                    <td className="px-3 py-2 text-right">
-                      <button
-                        onClick={() => setUnbindTarget(r)}
-                        className="rounded p-1 text-[var(--muted-foreground)] hover:bg-[var(--secondary)] hover:text-[var(--destructive)]"
-                        aria-label="Unbind connector"
-                        title="Unbind from workspace"
-                      >
-                        <Trash2 size={14} />
-                      </button>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
-      </div>
+      />
 
       {showRegister && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" onClick={() => setShowRegister(false)}>
@@ -272,7 +225,7 @@ export default function RemoteExecutorsPanel({ workspaceId }: Props) {
           onCancel={() => setUnbindTarget(null)}
         />
       )}
-    </div>
+    </>
   )
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1038,6 +1038,40 @@ export interface RemoteExecutor {
   description: string
   is_default: boolean
   last_seen_at?: string
+  // Live online state from the gateway's in-memory registry. The old
+  // client-side `last_seen_at < 90s` heuristic showed freshly-disconnected
+  // executors as online for 90s; this is the authoritative replacement.
+  is_online: boolean
+  client_ip?: string
+  client_ua?: string
+  codex_version?: string
+  os?: string
+  connected_at?: string
+  disconnected_at?: string
+}
+
+// CodexBrowser parallels RemoteExecutor: same shape so the unified
+// DeviceListPanel can render both without per-type branches.
+export interface CodexBrowser {
+  id: string
+  name: string
+  workspace_id: string
+  created_at: string
+  expires_at: string
+  last_used_at?: string
+  is_online: boolean
+  client_ip?: string
+  client_ua?: string
+  codex_version?: string
+  os?: string
+  connected_at?: string
+  disconnected_at?: string
+}
+
+export async function listCodexBrowsers(workspaceId: string): Promise<CodexBrowser[]> {
+  const res = await fetch(`/api/workspaces/${encodeURIComponent(workspaceId)}/browsers`)
+  if (!res.ok) throw new Error('Failed to list codex browsers')
+  return res.json()
 }
 
 export interface RegisterExecutorRequest {


### PR DESCRIPTION
## Summary
The two workspace-tab panels (Browsers, Connectors) used to look completely different and disagreed on what "Online" means. Unifies them, adds the missing client metadata (codex version, OS, IP), and replaces the buggy \`last_seen_at < 90s\` heuristic with an authoritative \`is_online\` from the live registry.

### Bug fix: online detection
\`codex-exec-gateway\` updated \`last_seen_at\` on **both** connect AND disconnect (\`internal/codexexecgateway/inbound.go\`). The frontend treated anything within 90s as Online, so a freshly-offline executor stayed "Online" for a minute and a half.

Split into:
- \`MarkConnected\` — bumps \`last_seen_at\` + \`connected_at\`, clears \`disconnected_at\`, stores client metadata.
- \`MarkDisconnected\` — stamps \`disconnected_at\` only. \`last_seen_at\` is "last evidence of life" again.

API now ships \`is_online\` directly from the in-memory \`ConnRegistry\`. UI heuristic deleted.

### New columns
- Connectors (\`executors\` table, migration 003): \`client_ip\`, \`client_ua\`, \`codex_version\`, \`os\`, \`connected_at\`, \`disconnected_at\`.
- Browsers (new \`codex_browser_sessions\` table, migration 026): one row per concurrent \`codex --remote\` ws session, same columns.

Both gateways extract IP via \`X-Forwarded-For\` chain → \`X-Real-IP\` → \`RemoteAddr\`, and parse \`codex_cli_rs/<ver> (<OS> ...)\` UAs via shared \`internal/clientmeta\`. Empty when codex doesn't emit a parseable UA (UI shows "—").

### Browsers session lifecycle
\`auth.SessionTracker\` interface (\`RemoteVerifier\` implements, \`HMAC\` doesn't). CXG's ws handler calls \`OpenSession\` on accept and defers \`CloseSession\` in a bg goroutine on disconnect. Open/close hit two new agentserver internal endpoints — open re-verifies the token bcrypt + expiry + revocation policy so a buggy CXG can't fabricate sessions for arbitrary token ids.

### Unified UI
\`web/src/components/DeviceListPanel.tsx\` is the shared table; both panels supply rows + per-row actions + a header button.

### Schema
Two additive migrations (one in each gateway DB), no downtime, no destructive changes. \`last_seen_at\` stays on the executor row for back-compat.

### Chart
0.62.1 → 0.62.2.

## Test plan
- [x] \`go test ./internal/clientmeta/ ./internal/codexexecgateway/... ./internal/server/\` green
- [x] \`pnpm tsc --noEmit && pnpm build\` green
- [ ] After deploy: \`codex exec-server --remote ...\` from a laptop → Connectors row shows the laptop's IP + codex version. Kill it → flips Offline within next 10s poll, last-seen shows disconnect time (not connect time).
- [ ] \`codex --remote wss://codex-app.... --remote-auth-token-env X\` from a laptop → Browsers row goes Online with the IP + version. Disconnect → goes Offline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)