### PR TITLE
refactor(codex-exec-gateway): drop bcrypt, mint HMAC ws ticket at register

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.63.0
-appVersion: "0.63.0"
+version: 0.64.0
+appVersion: "0.64.0"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/internal/codexexecgateway/bridge_test.go
+++ b/internal/codexexecgateway/bridge_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/crypto/bcrypt"
+	"github.com/agentserver/agentserver/internal/codexexecgateway/handlers"
 	"nhooyr.io/websocket"
 )
 
@@ -34,20 +34,22 @@ func mintBridgeToken(secret []byte, p CapPayload) string {
 	return si + "." + enc.EncodeToString(mac.Sum(nil))
 }
 
-// connectInbound registers an executor (db row + bcrypt hash + workspace
-// binding to "ws_1" so bridge ownership checks pass), dials the inbound
-// endpoint, and waits until the registry shows a live conn for exeID.
+// connectInbound registers an executor (db row + workspace binding to "ws_1"
+// so bridge ownership checks pass), dials the inbound endpoint with an HMAC
+// ticket, and waits until the registry shows a live conn for exeID.
 func connectInbound(t *testing.T, srv *Server, baseURL, exeID string) *websocket.Conn {
 	t.Helper()
-	hash, _ := bcrypt.GenerateFromPassword([]byte("rt"), bcrypt.DefaultCost)
 	srv.store.CreateExecutor(context.Background(), Executor{
 		ExeID: exeID, UserID: "u", RegisteredAt: time.Now().UTC(),
-	}, string(hash))
-	// Bind to ws_1 — all bridge tests mint tokens with WorkspaceID="ws_1".
+	})
 	if err := srv.store.BindWorkspaceExecutor(context.Background(), "ws_1", exeID, "test-"+exeID, "", false); err != nil {
 		t.Fatalf("BindWorkspaceExecutor: %v", err)
 	}
-	url := "ws" + baseURL[len("http"):] + "/codex-exec/" + exeID + "?token=rt"
+	ticket, err := handlers.MintWSTicket(exeID, srv.config.AgentserverInternalSecret)
+	if err != nil {
+		t.Fatalf("MintWSTicket: %v", err)
+	}
+	url := "ws" + baseURL[len("http"):] + "/codex-exec/" + exeID + "?token=" + ticket
 	c, _, err := websocket.Dial(context.Background(), url, nil)
 	if err != nil {
 		t.Fatalf("inbound dial: %v", err)
@@ -93,10 +95,9 @@ func TestBridge_Rejects403WhenExeIDNotInWorkspace(t *testing.T) {
 	// DB-backed: token's workspace_id has no binding to the URL's exe_id
 	// → /bridge returns 403 via the workspace_executors ownership check.
 	hs, srv := newInboundTestServer(t)
-	hash, _ := bcrypt.GenerateFromPassword([]byte("rt"), bcrypt.DefaultCost)
 	srv.store.CreateExecutor(context.Background(), Executor{
 		ExeID: "exe_target", UserID: "u", RegisteredAt: time.Now().UTC(),
-	}, string(hash))
+	})
 	// Intentionally no BindWorkspaceExecutor — ws_1 does not own exe_target.
 	now := time.Now().Unix()
 	tok := mintBridgeToken(srv.config.CapTokenHMACSecret, CapPayload{

--- a/internal/codexexecgateway/handlers/cloud_register.go
+++ b/internal/codexexecgateway/handlers/cloud_register.go
@@ -11,14 +11,14 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
-	"golang.org/x/crypto/bcrypt"
 )
 
 // CloudRegisterStore is the subset of *codexexecgateway.Store the
 // upstream-compat /cloud/executor/{id}/register handler needs.
-type CloudRegisterStore interface {
-	GetRegistrationTokenHash(ctx context.Context, exeID string) (string, error)
-}
+// Ownership lookup is asserted via the ownerStore type-assertion in
+// assertExeOwnedByUser; pure CloudRegister callers only need the empty
+// interface here, which we keep as a sentinel for future shared methods.
+type CloudRegisterStore interface{}
 
 // cloudRegisterResponse mirrors the upstream codex exec-server registry
 // response shape. Codex v0.130 expects {id, executor_id, url}; main has
@@ -72,19 +72,20 @@ func (v *AgentserverValidator) Validate(ctx context.Context, req map[string]stri
 
 // CloudRegister handles POST /cloud/executor/{exe_id}/register.
 //
-// Auth: prefers codex 0.132+ schemes (Bearer access_token or
-// AgentAssertion) validated via agentserver. Falls back to legacy
-// bcrypt bearer token (codex < 0.132) for backward compat.
+// Auth: codex 0.132+ schemes only — Bearer (ChatGPT access_token) or
+// AgentAssertion (Agent Identity), validated via agentserver. The
+// pre-0.132 bcrypt registration_token bearer is gone (PR removing it).
 //
-// Our existing inbound handler at `/codex-exec/{exe_id}?token=...` is
-// the actual ws endpoint; this handler verifies the bearer once and
-// returns that URL with the token plumbed through.
+// On success, mints a short-lived HMAC ws ticket and returns
+// `wss://.../codex-exec/{exe_id}?token=<ticket>`. The inbound ws
+// handler verifies the ticket signature locally — no DB hop, no JWT
+// verify, no validator round-trip.
 //
 // publicWSBaseURL is the externally-visible wss:// origin (e.g.
 // "wss://codex-exec.agent.cs.ac.cn:443"). When empty, the response URL
 // is synthesised from r.Host with wss scheme — best-effort fallback for
 // dev / direct in-cluster use.
-func CloudRegister(store CloudRegisterStore, publicWSBaseURL string, validator AgentserverValidator) http.HandlerFunc {
+func CloudRegister(store CloudRegisterStore, publicWSBaseURL string, validator AgentserverValidator, wsTicketSecret string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		exeID := chi.URLParam(r, "exe_id")
 		if exeID == "" {
@@ -92,36 +93,23 @@ func CloudRegister(store CloudRegisterStore, publicWSBaseURL string, validator A
 			return
 		}
 
-		// 1. New codex 0.132+ path: try Bearer (ChatGPT) or
-		//    AgentAssertion (Agent Identity) via agentserver.
 		authHeader := r.Header.Get("Authorization")
-		if userID, ok := classifyAndValidate(r.Context(), validator,
-			authHeader, r.Header.Get("ChatGPT-Account-ID")); ok {
-			if err := assertExeOwnedByUser(r.Context(), store, exeID, userID); err != nil {
-				writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
-				return
-			}
-			respondWithWSURL(w, r, exeID, authHeader, publicWSBaseURL)
-			return
-		}
-
-		// 2. Legacy bcrypt bearer path for codex < 0.132 — kept until
-		//    we drop support, then this block goes away.
-		bearer, ok := extractBearer(r)
-		if !ok || bearer == "" {
-			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "missing bearer"})
-			return
-		}
-		hash, err := store.GetRegistrationTokenHash(r.Context(), exeID)
-		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal"})
-			return
-		}
-		if hash == "" || bcrypt.CompareHashAndPassword([]byte(hash), []byte(bearer)) != nil {
+		userID, ok := classifyAndValidate(r.Context(), validator,
+			authHeader, r.Header.Get("ChatGPT-Account-ID"))
+		if !ok {
 			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
 			return
 		}
-		respondWithWSURL(w, r, exeID, "Bearer "+bearer, publicWSBaseURL)
+		if err := assertExeOwnedByUser(r.Context(), store, exeID, userID); err != nil {
+			writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
+			return
+		}
+		ticket, err := MintWSTicket(exeID, wsTicketSecret)
+		if err != nil {
+			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "mint ws ticket: " + err.Error()})
+			return
+		}
+		respondWithWSURL(w, r, exeID, ticket, publicWSBaseURL)
 	}
 }
 
@@ -179,29 +167,15 @@ func assertExeOwnedByUser(ctx context.Context, store CloudRegisterStore, exeID, 
 	return nil
 }
 
-func respondWithWSURL(w http.ResponseWriter, r *http.Request, exeID, authHeader, publicWSBaseURL string) {
+func respondWithWSURL(w http.ResponseWriter, r *http.Request, exeID, ticket, publicWSBaseURL string) {
 	base := publicWSBaseURL
 	if base == "" {
 		base = synthBaseURL(r)
 	}
-	// The WS URL has its own bearer cap-token in the query string; the
-	// auth header above only authorized the register call itself.
-	tokenForWS := strings.TrimPrefix(strings.TrimPrefix(authHeader, "Bearer "), "AgentAssertion ")
-	wsURL := base + "/codex-exec/" + url.PathEscape(exeID) + "?token=" +
-		url.QueryEscape(tokenForWS)
+	wsURL := base + "/codex-exec/" + url.PathEscape(exeID) + "?token=" + url.QueryEscape(ticket)
 	writeJSON(w, http.StatusOK, cloudRegisterResponse{
 		ID: exeID, ExecutorID: exeID, URL: wsURL,
 	})
-}
-
-// extractBearer returns the Authorization: Bearer <token> value.
-func extractBearer(r *http.Request) (string, bool) {
-	h := r.Header.Get("Authorization")
-	const prefix = "Bearer "
-	if !strings.HasPrefix(h, prefix) {
-		return "", false
-	}
-	return strings.TrimPrefix(h, prefix), true
 }
 
 // synthBaseURL composes a wss:// base from the incoming request's Host.

--- a/internal/codexexecgateway/handlers/cloud_register_test.go
+++ b/internal/codexexecgateway/handlers/cloud_register_test.go
@@ -6,30 +6,19 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/go-chi/chi/v5"
-	"golang.org/x/crypto/bcrypt"
 )
 
-func bcryptHash(plain string) (string, error) {
-	h, err := bcrypt.GenerateFromPassword([]byte(plain), bcrypt.MinCost)
-	return string(h), err
-}
-
-// mockCloudRegisterStore implements CloudRegisterStore and also exposes
+// mockCloudRegisterStore implements CloudRegisterStore and exposes
 // UserIDForExecutor (matched by assertExeOwnedByUser's ad-hoc interface
 // assertion). Lets us exercise CloudRegister without a real DB.
 type mockCloudRegisterStore struct {
-	hash       string
-	hashErr    error
 	owner      string
 	ownerErr   error
 	registered bool // false → UserIDForExecutor returns "" (unknown executor)
-}
-
-func (m *mockCloudRegisterStore) GetRegistrationTokenHash(ctx context.Context, exeID string) (string, error) {
-	return m.hash, m.hashErr
 }
 
 func (m *mockCloudRegisterStore) UserIDForExecutor(ctx context.Context, exeID string) (string, error) {
@@ -39,16 +28,14 @@ func (m *mockCloudRegisterStore) UserIDForExecutor(ctx context.Context, exeID st
 	return m.owner, m.ownerErr
 }
 
-// newStoreWithExecutor returns a mock store that "knows" an executor
-// row exists for exeID owned by userID.
 func newStoreWithExecutor(t *testing.T, exeID, userID string) *mockCloudRegisterStore {
 	t.Helper()
 	return &mockCloudRegisterStore{owner: userID, registered: true}
 }
 
+const testTicketSecret = "ticket-secret"
+
 func TestCloudRegister_BearerScheme_DelegatesToAgentserver(t *testing.T) {
-	// Stub agentserver: any call to /internal/codex-auth/validate with
-	// scheme=bearer + matching token returns user-id "u-1".
 	agentSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/internal/codex-auth/validate" {
 			http.Error(w, "wrong path", 404)
@@ -73,7 +60,7 @@ func TestCloudRegister_BearerScheme_DelegatesToAgentserver(t *testing.T) {
 	h := CloudRegister(store, "wss://test", AgentserverValidator{
 		BaseURL:        agentSrv.URL,
 		InternalSecret: "shh",
-	})
+	}, testTicketSecret)
 	req := httptest.NewRequest(http.MethodPost, "/cloud/executor/exe_x/register", nil)
 	req.Header.Set("Authorization", "Bearer valid-bearer")
 	rctx := chi.NewRouteContext()
@@ -92,8 +79,15 @@ func TestCloudRegister_BearerScheme_DelegatesToAgentserver(t *testing.T) {
 	if resp.ExecutorID != "exe_x" {
 		t.Fatalf("executor_id = %q", resp.ExecutorID)
 	}
-	if resp.URL == "" || resp.URL[:5] != "wss:/" {
+	if !strings.HasPrefix(resp.URL, "wss://test/codex-exec/exe_x?token=") {
 		t.Fatalf("url = %q", resp.URL)
+	}
+
+	// Verify the ticket in the URL passes VerifyWSTicket with the same secret.
+	const prefix = "wss://test/codex-exec/exe_x?token="
+	ticket := strings.TrimPrefix(resp.URL, prefix)
+	if err := VerifyWSTicket(ticket, "exe_x", testTicketSecret); err != nil {
+		t.Fatalf("ticket should verify: %v", err)
 	}
 }
 
@@ -109,7 +103,7 @@ func TestCloudRegister_BearerScheme_WrongOwner(t *testing.T) {
 	h := CloudRegister(store, "wss://test", AgentserverValidator{
 		BaseURL:        agentSrv.URL,
 		InternalSecret: "shh",
-	})
+	}, testTicketSecret)
 	req := httptest.NewRequest(http.MethodPost, "/cloud/executor/exe_x/register", nil)
 	req.Header.Set("Authorization", "Bearer some-token")
 	rctx := chi.NewRouteContext()
@@ -122,27 +116,20 @@ func TestCloudRegister_BearerScheme_WrongOwner(t *testing.T) {
 	}
 }
 
-// When the validator is unconfigured (BaseURL=""), the legacy bcrypt
-// fallback path must still authenticate codex < 0.132 clients.
-func TestCloudRegister_LegacyBcryptFallback(t *testing.T) {
-	// bcrypt of "legacy-token" (cost 4 to keep test snappy).
-	// Generated via: bcrypt.GenerateFromPassword([]byte("legacy-token"), 4).
-	// We compute it at test time to avoid a hardcoded constant.
-	hash, err := bcryptHash("legacy-token")
-	if err != nil {
-		t.Fatalf("bcryptHash: %v", err)
-	}
-	store := &mockCloudRegisterStore{hash: hash}
-	h := CloudRegister(store, "wss://test", AgentserverValidator{})
+// Without validator configured (BaseURL empty), every register attempt
+// must be rejected — no legacy bcrypt fallback anymore.
+func TestCloudRegister_RejectsWithoutValidator(t *testing.T) {
+	store := newStoreWithExecutor(t, "exe_x", "u-1")
+	h := CloudRegister(store, "wss://test", AgentserverValidator{}, testTicketSecret)
 
 	req := httptest.NewRequest(http.MethodPost, "/cloud/executor/exe_x/register", nil)
-	req.Header.Set("Authorization", "Bearer legacy-token")
+	req.Header.Set("Authorization", "Bearer any-token")
 	rctx := chi.NewRouteContext()
 	rctx.URLParams.Add("exe_id", "exe_x")
 	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
 	rr := httptest.NewRecorder()
 	h(rr, req)
-	if rr.Code != http.StatusOK {
-		t.Fatalf("want 200, got %d body=%s", rr.Code, rr.Body.String())
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d body=%s", rr.Code, rr.Body.String())
 	}
 }

--- a/internal/codexexecgateway/handlers/register.go
+++ b/internal/codexexecgateway/handlers/register.go
@@ -5,22 +5,18 @@ package handlers
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/agentserver/agentserver/internal/codexexecgateway/execmodel"
 	"github.com/go-chi/chi/v5"
 	"github.com/google/uuid"
-	"golang.org/x/crypto/bcrypt"
 )
 
 // Store is the subset of storage required by the register handler.
 type Store interface {
-	CreateExecutor(ctx context.Context, e execmodel.Executor, registrationTokenHash string) error
+	CreateExecutor(ctx context.Context, e execmodel.Executor) error
 	DeleteExecutor(ctx context.Context, exeID string) error
 }
 
@@ -33,13 +29,15 @@ type registerRequest struct {
 }
 
 type registerResponse struct {
-	ExeID             string `json:"exe_id"`
-	RegistrationToken string `json:"registration_token"`
+	ExeID string `json:"exe_id"`
 }
 
-// Register returns an http.HandlerFunc that creates a new executor row and
-// returns the freshly-minted (raw) registration token. The DB only stores
-// the bcrypt hash — the raw token is never persisted or logged.
+// Register returns an http.HandlerFunc that creates a new executor row
+// and returns its id. The codex 0.132 bcrypt registration_token path
+// is gone — auth on /cloud/.../register now goes through Agent Identity
+// JWT or ChatGPT access_token validated by agentserver, and the inbound
+// ws verifies a short-lived HMAC ticket minted at register time. So
+// this endpoint no longer mints any per-executor bearer.
 func Register(store Store) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		userID := r.Header.Get("X-User-Id")
@@ -52,30 +50,17 @@ func Register(store Store) http.HandlerFunc {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
 			return
 		}
-		raw, err := generateToken()
-		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal"})
-			return
-		}
-		hash, err := bcrypt.GenerateFromPassword([]byte(raw), bcrypt.DefaultCost)
-		if err != nil {
-			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal"})
-			return
-		}
 		exe := execmodel.Executor{
 			ExeID:        "exe_" + uuid.NewString(),
 			UserID:       userID,
 			DisplayName:  req.DisplayName,
 			RegisteredAt: time.Now().UTC(),
 		}
-		if err := store.CreateExecutor(r.Context(), exe, string(hash)); err != nil {
+		if err := store.CreateExecutor(r.Context(), exe); err != nil {
 			writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "create executor"})
 			return
 		}
-		writeJSON(w, http.StatusCreated, registerResponse{
-			ExeID:             exe.ExeID,
-			RegistrationToken: raw,
-		})
+		writeJSON(w, http.StatusCreated, registerResponse{ExeID: exe.ExeID})
 	}
 }
 
@@ -95,14 +80,6 @@ func DeleteExecutor(store Store) http.HandlerFunc {
 		}
 		w.WriteHeader(http.StatusNoContent)
 	}
-}
-
-func generateToken() (string, error) {
-	b := make([]byte, 32)
-	if _, err := rand.Read(b); err != nil {
-		return "", fmt.Errorf("rand: %w", err)
-	}
-	return hex.EncodeToString(b), nil
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {

--- a/internal/codexexecgateway/handlers/ws_ticket.go
+++ b/internal/codexexecgateway/handlers/ws_ticket.go
@@ -1,0 +1,70 @@
+package handlers
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// wsTicketTTL bounds the window between the cloud-register response and
+// the immediately-following ws upgrade. Codex re-registers on every
+// reconnect, so we don't need long-lived tickets.
+const wsTicketTTL = 5 * time.Minute
+
+// MintWSTicket returns a short-lived bearer that authorizes the
+// `/codex-exec/{exe_id}?token=...` ws upgrade. Format:
+//
+//	<exe_id>.<expiry_unix>.<base64url(HMAC-SHA256(secret, "<exe_id>.<expiry>"))>
+//
+// The inbound handler recomputes the HMAC with its own secret and
+// confirms the exe_id matches and the expiry is in the future. No DB
+// round-trip; no bcrypt; no JWT verification.
+func MintWSTicket(exeID, secret string) (string, error) {
+	if secret == "" {
+		return "", fmt.Errorf("internal secret not configured")
+	}
+	expiry := time.Now().Add(wsTicketTTL).Unix()
+	payload := exeID + "." + strconv.FormatInt(expiry, 10)
+	mac := hmac.New(sha256.New, []byte(secret))
+	mac.Write([]byte(payload))
+	sig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return payload + "." + sig, nil
+}
+
+// VerifyWSTicket returns nil iff the ticket is well-formed, signed with
+// `secret`, names the expected exe_id, and has not yet expired.
+func VerifyWSTicket(ticket, expectedExeID, secret string) error {
+	if secret == "" {
+		return fmt.Errorf("internal secret not configured")
+	}
+	parts := strings.Split(ticket, ".")
+	if len(parts) != 3 {
+		return fmt.Errorf("malformed ticket")
+	}
+	exeID, expStr, sigB64 := parts[0], parts[1], parts[2]
+	if exeID != expectedExeID {
+		return fmt.Errorf("ticket exe_id mismatch")
+	}
+	exp, err := strconv.ParseInt(expStr, 10, 64)
+	if err != nil {
+		return fmt.Errorf("bad expiry: %w", err)
+	}
+	if time.Now().Unix() >= exp {
+		return fmt.Errorf("ticket expired")
+	}
+	want := hmac.New(sha256.New, []byte(secret))
+	want.Write([]byte(exeID + "." + expStr))
+	wantSig := want.Sum(nil)
+	gotSig, err := base64.RawURLEncoding.DecodeString(sigB64)
+	if err != nil {
+		return fmt.Errorf("bad signature encoding: %w", err)
+	}
+	if !hmac.Equal(wantSig, gotSig) {
+		return fmt.Errorf("bad signature")
+	}
+	return nil
+}

--- a/internal/codexexecgateway/handlers_internal_api_test.go
+++ b/internal/codexexecgateway/handlers_internal_api_test.go
@@ -37,7 +37,7 @@ func TestInternalConnected_ReturnsIntersection(t *testing.T) {
 		{ExeID: "exe_on", UserID: "u", Description: "online", DefaultCwd: "/x", RegisteredAt: time.Now().UTC()},
 		{ExeID: "exe_off", UserID: "u", Description: "offline", DefaultCwd: "/y", RegisteredAt: time.Now().UTC()},
 	} {
-		store.CreateExecutor(context.Background(), e, "h")
+		store.CreateExecutor(context.Background(), e)
 		store.BindWorkspaceExecutor(context.Background(), "ws_a", e.ExeID, e.ExeID, "", e.ExeID == "exe_on")
 	}
 	srv.registry.Register("exe_on", newInboundConn("exe_on", nil, nil))

--- a/internal/codexexecgateway/handlers_register_test.go
+++ b/internal/codexexecgateway/handlers_register_test.go
@@ -7,8 +7,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-
-	"golang.org/x/crypto/bcrypt"
 )
 
 func TestHandleRegister_HappyPath(t *testing.T) {
@@ -28,22 +26,13 @@ func TestHandleRegister_HappyPath(t *testing.T) {
 		t.Fatalf("want 201, got %d body=%s", rr.Code, rr.Body.String())
 	}
 	var resp struct {
-		ExeID             string `json:"exe_id"`
-		RegistrationToken string `json:"registration_token"`
+		ExeID string `json:"exe_id"`
 	}
 	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if !strings.HasPrefix(resp.ExeID, "exe_") || resp.RegistrationToken == "" {
+	if !strings.HasPrefix(resp.ExeID, "exe_") {
 		t.Fatalf("bad response: %+v", resp)
-	}
-	// Token round-trip: bcrypt hash from DB must verify against returned token.
-	hash, err := store.GetRegistrationTokenHash(req.Context(), resp.ExeID)
-	if err != nil || hash == "" {
-		t.Fatalf("hash: %v %q", err, hash)
-	}
-	if err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(resp.RegistrationToken)); err != nil {
-		t.Fatalf("bcrypt verify: %v", err)
 	}
 }
 

--- a/internal/codexexecgateway/handlers_workspace_binding_test.go
+++ b/internal/codexexecgateway/handlers_workspace_binding_test.go
@@ -20,7 +20,7 @@ func TestWorkspaceBinding_PostListDelete(t *testing.T) {
 	// Pre-seed an executor.
 	store.CreateExecutor(context.Background(), Executor{
 		ExeID: "exe_w1", UserID: "u", Description: "alpha", RegisteredAt: time.Now().UTC(),
-	}, "h")
+	})
 
 	// POST
 	body := bytes.NewReader([]byte(`{"exe_id":"exe_w1","is_default":true}`))

--- a/internal/codexexecgateway/inbound.go
+++ b/internal/codexexecgateway/inbound.go
@@ -7,10 +7,10 @@ import (
 	"time"
 
 	"github.com/agentserver/agentserver/internal/clientmeta"
+	"github.com/agentserver/agentserver/internal/codexexecgateway/handlers"
 	"github.com/agentserver/agentserver/internal/relaypb"
 	"github.com/agentserver/agentserver/internal/wsbridge"
 	"github.com/go-chi/chi/v5"
-	"golang.org/x/crypto/bcrypt"
 	"google.golang.org/protobuf/proto"
 	"nhooyr.io/websocket"
 )
@@ -28,19 +28,8 @@ func (s *Server) handleInbound(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	hash, err := s.store.GetRegistrationTokenHash(r.Context(), exeID)
-	if err != nil {
-		s.logger.Error("inbound: get token hash", "exe_id", exeID, "error", err)
-		http.Error(w, "internal error", http.StatusInternalServerError)
-		return
-	}
-	if hash == "" {
-		slog.Warn("inbound: unauthorized", "exe_id", exeID, "reason", "unknown_exe_id", "remote", r.RemoteAddr)
-		http.Error(w, "unauthorized", http.StatusUnauthorized)
-		return
-	}
-	if err := bcrypt.CompareHashAndPassword([]byte(hash), []byte(token)); err != nil {
-		slog.Warn("inbound: unauthorized", "exe_id", exeID, "reason", "bad_token", "remote", r.RemoteAddr)
+	if err := handlers.VerifyWSTicket(token, exeID, s.config.AgentserverInternalSecret); err != nil {
+		slog.Warn("inbound: unauthorized", "exe_id", exeID, "reason", "bad_ticket", "remote", r.RemoteAddr, "error", err.Error())
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}

--- a/internal/codexexecgateway/inbound_test.go
+++ b/internal/codexexecgateway/inbound_test.go
@@ -7,14 +7,16 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/crypto/bcrypt"
+	"github.com/agentserver/agentserver/internal/codexexecgateway/handlers"
 	"nhooyr.io/websocket"
 )
+
+const testInboundSecret = "ticket-secret"
 
 func newInboundTestServer(t *testing.T) (*httptest.Server, *Server) {
 	t.Helper()
 	store := newTestStore(t)
-	cfg := Config{CapTokenHMACSecret: []byte("k"), InternalSharedSecret: "s"}
+	cfg := Config{CapTokenHMACSecret: []byte("k"), InternalSharedSecret: "s", AgentserverInternalSecret: testInboundSecret}
 	srv, err := NewServer(cfg, store)
 	if err != nil {
 		t.Fatalf("NewServer: %v", err)
@@ -27,10 +29,9 @@ func newInboundTestServer(t *testing.T) (*httptest.Server, *Server) {
 func TestInbound_RejectsBadToken(t *testing.T) {
 	hs, srv := newInboundTestServer(t)
 	ctx := context.Background()
-	hash, _ := bcrypt.GenerateFromPassword([]byte("right_token"), bcrypt.DefaultCost)
 	srv.store.CreateExecutor(ctx, Executor{
 		ExeID: "exe_inb1", UserID: "u", RegisteredAt: time.Now().UTC(),
-	}, string(hash))
+	})
 
 	wsURL := "ws" + hs.URL[len("http"):] + "/codex-exec/exe_inb1?token=wrong"
 	_, resp, err := websocket.Dial(ctx, wsURL, nil)
@@ -45,12 +46,15 @@ func TestInbound_RejectsBadToken(t *testing.T) {
 func TestInbound_AcceptsAndRegisters(t *testing.T) {
 	hs, srv := newInboundTestServer(t)
 	ctx := context.Background()
-	hash, _ := bcrypt.GenerateFromPassword([]byte("good"), bcrypt.DefaultCost)
 	srv.store.CreateExecutor(ctx, Executor{
 		ExeID: "exe_inb2", UserID: "u", RegisteredAt: time.Now().UTC(),
-	}, string(hash))
+	})
+	ticket, err := handlers.MintWSTicket("exe_inb2", testInboundSecret)
+	if err != nil {
+		t.Fatalf("mint ticket: %v", err)
+	}
 
-	wsURL := "ws" + hs.URL[len("http"):] + "/codex-exec/exe_inb2?token=good"
+	wsURL := "ws" + hs.URL[len("http"):] + "/codex-exec/exe_inb2?token=" + ticket
 	c, _, err := websocket.Dial(ctx, wsURL, nil)
 	if err != nil {
 		t.Fatalf("dial: %v", err)
@@ -73,12 +77,15 @@ func TestInbound_AcceptsAndRegisters(t *testing.T) {
 func TestInbound_EvictsOldConn(t *testing.T) {
 	hs, srv := newInboundTestServer(t)
 	ctx := context.Background()
-	hash, _ := bcrypt.GenerateFromPassword([]byte("tok"), bcrypt.DefaultCost)
 	srv.store.CreateExecutor(ctx, Executor{
 		ExeID: "exe_inb3", UserID: "u", RegisteredAt: time.Now().UTC(),
-	}, string(hash))
+	})
+	ticket, err := handlers.MintWSTicket("exe_inb3", testInboundSecret)
+	if err != nil {
+		t.Fatalf("mint ticket: %v", err)
+	}
 
-	wsURL := "ws" + hs.URL[len("http"):] + "/codex-exec/exe_inb3?token=tok"
+	wsURL := "ws" + hs.URL[len("http"):] + "/codex-exec/exe_inb3?token=" + ticket
 
 	// First connection.
 	c1, _, err := websocket.Dial(ctx, wsURL, nil)

--- a/internal/codexexecgateway/multiplex_e2e_test.go
+++ b/internal/codexexecgateway/multiplex_e2e_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/agentserver/agentserver/internal/codexexecgateway/handlers"
 	"github.com/agentserver/agentserver/internal/relaypb"
-	"golang.org/x/crypto/bcrypt"
 	"google.golang.org/protobuf/proto"
 	"nhooyr.io/websocket"
 )
@@ -88,14 +88,17 @@ func readRelayFrame(t *testing.T, ctx context.Context, c *websocket.Conn) *relay
 // responses tagged with the right stream_id).
 func connectInboundRaw(t *testing.T, srv *Server, baseURL, exeID string) *websocket.Conn {
 	t.Helper()
-	hash, _ := bcrypt.GenerateFromPassword([]byte("rt"), bcrypt.DefaultCost)
 	srv.store.CreateExecutor(context.Background(), Executor{
 		ExeID: exeID, UserID: "u", RegisteredAt: time.Now().UTC(),
-	}, string(hash))
+	})
 	if err := srv.store.BindWorkspaceExecutor(context.Background(), "ws_1", exeID, "test-"+exeID, "", false); err != nil {
 		t.Fatalf("BindWorkspaceExecutor: %v", err)
 	}
-	url := "ws" + strings.TrimPrefix(baseURL, "http") + "/codex-exec/" + exeID + "?token=rt"
+	ticket, err := handlers.MintWSTicket(exeID, srv.config.AgentserverInternalSecret)
+	if err != nil {
+		t.Fatalf("MintWSTicket: %v", err)
+	}
+	url := "ws" + strings.TrimPrefix(baseURL, "http") + "/codex-exec/" + exeID + "?token=" + ticket
 	c, _, err := websocket.Dial(context.Background(), url, nil)
 	if err != nil {
 		t.Fatalf("inbound dial: %v", err)

--- a/internal/codexexecgateway/server.go
+++ b/internal/codexexecgateway/server.go
@@ -172,7 +172,8 @@ func (s *Server) Routes() http.Handler {
 			handlers.AgentserverValidator{
 				BaseURL:        s.config.AgentserverInternalURL,
 				InternalSecret: s.config.AgentserverInternalSecret,
-			}))
+			},
+			s.config.AgentserverInternalSecret))
 
 	// *Store satisfies handlers.Store, handlers.BindingStore, and
 	// handlers.InternalConnectedStore directly — no adapter needed because

--- a/internal/codexexecgateway/store.go
+++ b/internal/codexexecgateway/store.go
@@ -84,14 +84,17 @@ func (s *Store) migrate() error {
 	return nil
 }
 
-// CreateExecutor inserts a new executor row. Caller supplies the bcrypt hash.
-func (s *Store) CreateExecutor(ctx context.Context, e Executor, registrationTokenHash string) error {
+// CreateExecutor inserts a new executor row. The legacy registration_token_hash
+// column is written as empty string (NOT NULL constraint) and is no longer
+// consumed by any auth path — kept to avoid a schema migration on a column
+// that will be dropped in a follow-up.
+func (s *Store) CreateExecutor(ctx context.Context, e Executor) error {
 	_, err := s.db.ExecContext(ctx, `
 		INSERT INTO executors (exe_id, user_id, display_name, description, default_cwd,
 		                       registration_token_hash, registered_at)
-		VALUES ($1, $2, NULLIF($3,''), NULLIF($4,''), NULLIF($5,''), $6, $7)`,
+		VALUES ($1, $2, NULLIF($3,''), NULLIF($4,''), NULLIF($5,''), '', $6)`,
 		e.ExeID, e.UserID, e.DisplayName, e.Description, e.DefaultCwd,
-		registrationTokenHash, e.RegisteredAt)
+		e.RegisteredAt)
 	if err != nil {
 		return fmt.Errorf("insert executor: %w", err)
 	}
@@ -137,20 +140,6 @@ func (s *Store) GetExecutor(ctx context.Context, exeID string) (*Executor, error
 		e.DisconnectedAt = &t
 	}
 	return &e, nil
-}
-
-// GetRegistrationTokenHash returns the bcrypt hash used to authenticate
-// /codex-exec/{exe_id} ws connections.
-func (s *Store) GetRegistrationTokenHash(ctx context.Context, exeID string) (string, error) {
-	var hash string
-	err := s.db.QueryRowContext(ctx, `SELECT registration_token_hash FROM executors WHERE exe_id=$1`, exeID).Scan(&hash)
-	if err == sql.ErrNoRows {
-		return "", nil
-	}
-	if err != nil {
-		return "", fmt.Errorf("get registration token hash: %w", err)
-	}
-	return hash, nil
 }
 
 // UpdateLastSeen sets the last_seen_at timestamp to NOW().

--- a/internal/codexexecgateway/store_test.go
+++ b/internal/codexexecgateway/store_test.go
@@ -35,7 +35,7 @@ func TestStore_CreateAndGetExecutor(t *testing.T) {
 		DefaultCwd:   "/home/daisy",
 		RegisteredAt: time.Now().UTC(),
 	}
-	if err := store.CreateExecutor(ctx, exe, "hashed_token"); err != nil {
+	if err := store.CreateExecutor(ctx, exe); err != nil {
 		t.Fatalf("CreateExecutor: %v", err)
 	}
 	got, err := store.GetExecutor(ctx, "exe_test1")
@@ -51,7 +51,7 @@ func TestStore_BindAndListWorkspaceExecutors(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()
 	exe := Executor{ExeID: "exe_a", UserID: "u1", Description: "alpha", RegisteredAt: time.Now().UTC()}
-	if err := store.CreateExecutor(ctx, exe, "h"); err != nil {
+	if err := store.CreateExecutor(ctx, exe); err != nil {
 		t.Fatalf("CreateExecutor: %v", err)
 	}
 	if err := store.BindWorkspaceExecutor(ctx, "ws_1", "exe_a", "alpha", "", true); err != nil {
@@ -70,7 +70,7 @@ func TestStore_UnbindWorkspaceExecutor(t *testing.T) {
 	store := newTestStore(t)
 	ctx := context.Background()
 	exe := Executor{ExeID: "exe_b", UserID: "u1", RegisteredAt: time.Now().UTC()}
-	store.CreateExecutor(ctx, exe, "h")
+	store.CreateExecutor(ctx, exe)
 	store.BindWorkspaceExecutor(ctx, "ws_1", "exe_b", "beta", "", false)
 	if err := store.UnbindWorkspaceExecutor(ctx, "ws_1", "exe_b"); err != nil {
 		t.Fatalf("UnbindWorkspaceExecutor: %v", err)
@@ -89,7 +89,7 @@ func TestStore_ConnectedExecutorsForWorkspace(t *testing.T) {
 		{ExeID: "exe_x", UserID: "u1", Description: "x desc", DefaultCwd: "/x", RegisteredAt: now},
 		{ExeID: "exe_y", UserID: "u1", Description: "y desc", DefaultCwd: "/y", RegisteredAt: now},
 	} {
-		store.CreateExecutor(ctx, e, "h")
+		store.CreateExecutor(ctx, e)
 	}
 	store.BindWorkspaceExecutor(ctx, "ws_1", "exe_x", "x", "", true)
 	store.BindWorkspaceExecutor(ctx, "ws_1", "exe_y", "y", "", false)

--- a/internal/server/codex_executors.go
+++ b/internal/server/codex_executors.go
@@ -30,33 +30,28 @@ type registerExecutorReq struct {
 }
 
 type registerExecutorResp struct {
-	ExeID             string `json:"exe_id"`
-	RegistrationToken string `json:"registration_token"`
+	ExeID string `json:"exe_id"`
 	// ConnectCommand is the one-liner the user pastes on the machine
 	// they want to expose as an executor. Empty when the gateway public
 	// host isn't configured — the UI falls back to a generic template.
-	// Kept for backward compatibility with UI clients predating the
-	// 3-variant bundle (set to the Agent Identity command when codexAuth
-	// is enabled so old clients still get a working command).
 	ConnectCommand string `json:"connect_command,omitempty"`
-	// AgentIdentityJWT is the codex Agent Identity JWT minted alongside
-	// the bcrypt registration token. Present only when codexAuth is
-	// enabled (CODEX_AUTH_ISSUER_URL set).
+	// AgentIdentityJWT is the codex Agent Identity JWT minted for this
+	// executor. Present only when codexAuth is enabled
+	// (CODEX_AUTH_ISSUER_URL set).
 	AgentIdentityJWT string `json:"agent_identity_jwt,omitempty"`
-	// ConnectCommands is the 3-variant bundle surfaced by the Add
+	// ConnectCommands is the single-variant bundle surfaced by the Add
 	// Connector UI. Empty when codexAuth is disabled.
 	ConnectCommands ConnectCommands `json:"connect_commands,omitempty"`
 }
 
-// ConnectCommands is the 3-variant connect-command bundle returned by
-// the Add Connector API. Agent Identity is the recommended path for
-// unattended machines; ChatGPT browser is the recommended path for
-// developer laptops; ChatGPT device-auth covers the headless +
-// ChatGPT-account case.
+// ConnectCommands is the Agent-Identity-only connect-command bundle
+// returned by the Add Connector API. The pre-0.132 bcrypt path and the
+// ChatGPT device-auth variant are gone — auth at /cloud/.../register
+// now goes through the Agent Identity JWT (validated by agentserver),
+// and the inbound ws verifies a short-lived HMAC ticket minted at
+// register time.
 type ConnectCommands struct {
-	AgentIdentity     string `json:"agent_identity"`
-	ChatgptBrowser    string `json:"chatgpt_browser"`
-	ChatgptDeviceAuth string `json:"chatgpt_device_auth"`
+	AgentIdentity string `json:"agent_identity"`
 }
 
 // handleRegisterExecutor mints a new executor owned by the calling user
@@ -144,53 +139,28 @@ func (s *Server) handleRegisterExecutor(w http.ResponseWriter, r *http.Request) 
 		}
 	}
 
-	resp := registerExecutorResp{
-		ExeID:             reg.ExeID,
-		RegistrationToken: reg.RegistrationToken,
-	}
+	resp := registerExecutorResp{ExeID: reg.ExeID}
 	if aiResult != nil {
 		resp.AgentIdentityJWT = aiResult.JWT
 	}
-	if s.CodexExecGatewayPublicHost != "" {
+	if s.CodexExecGatewayPublicHost != "" && s.CodexAuthIssuerURL != "" && aiResult != nil {
 		// Upstream codex `exec-server --remote` contract:
-		//   1. POST <base_url>/cloud/executor/{id}/register with Bearer <token>
-		//   2. Server returns {executor_id, url}, codex then ws-dials url.
-		// Surface the user's `name` as codex's --name (visible in their
-		// shell + tracing) so it lines up with what the LLM sees.
+		//   1. POST <base_url>/cloud/executor/{id}/register with the
+		//      Agent Identity JWT (Authorization: AgentAssertion ...).
+		//   2. Server validates the JWT, returns {executor_id, url}
+		//      with a short-lived HMAC ticket in ?token=.
+		//   3. codex ws-dials url; inbound verifies the HMAC ticket.
+		// Note `-c chatgpt_base_url=` not `chatgpt.base_url=` —
+		// the codex config field is the snake_case top-level key, the
+		// dotted form silently no-ops.
 		gatewayURL := "https://" + s.CodexExecGatewayPublicHost
 		issuer := s.CodexAuthIssuerURL
-		if issuer == "" {
-			// codexAuth disabled — legacy bearer-only command (no Agent
-			// Identity, no ChatGPT login). Preserves pre-D3 behaviour.
-			resp.ConnectCommand = fmt.Sprintf(
-				"export CODEX_EXEC_SERVER_REMOTE_BEARER_TOKEN='%s'\ncodex exec-server --remote '%s' --executor-id '%s' --name '%s'",
-				reg.RegistrationToken, gatewayURL, reg.ExeID, req.Name)
-		} else {
-			// codexAuth enabled — two practical paths:
-			//   1. Agent Identity — paste-and-go, no login.
-			//   2. ChatGPT device-auth — `codex login --device-auth
-			//      --experimental_issuer ...` shows a URL + short code;
-			//      user opens the URL in any browser (phone or laptop),
-			//      enters the code, clicks Approve.
-			//
-			// Note: the "pure browser" path `codex login
-			// --experimental_issuer ...` (without --device-auth) is
-			// BROKEN in codex 0.132 — `cli/src/main.rs:1194` calls
-			// run_login_with_chatgpt without forwarding
-			// login_cli.issuer_base_url, so the browser pops open
-			// auth.openai.com regardless of the flag. Device-auth path
-			// at `:1170` does plumb the override through. Until codex
-			// upstream fixes the browser path we don't expose it here.
-			resp.ConnectCommands = ConnectCommands{
-				AgentIdentity: fmt.Sprintf(
-					"export CODEX_ACCESS_TOKEN='%s'\nexport CODEX_AGENT_IDENTITY_AUTHAPI_BASE_URL='%s'\ncodex -c chatgpt.base_url='%s' exec-server --remote '%s' --executor-id '%s' --name '%s' --use-agent-identity-auth",
-					aiResult.JWT, issuer, issuer, gatewayURL, reg.ExeID, req.Name),
-				ChatgptDeviceAuth: fmt.Sprintf(
-					"codex login --device-auth --experimental_issuer %s\nexport CODEX_REFRESH_TOKEN_URL_OVERRIDE='%s/oauth/token'\ncodex exec-server --remote '%s' --executor-id '%s' --name '%s'",
-					issuer, issuer, gatewayURL, reg.ExeID, req.Name),
-			}
-			resp.ConnectCommand = resp.ConnectCommands.AgentIdentity
+		resp.ConnectCommands = ConnectCommands{
+			AgentIdentity: fmt.Sprintf(
+				"export CODEX_ACCESS_TOKEN='%s'\nexport CODEX_AGENT_IDENTITY_AUTHAPI_BASE_URL='%s'\ncodex -c chatgpt_base_url='%s' exec-server --remote '%s' --executor-id '%s' --name '%s' --use-agent-identity-auth",
+				aiResult.JWT, issuer, issuer, gatewayURL, reg.ExeID, req.Name),
 		}
+		resp.ConnectCommand = resp.ConnectCommands.AgentIdentity
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/internal/server/codex_executors_client.go
+++ b/internal/server/codex_executors_client.go
@@ -40,12 +40,11 @@ type RegisterExecutorRequest struct {
 	DisplayName string `json:"display_name,omitempty"`
 }
 
-// RegisterExecutorResponse matches codex-exec-gateway's response (raw
-// token is returned ONCE — agentserver forwards it to the web UI for
-// one-time display, never stores it).
+// RegisterExecutorResponse matches codex-exec-gateway's response. The
+// pre-0.132 bcrypt registration_token is gone — auth on
+// /cloud/.../register now uses the Agent Identity JWT.
 type RegisterExecutorResponse struct {
-	ExeID             string `json:"exe_id"`
-	RegistrationToken string `json:"registration_token"`
+	ExeID string `json:"exe_id"`
 }
 
 // ListedExecutor matches codex-exec-gateway's

--- a/internal/server/codex_executors_client_test.go
+++ b/internal/server/codex_executors_client_test.go
@@ -26,7 +26,7 @@ func TestExecutorsClient_Register(t *testing.T) {
 			t.Errorf("body = %s", body)
 		}
 		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(RegisterExecutorResponse{ExeID: "exe_xxx", RegistrationToken: "tok"})
+		_ = json.NewEncoder(w).Encode(RegisterExecutorResponse{ExeID: "exe_xxx"})
 	}))
 	defer srv.Close()
 
@@ -35,7 +35,7 @@ func TestExecutorsClient_Register(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Register: %v", err)
 	}
-	if resp.ExeID != "exe_xxx" || resp.RegistrationToken != "tok" {
+	if resp.ExeID != "exe_xxx" {
 		t.Errorf("resp = %+v", resp)
 	}
 }

--- a/internal/server/codex_executors_test.go
+++ b/internal/server/codex_executors_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/agentserver/agentserver/internal/auth"
@@ -44,9 +43,7 @@ func TestHandleRegisterExecutor_HappyPath(t *testing.T) {
 	stub.HandleFunc("/api/codex-exec/register", func(w http.ResponseWriter, r *http.Request) {
 		registerCalls++
 		w.WriteHeader(http.StatusCreated)
-		_ = json.NewEncoder(w).Encode(map[string]string{
-			"exe_id": "exe_test", "registration_token": "tok_abc",
-		})
+		_ = json.NewEncoder(w).Encode(map[string]string{"exe_id": "exe_test"})
 	})
 	stub.HandleFunc("/api/codex-exec/workspaces/ws_a/executors", func(w http.ResponseWriter, r *http.Request) {
 		bindCalls++
@@ -56,11 +53,10 @@ func TestHandleRegisterExecutor_HappyPath(t *testing.T) {
 	defer cleanup()
 	seedWorkspaceMember(t, srv.DB, "ws_a", "u1", "owner")
 
-	body := bytes.NewReader([]byte(`{"description":"my mac"}`))
+	body := bytes.NewReader([]byte(`{"name":"laptop"}`))
 	req := httptest.NewRequest(http.MethodPost, "/api/workspaces/ws_a/executors", body).
 		WithContext(auth.ContextWithUserID(context.Background(), "u1"))
 	req.Header.Set("Content-Type", "application/json")
-	// Plumb the wid URL param via chi context.
 	req = withChiURLParam(req, "wid", "ws_a")
 	rr := httptest.NewRecorder()
 	srv.handleRegisterExecutor(rr, req)
@@ -69,19 +65,8 @@ func TestHandleRegisterExecutor_HappyPath(t *testing.T) {
 	}
 	var resp registerExecutorResp
 	json.Unmarshal(rr.Body.Bytes(), &resp)
-	if resp.ExeID != "exe_test" || resp.RegistrationToken != "tok_abc" {
+	if resp.ExeID != "exe_test" {
 		t.Errorf("resp = %+v", resp)
-	}
-	// Upstream-compat command: bearer in env + register POST. codex
-	// auto-derives the ws URL from the /cloud/executor/.../register response.
-	if !strings.Contains(resp.ConnectCommand, "CODEX_EXEC_SERVER_REMOTE_BEARER_TOKEN='tok_abc'") {
-		t.Errorf("connect_command missing bearer token: %q", resp.ConnectCommand)
-	}
-	if !strings.Contains(resp.ConnectCommand, "--remote 'https://codex-exec.example.com'") {
-		t.Errorf("connect_command missing --remote: %q", resp.ConnectCommand)
-	}
-	if !strings.Contains(resp.ConnectCommand, "--executor-id 'exe_test'") {
-		t.Errorf("connect_command missing --executor-id: %q", resp.ConnectCommand)
 	}
 	if registerCalls != 1 || bindCalls != 1 {
 		t.Errorf("register=%d bind=%d", registerCalls, bindCalls)

--- a/web/src/components/RemoteExecutorsPanel.tsx
+++ b/web/src/components/RemoteExecutorsPanel.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { Plus, Trash2, Copy, Check, X, Server } from 'lucide-react'
 import {
-  type RemoteExecutor, type RegisterExecutorResponse, type ConnectCommands,
+  type RemoteExecutor, type RegisterExecutorResponse,
   listRemoteExecutors, registerRemoteExecutor, unbindRemoteExecutor,
 } from '../lib/api'
 import { ConfirmModal } from './Modals'
@@ -184,11 +184,11 @@ export default function RemoteExecutorsPanel({ workspaceId }: Props) {
               </button>
             </div>
             <p className="mb-3 text-sm text-[var(--muted-foreground)]">
-              Run this on the machine you want to expose. The token won't be shown again — copy it now.
+              Run this on the machine you want to expose. The Agent Identity JWT won't be shown again — copy it now.
             </p>
-            {generated.connect_commands ? (
+            {generated.connect_commands?.agent_identity ? (
               <div className="mb-4">
-                <ConnectCommandsPanel cmds={generated.connect_commands} />
+                <SingleCommandBlock cmd={generated.connect_commands.agent_identity} />
               </div>
             ) : generated.connect_command ? (
               <div className="mb-4">
@@ -197,9 +197,8 @@ export default function RemoteExecutorsPanel({ workspaceId }: Props) {
             ) : (
               <div className="mb-4 rounded-md border border-[var(--border)] bg-[var(--background)] p-3 font-mono text-xs text-[var(--foreground)]">
                 <div>exe_id: {generated.exe_id}</div>
-                <div>registration_token: {generated.registration_token}</div>
                 <div className="mt-2 text-[var(--muted-foreground)]">
-                  Gateway public host not configured — compose the connect URL manually with your operator.
+                  Gateway public host or codex-auth not configured — compose the connect command manually with your operator.
                 </div>
               </div>
             )}
@@ -253,87 +252,3 @@ function SingleCommandBlock({ cmd }: { cmd: string }) {
   )
 }
 
-type ConnectTabKey = keyof ConnectCommands
-
-const CONNECT_TABS: { key: ConnectTabKey; label: string; hint: string }[] = [
-  {
-    key: 'agent_identity',
-    label: 'Agent Identity (recommended)',
-    hint: 'Paste-and-go. No login. Best for unattended machines.',
-  },
-  {
-    key: 'chatgpt_device_auth',
-    label: 'codex login --device-auth',
-    hint:
-      'For ChatGPT-account semantics. Opens a URL + short code; enter the ' +
-      'code in any browser (phone or laptop), click Approve. Works on both ' +
-      'headless and desktop machines.',
-  },
-  // chatgpt_browser tab intentionally omitted: codex 0.132's pure browser
-  // login path (`codex login --experimental_issuer ...` without
-  // --device-auth) ignores the issuer override and always hits
-  // auth.openai.com (upstream bug in cli/src/main.rs:1194). Device-auth
-  // is the working substitute for browser users until that's fixed.
-]
-
-function ConnectCommandsPanel({ cmds }: { cmds: ConnectCommands }) {
-  // Default to the first tab whose command is actually populated, falling
-  // back to agent_identity if none are (so the panel still renders something).
-  const firstAvailable = CONNECT_TABS.find((t) => cmds[t.key])?.key ?? 'agent_identity'
-  const [tab, setTab] = useState<ConnectTabKey>(firstAvailable)
-  const [copied, setCopied] = useState(false)
-  const current = cmds[tab] || ''
-
-  const onCopy = async () => {
-    if (!current) return
-    await navigator.clipboard.writeText(current)
-    setCopied(true)
-    setTimeout(() => setCopied(false), 1500)
-  }
-
-  return (
-    <div>
-      <div className="mb-3 flex flex-wrap gap-2">
-        {CONNECT_TABS.map(({ key, label }) => {
-          const active = tab === key
-          const disabled = !cmds[key]
-          return (
-            <button
-              key={key}
-              type="button"
-              disabled={disabled}
-              onClick={() => setTab(key)}
-              className={[
-                'rounded-md border px-3 py-1 text-xs font-medium transition-colors',
-                active
-                  ? 'border-[var(--primary)] bg-[var(--primary)] text-[var(--primary-foreground)]'
-                  : 'border-[var(--border)] bg-[var(--card)] text-[var(--foreground)] hover:bg-[var(--secondary)]',
-                disabled ? 'cursor-not-allowed opacity-40' : '',
-              ].join(' ')}
-              title={disabled ? 'Not available for this connector' : undefined}
-            >
-              {label}
-            </button>
-          )
-        })}
-      </div>
-      <p className="mb-2 text-[11px] text-[var(--muted-foreground)]">
-        {CONNECT_TABS.find((t) => t.key === tab)!.hint}
-      </p>
-      <div className="flex items-center gap-2">
-        <pre className="flex-1 overflow-x-auto rounded-md border border-[var(--border)] bg-[var(--background)] p-3 font-mono text-xs text-[var(--foreground)] whitespace-pre-wrap break-all">
-          {current || <span className="italic opacity-60">(not available)</span>}
-        </pre>
-        <button
-          onClick={onCopy}
-          disabled={!current}
-          className="rounded-md border border-[var(--border)] p-2 text-[var(--foreground)] hover:bg-[var(--secondary)] disabled:cursor-not-allowed disabled:opacity-40"
-          aria-label="Copy command"
-          title="Copy"
-        >
-          {copied ? <Check size={14} /> : <Copy size={14} />}
-        </button>
-      </div>
-    </div>
-  )
-}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1082,21 +1082,17 @@ export interface RegisterExecutorRequest {
 
 export interface ConnectCommands {
   agent_identity?: string
-  chatgpt_browser?: string
-  chatgpt_device_auth?: string
 }
 
 export interface RegisterExecutorResponse {
   exe_id: string
-  registration_token: string
-  // Legacy single-string command, still populated for backwards compat
-  // (Agent Identity command when codexAuth is enabled, bearer-token
-  // command otherwise).
+  // Same string as connect_commands.agent_identity, kept for older
+  // clients that read the single-string field.
   connect_command?: string
-  // Optional JWT minted for the executor's Agent Identity bundle.
+  // The Agent Identity JWT minted for this executor.
   agent_identity_jwt?: string
-  // New: 3-flavor command bundle (agent_identity / chatgpt_browser /
-  // chatgpt_device_auth). Present only when codexAuth is enabled.
+  // Single-variant Agent-Identity command bundle. Present only when
+  // codexAuth is enabled.
   connect_commands?: ConnectCommands
 }
 


### PR DESCRIPTION
## Problem
The codex-exec-gateway inbound ws handler did a bcrypt compare against \`registration_token_hash\`. In the codex 0.132+ Agent Identity flow the user has no bcrypt token — only a JWT — so register succeeded but the immediately-following ws upgrade got rejected with \`bad_token\`, and codex looped register→401→backoff forever.

## Design choice
Three options for ws auth: (A) JWT in URL, locally verify; (B) HMAC capability ticket, locally verify; (C) trust nothing — drop ws auth.

(C) is wrong: the ws endpoint is public (EdgeOne→istio→pod), anyone with exe_id could hijack.

(B) keeps the registered JWT off proxy access logs (it has a long TTL) and avoids the JWT-verify network hop in the hot path. Picked (B). The ticket is OAuth-PoP / AWS-pre-signed-URL style.

## Change
- \`handlers/ws_ticket.go\` — \`MintWSTicket\` / \`VerifyWSTicket\` (HMAC-SHA256, 5-min TTL, signed with \`AgentserverInternalSecret\`).
- \`handlers/cloud_register.go\` — drop bcrypt fallback. Only validator-backed Bearer / AgentAssertion; mint ticket; respond with \`wss://...?token=<ticket>\`.
- \`inbound.go\` — replace bcrypt with \`VerifyWSTicket\`.
- \`handlers/register.go\` — drop bcrypt minting; response is \`{exe_id}\` only.
- \`store.go\` — \`CreateExecutor\` no longer takes a hash; column written as \`''\` (will be dropped in a follow-up migration).
- \`internal/server/codex_executors.go\` — single Agent-Identity connect command tab; drop ChatGPT device-auth tab (it was a bcrypt variant). Fix \`-c chatgpt_base_url=\` (was \`chatgpt.base_url=\` which codex silently no-ops).
- \`RemoteExecutorsPanel.tsx\` + \`api.ts\` — single-tab UI.
- Tests updated to use ticket; all bcrypt usages gone from this package.

## Chart
0.63.0 → 0.64.0

## Test plan
- [x] go test ./... (all passing)
- [x] web build
- [ ] live: codex exec-server --remote --use-agent-identity-auth → register OK → ws connect OK (no \`bad_token\`)