### PR TITLE
fix(codex-broker): buffer turn/completed if it arrives before Turn registers

### DIFF
--- a/internal/codexappgateway/broker/conn.go
+++ b/internal/codexappgateway/broker/conn.go
@@ -23,10 +23,11 @@ type Conn struct {
 	writeMu sync.Mutex
 	nextID  atomic.Int64
 
-	mu           sync.Mutex
-	pendingResp  map[int64]chan rpcResponse   // request id → 1-buffered chan
-	pendingTurns map[string]chan turnPayload  // turn id → 1-buffered chan
-	itemsByTurn  map[string][]json.RawMessage // turn id → accumulated item/completed payloads
+	mu             sync.Mutex
+	pendingResp    map[int64]chan rpcResponse   // request id → 1-buffered chan
+	pendingTurns   map[string]chan turnPayload  // turn id → 1-buffered chan
+	itemsByTurn    map[string][]json.RawMessage // turn id → accumulated item/completed payloads
+	completedTurns map[string]turnPayload       // turn/completed arrived before Turn() finished registering — see deliverTurn for the race
 
 	closeOnce sync.Once
 	closed    chan struct{}
@@ -48,11 +49,12 @@ func Dial(ctx context.Context, wsURL string) (*Conn, error) {
 	ws.SetReadLimit(64 << 20)
 
 	c := &Conn{
-		ws:           ws,
-		pendingResp:  make(map[int64]chan rpcResponse),
-		pendingTurns: make(map[string]chan turnPayload),
-		itemsByTurn:  make(map[string][]json.RawMessage),
-		closed:       make(chan struct{}),
+		ws:             ws,
+		pendingResp:    make(map[int64]chan rpcResponse),
+		pendingTurns:   make(map[string]chan turnPayload),
+		itemsByTurn:    make(map[string][]json.RawMessage),
+		completedTurns: make(map[string]turnPayload),
+		closed:         make(chan struct{}),
 	}
 
 	// Send initialize synchronously (no reader yet, so we read inline).
@@ -187,10 +189,6 @@ func (c *Conn) deliverTurn(turnID string, payload turnPayload) {
 	items := c.itemsByTurn[turnID]
 	delete(c.pendingTurns, turnID)
 	delete(c.itemsByTurn, turnID)
-	c.mu.Unlock()
-	if !ok {
-		return
-	}
 	// Inject the accumulated item/completed payloads into Turn.items.
 	// turn/completed's Turn.items is empty in codex's v2 protocol
 	// (TurnItemsView::NotLoaded); the items arrived as separate
@@ -201,6 +199,19 @@ func (c *Conn) deliverTurn(turnID string, payload turnPayload) {
 			payload.Raw = merged
 		}
 	}
+	if !ok {
+		// Race: turn/completed arrived before Turn() finished registering
+		// pendingTurns. Turn() registers AFTER waitResp on turn/start
+		// returns, so a server that streams turn/start ack + turn/completed
+		// back-to-back (and codex does this for cached/empty turns, plus
+		// the in-process fake server in tests) can have its completion
+		// dispatched by readLoop before Turn's goroutine wakes up to
+		// register. Buffer the payload; Turn() will drain on registration.
+		c.completedTurns[turnID] = payload
+		c.mu.Unlock()
+		return
+	}
+	c.mu.Unlock()
 	ch <- payload
 }
 
@@ -239,6 +250,9 @@ func (c *Conn) failAllPending(err error) {
 	}
 	for tid := range c.itemsByTurn {
 		delete(c.itemsByTurn, tid)
+	}
+	for tid := range c.completedTurns {
+		delete(c.completedTurns, tid)
 	}
 	c.mu.Unlock()
 	c.closeErr.CompareAndSwap(nil, &errHolder{err})
@@ -310,6 +324,15 @@ func (c *Conn) Turn(ctx context.Context, threadID string, callerParams json.RawM
 
 	turnCh := make(chan turnPayload, 1)
 	c.mu.Lock()
+	// Race-fix companion to deliverTurn: if turn/completed already arrived
+	// (and was buffered there because no pending receiver existed yet),
+	// consume it now instead of registering and blocking forever.
+	if buffered, ok := c.completedTurns[startResp.Turn.ID]; ok {
+		delete(c.completedTurns, startResp.Turn.ID)
+		c.mu.Unlock()
+		log.Printf("broker.Turn: turn/completed (preregistered) thread=%s turn=%s totalMs=%d items=0", threadID, startResp.Turn.ID, time.Since(startedAt).Milliseconds())
+		return buffered.Raw, nil
+	}
 	c.pendingTurns[startResp.Turn.ID] = turnCh
 	c.mu.Unlock()
 

--- a/internal/codexappgateway/broker/conn_race_test.go
+++ b/internal/codexappgateway/broker/conn_race_test.go
@@ -1,0 +1,75 @@
+package broker
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestDeliverTurn_BuffersWhenNoPendingReceiver pins the race fix for
+// the case where the broker's readLoop dispatches turn/completed
+// before Turn() has acquired the mutex to register pendingTurns.
+// Without the buffer, the payload is silently dropped and Turn blocks
+// until brokerTimeout. The bug intermittently broke prod tests at
+// CI's typical scheduling (e.g. TestPoolReusesConnForSameWorkspace),
+// surfacing as "ack received, no completion, 5-min timeout".
+func TestDeliverTurn_BuffersWhenNoPendingReceiver(t *testing.T) {
+	c := &Conn{
+		pendingResp:    make(map[int64]chan rpcResponse),
+		pendingTurns:   make(map[string]chan turnPayload),
+		itemsByTurn:    make(map[string][]json.RawMessage),
+		completedTurns: make(map[string]turnPayload),
+		closed:         make(chan struct{}),
+	}
+
+	// Simulate readLoop receiving turn/completed before Turn() registers.
+	want := turnPayload{Raw: json.RawMessage(`{"id":"trn-x","status":"completed"}`)}
+	c.deliverTurn("trn-x", want)
+
+	c.mu.Lock()
+	got, ok := c.completedTurns["trn-x"]
+	c.mu.Unlock()
+	if !ok {
+		t.Fatal("deliverTurn dropped payload silently when no pendingTurns entry — race fix regressed")
+	}
+	if string(got.Raw) != string(want.Raw) {
+		t.Errorf("buffered payload differs: got %s want %s", got.Raw, want.Raw)
+	}
+}
+
+// TestDeliverTurn_MergesBufferedItemsBeforeBuffering verifies that when
+// deliverTurn buffers a payload (race path), it still folds in the
+// item/completed notifications that arrived earlier — same invariant
+// the normal delivery path holds. Without this, a Turn that hits the
+// buffer path would return Turn.items=[] even when items were streamed.
+func TestDeliverTurn_MergesBufferedItemsBeforeBuffering(t *testing.T) {
+	c := &Conn{
+		pendingResp:    make(map[int64]chan rpcResponse),
+		pendingTurns:   make(map[string]chan turnPayload),
+		itemsByTurn:    make(map[string][]json.RawMessage),
+		completedTurns: make(map[string]turnPayload),
+		closed:         make(chan struct{}),
+	}
+	// One streamed item.
+	c.itemsByTurn["trn-x"] = []json.RawMessage{
+		json.RawMessage(`{"type":"agentMessage","id":"m1","text":"hi"}`),
+	}
+	// No pending receiver — falls through to buffer path.
+	c.deliverTurn("trn-x", turnPayload{Raw: json.RawMessage(`{"id":"trn-x","items":[]}`)})
+
+	c.mu.Lock()
+	got, ok := c.completedTurns["trn-x"]
+	c.mu.Unlock()
+	if !ok {
+		t.Fatal("expected payload in completedTurns")
+	}
+	// Items field should now contain the streamed agentMessage.
+	var decoded struct {
+		Items []map[string]any `json:"items"`
+	}
+	if err := json.Unmarshal(got.Raw, &decoded); err != nil {
+		t.Fatalf("decode buffered payload: %v", err)
+	}
+	if len(decoded.Items) != 1 || decoded.Items[0]["text"] != "hi" {
+		t.Errorf("expected merged items=[{agentMessage hi}], got %v", decoded.Items)
+	}
+}


### PR DESCRIPTION
## Summary

- Race in \`Conn.Turn\` / \`deliverTurn\`: pendingTurns[turnID] is registered AFTER waitResp on turn/start returns; if codex (or the test fake server) writes turn/start ack + turn/completed back-to-back, readLoop dispatches the completion BEFORE Turn registers its receiver, payload was silently dropped, Turn blocked on brokerTimeout
- Listener-attach fix in #140 made this visible — each Turn now does 2 RPCs, more scheduling slop, more chance of hitting the window
- Fix: deliverTurn buffers payload in a new \`completedTurns\` map when no receiver; Turn checks the buffer on registration

## Diagnosis

Local repro without \`-race\` at count=200 reliably hit the wedge; with the fix the same suite passes count=200 clean. CI was hitting it 1 in 1–2 runs (different test failed each time, all same shape — \`ack received in <50ms, then bare \"turn timed out\"\` at the test's outer timeout).

Pre-#140 the race window existed too but was rarely triggered (Turn's single RPC roundtrip gave the scheduler enough time). The 30s test-timeout bump in #142 masked the symptom on locally-fast machines but the bug remained.

## Test plan

- [x] \`TestDeliverTurn_BuffersWhenNoPendingReceiver\` (new): asserts buffer path stores instead of dropping
- [x] \`TestDeliverTurn_MergesBufferedItemsBeforeBuffering\` (new): item-merge invariant holds on buffer path
- [x] \`go test ./internal/codexappgateway/broker/ -count=200 -timeout 600s\` clean (was FAIL within ~20 iters pre-fix)
- [x] \`go test ./internal/codexappgateway/broker/ -race -count=50\` clean
- [ ] CI green this time, chart 0.64.2 finally publishes

🤖 Generated with [Claude Code](https://claude.com/claude-code)