### PR TITLE
fix(ui): bump device table font + widen IP column for IPv6

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.62.4
-appVersion: "0.62.4"
+version: 0.62.5
+appVersion: "0.62.5"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/web/dist/index.html
+++ b/web/dist/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>agentserver</title>
-    <script type="module" crossorigin src="/assets/index-BQ3dNF7v.js"></script>
-    <link rel="stylesheet" crossorigin href="/assets/index-DYwLjhrL.css">
+    <script type="module" crossorigin src="/assets/index-DONpCdmU.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-D3xyCel9.css">
   </head>
   <body>
     <div id="root"></div>

--- a/web/src/components/DeviceListPanel.tsx
+++ b/web/src/components/DeviceListPanel.tsx
@@ -74,15 +74,15 @@ export function DeviceListPanel({
           </div>
         ) : (
           <div className="overflow-hidden rounded-md border border-[var(--border)]">
-            <table className="w-full table-fixed border-collapse text-xs">
+            <table className="w-full table-fixed border-collapse text-sm">
               <thead className="bg-[var(--secondary)] text-[var(--muted-foreground)]">
                 <tr>
                   <th className="w-20 px-3 py-2 text-left font-medium">Status</th>
                   <th className="px-3 py-2 text-left font-medium">Name</th>
                   <th className="w-24 px-3 py-2 text-left font-medium">OS</th>
                   <th className="w-24 px-3 py-2 text-left font-medium">Codex</th>
-                  <th className="w-36 px-3 py-2 text-left font-medium">IP</th>
-                  <th className="w-40 px-3 py-2 text-left font-medium">Last seen</th>
+                  <th className="w-72 px-3 py-2 text-left font-medium">IP</th>
+                  <th className="w-44 px-3 py-2 text-left font-medium">Last seen</th>
                   <th className="w-16 px-3 py-2 text-right font-medium">Actions</th>
                 </tr>
               </thead>
@@ -98,7 +98,7 @@ export function DeviceListPanel({
                           size={8}
                           className={r.is_online ? 'fill-emerald-500 text-emerald-500' : 'fill-gray-400 text-gray-400'}
                         />
-                        <span className="text-[11px] text-[var(--muted-foreground)]">
+                        <span className="text-[var(--muted-foreground)]">
                           {r.is_online ? 'Online' : 'Offline'}
                         </span>
                       </span>
@@ -106,7 +106,7 @@ export function DeviceListPanel({
                     <td className="px-3 py-2">
                       <div className="truncate font-medium text-[var(--foreground)]">{r.name}</div>
                       {r.description && (
-                        <div className="truncate text-[11px] text-[var(--muted-foreground)]">{r.description}</div>
+                        <div className="truncate text-xs text-[var(--muted-foreground)]">{r.description}</div>
                       )}
                     </td>
                     <td className="px-3 py-2 text-[var(--muted-foreground)]">
@@ -115,10 +115,10 @@ export function DeviceListPanel({
                     <td className="px-3 py-2 text-[var(--muted-foreground)]">
                       {r.codex_version || <span className="italic opacity-60">—</span>}
                     </td>
-                    <td className="px-3 py-2 font-mono text-[11px] text-[var(--muted-foreground)]">
+                    <td className="truncate px-3 py-2 font-mono text-[var(--muted-foreground)]" title={r.client_ip}>
                       {r.client_ip || <span className="font-sans italic opacity-60">—</span>}
                     </td>
-                    <td className="px-3 py-2 text-[11px] text-[var(--muted-foreground)]">
+                    <td className="px-3 py-2 text-[var(--muted-foreground)]">
                       {formatLastSeen(r)}
                     </td>
                     <td className="px-3 py-2 text-right">{actions(r)}</td>


### PR DESCRIPTION
## Summary
Two small follow-ups to #130's DeviceListPanel:

- **Font size** \`text-xs\` → \`text-sm\` (12 → 14px) on the table cells. The description sub-line under Name stays \`text-xs\` so the hierarchy holds.
- **IP column** \`w-36\` → \`w-72\` (144 → 288px). An IPv6 in full form is 39 chars — didn't fit before. Added \`truncate\` + \`title\` attr so anything still wider than 288px is hover-revealable instead of layout-breaking.

Bump chart 0.62.4 → 0.62.5.

## Test plan
- [x] tsc + vite build green
- [ ] Visual: Connectors and Browsers tabs render with the larger font; an IPv6-only row shows the full address (no truncation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)