### PR TITLE
fix(codexauth): use --experimental_issuer + drop browser-only tab (codex 0.132)

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.62.3
-appVersion: "0.62.3"
+version: 0.62.4
+appVersion: "0.62.4"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/internal/server/codex_executors.go
+++ b/internal/server/codex_executors.go
@@ -166,18 +166,27 @@ func (s *Server) handleRegisterExecutor(w http.ResponseWriter, r *http.Request) 
 				"export CODEX_EXEC_SERVER_REMOTE_BEARER_TOKEN='%s'\ncodex exec-server --remote '%s' --executor-id '%s' --name '%s'",
 				reg.RegistrationToken, gatewayURL, reg.ExeID, req.Name)
 		} else {
-			// codexAuth enabled — surface all 3 variants. Keep the legacy
-			// single-string field populated with the Agent Identity
-			// command so unrevised UI clients still get a working paste.
+			// codexAuth enabled — two practical paths:
+			//   1. Agent Identity — paste-and-go, no login.
+			//   2. ChatGPT device-auth — `codex login --device-auth
+			//      --experimental_issuer ...` shows a URL + short code;
+			//      user opens the URL in any browser (phone or laptop),
+			//      enters the code, clicks Approve.
+			//
+			// Note: the "pure browser" path `codex login
+			// --experimental_issuer ...` (without --device-auth) is
+			// BROKEN in codex 0.132 — `cli/src/main.rs:1194` calls
+			// run_login_with_chatgpt without forwarding
+			// login_cli.issuer_base_url, so the browser pops open
+			// auth.openai.com regardless of the flag. Device-auth path
+			// at `:1170` does plumb the override through. Until codex
+			// upstream fixes the browser path we don't expose it here.
 			resp.ConnectCommands = ConnectCommands{
 				AgentIdentity: fmt.Sprintf(
 					"export CODEX_ACCESS_TOKEN='%s'\nexport CODEX_AGENT_IDENTITY_AUTHAPI_BASE_URL='%s'\ncodex -c chatgpt.base_url='%s' exec-server --remote '%s' --executor-id '%s' --name '%s' --use-agent-identity-auth",
 					aiResult.JWT, issuer, issuer, gatewayURL, reg.ExeID, req.Name),
-				ChatgptBrowser: fmt.Sprintf(
-					"codex login --issuer %s\nexport CODEX_REFRESH_TOKEN_URL_OVERRIDE='%s/oauth/token'\ncodex exec-server --remote '%s' --executor-id '%s' --name '%s'",
-					issuer, issuer, gatewayURL, reg.ExeID, req.Name),
 				ChatgptDeviceAuth: fmt.Sprintf(
-					"codex login --device-auth --issuer %s\nexport CODEX_REFRESH_TOKEN_URL_OVERRIDE='%s/oauth/token'\ncodex exec-server --remote '%s' --executor-id '%s' --name '%s'",
+					"codex login --device-auth --experimental_issuer %s\nexport CODEX_REFRESH_TOKEN_URL_OVERRIDE='%s/oauth/token'\ncodex exec-server --remote '%s' --executor-id '%s' --name '%s'",
 					issuer, issuer, gatewayURL, reg.ExeID, req.Name),
 			}
 			resp.ConnectCommand = resp.ConnectCommands.AgentIdentity

--- a/web/src/components/RemoteExecutorsPanel.tsx
+++ b/web/src/components/RemoteExecutorsPanel.tsx
@@ -258,19 +258,22 @@ type ConnectTabKey = keyof ConnectCommands
 const CONNECT_TABS: { key: ConnectTabKey; label: string; hint: string }[] = [
   {
     key: 'agent_identity',
-    label: 'Agent Identity (headless)',
-    hint: 'Best for unattended machines. One paste, done.',
-  },
-  {
-    key: 'chatgpt_browser',
-    label: 'codex login (browser)',
-    hint: 'For desktops. SSO with your agentserver session.',
+    label: 'Agent Identity (recommended)',
+    hint: 'Paste-and-go. No login. Best for unattended machines.',
   },
   {
     key: 'chatgpt_device_auth',
     label: 'codex login --device-auth',
-    hint: 'Headless + ChatGPT-account semantics. Enter a code in a browser.',
+    hint:
+      'For ChatGPT-account semantics. Opens a URL + short code; enter the ' +
+      'code in any browser (phone or laptop), click Approve. Works on both ' +
+      'headless and desktop machines.',
   },
+  // chatgpt_browser tab intentionally omitted: codex 0.132's pure browser
+  // login path (`codex login --experimental_issuer ...` without
+  // --device-auth) ignores the issuer override and always hits
+  // auth.openai.com (upstream bug in cli/src/main.rs:1194). Device-auth
+  // is the working substitute for browser users until that's fixed.
 ]
 
 function ConnectCommandsPanel({ cmds }: { cmds: ConnectCommands }) {


### PR DESCRIPTION
Discovered when live-testing \`codex login\` against the deployed codex-auth subdomain.

## Two real codex 0.132 quirks

### 1. Flag name is \`--experimental_issuer\` (hidden), not \`--issuer\`

\`\`\`
\$ codex login --issuer https://codex-auth.agent.cs.ac.cn
error: unexpected argument '--issuer' found

\$ codex login --experimental_issuer https://codex-auth.agent.cs.ac.cn   # works
\`\`\`

The flag is defined hidden in \`cli/src/main.rs\`:
\`\`\`rust
#[arg(long = "experimental_issuer", value_name = "URL", hide = true)]
issuer_base_url: Option<String>,
\`\`\`

### 2. Pure-browser PKCE path is broken upstream

Even with the right flag, \`codex login --experimental_issuer ...\` pops up \`https://auth.openai.com/oauth/authorize?...\` instead of our issuer. Reading \`cli/src/main.rs:1194\`:

\`\`\`rust
} else if login_cli.use_device_code {
    run_login_with_device_code(login_cli.config_overrides, login_cli.issuer_base_url, ...);   // ← issuer passed
} else {
    run_login_with_chatgpt(login_cli.config_overrides).await;   // ← issuer NOT passed
}
\`\`\`

Confirmed by reading \`run_login_with_chatgpt\` (\`cli/src/login.rs:117\`) which calls \`ServerOptions::new\` that hardcodes \`issuer: DEFAULT_ISSUER\` (\`https://auth.openai.com\`).

The device-auth path (\`run_login_with_device_code\` in \`cli/src/login.rs:286\`) properly does \`opts.issuer = iss\`.

## Resolution

- Use \`--experimental_issuer\` in connect-commands (works for the device-auth path).
- Drop the \`chatgpt_browser\` UI tab entirely. Until codex upstream plumbs the override into the browser path, anyone wanting ChatGPT-account login uses \`--device-auth\` (which works on desktops too — just paste the URL into any browser).
- Spec amendment + upstream issue tracking can land separately.

Chart 0.62.3 → 0.62.4.

## Test plan

- [x] Build clean (\`go build\` + \`npm run build\`)
- [ ] After merge + pulumi up: \`codex login --device-auth --experimental_issuer https://codex-auth.agent.cs.ac.cn\` succeeds (Agent Identity already verified via earlier paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)