### PR TITLE
test(broker): bump test timeouts 5s → 30s for CI headroom

### DIFF
--- a/internal/codexappgateway/broker/conn_approval_test.go
+++ b/internal/codexappgateway/broker/conn_approval_test.go
@@ -51,14 +51,14 @@ func TestConnAutoApprovesRequestUserInput(t *testing.T) {
 	})
 	defer stop()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	conn, err := Dial(ctx, url)
 	if err != nil {
 		t.Fatalf("Dial: %v", err)
 	}
 	defer conn.Close()
-	if _, err := conn.Turn(ctx, "thr-1", json.RawMessage(`{"input":[{"type":"text","text":"hi"}]}`), 5*time.Second); err != nil {
+	if _, err := conn.Turn(ctx, "thr-1", json.RawMessage(`{"input":[{"type":"text","text":"hi"}]}`), 30*time.Second); err != nil {
 		t.Fatalf("Turn: %v", err)
 	}
 }
@@ -95,14 +95,14 @@ func TestConnAutoApprovesPermissionsWithEmptyProfile(t *testing.T) {
 		})
 	})
 	defer stop()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	conn, err := Dial(ctx, url)
 	if err != nil {
 		t.Fatalf("Dial: %v", err)
 	}
 	defer conn.Close()
-	if _, err := conn.Turn(ctx, "thr-2", json.RawMessage(`{"input":[]}`), 5*time.Second); err != nil {
+	if _, err := conn.Turn(ctx, "thr-2", json.RawMessage(`{"input":[]}`), 30*time.Second); err != nil {
 		t.Fatalf("Turn: %v", err)
 	}
 }
@@ -136,14 +136,14 @@ func TestConnRepliesMethodNotFoundForUnknownServerRequest(t *testing.T) {
 	})
 	defer stop()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	conn, err := Dial(ctx, url)
 	if err != nil {
 		t.Fatalf("Dial: %v", err)
 	}
 	defer conn.Close()
-	if _, err := conn.Turn(ctx, "thr-u", json.RawMessage(`{"input":[]}`), 5*time.Second); err != nil {
+	if _, err := conn.Turn(ctx, "thr-u", json.RawMessage(`{"input":[]}`), 30*time.Second); err != nil {
 		t.Fatalf("Turn: %v", err)
 	}
 

--- a/internal/codexappgateway/broker/conn_interrupt_test.go
+++ b/internal/codexappgateway/broker/conn_interrupt_test.go
@@ -28,7 +28,7 @@ func TestConnTurnInterruptOnTimeout(t *testing.T) {
 	})
 	defer stop()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	conn, err := Dial(ctx, url)
 	if err != nil {
@@ -70,7 +70,7 @@ func TestConnTurnFailsOnWSClose(t *testing.T) {
 		t.Fatalf("Dial: %v", err)
 	}
 	defer conn.Close()
-	_, err = conn.Turn(ctx, "thr-x", json.RawMessage(`{"input":[]}`), 5*time.Second)
+	_, err = conn.Turn(ctx, "thr-x", json.RawMessage(`{"input":[]}`), 30*time.Second)
 	if err == nil {
 		t.Fatal("expected error on ws close")
 	}
@@ -98,7 +98,7 @@ func TestConnTurnTimeoutClosesConn(t *testing.T) {
 	})
 	defer stop()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	conn, err := Dial(ctx, url)
 	if err != nil {

--- a/internal/codexappgateway/broker/conn_resume_test.go
+++ b/internal/codexappgateway/broker/conn_resume_test.go
@@ -42,7 +42,7 @@ func TestConnTurn_AbortsIfThreadResumeErrors(t *testing.T) {
 	})
 	defer stop()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	conn, err := Dial(ctx, url)
 	if err != nil {
@@ -52,7 +52,7 @@ func TestConnTurn_AbortsIfThreadResumeErrors(t *testing.T) {
 
 	_, err = conn.Turn(ctx, "thr-err",
 		json.RawMessage(`{"input":[{"type":"text","text":"hi"}]}`),
-		5*time.Second)
+		30*time.Second)
 	if err == nil {
 		t.Fatal("expected error from Turn when thread/resume fails")
 	}
@@ -116,7 +116,7 @@ func TestConnTurn_SendsThreadResumeBeforeTurnStart(t *testing.T) {
 	})
 	defer stop()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	conn, err := Dial(ctx, url)
 	if err != nil {
@@ -126,7 +126,7 @@ func TestConnTurn_SendsThreadResumeBeforeTurnStart(t *testing.T) {
 
 	if _, err := conn.Turn(ctx, "thr-listener",
 		json.RawMessage(`{"input":[{"type":"text","text":"hi"}]}`),
-		5*time.Second); err != nil {
+		30*time.Second); err != nil {
 		t.Fatalf("Turn: %v", err)
 	}
 }

--- a/internal/codexappgateway/broker/conn_thread_test.go
+++ b/internal/codexappgateway/broker/conn_thread_test.go
@@ -29,7 +29,7 @@ func TestConnStartThread(t *testing.T) {
 		})
 	})
 	defer stop()
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	conn, err := Dial(ctx, url)
 	if err != nil {

--- a/internal/codexappgateway/broker/conn_turn_test.go
+++ b/internal/codexappgateway/broker/conn_turn_test.go
@@ -69,7 +69,7 @@ func TestConnTurnSuccessful(t *testing.T) {
 	})
 	defer stop()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	conn, err := Dial(ctx, url)
 	if err != nil {
@@ -77,7 +77,7 @@ func TestConnTurnSuccessful(t *testing.T) {
 	}
 	defer conn.Close()
 
-	rawTurn, err := conn.Turn(ctx, "thr-abc", json.RawMessage(`{"input":[{"type":"text","text":"hi"}]}`), 5*time.Second)
+	rawTurn, err := conn.Turn(ctx, "thr-abc", json.RawMessage(`{"input":[{"type":"text","text":"hi"}]}`), 30*time.Second)
 	if err != nil {
 		t.Fatalf("Turn: %v", err)
 	}
@@ -116,7 +116,7 @@ func TestReadLoopDoesNotLeakWatcherGoroutines(t *testing.T) {
 	})
 	defer stop()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	before := runtime.NumGoroutine()
 
@@ -124,7 +124,7 @@ func TestReadLoopDoesNotLeakWatcherGoroutines(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Dial: %v", err)
 	}
-	if _, err := conn.Turn(ctx, "t", json.RawMessage(`{"input":[]}`), 5*time.Second); err != nil {
+	if _, err := conn.Turn(ctx, "t", json.RawMessage(`{"input":[]}`), 30*time.Second); err != nil {
 		t.Fatalf("Turn: %v", err)
 	}
 	conn.Close()
@@ -152,7 +152,7 @@ func TestTurnCallerCtxCancelCleansPendingResp(t *testing.T) {
 	})
 	defer stop()
 
-	dctx, dcancel := context.WithTimeout(context.Background(), 5*time.Second)
+	dctx, dcancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer dcancel()
 	conn, err := Dial(dctx, url)
 	if err != nil {
@@ -165,7 +165,7 @@ func TestTurnCallerCtxCancelCleansPendingResp(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 		ccancel()
 	}()
-	_, err = conn.Turn(cctx, "t", json.RawMessage(`{"input":[]}`), 5*time.Second)
+	_, err = conn.Turn(cctx, "t", json.RawMessage(`{"input":[]}`), 30*time.Second)
 	if err == nil {
 		t.Fatal("expected ctx cancellation error")
 	}
@@ -222,7 +222,7 @@ func TestConnTurnAccumulatesItemsFromItemCompleted(t *testing.T) {
 	})
 	defer stop()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	conn, err := Dial(ctx, url)
 	if err != nil {
@@ -230,7 +230,7 @@ func TestConnTurnAccumulatesItemsFromItemCompleted(t *testing.T) {
 	}
 	defer conn.Close()
 
-	raw, err := conn.Turn(ctx, "thr-a", json.RawMessage(`{"input":[{"type":"text","text":"hi"}]}`), 5*time.Second)
+	raw, err := conn.Turn(ctx, "thr-a", json.RawMessage(`{"input":[{"type":"text","text":"hi"}]}`), 30*time.Second)
 	if err != nil {
 		t.Fatalf("Turn: %v", err)
 	}

--- a/internal/codexappgateway/broker/pool_test.go
+++ b/internal/codexappgateway/broker/pool_test.go
@@ -77,7 +77,7 @@ func TestPoolReusesConnForSameWorkspace(t *testing.T) {
 	p := NewPool(resolver, 5*time.Minute)
 	defer p.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
 	for i := 0; i < 3; i++ {
@@ -85,7 +85,7 @@ func TestPoolReusesConnForSameWorkspace(t *testing.T) {
 		if err != nil {
 			t.Fatalf("iter %d Get: %v", i, err)
 		}
-		if _, err := conn.Turn(ctx, "thr-x", json.RawMessage(`{"input":[]}`), 5*time.Second); err != nil {
+		if _, err := conn.Turn(ctx, "thr-x", json.RawMessage(`{"input":[]}`), 30*time.Second); err != nil {
 			t.Fatalf("iter %d Turn: %v", i, err)
 		}
 	}
@@ -112,13 +112,13 @@ func TestPoolReapsIdleConn(t *testing.T) {
 	p := NewPool(resolver, 100*time.Millisecond)
 	defer p.Close()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 	conn, err := p.Get(ctx, "ws-A")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
-	if _, err := conn.Turn(ctx, "thr-x", json.RawMessage(`{"input":[]}`), 5*time.Second); err != nil {
+	if _, err := conn.Turn(ctx, "thr-x", json.RawMessage(`{"input":[]}`), 30*time.Second); err != nil {
 		t.Fatalf("Turn: %v", err)
 	}
 


### PR DESCRIPTION
## Summary

- After #140 each \`Turn\` sends 2 RPCs instead of 1 (thread/resume + turn/start)
- GitHub Actions runners intermittently exceed the 5-second budget on ONE random test per run — symptom: \`ack ackMs<50\` then bare \`turn timed out\` at exactly 5003ms
- Different test fails each CI run; locally passes 100% with \`-race -count=5\`
- Bump 5s → 30s in tests that exercise normal flow; leave the deliberate 200ms / 100ms short timeouts (interrupt + abort tests) untouched

This unblocks the chart 0.64.2 publish (was skipped due to test failure in #141's CI run).

## Test plan

- [x] \`go test ./internal/codexappgateway/broker/ -race -count=2\` clean
- [x] No production code changed; only test ctx/Turn timeout parameters
- [ ] CI green this time

🤖 Generated with [Claude Code](https://claude.com/claude-code)