### PR TITLE
fix(dashboard): capture codex_version + OS for Connectors and Browsers

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.0
-appVersion: "0.64.0"
+version: 0.64.1
+appVersion: "0.64.1"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/internal/codexappgateway/auth/auth.go
+++ b/internal/codexappgateway/auth/auth.go
@@ -41,6 +41,16 @@ type SessionTracker interface {
 	CloseSession(ctx context.Context, sessionID string) error
 }
 
+// SessionMetaUpdater is an optional capability for backfilling
+// client-info columns on the session row after the ws was already
+// opened. codex 0.132's ws upgrade carries no User-Agent, but the
+// first JSON-RPC frame is `initialize` and includes clientInfo
+// (name + version). The handler snoops that frame and calls this
+// method to fill the dashboard columns.
+type SessionMetaUpdater interface {
+	UpdateSessionMeta(ctx context.Context, sessionID, clientUA, codexVersion, osStr string) error
+}
+
 // HMAC is the phase-1 Authenticator.
 type HMAC struct{ secret []byte }
 

--- a/internal/codexappgateway/auth/remote_verifier.go
+++ b/internal/codexappgateway/auth/remote_verifier.go
@@ -138,6 +138,42 @@ func (v *RemoteVerifier) OpenSession(ctx context.Context, token, clientIP, clien
 	return Identity{UserID: out.UserID, WorkspaceID: out.WorkspaceID}, out.SessionID, nil
 }
 
+// UpdateSessionMeta calls agentserver's session-update endpoint to
+// backfill client_ua / codex_version / os on the row inserted at
+// OpenSession time. Implements auth.SessionMetaUpdater. A 404/405
+// response (agentserver older than this client) is treated as a
+// silent no-op so rolling deploys don't error.
+func (v *RemoteVerifier) UpdateSessionMeta(ctx context.Context, sessionID, clientUA, codexVersion, osStr string) error {
+	body, err := json.Marshal(map[string]string{
+		"session_id":    sessionID,
+		"client_ua":     clientUA,
+		"codex_version": codexVersion,
+		"os":            osStr,
+	})
+	if err != nil {
+		return fmt.Errorf("marshal session-update body: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, v.baseURL+"/api/internal/codex/tokens/session-update", bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("build session-update request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Internal-Secret", v.bearer)
+	resp, err := v.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("session-update call: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound || resp.StatusCode == http.StatusMethodNotAllowed {
+		return nil
+	}
+	if resp.StatusCode != http.StatusNoContent {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("session-update call: status=%d body=%q", resp.StatusCode, b)
+	}
+	return nil
+}
+
 // CloseSession stamps disconnected_at on the row. Best-effort — callers
 // invoke from a deferred goroutine with a short bg ctx so the ws close
 // path is never blocked on it. Implements auth.SessionTracker.

--- a/internal/codexappgateway/server.go
+++ b/internal/codexappgateway/server.go
@@ -2,11 +2,13 @@ package codexappgateway
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/agentserver/agentserver/internal/codexappgateway/approvalfilter"
@@ -360,7 +362,33 @@ func (s *Server) handleCodexAppWS(w http.ResponseWriter, r *http.Request) {
 	defer childWS.Close(websocket.StatusNormalClosure, "gateway closing")
 
 	s.sup.Touch(key)
+	// Snoop the first client→server frame for JSON-RPC `initialize` so we
+	// can backfill codex_version / client_ua on the session row — codex's
+	// ws upgrade carries no UA, so the row inserted by OpenSession is
+	// otherwise blank. Best-effort; failures are logged and dropped.
+	var initOnce sync.Once
 	intc := wsbridge.Interceptor{
+		OnClientFrame: func(frame []byte) []byte {
+			initOnce.Do(func() {
+				if sessionID == "" {
+					return
+				}
+				updater, ok := s.auth.(auth.SessionMetaUpdater)
+				if !ok {
+					return
+				}
+				ua, version, osStr, ok := parseInitializeClientInfo(frame)
+				if !ok {
+					return
+				}
+				ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+				defer cancel()
+				if uerr := updater.UpdateSessionMeta(ctx, sessionID, ua, version, osStr); uerr != nil {
+					s.logger.Warn("session-meta update", "err", uerr, "session", sessionID)
+				}
+			})
+			return nil
+		},
 		OnServerFrame: func(frame []byte) []byte {
 			if resp, ok := approvalfilter.TryReply(frame); ok {
 				// Auto-accept: write the synthesized response back to upstream
@@ -379,5 +407,45 @@ func (s *Server) handleCodexAppWS(w http.ResponseWriter, r *http.Request) {
 	if err := wsbridge.RunProxyWithInterceptor(ctx, userWS, childWS, intc, func() { s.sup.Touch(key) }); err != nil {
 		s.logger.Info("proxy ended", "err", err, "key", key)
 	}
+}
+
+// parseInitializeClientInfo inspects a single ws frame and, if it's a
+// JSON-RPC `initialize` request with a clientInfo block, returns
+// ("<name>/<version>", "<version>", "", true). OS is not present in
+// codex's initialize protocol — that column stays empty without a
+// codex client patch.
+//
+// Tolerant on shape: anything that doesn't decode or doesn't look like
+// initialize returns ok=false so the caller silently skips.
+func parseInitializeClientInfo(frame []byte) (ua, version, osStr string, ok bool) {
+	var msg struct {
+		Method string `json:"method"`
+		Params struct {
+			ClientInfo struct {
+				Name    string `json:"name"`
+				Version string `json:"version"`
+			} `json:"clientInfo"`
+		} `json:"params"`
+	}
+	if err := json.Unmarshal(frame, &msg); err != nil {
+		return "", "", "", false
+	}
+	if msg.Method != "initialize" {
+		return "", "", "", false
+	}
+	name := msg.Params.ClientInfo.Name
+	v := msg.Params.ClientInfo.Version
+	if name == "" && v == "" {
+		return "", "", "", false
+	}
+	ua = name
+	if v != "" {
+		if ua != "" {
+			ua += "/" + v
+		} else {
+			ua = v
+		}
+	}
+	return ua, v, "", true
 }
 

--- a/internal/codexappgateway/server_initialize_test.go
+++ b/internal/codexappgateway/server_initialize_test.go
@@ -1,0 +1,68 @@
+package codexappgateway
+
+import "testing"
+
+func TestParseInitializeClientInfo(t *testing.T) {
+	cases := []struct {
+		name        string
+		frame       string
+		wantOK      bool
+		wantUA      string
+		wantVersion string
+	}{
+		{
+			name:        "codex cli initialize",
+			frame:       `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"clientInfo":{"name":"codex_cli_rs","version":"0.132.0"}}}`,
+			wantOK:      true,
+			wantUA:      "codex_cli_rs/0.132.0",
+			wantVersion: "0.132.0",
+		},
+		{
+			name:        "vscode initialize with title",
+			frame:       `{"method":"initialize","params":{"clientInfo":{"name":"codex_vscode","title":"VS Code","version":"0.1.0"},"capabilities":{}}}`,
+			wantOK:      true,
+			wantUA:      "codex_vscode/0.1.0",
+			wantVersion: "0.1.0",
+		},
+		{
+			name:   "non-initialize method",
+			frame:  `{"method":"thread/start","params":{}}`,
+			wantOK: false,
+		},
+		{
+			name:   "no clientInfo",
+			frame:  `{"method":"initialize","params":{}}`,
+			wantOK: false,
+		},
+		{
+			name:   "invalid JSON",
+			frame:  `not json`,
+			wantOK: false,
+		},
+		{
+			name:   "binary noise",
+			frame:  "\x00\x01\x02",
+			wantOK: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			ua, version, osStr, ok := parseInitializeClientInfo([]byte(c.frame))
+			if ok != c.wantOK {
+				t.Fatalf("ok = %v, want %v (ua=%q version=%q os=%q)", ok, c.wantOK, ua, version, osStr)
+			}
+			if !ok {
+				return
+			}
+			if ua != c.wantUA {
+				t.Errorf("ua = %q, want %q", ua, c.wantUA)
+			}
+			if version != c.wantVersion {
+				t.Errorf("version = %q, want %q", version, c.wantVersion)
+			}
+			if osStr != "" {
+				t.Errorf("os = %q, want empty (not in initialize protocol)", osStr)
+			}
+		})
+	}
+}

--- a/internal/codexexecgateway/handlers/cloud_register.go
+++ b/internal/codexexecgateway/handlers/cloud_register.go
@@ -10,15 +10,24 @@ import (
 	"strings"
 	"time"
 
+	"github.com/agentserver/agentserver/internal/clientmeta"
 	"github.com/go-chi/chi/v5"
 )
 
 // CloudRegisterStore is the subset of *codexexecgateway.Store the
 // upstream-compat /cloud/executor/{id}/register handler needs.
 // Ownership lookup is asserted via the ownerStore type-assertion in
-// assertExeOwnedByUser; pure CloudRegister callers only need the empty
-// interface here, which we keep as a sentinel for future shared methods.
+// assertExeOwnedByUser; the meta-update is optional and skipped if
+// the store doesn't implement clientMetaStore.
 type CloudRegisterStore interface{}
+
+// clientMetaStore is optionally implemented by CloudRegisterStore values
+// to receive codex client metadata captured at register time (UA, IP,
+// version, OS). The ws upgrade carries no UA, so this is the only place
+// to get it on the codex 0.132+ wire.
+type clientMetaStore interface {
+	UpdateClientMetaFromRegister(ctx context.Context, exeID, clientIP, clientUA, codexVersion, osStr string) error
+}
 
 // cloudRegisterResponse mirrors the upstream codex exec-server registry
 // response shape. Codex v0.130 expects {id, executor_id, url}; main has
@@ -103,6 +112,14 @@ func CloudRegister(store CloudRegisterStore, publicWSBaseURL string, validator A
 		if err := assertExeOwnedByUser(r.Context(), store, exeID, userID); err != nil {
 			writeJSON(w, http.StatusForbidden, map[string]string{"error": err.Error()})
 			return
+		}
+		if meta, ok := store.(clientMetaStore); ok {
+			ua := r.Header.Get("User-Agent")
+			version, osStr := clientmeta.ParseCodexUA(ua)
+			ip := clientmeta.ClientIP(r)
+			// Failure here is non-fatal — the row already exists and
+			// missing metadata just keeps the UI columns at "—".
+			_ = meta.UpdateClientMetaFromRegister(r.Context(), exeID, ip, ua, version, osStr)
 		}
 		ticket, err := MintWSTicket(exeID, wsTicketSecret)
 		if err != nil {

--- a/internal/codexexecgateway/store.go
+++ b/internal/codexexecgateway/store.go
@@ -142,6 +142,28 @@ func (s *Store) GetExecutor(ctx context.Context, exeID string) (*Executor, error
 	return &e, nil
 }
 
+// UpdateClientMetaFromRegister stamps client metadata captured at HTTP
+// register time. Codex's reqwest client carries a `codex_cli_rs/...`
+// User-Agent on that POST, but its `tokio_tungstenite::connect_async`
+// ws upgrade doesn't carry any UA, so the inbound handler has nothing
+// to parse. This method preserves the register-time values across
+// register → ws → register cycles by writing them once at register.
+// Empty values are stored as NULL so the UI can render "—".
+func (s *Store) UpdateClientMetaFromRegister(ctx context.Context, exeID, clientIP, clientUA, codexVersion, osStr string) error {
+	_, err := s.db.ExecContext(ctx, `
+		UPDATE executors
+		   SET client_ip      = COALESCE(NULLIF($2, ''), client_ip),
+		       client_ua      = COALESCE(NULLIF($3, ''), client_ua),
+		       codex_version  = COALESCE(NULLIF($4, ''), codex_version),
+		       os             = COALESCE(NULLIF($5, ''), os)
+		 WHERE exe_id = $1`,
+		exeID, clientIP, clientUA, codexVersion, osStr)
+	if err != nil {
+		return fmt.Errorf("update client meta: %w", err)
+	}
+	return nil
+}
+
 // UpdateLastSeen sets the last_seen_at timestamp to NOW().
 //
 // Kept for callers that just want to register liveness without metadata.
@@ -156,19 +178,21 @@ func (s *Store) UpdateLastSeen(ctx context.Context, exeID string) error {
 }
 
 // MarkConnected records a new inbound ws connect: bumps last_seen_at and
-// connected_at to NOW(), clears disconnected_at, and overwrites the
-// client-info columns. Empty strings for codexVersion / os are stored as
-// NULL so the UI can render "—" without further mapping.
+// connected_at to NOW(), clears disconnected_at, and refreshes the
+// client-info columns. Empty inputs preserve the existing column value
+// (via COALESCE) instead of wiping it — codex 0.132's ws upgrade carries
+// no User-Agent, so the codex_version / os captured at HTTP register
+// time would otherwise be lost on the very next ws connect.
 func (s *Store) MarkConnected(ctx context.Context, exeID, clientIP, clientUA, codexVersion, osStr string) error {
 	_, err := s.db.ExecContext(ctx, `
 		UPDATE executors
 		   SET last_seen_at    = NOW(),
 		       connected_at    = NOW(),
 		       disconnected_at = NULL,
-		       client_ip       = NULLIF($2, ''),
-		       client_ua       = NULLIF($3, ''),
-		       codex_version   = NULLIF($4, ''),
-		       os              = NULLIF($5, '')
+		       client_ip       = COALESCE(NULLIF($2, ''), client_ip),
+		       client_ua       = COALESCE(NULLIF($3, ''), client_ua),
+		       codex_version   = COALESCE(NULLIF($4, ''), codex_version),
+		       os              = COALESCE(NULLIF($5, ''), os)
 		 WHERE exe_id = $1`,
 		exeID, clientIP, clientUA, codexVersion, osStr)
 	if err != nil {

--- a/internal/db/codex_browser_sessions.go
+++ b/internal/db/codex_browser_sessions.go
@@ -37,6 +37,26 @@ func (db *DB) CreateCodexBrowserSession(ctx context.Context, s CodexBrowserSessi
 	return nil
 }
 
+// UpdateCodexBrowserSessionMeta refreshes the client-info columns on a
+// session row, preserving any existing value when the input is empty
+// (COALESCE+NULLIF). Used by CXG to backfill codex_version / client_ua
+// after snooping the JSON-RPC `initialize.clientInfo` from the first
+// frame — codex 0.132's ws upgrade carries no User-Agent, so the
+// session row inserted at OpenSession time has nothing to record.
+func (db *DB) UpdateCodexBrowserSessionMeta(ctx context.Context, sessionID, clientUA, codexVersion, osStr string) error {
+	_, err := db.ExecContext(ctx, `
+		UPDATE codex_browser_sessions
+		   SET client_ua     = COALESCE(NULLIF($2, ''), client_ua),
+		       codex_version = COALESCE(NULLIF($3, ''), codex_version),
+		       os            = COALESCE(NULLIF($4, ''), os)
+		 WHERE id = $1`,
+		sessionID, clientUA, codexVersion, osStr)
+	if err != nil {
+		return fmt.Errorf("update codex_browser_sessions meta: %w", err)
+	}
+	return nil
+}
+
 // CloseCodexBrowserSession stamps disconnected_at. Idempotent: a missing or
 // already-closed row is a no-op.
 func (db *DB) CloseCodexBrowserSession(ctx context.Context, id string) error {

--- a/internal/server/codex_browser_sessions_internal.go
+++ b/internal/server/codex_browser_sessions_internal.go
@@ -101,6 +101,30 @@ type sessionCloseReq struct {
 	SessionID string `json:"session_id"`
 }
 
+type sessionUpdateReq struct {
+	SessionID    string `json:"session_id"`
+	ClientUA     string `json:"client_ua"`
+	CodexVersion string `json:"codex_version"`
+	OS           string `json:"os"`
+}
+
+// handleCodexSessionUpdate refreshes the meta columns on an existing
+// browser-session row (set by CXG after parsing the JSON-RPC initialize
+// frame). Idempotent — missing rows return 204 same as present.
+func (s *Server) handleCodexSessionUpdate(w http.ResponseWriter, r *http.Request) {
+	var req sessionUpdateReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.SessionID == "" {
+		http.Error(w, "session_id required", http.StatusBadRequest)
+		return
+	}
+	if err := s.DB.UpdateCodexBrowserSessionMeta(r.Context(), req.SessionID, req.ClientUA, req.CodexVersion, req.OS); err != nil {
+		log.Printf("session-update: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // handleCodexSessionClose stamps disconnected_at on the row. Idempotent.
 // Auth: X-Internal-Secret (same as the other internal endpoints) so any
 // agentserver-pod-local caller can close — no per-session capability is

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -247,6 +247,14 @@ func (s *Server) Router() http.Handler {
 		}
 		s.handleCodexSessionClose(w, r)
 	})
+	r.Post("/api/internal/codex/tokens/session-update", func(w http.ResponseWriter, r *http.Request) {
+		secret := os.Getenv("INTERNAL_API_SECRET")
+		if secret != "" && r.Header.Get("X-Internal-Secret") != secret {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		s.handleCodexSessionUpdate(w, r)
+	})
 
 	// Internal API for ModelServer token retrieval (no cookie auth).
 	r.Get("/internal/workspaces/{id}/modelserver-token", s.handleInternalModelserverToken)


### PR DESCRIPTION
## Problem
Dashboard Connectors and Browsers panels show empty OS / Codex version columns. Codex 0.132's ws clients use \`tokio_tungstenite::connect_async\` without setting User-Agent, so the inbound ws handlers parsed an empty UA → blank columns.

## Fix

**Connectors** (\`codex exec-server --remote\`):
- The HTTP register call DOES carry reqwest's UA \`codex_cli_rs/0.132.0 (Darwin 24.4.0; arm64)\`. cloud_register handler parses it and writes via new \`UpdateClientMetaFromRegister\` store method.
- \`MarkConnected\` was wiping these columns on every ws reconnect (empty UA → stored NULL). Switched to COALESCE+NULLIF so empty inputs preserve existing values.

**Browsers** (\`codex --remote\`):
- ws upgrade has no UA, but the first JSON-RPC frame is \`initialize\` with \`params.clientInfo {name, version}\`. codex-app-gateway snoops the first client→server frame via OnClientFrame interceptor, extracts clientInfo, calls new \`/api/internal/codex/tokens/session-update\` endpoint to backfill the row.
- OS column stays empty for Browsers — initialize.clientInfo carries no OS field. Would need a one-line codex client patch (or upstream PR) to add it.

## Chart
0.64.0 → 0.64.1

## Test plan
- [x] go test ./internal/codexappgateway/ ./internal/codexexecgateway/ ./internal/db/ ./internal/server/
- [x] parseInitializeClientInfo unit test (codex cli / vscode / non-init / no clientInfo / invalid JSON / binary)
- [ ] live: register codex exec-server and check Connectors panel shows version + OS
- [ ] live: start codex --remote and check Browsers panel shows version