### PR TITLE
chore(chart): bump 0.64.2 → 0.64.3

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.2
-appVersion: "0.64.2"
+version: 0.64.3
+appVersion: "0.64.3"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
## Summary

Bumps Helm chart 0.64.2 → 0.64.3 to cover the cumulative fixes since the last chart bump:

- #144 \`fix(codex-im): treat 'no rollout found for thread id' as thread-not-found\` — retry-with-fresh-thread when codex's rollout file is missing (returning user case)
- #146 \`fix(codex-broker): per-conn attached-set, only thread/resume when needed\` — fixes first-time-user wedge introduced by #140, aligns broker with codex TUI's listener-attach pattern
- #147 \`feat(codex-app-gateway): block client→app-server local IO RPCs\` — \`!\`, command/exec/*, fs/* — closes pod-escape RPC surface

## Follow-ups (out of this PR)

After merge:
1. \`git tag v0.64.3 && git push --tags\` so CI builds versioned images (agentserver:0.64.3 via type=semver)
2. Bump pulumi \`/root/k8s/stacks/agentserver.ts\`: chart 0.64.2 → 0.64.3 and image.tag 0.64.1 → 0.64.3 for agentserver core + codex-exec-gateway
3. \`pulumi up --stack nj-prod\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)