### PR TITLE
fix(codex-broker): swallow 'no rollout found' for fresh threads in ensureListener

### DIFF
--- a/internal/codexappgateway/broker/conn.go
+++ b/internal/codexappgateway/broker/conn.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"log"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -433,6 +434,23 @@ func (c *Conn) ensureListener(ctx context.Context, threadID string) error {
 		return c.closeErrOr(errors.New("connection closed before thread/resume response"))
 	}
 	if resp.Error != nil {
+		// "no rollout found for thread id ..." (codex
+		// thread_processor.rs:3589) fires when thread/resume tries to
+		// load a thread whose rollout file isn't on disk yet. For a
+		// fresh thread (just created via StartThread, no turns yet),
+		// codex hasn't flushed the rollout, so this is expected and
+		// harmless — the listener was already auto-attached by
+		// thread/start (thread_processor.rs:1115). Swallow and proceed:
+		// the immediate turn/start will run on the existing listener.
+		//
+		// If the thread was supposed to be persisted and isn't (e.g. CXG
+		// subprocess restart wiped the rollout volume), turn/start that
+		// follows will hit the SAME error and surface it to agentserver,
+		// where the isThreadNotFoundErr path retries with a fresh thread.
+		if strings.Contains(resp.Error.Message, "no rollout found for thread id") ||
+			strings.Contains(resp.Error.Message, "no rollout found for conversation id") {
+			return nil
+		}
 		return &TurnRPCError{Code: resp.Error.Code, Message: resp.Error.Message, Data: resp.Error.Data}
 	}
 	return nil

--- a/internal/codexappgateway/broker/conn_resume_test.go
+++ b/internal/codexappgateway/broker/conn_resume_test.go
@@ -9,6 +9,64 @@ import (
 	"nhooyr.io/websocket"
 )
 
+// TestConnTurn_SwallowsNoRolloutFoundOnFreshThread locks in that
+// `thread/resume` returning "no rollout found for thread id ..." does
+// NOT abort the turn. Codex emits this for a thread that's in memory
+// but whose rollout file hasn't been flushed to disk yet (i.e. a thread
+// just created via StartThread with no turns yet). The listener was
+// auto-attached at thread/start time so it's safe to proceed; otherwise
+// every first-message-per-thread would surface as "Codex 处理失败".
+func TestConnTurn_SwallowsNoRolloutFoundOnFreshThread(t *testing.T) {
+	url, stop := fakeCodexServer(t, func(t *testing.T, ctx context.Context, c *websocket.Conn) {
+		replayHandshake(t, ctx, c)
+
+		// thread/resume → reply with "no rollout found" (codex's exact
+		// wording from thread_processor.rs:3589).
+		f := readFrame(t, ctx, c)
+		if f["method"] != "thread/resume" {
+			t.Fatalf("first frame method = %v, want thread/resume", f["method"])
+		}
+		writeJSON(t, ctx, c, map[string]any{
+			"jsonrpc": "2.0", "id": f["id"],
+			"error": map[string]any{"code": -32600, "message": "no rollout found for thread id thr-fresh"},
+		})
+
+		// Turn MUST still proceed to turn/start.
+		ts := readFrame(t, ctx, c)
+		if ts["method"] != "turn/start" {
+			t.Fatalf("second frame method = %v, want turn/start (ensureListener should have swallowed no-rollout)", ts["method"])
+		}
+		writeJSON(t, ctx, c, map[string]any{
+			"jsonrpc": "2.0", "id": ts["id"],
+			"result": map[string]any{"turn": map[string]any{"id": "trn-fresh"}},
+		})
+		writeJSON(t, ctx, c, map[string]any{
+			"jsonrpc": "2.0", "method": "turn/completed",
+			"params": map[string]any{
+				"threadId": "thr-fresh",
+				"turn": map[string]any{
+					"id": "trn-fresh", "status": "completed",
+					"items": []any{}, "itemsView": "full", "error": nil,
+				},
+			},
+		})
+	})
+	defer stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	conn, err := Dial(ctx, url)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer conn.Close()
+	if _, err := conn.Turn(ctx, "thr-fresh",
+		json.RawMessage(`{"input":[{"type":"text","text":"hi"}]}`),
+		30*time.Second); err != nil {
+		t.Fatalf("Turn: %v", err)
+	}
+}
+
 // TestConnTurn_AbortsIfThreadResumeErrors locks in that an error reply to
 // the thread/resume preamble surfaces from Turn without ever firing
 // turn/start. Avoids leaking RPC IDs and turn state when the listener


### PR DESCRIPTION
## Summary

Regression from #140: every first message from a brand-new IM user surfaces as \`⚠️ Codex 处理失败\` immediately. \`#144\`'s heuristic extension can't recover because its precondition (\`sess.CodexThreadID != nil\`) excludes first-time users.

## Trace

1. agentserver: \`sess.CodexThreadID = nil\` (first time)
2. \`turn_api\` → \`broker.StartThread\` → codex creates thread X in memory
3. \`turn_api\` → \`broker.Turn(X)\` → ensureListener → \`thread/resume(X)\`
4. codex: \`load_thread_from_disk(X)\` → \`ThreadStoreError::ThreadNotFound\` → \`"no rollout found for thread id X"\` (\`thread_processor.rs:3589\`) — rollout not flushed yet, thread is in-memory-only
5. ensureListener returns \`*TurnRPCError\` → Turn aborts before turn/start
6. agentserver: \`sess.CodexThreadID == nil\` → retry path skipped → user gets generic error
7. Repeats forever on every message

## Fix

ensureListener swallows the \`no rollout found\` error class specifically and proceeds to turn/start. Justification:

- For fresh threads: \`thread/start\` already auto-attached the listener (\`thread_processor.rs:1115\`), so re-attach is unnecessary
- For stale threads (rollout actually missing): \`turn/start\` will hit the same error, surface it as TurnRPCError, and agentserver's #144 heuristic kicks in to retry on fresh thread

Codex TUI doesn't hit this because it doesn't preemptively call thread/resume after thread/start.

## Test plan

- [x] \`TestConnTurn_SwallowsNoRolloutFoundOnFreshThread\` (new): asserts Turn proceeds to turn/start after \"no rollout\" error
- [x] \`TestConnTurn_AbortsIfThreadResumeErrors\` still passes — other RPC errors still abort
- [x] \`go test ./internal/codexappgateway/broker/ -race -count=2\` clean
- [ ] Post-deploy: first-time IM user gets reply on first message

🤖 Generated with [Claude Code](https://claude.com/claude-code)