### PR TITLE
fix(codex-broker): per-conn attached-set, only thread/resume when needed

### DIFF
--- a/internal/codexappgateway/broker/conn.go
+++ b/internal/codexappgateway/broker/conn.go
@@ -23,11 +23,12 @@ type Conn struct {
 	writeMu sync.Mutex
 	nextID  atomic.Int64
 
-	mu             sync.Mutex
-	pendingResp    map[int64]chan rpcResponse   // request id → 1-buffered chan
-	pendingTurns   map[string]chan turnPayload  // turn id → 1-buffered chan
-	itemsByTurn    map[string][]json.RawMessage // turn id → accumulated item/completed payloads
-	completedTurns map[string]turnPayload       // turn/completed arrived before Turn() finished registering — see deliverTurn for the race
+	mu              sync.Mutex
+	pendingResp     map[int64]chan rpcResponse   // request id → 1-buffered chan
+	pendingTurns    map[string]chan turnPayload  // turn id → 1-buffered chan
+	itemsByTurn     map[string][]json.RawMessage // turn id → accumulated item/completed payloads
+	completedTurns  map[string]turnPayload       // turn/completed arrived before Turn() finished registering — see deliverTurn for the race
+	attachedThreads map[string]struct{}          // thread ids whose listener is wired to THIS connection — see Turn / StartThread for the lifecycle
 
 	closeOnce sync.Once
 	closed    chan struct{}
@@ -49,12 +50,13 @@ func Dial(ctx context.Context, wsURL string) (*Conn, error) {
 	ws.SetReadLimit(64 << 20)
 
 	c := &Conn{
-		ws:             ws,
-		pendingResp:    make(map[int64]chan rpcResponse),
-		pendingTurns:   make(map[string]chan turnPayload),
-		itemsByTurn:    make(map[string][]json.RawMessage),
-		completedTurns: make(map[string]turnPayload),
-		closed:         make(chan struct{}),
+		ws:              ws,
+		pendingResp:     make(map[int64]chan rpcResponse),
+		pendingTurns:    make(map[string]chan turnPayload),
+		itemsByTurn:     make(map[string][]json.RawMessage),
+		completedTurns:  make(map[string]turnPayload),
+		attachedThreads: make(map[string]struct{}),
+		closed:          make(chan struct{}),
 	}
 
 	// Send initialize synchronously (no reader yet, so we read inline).
@@ -254,6 +256,9 @@ func (c *Conn) failAllPending(err error) {
 	for tid := range c.completedTurns {
 		delete(c.completedTurns, tid)
 	}
+	for tid := range c.attachedThreads {
+		delete(c.attachedThreads, tid)
+	}
 	c.mu.Unlock()
 	c.closeErr.CompareAndSwap(nil, &errHolder{err})
 }
@@ -271,14 +276,29 @@ func (c *Conn) Turn(ctx context.Context, threadID string, callerParams json.RawM
 	// codex turn_processor.rs turn_start_inner — only thread/start,
 	// thread/resume, thread/fork, and thread/realtime/start trigger
 	// ensure_conversation_listener). After a broker reconnect (new
-	// connection_id) or after the listener task exits on next_event=Err,
-	// turn/start would ack but events have no consumer — the broker
-	// observes 5-minute brokerTimeout with items=0. thread/resume is
-	// idempotent (thread_lifecycle.rs:242 listener_matches short-circuit)
-	// so paying one extra loopback RPC per turn is the simplest fix that
-	// also covers same-conn listener-died failures.
-	if err := c.ensureListener(ctx, threadID); err != nil {
-		return nil, fmt.Errorf("ensure listener: %w", err)
+	// connection_id) the listener tied to the old connection_id is gone,
+	// so the first turn we issue for a known thread on a fresh conn must
+	// thread/resume to (re-)attach. Codex's TUI follows the same pattern
+	// (see codex tui app_server_session.rs:resume_thread — explicit
+	// thread/resume on bootstrap, never on subsequent turns).
+	//
+	// Skip when codex's thread_created broadcast already attached the
+	// listener for us: that fires on thread/start AND thread/resume (see
+	// codex core/agent/control.rs notify_thread_created at :311 and :609,
+	// dispatched by lib.rs:1022 main loop to every initialized connection).
+	// Tracked via attachedThreads, populated by StartThread and by every
+	// successful ensureListener below. Resets implicitly when the Conn is
+	// discarded — Pool will dial fresh on the next Get.
+	c.mu.Lock()
+	_, alreadyAttached := c.attachedThreads[threadID]
+	c.mu.Unlock()
+	if !alreadyAttached {
+		if err := c.ensureListener(ctx, threadID); err != nil {
+			return nil, fmt.Errorf("ensure listener: %w", err)
+		}
+		c.mu.Lock()
+		c.attachedThreads[threadID] = struct{}{}
+		c.mu.Unlock()
 	}
 
 	id := c.nextID.Add(1)
@@ -475,6 +495,16 @@ func (c *Conn) StartThread(ctx context.Context) (string, error) {
 	if tsResp.Thread.ID == "" {
 		return "", errors.New("thread/start result missing thread.id")
 	}
+	// Codex's thread_created broadcast (control.rs:311 → lib.rs:1022 main
+	// loop) attached the per-thread listener for THIS connection
+	// already, so the immediate next Turn() on this thread does not need
+	// thread/resume. Record so it's skipped — calling thread/resume
+	// before the rollout is flushed to disk would 500 with "no rollout
+	// found for thread id ..." (thread_processor.rs:3589), wedging
+	// every first-message-per-thread.
+	c.mu.Lock()
+	c.attachedThreads[tsResp.Thread.ID] = struct{}{}
+	c.mu.Unlock()
 	return tsResp.Thread.ID, nil
 }
 

--- a/internal/codexappgateway/broker/conn_resume_test.go
+++ b/internal/codexappgateway/broker/conn_resume_test.go
@@ -9,6 +9,142 @@ import (
 	"nhooyr.io/websocket"
 )
 
+// TestConnTurn_SkipsResumeOnSubsequentTurnSameThread locks in the
+// per-conn attached-set optimization: after the first Turn() on a
+// thread has thread/resume'd it (or StartThread auto-registered it),
+// subsequent Turn() calls on the same thread on the same Conn MUST
+// NOT re-issue thread/resume. The listener is already wired for the
+// connection lifetime; re-issuing is redundant and would 500 the
+// first message of fresh threads against codex (rollout not flushed
+// yet, see thread_processor.rs:3589).
+func TestConnTurn_SkipsResumeOnSubsequentTurnSameThread(t *testing.T) {
+	resumeCount := 0
+	url, stop := fakeCodexServer(t, func(t *testing.T, ctx context.Context, c *websocket.Conn) {
+		replayHandshake(t, ctx, c)
+		for {
+			f, err := readNoFatal(ctx, c)
+			if err != nil {
+				return
+			}
+			switch f["method"] {
+			case "thread/resume":
+				resumeCount++
+				writeJSON(t, ctx, c, map[string]any{"jsonrpc": "2.0", "id": f["id"], "result": map[string]any{}})
+			case "turn/start":
+				writeJSON(t, ctx, c, map[string]any{
+					"jsonrpc": "2.0", "id": f["id"],
+					"result": map[string]any{"turn": map[string]any{"id": "trn-skip"}},
+				})
+				writeJSON(t, ctx, c, map[string]any{
+					"jsonrpc": "2.0", "method": "turn/completed",
+					"params": map[string]any{"threadId": "thr-skip", "turn": map[string]any{
+						"id": "trn-skip", "status": "completed",
+						"items": []any{}, "itemsView": "full", "error": nil,
+					}},
+				})
+			}
+		}
+	})
+	defer stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	conn, err := Dial(ctx, url)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer conn.Close()
+
+	for i := 0; i < 3; i++ {
+		if _, err := conn.Turn(ctx, "thr-skip",
+			json.RawMessage(`{"input":[{"type":"text","text":"hi"}]}`),
+			30*time.Second); err != nil {
+			t.Fatalf("Turn iter %d: %v", i, err)
+		}
+	}
+	// First Turn attaches; iter 1 and 2 must not re-attach.
+	if resumeCount != 1 {
+		t.Errorf("thread/resume sent %d times, want exactly 1 across 3 turns", resumeCount)
+	}
+}
+
+// TestStartThread_RegistersListenerAttachment locks in that the
+// thread id returned by StartThread is treated as already-attached by
+// subsequent Turn() calls. codex's thread_created broadcast wired the
+// listener for this connection at thread/start time, so an explicit
+// thread/resume is both unnecessary AND broken (fires "no rollout
+// found" before the rollout has flushed).
+func TestStartThread_RegistersListenerAttachment(t *testing.T) {
+	sawResume := false
+	url, stop := fakeCodexServer(t, func(t *testing.T, ctx context.Context, c *websocket.Conn) {
+		replayHandshake(t, ctx, c)
+		// thread/start reply.
+		ts := readFrame(t, ctx, c)
+		if ts["method"] != "thread/start" {
+			t.Fatalf("first frame = %v, want thread/start", ts["method"])
+		}
+		writeJSON(t, ctx, c, map[string]any{
+			"jsonrpc": "2.0", "id": ts["id"],
+			"result": map[string]any{
+				"thread":         map[string]any{"id": "thr-fresh", "sessionId": "s", "createdAt": 0, "updatedAt": 0},
+				"model":          "gpt-x",
+				"modelProvider":  "openai",
+				"serviceTier":    nil,
+				"cwd":            "/tmp/codex",
+				"approvalPolicy": "onRequest",
+			},
+		})
+		// Subsequent turn — must be turn/start directly, not thread/resume.
+		for {
+			f, err := readNoFatal(ctx, c)
+			if err != nil {
+				return
+			}
+			if f["method"] == "thread/resume" {
+				sawResume = true
+				writeJSON(t, ctx, c, map[string]any{"jsonrpc": "2.0", "id": f["id"], "result": map[string]any{}})
+				continue
+			}
+			if f["method"] == "turn/start" {
+				writeJSON(t, ctx, c, map[string]any{
+					"jsonrpc": "2.0", "id": f["id"],
+					"result": map[string]any{"turn": map[string]any{"id": "trn-fresh"}},
+				})
+				writeJSON(t, ctx, c, map[string]any{
+					"jsonrpc": "2.0", "method": "turn/completed",
+					"params": map[string]any{"threadId": "thr-fresh", "turn": map[string]any{
+						"id": "trn-fresh", "status": "completed",
+						"items": []any{}, "itemsView": "full", "error": nil,
+					}},
+				})
+				return
+			}
+		}
+	})
+	defer stop()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	conn, err := Dial(ctx, url)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer conn.Close()
+
+	tid, err := conn.StartThread(ctx)
+	if err != nil {
+		t.Fatalf("StartThread: %v", err)
+	}
+	if _, err := conn.Turn(ctx, tid,
+		json.RawMessage(`{"input":[{"type":"text","text":"hi"}]}`),
+		30*time.Second); err != nil {
+		t.Fatalf("Turn: %v", err)
+	}
+	if sawResume {
+		t.Error("Turn issued thread/resume after StartThread — broadcast-attached listener was not recorded")
+	}
+}
+
 // TestConnTurn_AbortsIfThreadResumeErrors locks in that an error reply to
 // the thread/resume preamble surfaces from Turn without ever firing
 // turn/start. Avoids leaking RPC IDs and turn state when the listener


### PR DESCRIPTION
## Summary

Replaces #140's \"always thread/resume\" with codex TUI's pattern: track per-connection listener attachments, skip thread/resume when the listener is already known to be wired.

Closes the regression that made every first-message-per-thread fail with \`⚠️ Codex 处理失败\` (immediate). #144's heuristic extension covered the post-restart stale-thread case, but not the fresh-thread case — first-time users had no \`codex_thread_id\` so the retry precondition (\`sess.CodexThreadID != nil\`) never fired.

## Why

#140's blanket thread/resume hits three cases. One of them is broken:

| Case | Old (#140) | New |
|---|---|---|
| Fresh dial → existing thread | thread/resume re-attaches ✓ | same |
| StartThread + Turn (same conn) | thread/resume → \"no rollout found\" → abort ✗ | broadcast already attached → skipped ✓ |
| 2nd+ turn on known thread (same conn) | redundant RPC ✓ but wasteful | skipped ✓ |

Codex's \`thread_created\` broadcast (\`core/agent/control.rs:311\` + \`:609\` → \`app-server/lib.rs:1022\` main loop \`thread_created_rx\`) wires the listener for ALL initialized connections at thread/start and thread/resume time. So if WE were the connection that just thread/start'd or thread/resume'd, the listener is on us — no need to re-attach.

Codex TUI does exactly this: see \`tui/app_server_session.rs::resume_thread\` (called from bootstrap, not from every turn) and the explicit comment at \`tui/session_lifecycle.rs:245\` calling out that \`thread/resume\` is what establishes the listener.

## Mechanism

- New \`Conn.attachedThreads map[string]struct{}\`, mu-guarded
- \`StartThread\` inserts the returned id (broadcast already attached it)
- \`Turn\` checks the set: skip ensureListener if present, otherwise call it and record on success
- \`failAllPending\` clears the set when the Conn dies (Pool dials fresh on next Get)

## Test plan

- [x] \`TestConnTurn_SkipsResumeOnSubsequentTurnSameThread\` (new): 3 turns same thread → exactly 1 thread/resume on the wire
- [x] \`TestStartThread_RegistersListenerAttachment\` (new): StartThread + Turn → no thread/resume sent
- [x] Existing tests still pass:
  - \`TestConnTurn_SendsThreadResumeBeforeTurnStart\` (first turn on a thread we didn't create)
  - \`TestConnTurn_AbortsIfThreadResumeErrors\` (resume error path still aborts when we genuinely need to resume)
  - \`TestPoolReusesConnForSameWorkspace\` (3 turns reuse the same Conn, attached set in effect)
- [x] \`go test ./internal/codexappgateway/broker/ -race -count=2\` clean
- [x] \`go test ./internal/codexappgateway/broker/ -count=50\` (no race) clean
- [ ] Post-deploy: first-time IM user gets reply on first message (no \`Codex 处理失败\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)