### PR TITLE
fix(codex-broker): send thread/resume before each turn/start

### DIFF
--- a/internal/codexappgateway/broker/conn.go
+++ b/internal/codexappgateway/broker/conn.go
@@ -253,6 +253,20 @@ func (c *Conn) Turn(ctx context.Context, threadID string, callerParams json.RawM
 		return nil, fmt.Errorf("merge params: %w", err)
 	}
 
+	// turn/start does NOT auto-attach the per-thread event listener (see
+	// codex turn_processor.rs turn_start_inner — only thread/start,
+	// thread/resume, thread/fork, and thread/realtime/start trigger
+	// ensure_conversation_listener). After a broker reconnect (new
+	// connection_id) or after the listener task exits on next_event=Err,
+	// turn/start would ack but events have no consumer — the broker
+	// observes 5-minute brokerTimeout with items=0. thread/resume is
+	// idempotent (thread_lifecycle.rs:242 listener_matches short-circuit)
+	// so paying one extra loopback RPC per turn is the simplest fix that
+	// also covers same-conn listener-died failures.
+	if err := c.ensureListener(ctx, threadID); err != nil {
+		return nil, fmt.Errorf("ensure listener: %w", err)
+	}
+
 	id := c.nextID.Add(1)
 	respCh := make(chan rpcResponse, 1)
 	c.mu.Lock()
@@ -360,6 +374,40 @@ func (c *Conn) Turn(ctx context.Context, threadID string, callerParams json.RawM
 		c.Close()
 		return nil, &TimeoutError{ThreadID: threadID, TurnID: startResp.Turn.ID}
 	}
+}
+
+// ensureListener sends thread/resume so codex (re-)attaches the
+// per-thread event listener to this ws connection. Idempotent on the
+// codex side — listener_matches short-circuits when the listener is
+// already wired to the same conversation. Result body is discarded.
+func (c *Conn) ensureListener(ctx context.Context, threadID string) error {
+	id := c.nextID.Add(1)
+	respCh := make(chan rpcResponse, 1)
+	c.mu.Lock()
+	c.pendingResp[id] = respCh
+	c.mu.Unlock()
+
+	params, _ := json.Marshal(map[string]string{"thread_id": threadID})
+	if err := c.writeJSON(ctx, rpcRequest{JSONRPC: "2.0", ID: &id, Method: "thread/resume", Params: params}); err != nil {
+		c.mu.Lock()
+		delete(c.pendingResp, id)
+		c.mu.Unlock()
+		return fmt.Errorf("write thread/resume: %w", err)
+	}
+	resp, ok := waitResp(ctx, respCh)
+	if !ok {
+		c.mu.Lock()
+		delete(c.pendingResp, id)
+		c.mu.Unlock()
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		return c.closeErrOr(errors.New("connection closed before thread/resume response"))
+	}
+	if resp.Error != nil {
+		return &TurnRPCError{Code: resp.Error.Code, Message: resp.Error.Message, Data: resp.Error.Data}
+	}
+	return nil
 }
 
 // StartThread issues thread/start with empty params and returns the new

--- a/internal/codexappgateway/broker/conn.go
+++ b/internal/codexappgateway/broker/conn.go
@@ -387,7 +387,12 @@ func (c *Conn) ensureListener(ctx context.Context, threadID string) error {
 	c.pendingResp[id] = respCh
 	c.mu.Unlock()
 
-	params, _ := json.Marshal(map[string]string{"thread_id": threadID})
+	// ThreadResumeParams has #[serde(rename_all = "camelCase")] in
+	// codex-rs/app-server-protocol/src/protocol/v2/thread.rs — wire
+	// field is threadId, NOT thread_id. Wrong casing would surface as
+	// "missing field threadId" on every turn (verified by reading the
+	// struct serde attrs, not by trust).
+	params, _ := json.Marshal(map[string]string{"threadId": threadID})
 	if err := c.writeJSON(ctx, rpcRequest{JSONRPC: "2.0", ID: &id, Method: "thread/resume", Params: params}); err != nil {
 		c.mu.Lock()
 		delete(c.pendingResp, id)

--- a/internal/codexappgateway/broker/conn_approval_test.go
+++ b/internal/codexappgateway/broker/conn_approval_test.go
@@ -12,6 +12,7 @@ import (
 func TestConnAutoApprovesRequestUserInput(t *testing.T) {
 	url, stop := fakeCodexServer(t, func(t *testing.T, ctx context.Context, c *websocket.Conn) {
 		replayHandshake(t, ctx, c)
+		replayThreadResume(t, ctx, c)
 
 		// turn/start → reply
 		ts := readFrame(t, ctx, c)
@@ -65,6 +66,7 @@ func TestConnAutoApprovesRequestUserInput(t *testing.T) {
 func TestConnAutoApprovesPermissionsWithEmptyProfile(t *testing.T) {
 	url, stop := fakeCodexServer(t, func(t *testing.T, ctx context.Context, c *websocket.Conn) {
 		replayHandshake(t, ctx, c)
+		replayThreadResume(t, ctx, c)
 		ts := readFrame(t, ctx, c)
 		writeJSON(t, ctx, c, map[string]any{"jsonrpc": "2.0", "id": ts["id"], "result": map[string]any{"turn": map[string]any{"id": "trn-2"}}})
 
@@ -114,6 +116,7 @@ func TestConnRepliesMethodNotFoundForUnknownServerRequest(t *testing.T) {
 	gotReply := make(chan map[string]any, 1)
 	url, stop := fakeCodexServer(t, func(t *testing.T, ctx context.Context, c *websocket.Conn) {
 		replayHandshake(t, ctx, c)
+		replayThreadResume(t, ctx, c)
 		ts := readFrame(t, ctx, c)
 		writeJSON(t, ctx, c, map[string]any{"jsonrpc": "2.0", "id": ts["id"], "result": map[string]any{"turn": map[string]any{"id": "trn-u"}}})
 		// Send a made-up server request mid-turn.

--- a/internal/codexappgateway/broker/conn_interrupt_test.go
+++ b/internal/codexappgateway/broker/conn_interrupt_test.go
@@ -14,6 +14,7 @@ func TestConnTurnInterruptOnTimeout(t *testing.T) {
 	gotInterrupt := make(chan map[string]any, 1)
 	url, stop := fakeCodexServer(t, func(t *testing.T, ctx context.Context, c *websocket.Conn) {
 		replayHandshake(t, ctx, c)
+		replayThreadResume(t, ctx, c)
 		ts := readFrame(t, ctx, c)
 		writeJSON(t, ctx, c, map[string]any{"jsonrpc": "2.0", "id": ts["id"], "result": map[string]any{"turn": map[string]any{"id": "trn-late"}}})
 		// Never send turn/completed; wait for interrupt.
@@ -55,6 +56,7 @@ func TestConnTurnInterruptOnTimeout(t *testing.T) {
 func TestConnTurnFailsOnWSClose(t *testing.T) {
 	url, stop := fakeCodexServer(t, func(t *testing.T, ctx context.Context, c *websocket.Conn) {
 		replayHandshake(t, ctx, c)
+		replayThreadResume(t, ctx, c)
 		ts := readFrame(t, ctx, c)
 		writeJSON(t, ctx, c, map[string]any{"jsonrpc": "2.0", "id": ts["id"], "result": map[string]any{"turn": map[string]any{"id": "trn-x"}}})
 		// Close ws mid-turn instead of sending turn/completed.
@@ -84,6 +86,7 @@ func TestConnTurnFailsOnWSClose(t *testing.T) {
 func TestConnTurnTimeoutClosesConn(t *testing.T) {
 	url, stop := fakeCodexServer(t, func(t *testing.T, ctx context.Context, c *websocket.Conn) {
 		replayHandshake(t, ctx, c)
+		replayThreadResume(t, ctx, c)
 		ts := readFrame(t, ctx, c)
 		writeJSON(t, ctx, c, map[string]any{"jsonrpc": "2.0", "id": ts["id"], "result": map[string]any{"turn": map[string]any{"id": "trn-z"}}})
 		// Never send turn/completed → caller will brokerTimeout.

--- a/internal/codexappgateway/broker/conn_resume_test.go
+++ b/internal/codexappgateway/broker/conn_resume_test.go
@@ -81,9 +81,14 @@ func TestConnTurn_SendsThreadResumeBeforeTurnStart(t *testing.T) {
 		if first["method"] != "thread/resume" {
 			t.Fatalf("first frame method = %v, want thread/resume", first["method"])
 		}
+		// codex's ThreadResumeParams uses #[serde(rename_all = "camelCase")] —
+		// the wire field is threadId. Asserting the exact key here is
+		// load-bearing: a snake_case typo would slip past Go-on-Go tests
+		// (fake server roundtrips whatever the client sends) yet fail
+		// against real codex with "missing field threadId".
 		params, _ := first["params"].(map[string]any)
-		if params["thread_id"] != "thr-listener" {
-			t.Errorf("thread/resume thread_id = %v, want thr-listener", params["thread_id"])
+		if params["threadId"] != "thr-listener" {
+			t.Errorf("thread/resume threadId = %v, want thr-listener", params["threadId"])
 		}
 		writeJSON(t, ctx, c, map[string]any{
 			"jsonrpc": "2.0", "id": first["id"], "result": map[string]any{},

--- a/internal/codexappgateway/broker/conn_resume_test.go
+++ b/internal/codexappgateway/broker/conn_resume_test.go
@@ -1,0 +1,127 @@
+package broker
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+)
+
+// TestConnTurn_AbortsIfThreadResumeErrors locks in that an error reply to
+// the thread/resume preamble surfaces from Turn without ever firing
+// turn/start. Avoids leaking RPC IDs and turn state when the listener
+// can't be established.
+func TestConnTurn_AbortsIfThreadResumeErrors(t *testing.T) {
+	sawTurnStart := make(chan struct{}, 1)
+	url, stop := fakeCodexServer(t, func(t *testing.T, ctx context.Context, c *websocket.Conn) {
+		replayHandshake(t, ctx, c)
+
+		// thread/resume → reply with error.
+		f := readFrame(t, ctx, c)
+		if f["method"] != "thread/resume" {
+			t.Fatalf("first frame method = %v, want thread/resume", f["method"])
+		}
+		writeJSON(t, ctx, c, map[string]any{
+			"jsonrpc": "2.0", "id": f["id"],
+			"error": map[string]any{"code": -32602, "message": "thread closing"},
+		})
+
+		// Any further frame would be turn/start — flag it as a failure.
+		for {
+			next, err := readNoFatal(ctx, c)
+			if err != nil {
+				return
+			}
+			if next["method"] == "turn/start" {
+				sawTurnStart <- struct{}{}
+				return
+			}
+		}
+	})
+	defer stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := Dial(ctx, url)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer conn.Close()
+
+	_, err = conn.Turn(ctx, "thr-err",
+		json.RawMessage(`{"input":[{"type":"text","text":"hi"}]}`),
+		5*time.Second)
+	if err == nil {
+		t.Fatal("expected error from Turn when thread/resume fails")
+	}
+
+	// Give the fake server a tick to see any erroneous turn/start that
+	// might have slipped through despite the resume error.
+	select {
+	case <-sawTurnStart:
+		t.Fatal("Turn sent turn/start despite thread/resume error — listener-attach guard failed")
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+// TestConnTurn_SendsThreadResumeBeforeTurnStart locks in the contract that
+// Conn.Turn fires thread/resume before turn/start so codex auto-attaches
+// the per-thread listener task on the current ws connection. Without this,
+// turn/start acks but events have no consumer (see codex
+// turn_processor.rs:turn_start_inner skipping ensure_conversation_listener)
+// — empirically observed as 5-minute brokerTimeout with items=0.
+func TestConnTurn_SendsThreadResumeBeforeTurnStart(t *testing.T) {
+	url, stop := fakeCodexServer(t, func(t *testing.T, ctx context.Context, c *websocket.Conn) {
+		replayHandshake(t, ctx, c)
+
+		// First post-handshake frame MUST be thread/resume.
+		first := readFrame(t, ctx, c)
+		if first["method"] != "thread/resume" {
+			t.Fatalf("first frame method = %v, want thread/resume", first["method"])
+		}
+		params, _ := first["params"].(map[string]any)
+		if params["thread_id"] != "thr-listener" {
+			t.Errorf("thread/resume thread_id = %v, want thr-listener", params["thread_id"])
+		}
+		writeJSON(t, ctx, c, map[string]any{
+			"jsonrpc": "2.0", "id": first["id"], "result": map[string]any{},
+		})
+
+		// Then turn/start.
+		ts := readFrame(t, ctx, c)
+		if ts["method"] != "turn/start" {
+			t.Fatalf("second frame method = %v, want turn/start", ts["method"])
+		}
+		writeJSON(t, ctx, c, map[string]any{
+			"jsonrpc": "2.0", "id": ts["id"],
+			"result": map[string]any{"turn": map[string]any{"id": "trn-listener"}},
+		})
+		writeJSON(t, ctx, c, map[string]any{
+			"jsonrpc": "2.0", "method": "turn/completed",
+			"params": map[string]any{
+				"threadId": "thr-listener",
+				"turn": map[string]any{
+					"id": "trn-listener", "status": "completed",
+					"items": []any{}, "itemsView": "full", "error": nil,
+				},
+			},
+		})
+	})
+	defer stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := Dial(ctx, url)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.Turn(ctx, "thr-listener",
+		json.RawMessage(`{"input":[{"type":"text","text":"hi"}]}`),
+		5*time.Second); err != nil {
+		t.Fatalf("Turn: %v", err)
+	}
+}

--- a/internal/codexappgateway/broker/conn_turn_test.go
+++ b/internal/codexappgateway/broker/conn_turn_test.go
@@ -25,6 +25,7 @@ func replayHandshake(t *testing.T, ctx context.Context, c *websocket.Conn) {
 func TestConnTurnSuccessful(t *testing.T) {
 	url, stop := fakeCodexServer(t, func(t *testing.T, ctx context.Context, c *websocket.Conn) {
 		replayHandshake(t, ctx, c)
+		replayThreadResume(t, ctx, c)
 
 		// Expect turn/start call.
 		ts := readFrame(t, ctx, c)
@@ -99,6 +100,7 @@ func TestConnTurnSuccessful(t *testing.T) {
 func TestReadLoopDoesNotLeakWatcherGoroutines(t *testing.T) {
 	url, stop := fakeCodexServer(t, func(t *testing.T, ctx context.Context, c *websocket.Conn) {
 		replayHandshake(t, ctx, c)
+		replayThreadResume(t, ctx, c)
 		// Reply to turn/start so Turn() can proceed.
 		ts := readFrame(t, ctx, c)
 		writeJSON(t, ctx, c, map[string]any{"jsonrpc": "2.0", "id": ts["id"], "result": map[string]any{"turn": map[string]any{"id": "trn-x"}}})
@@ -140,7 +142,10 @@ func TestReadLoopDoesNotLeakWatcherGoroutines(t *testing.T) {
 func TestTurnCallerCtxCancelCleansPendingResp(t *testing.T) {
 	url, stop := fakeCodexServer(t, func(t *testing.T, ctx context.Context, c *websocket.Conn) {
 		replayHandshake(t, ctx, c)
-		// Read turn/start but never reply, so caller hits ctx cancellation.
+		// Read thread/resume (Turn's listener-attach preamble) but never
+		// reply, so caller hits ctx cancellation inside ensureListener.
+		// Cleanup logic is identical to turn/start's, so this still pins
+		// the pendingResp leak guard.
 		_ = readFrame(t, ctx, c)
 		// Hold the ws open until the test ends.
 		<-ctx.Done()
@@ -182,6 +187,7 @@ func TestTurnCallerCtxCancelCleansPendingResp(t *testing.T) {
 func TestConnTurnAccumulatesItemsFromItemCompleted(t *testing.T) {
 	url, stop := fakeCodexServer(t, func(t *testing.T, ctx context.Context, c *websocket.Conn) {
 		replayHandshake(t, ctx, c)
+		replayThreadResume(t, ctx, c)
 		ts := readFrame(t, ctx, c)
 		writeJSON(t, ctx, c, map[string]any{
 			"jsonrpc": "2.0", "id": ts["id"],

--- a/internal/codexappgateway/broker/pool_test.go
+++ b/internal/codexappgateway/broker/pool_test.go
@@ -34,7 +34,14 @@ func countingCodexServer(t *testing.T) (urlFn func(workspaceID string) string, d
 			if err != nil {
 				return
 			}
-			if f["method"] == "turn/start" {
+			switch f["method"] {
+			case "thread/resume":
+				// Conn.Turn now fires thread/resume before turn/start to
+				// (re-)attach the per-thread listener. Reply with empty
+				// result — codex's real handler short-circuits when the
+				// listener already matches.
+				writeJSON(t, ctx, c, map[string]any{"jsonrpc": "2.0", "id": f["id"], "result": map[string]any{}})
+			case "turn/start":
 				writeJSON(t, ctx, c, map[string]any{"jsonrpc": "2.0", "id": f["id"], "result": map[string]any{"turn": map[string]any{"id": "trn-pool"}}})
 				writeJSON(t, ctx, c, map[string]any{
 					"jsonrpc": "2.0",

--- a/internal/codexappgateway/broker/testhelpers_test.go
+++ b/internal/codexappgateway/broker/testhelpers_test.go
@@ -44,6 +44,20 @@ func fakeCodexServer(t *testing.T, frame func(t *testing.T, ctx context.Context,
 	return url, srv.Close
 }
 
+// replayThreadResume reads the thread/resume frame Conn.Turn now sends
+// before turn/start (to (re-)attach the per-thread event listener) and
+// replies with an empty result. Place after replayHandshake and before
+// any frame your test cares about — the thread/resume preamble is
+// implementation detail to most tests.
+func replayThreadResume(t *testing.T, ctx context.Context, c *websocket.Conn) {
+	t.Helper()
+	f := readFrame(t, ctx, c)
+	if f["method"] != "thread/resume" {
+		t.Fatalf("expected thread/resume preamble, got %v", f["method"])
+	}
+	writeJSON(t, ctx, c, map[string]any{"jsonrpc": "2.0", "id": f["id"], "result": map[string]any{}})
+}
+
 func readFrame(t *testing.T, ctx context.Context, c *websocket.Conn) map[string]any {
 	t.Helper()
 	_, data, err := c.Read(ctx)

--- a/internal/codexappgateway/turn_api.go
+++ b/internal/codexappgateway/turn_api.go
@@ -99,6 +99,16 @@ func classifyTransport(err error) *transportError {
 	if errors.As(err, &te) {
 		return &transportError{Code: "brokerTimeout", Message: te.Error()}
 	}
+	// Codex returned a JSON-RPC error response (well-formed, not a
+	// transport failure). Surface this as its own code so the broker
+	// reconnect/restart heuristics in ops dashboards don't fire on
+	// what is actually a codex-side application error (e.g. the
+	// "thread closing; retry after the thread is closed" race that
+	// thread/resume returns under teardown).
+	var rpcErr *broker.TurnRPCError
+	if errors.As(err, &rpcErr) {
+		return &transportError{Code: "codexRPCError", Message: err.Error()}
+	}
 	msg := err.Error()
 	switch {
 	case strings.Contains(msg, "dial"), strings.Contains(msg, "connection refused"), strings.Contains(msg, "subprocess"):


### PR DESCRIPTION
## Summary

- Bug: WeChat IM turns through `broker.Turn` ack within ~50ms then hang forever with `items=0`, eventually 5-min `brokerTimeout` — repeats indefinitely on subsequent turns for the same thread, even after broker self-heal closes/redials the ws
- Root cause: codex app-server's `turn/start` handler does NOT call `ensure_conversation_listener` (only `thread/start`, `thread/resume`, `thread/fork`, `thread/realtime/start` do — see `codex-rs/app-server/src/request_processors/turn_processor.rs::turn_start_inner`). After a broker reconnect (new `connection_id`) or after the per-thread listener Tokio task exits on `next_event=Err`, `turn/start` still submits to codex's internal channel but events have no consumer, so `turn/completed` is never emitted
- Fix: prepend `thread/resume` to every `Turn`. The codex handler is idempotent — `thread_lifecycle.rs:242` `listener_matches` short-circuits when the listener already matches the current conversation. One loopback RPC per turn, covers both reconnect-after-timeout and listener-died-mid-conn

## Diagnosis trail

Captured live on prod via `/proc/PID/net/tcp` + `/proc/PID/task/*/status` after the codex-app-gateway subprocess wedged:

- subprocess process alive, all 20+ tokio workers idle in `futex_wait_queue` / `do_epoll_wait` — classic async runtime parked on a dead channel
- `/proc/23/net/tcp` showed only loopback connections, no outbound — confirms codex never reached the LLM call stage
- gateway↔subprocess ws TCP connection ESTABLISHED, `tx_queue=rx_queue=0` — proxy itself healthy
- codex `/healthz` returned 200 OK via port-forward — HTTP layer responsive, only the per-thread listener task wedged
- pattern matched `next_event() = Err(CodexErr::InternalAgentDied)` → listener task `break`s out of the `tokio::select!` loop at `thread_lifecycle.rs:284-290` → `clear_listener()` nullifies `listener_command_tx` → next `turn/start` submits successfully but events vanish

## Test plan

- [x] `TestConnTurn_SendsThreadResumeBeforeTurnStart` (new): fake subprocess asserts the first post-handshake frame is `thread/resume` with the correct `thread_id`, the second is `turn/start`. Verified RED first (failed with "first frame method = turn/start, want thread/resume"), then GREEN after impl
- [x] `TestConnTurn_AbortsIfThreadResumeErrors` (new): subprocess returns RPC error on `thread/resume`; assert `Turn` returns error and never writes `turn/start`
- [x] Existing four turn-driven fake-server tests + `countingCodexServer` in pool_test.go updated via a new `replayThreadResume` helper in testhelpers
- [x] `go test ./internal/codexappgateway/broker/ -race -count=5` clean
- [x] `go test ./internal/codexappgateway/... -race` clean
- [x] `go vet ./internal/codexappgateway/...` clean
- [ ] Post-deploy: send WeChat → expect ~5s reply
- [ ] Post-deploy: wait 15+ min idle → send WeChat → expect ~5s reply (this is the previously-100%-broken case)
- [ ] Post-deploy: `kubectl rollout restart` codex-app-gateway → send WeChat → expect ~5s reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)