### PR TITLE
fix(codex-im): treat 'no rollout found for thread id' as thread-not-found

### DIFF
--- a/internal/server/codex_im_inbound.go
+++ b/internal/server/codex_im_inbound.go
@@ -227,10 +227,21 @@ func (h *codexInboundHandler) processTurn(ctx context.Context, req codexInboundR
 // for the human-readable text. Examples seen in the wild:
 //
 //	codex rpc error -32600: thread not found: 019e4130-...
+//	codex rpc error -32600: no rollout found for thread id 019e4972-...
 //	thread "thr-abc" unknown
 //	missing thread
+//
+// "no rollout found for thread id" / "no rollout found for conversation id"
+// is what codex's app-server emits from thread_processor.rs:3589/3668 (and
+// is the canonical signal — codex-core/thread_manager.rs:877 detects the
+// same exact string to drive its own recovery). Confirmed against the
+// codex source rather than guessed.
 func isThreadNotFoundErr(msg string) bool {
 	lo := strings.ToLower(msg)
+	if strings.Contains(lo, "no rollout found for thread id") ||
+		strings.Contains(lo, "no rollout found for conversation id") {
+		return true
+	}
 	if !strings.Contains(lo, "thread") {
 		return false
 	}

--- a/internal/server/codex_im_inbound_test.go
+++ b/internal/server/codex_im_inbound_test.go
@@ -384,10 +384,19 @@ func TestIsThreadNotFoundErr(t *testing.T) {
 		"codex rpc error -32600: thread not found: abc": true,
 		`thread "thr-abc" unknown`:                      true,
 		"missing thread":                                true,
-		"some other error":                              false,
-		"thread is in progress":                         false,
-		"":                                              false,
-		"connection closed":                             false,
+		// "no rollout found for thread id" / "...conversation id" is the
+		// stable error string from codex thread_processor.rs:3589/3668,
+		// surfaced when the broker calls thread/resume on a thread codex
+		// no longer has on disk (e.g. subprocess restarted between turns).
+		// Without these matches the retry-on-fresh-thread path doesn't
+		// fire and the user sees "⚠️ Codex 处理失败".
+		"ensure listener: codex rpc error -32600: no rollout found for thread id 019e4972-6cf4": true,
+		"no rollout found for thread id abc":                  true,
+		"no rollout found for conversation id def":            true,
+		"some other error":                                    false,
+		"thread is in progress":                               false,
+		"":                                                    false,
+		"connection closed":                                   false,
 	}
 	for in, want := range cases {
 		if got := isThreadNotFoundErr(in); got != want {


### PR DESCRIPTION
## Summary

- Live user-impacting bug: WeChat message → \`⚠️ Codex 处理失败\` repeatedly, same user, same thread
- Root cause: codex's app-server returns \`-32600: no rollout found for thread id {id}\` (thread_processor.rs:3589/3668) when the broker's \`thread/resume\` hits a thread whose rollout file is gone — typical after a codex subprocess restart
- agentserver's \`isThreadNotFoundErr\` heuristic in codex_im_inbound.go only matched "not found" / "unknown" / "missing" alongside the literal substring "thread"; "no rollout found for thread id" contains "thread" but no contiguous "not found" → returned false → retry-with-fresh-thread path didn't fire → user wedged forever on the poisoned \`agent_sessions.codex_thread_id\`

The wording is stable — codex-core uses the exact same literal at \`thread_manager.rs:877\` to drive its own recovery, and codex's own integration tests assert this string (see thread_archive.rs:87, thread_resume.rs:173). Safe to match against.

## Test plan

- [x] TestIsThreadNotFoundErr extended with both the raw codex phrasing and the broker-wrapped version (\`ensure listener: codex rpc error -32600: no rollout found for thread id ...\`) — passes
- [x] \`go test ./internal/server/ -run TestIsThreadNotFoundErr\` clean
- [ ] Post-deploy: WeChat user's next message succeeds (clears their stale thread_id, creates new thread)

🤖 Generated with [Claude Code](https://claude.com/claude-code)