### PR TITLE
fix(spa): bounce to ?next= when already authed (codex-auth relay)

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.62.7
-appVersion: "0.62.7"
+version: 0.62.8
+appVersion: "0.62.8"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/internal/auth/oidc.go
+++ b/internal/auth/oidc.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 
@@ -87,10 +88,55 @@ func (m *OIDCManager) ProviderNamesForHost(host string) []string {
 
 const (
 	stateCookieName = "agentserver-oauth-state"
+	nextCookieName  = "agentserver-oauth-next"
 	stateCookieTTL  = 10 * time.Minute
 )
 
+// safeNext validates a `next` redirect target. Returns it unchanged if safe,
+// or "" to reject (preventing open redirect). Accepts:
+//
+//   - relative paths starting with "/" but not "//" (protocol-relative);
+//   - absolute https URLs whose host matches the configured cookie domain
+//     (e.g. "https://codex-auth.agent.cs.ac.cn/..." when cookieDomain is
+//     ".agent.cs.ac.cn"). This is the only way device/PKCE flows on the
+//     codex-auth subdomain can bounce back after main-app OIDC login.
+//
+// Rejects control chars (CR/LF header injection), oversize strings, and
+// anything that doesn't fit one of the two shapes above.
+func safeNext(next string) string {
+	if next == "" || len(next) > 2048 {
+		return ""
+	}
+	for _, c := range next {
+		if c < 0x20 || c == 0x7f {
+			return ""
+		}
+	}
+	if strings.HasPrefix(next, "/") {
+		if strings.HasPrefix(next, "//") {
+			return ""
+		}
+		return next
+	}
+	u, err := url.Parse(next)
+	if err != nil || u.Scheme != "https" || u.Host == "" {
+		return ""
+	}
+	cd := cookieDomain()
+	if cd == "" {
+		return ""
+	}
+	// cd looks like ".agent.cs.ac.cn"; require Host ends with it,
+	// and isn't itself just the bare leading-dot (defensive).
+	if !strings.HasSuffix("."+u.Host, cd) {
+		return ""
+	}
+	return next
+}
+
 // HandleLogin redirects the user to the IdP authorization endpoint.
+// If the request carries `?next=<safe-relative-path>`, the path is stashed
+// in a short-lived cookie so HandleCallback can bounce there after login.
 func (m *OIDCManager) HandleLogin(w http.ResponseWriter, r *http.Request, providerName string) {
 	p, ok := m.providers[providerName]
 	if !ok {
@@ -111,6 +157,18 @@ func (m *OIDCManager) HandleLogin(w http.ResponseWriter, r *http.Request, provid
 		SameSite: http.SameSiteLaxMode,
 		MaxAge:   int(stateCookieTTL.Seconds()),
 	})
+
+	if next := safeNext(r.URL.Query().Get("next")); next != "" {
+		http.SetCookie(w, &http.Cookie{
+			Name:     nextCookieName,
+			Value:    next,
+			Path:     "/",
+			HttpOnly: true,
+			Secure:   true,
+			SameSite: http.SameSiteLaxMode,
+			MaxAge:   int(stateCookieTTL.Seconds()),
+		})
+	}
 
 	cfg := p.OAuth2Config()
 	http.Redirect(w, r, cfg.AuthCodeURL(state), http.StatusFound)
@@ -196,7 +254,22 @@ func (m *OIDCManager) HandleCallback(w http.ResponseWriter, r *http.Request, pro
 	}
 
 	SetTokenCookie(w, authToken)
-	http.Redirect(w, r, "/", http.StatusFound)
+
+	dest := "/"
+	if c, err := r.Cookie(nextCookieName); err == nil {
+		if next := safeNext(c.Value); next != "" {
+			dest = next
+		}
+		http.SetCookie(w, &http.Cookie{
+			Name:     nextCookieName,
+			Value:    "",
+			Path:     "/",
+			MaxAge:   -1,
+			HttpOnly: true,
+			Secure:   true,
+		})
+	}
+	http.Redirect(w, r, dest, http.StatusFound)
 }
 
 // resolveUser finds or creates a user for the given OIDC identity.

--- a/internal/auth/oidc_next_test.go
+++ b/internal/auth/oidc_next_test.go
@@ -1,0 +1,45 @@
+package auth
+
+import (
+	"os"
+	"testing"
+)
+
+func TestSafeNext(t *testing.T) {
+	t.Setenv("AGENTSERVER_COOKIE_DOMAIN", ".agent.cs.ac.cn")
+
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", ""},
+		{"/", "/"},
+		{"/codex-auth/codex/device", "/codex-auth/codex/device"},
+		{"/path?q=1&r=2", "/path?q=1&r=2"},
+
+		{"//evil.com/path", ""}, // protocol-relative
+		{"https://evil.com/foo", ""},
+		{"http://codex-auth.agent.cs.ac.cn/x", ""}, // wrong scheme
+		{"javascript:alert(1)", ""},
+		{"https://agent.cs.ac.cn.evil.com/x", ""}, // suffix-attack
+
+		{"https://codex-auth.agent.cs.ac.cn/codex/device", "https://codex-auth.agent.cs.ac.cn/codex/device"},
+		{"https://agent.cs.ac.cn/x", "https://agent.cs.ac.cn/x"},
+
+		{"/x\r\nSet-Cookie: a=b", ""}, // CRLF injection
+	}
+	for _, c := range cases {
+		if got := safeNext(c.in); got != c.want {
+			t.Errorf("safeNext(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+
+	// No cookie domain → absolute URLs rejected even if scheme/host look ok.
+	os.Unsetenv("AGENTSERVER_COOKIE_DOMAIN")
+	if got := safeNext("https://codex-auth.agent.cs.ac.cn/x"); got != "" {
+		t.Errorf("expected absolute URL rejected without cookieDomain, got %q", got)
+	}
+	if got := safeNext("/relative"); got != "/relative" {
+		t.Errorf("relative path should still work without cookieDomain, got %q", got)
+	}
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -287,6 +287,21 @@ export default function App() {
     )
   }
 
+  // Already authenticated and landed here via ?next= (typically codex-auth's
+  // device/PKCE redirect). Bounce to next before rendering the dashboard, or
+  // the user sees the dashboard instead of the codex-auth verify form.
+  if (authed && location.pathname === '/') {
+    const next = new URLSearchParams(location.search).get('next')
+    if (next) {
+      window.location.href = next
+      return (
+        <div className="flex min-h-screen items-center justify-center">
+          <span className="text-[var(--muted-foreground)]">Redirecting...</span>
+        </div>
+      )
+    }
+  }
+
   if (!authed) {
     // If landing on protected OAuth pages without auth, save params
     // so they survive OIDC redirects.

--- a/web/src/components/Login.tsx
+++ b/web/src/components/Login.tsx
@@ -129,15 +129,23 @@ export function Login({ onSuccess }: LoginProps) {
               </div>
             )}
             <div className={passwordAuth ? "mt-4 space-y-2" : "space-y-2"}>
-              {oidcProviders.map((provider) => (
-                <a
-                  key={provider}
-                  href={`/api/auth/oidc/${provider}/login`}
-                  className="flex w-full items-center justify-center rounded-md border border-[var(--input)] bg-[var(--background)] px-4 py-2 text-sm font-medium text-[var(--foreground)] hover:bg-[var(--accent)] hover:text-[var(--accent-foreground)]"
-                >
-                  {providerLabels[provider] || `Sign in with ${provider}`}
-                </a>
-              ))}
+              {oidcProviders.map((provider) => {
+                // Forward ?next= through the OIDC round-trip so HandleCallback
+                // can bounce back to (e.g.) the codex-auth verify page.
+                const next = new URLSearchParams(window.location.search).get('next')
+                const href = next
+                  ? `/api/auth/oidc/${provider}/login?next=${encodeURIComponent(next)}`
+                  : `/api/auth/oidc/${provider}/login`
+                return (
+                  <a
+                    key={provider}
+                    href={href}
+                    className="flex w-full items-center justify-center rounded-md border border-[var(--input)] bg-[var(--background)] px-4 py-2 text-sm font-medium text-[var(--foreground)] hover:bg-[var(--accent)] hover:text-[var(--accent-foreground)]"
+                  >
+                    {providerLabels[provider] || `Sign in with ${provider}`}
+                  </a>
+                )
+              })}
             </div>
           </div>
         )}


### PR DESCRIPTION
## Problem
codex 0.132 `codex login --device-auth --experimental_issuer https://codex-auth...`
sends user to codex-auth subdomain's verify page. Two bugs lost the `?next=` redirect
chain back to that page:

1. **SPA**: only consulted `?next=` inside `Login.onSuccess`. Already-authed users
   landed on the dashboard.
2. **OIDC callback**: hardcoded `http.Redirect(w, r, "/", 302)`. Users signing in
   via OIDC (the typical path) got bounced to dashboard with no way back.

## Fix
- `App.tsx`: bounce to `?next=` when `authed && pathname === '/'`.
- `oidc.go`: HandleLogin stashes validated `?next=` in cookie; HandleCallback
  pops & redirects to it.
- `safeNext`: rejects open redirects (relative `/`, or absolute https URL whose
  host matches `AGENTSERVER_COOKIE_DOMAIN`).
- `Login.tsx`: OIDC links forward `?next=` from URL search.
- Test coverage for `safeNext` (CRLF, suffix attack, missing cookieDomain).

## Chart
0.62.7 → 0.62.8

## Test plan
- [x] go test ./internal/auth/ -run TestSafeNext
- [ ] live: codex login --device-auth from a logged-out browser using OIDC SSO