### PR TITLE
fix(cxg): fall back to Verify when session-open returns 404

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.62.2
-appVersion: "0.62.2"
+version: 0.62.3
+appVersion: "0.62.3"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/internal/codexappgateway/auth/remote_verifier.go
+++ b/internal/codexappgateway/auth/remote_verifier.go
@@ -86,6 +86,11 @@ func (v *RemoteVerifier) Verify(ctx context.Context, token string) (Identity, er
 // OpenSession verifies the token AND inserts a browser-session row in
 // codex_browser_sessions, returning the session id so the caller can close
 // it on ws disconnect. Implements auth.SessionTracker.
+//
+// If agentserver doesn't expose session-open (404 on rolling deploys where
+// CXG ships before agentserver, or against test stubs), falls back to
+// plain Verify so codex --remote keeps working — sessions just aren't
+// tracked in codex_browser_sessions until agentserver catches up.
 func (v *RemoteVerifier) OpenSession(ctx context.Context, token, clientIP, clientUA, codexVersion, osStr string) (Identity, string, error) {
 	body, err := json.Marshal(map[string]string{
 		"token":         token,
@@ -110,6 +115,13 @@ func (v *RemoteVerifier) OpenSession(ctx context.Context, token, clientIP, clien
 	defer resp.Body.Close()
 	if resp.StatusCode == http.StatusUnauthorized {
 		return Identity{}, "", ErrUnauthorized
+	}
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusMethodNotAllowed {
+		id, vErr := v.Verify(ctx, token)
+		if vErr != nil {
+			return Identity{}, "", vErr
+		}
+		return id, "", nil
 	}
 	if resp.StatusCode != http.StatusOK {
 		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))


### PR DESCRIPTION
## Summary
Follow-up to #130. v0.62.2 build failed because RemoteVerifier.OpenSession returned an error on 404 from the test stubs (which only implement /verify, not session-open), and the CXG ws handler maps any verify error to 401 → tests fail \"expected handshake response status code 101 but got 401\".

Fall back to plain Verify on 404 / 405 so CXG degrades cleanly when agentserver doesn't yet expose session-open. Same behavior matters in production during rolling deploys where CXG ships before agentserver — codex --remote keeps working, just no Browsers-tab session tracking until agentserver catches up.

Chart 0.62.2 → 0.62.3.

## Test plan
- [x] \`go test ./internal/codexappgateway/...\` passes (the two tests that 401'd on v0.62.2 now go green; only the perennial broker flake remains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)