### PR TITLE
chore(chart): bump 0.64.1 → 0.64.2

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.1
-appVersion: "0.64.1"
+version: 0.64.2
+appVersion: "0.64.2"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
## Summary

- Bumps the Helm chart from 0.64.1 to 0.64.2 so the codex-broker
  listener-attach fix merged in #140 becomes pullable by pulumi
  (which pins by chart version, not image tag)

## Test plan

- [x] CI builds + publishes `agentserver-0.64.2.tgz`
- [ ] Follow-up: update `/root/k8s/stacks/agentserver.ts` chart version to 0.64.2 and `pulumi up`

🤖 Generated with [Claude Code](https://claude.com/claude-code)