### PR TITLE
fix(codexauth): device interval as string (codex 0.132 expects String)

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.62.6
-appVersion: "0.62.6"
+version: 0.62.7
+appVersion: "0.62.7"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/internal/codexauth/device.go
+++ b/internal/codexauth/device.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	deviceCodeTTL      = 15 * time.Minute
-	devicePollInterval = 5
+	devicePollInterval = "5"
 )
 
 // userCodeAlphabet excludes I, O, 0, 1 to reduce read-aloud confusion.


### PR DESCRIPTION
## Root cause
codex 0.132 `cli/login/device_code_auth.rs:50` deserializes `interval` via `String::deserialize` then parses to `u64`. Our endpoint returned an integer → `invalid type: integer \`5\`, expected a string`.

## Change
- `internal/codexauth/device.go`: `devicePollInterval` const `5` → `"5"` so JSON marshals as string
- Chart bump 0.62.6 → 0.62.7

## Test plan
- [x] live test: codex login --device-auth --experimental_issuer https://codex-auth.agent.cs.ac.cn → no parse error