### PR TITLE
feat(codex-im): forward WeChat images to codex (TUI-aligned)

### DIFF
--- a/internal/imbridge/bridge.go
+++ b/internal/imbridge/bridge.go
@@ -472,7 +472,7 @@ func (b *Bridge) forwardToAgentserver(ctx context.Context, binding BridgeBinding
 // Mirrors forwardToAgentserver's shape (HTTP-based, fire-and-forget
 // for the reply — that comes back via /api/internal/imbridge/send).
 func (b *Bridge) forwardToCodex(ctx context.Context, binding BridgeBinding, msg InboundMessage) (bool, error) {
-	body, err := json.Marshal(map[string]any{
+	payload := map[string]any{
 		"channel_id":         binding.ChannelID,
 		"workspace_id":       binding.WorkspaceID,
 		"wechat_user_id":     msg.FromUserID,
@@ -480,7 +480,28 @@ func (b *Bridge) forwardToCodex(ctx context.Context, binding BridgeBinding, msg 
 		"text":               msg.Text,
 		"quoted_text":        msg.QuotedText,
 		"quoted_sender":      msg.QuotedSender,
-	})
+	}
+	// Forward media so codex turn input can include the image as a data
+	// URL. forwardToNanoClaw has had this since day one; the codex path
+	// was added without it, which is why images "disappeared" before
+	// reaching the LLM. Pattern matches forwardToNanoClaw exactly
+	// (base64 + media_type), so codex_im_inbound can reuse the same
+	// decoder.
+	if len(msg.MediaData) > 0 {
+		payload["media_data"] = base64.StdEncoding.EncodeToString(msg.MediaData)
+		payload["media_type"] = msg.MediaType
+		if msg.MediaFilename != "" {
+			payload["media_filename"] = msg.MediaFilename
+		}
+	}
+	if len(msg.QuotedMediaData) > 0 {
+		payload["quoted_media_data"] = base64.StdEncoding.EncodeToString(msg.QuotedMediaData)
+		payload["quoted_media_type"] = msg.QuotedMediaType
+		if msg.QuotedMediaFilename != "" {
+			payload["quoted_media_filename"] = msg.QuotedMediaFilename
+		}
+	}
+	body, err := json.Marshal(payload)
 	if err != nil {
 		return false, fmt.Errorf("marshal codex inbound: %w", err)
 	}

--- a/internal/imbridge/bridge.go
+++ b/internal/imbridge/bridge.go
@@ -481,25 +481,20 @@ func (b *Bridge) forwardToCodex(ctx context.Context, binding BridgeBinding, msg 
 		"quoted_text":        msg.QuotedText,
 		"quoted_sender":      msg.QuotedSender,
 	}
-	// Forward media so codex turn input can include the image as a data
-	// URL. forwardToNanoClaw has had this since day one; the codex path
-	// was added without it, which is why images "disappeared" before
-	// reaching the LLM. Pattern matches forwardToNanoClaw exactly
-	// (base64 + media_type), so codex_im_inbound can reuse the same
-	// decoder.
+	// Forward image bytes so codex turn input can carry them as a
+	// `data:<mime>;base64,...` URL (UserInput::Image). Mirrors
+	// forwardToNanoClaw's media payload shape, minus the filename —
+	// codex has no File variant and the image case doesn't need the
+	// filename. File attachments still come through imbridge's text
+	// fallback ("[User sent a file: X]" via describeWeixinMedia); a
+	// proper file-content path is deferred until designed.
 	if len(msg.MediaData) > 0 {
 		payload["media_data"] = base64.StdEncoding.EncodeToString(msg.MediaData)
 		payload["media_type"] = msg.MediaType
-		if msg.MediaFilename != "" {
-			payload["media_filename"] = msg.MediaFilename
-		}
 	}
 	if len(msg.QuotedMediaData) > 0 {
 		payload["quoted_media_data"] = base64.StdEncoding.EncodeToString(msg.QuotedMediaData)
 		payload["quoted_media_type"] = msg.QuotedMediaType
-		if msg.QuotedMediaFilename != "" {
-			payload["quoted_media_filename"] = msg.QuotedMediaFilename
-		}
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {

--- a/internal/server/codex_im_inbound.go
+++ b/internal/server/codex_im_inbound.go
@@ -70,13 +70,15 @@ type codexInboundRequest struct {
 	// Media fields mirror imbridge bridge.go's payload shape. MediaType
 	// is "image" / "file" (the bare token imbridge uses, not a MIME).
 	// MediaData is base64-encoded raw bytes; buildCodexInput sniffs the
-	// real MIME and forwards images to codex as data: URLs.
+	// real MIME and forwards images to codex as data: URLs. Only
+	// MediaType="image" is consumed today — file attachments fall back
+	// to imbridge's existing "[User sent a file: X]" text marker
+	// because codex's UserInput has no File variant and a sensible
+	// inline-content scheme isn't designed yet.
 	MediaType       string `json:"media_type,omitempty"`
 	MediaData       string `json:"media_data,omitempty"` // base64
-	MediaFilename   string `json:"media_filename,omitempty"`
-	QuotedMediaType     string `json:"quoted_media_type,omitempty"`
-	QuotedMediaData     string `json:"quoted_media_data,omitempty"` // base64
-	QuotedMediaFilename string `json:"quoted_media_filename,omitempty"`
+	QuotedMediaType string `json:"quoted_media_type,omitempty"`
+	QuotedMediaData string `json:"quoted_media_data,omitempty"` // base64
 }
 
 func (h *codexInboundHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -287,104 +289,52 @@ func transportToUserMessage(t *CodexTransportError) string {
 }
 
 // buildCodexInput constructs the codex turn/start params.input from the
-// inbound WeChat message. Text + image media + text-file content are
-// forwarded.
+// inbound WeChat message.
 //
-// Codex v2 UserInput supports only Text / Image / LocalImage / Skill /
-// Mention — there's no `File` variant. So file attachments are routed
-// as follows:
+// Codex v2 UserInput supports Text / Image / LocalImage / Skill /
+// Mention. We use Image only (LocalImage requires path access that the
+// cloud app-server can't satisfy). Images are encoded as
+// `data:<mime>;base64,...` URLs — codex test suite covers this shape
+// at v2/tests.rs:3254. Image inputs do NOT count toward
+// MAX_USER_INPUT_TEXT_CHARS (text_char_count returns 0 for non-Text
+// variants), so multi-MB photos pass.
 //
-//   - image bytes → UserInput::Image as a `data:<mime>;base64,...` URL.
-//     Codex test suite covers this shape at v2/tests.rs:3254. Images
-//     do NOT count toward MAX_USER_INPUT_TEXT_CHARS (text_char_count
-//     returns 0 for non-Text variants).
-//   - text-detectable file content (sniffed as text/*) → fenced-code
-//     block appended to the Text input. Truncated to fileMaxChars
-//     so a giant log doesn't blow the codex input limit (1 Mi chars
-//     per protocol/src/user_input.rs).
-//   - binary files → no content forwarded. imbridge already injected
-//     "[User sent a file: name]" via describeWeixinMedia when the
-//     user sent a file without a caption, so the LLM at least knows
-//     a file arrived.
+// Ordering matches codex's native TUI client: images first, text last
+// (chatwidget.rs builds items as remote/local images then Text). Quoted
+// (older) image is placed before the current image. Empty text is
+// dropped — TUI also skips the Text item when the user sends only
+// images.
 //
-// Quoted (older) media is placed before current media to preserve
-// chronological order as the user sees it.
+// File attachments (MediaType="file"): no content forwarded today.
+// imbridge already injected "[User sent a file: name]" into req.Text
+// via describeWeixinMedia when the user sent a file without a caption,
+// so the LLM at least sees the filename. A proper file-content path
+// isn't designed yet — codex has no File variant and inlining text
+// files has ergonomics we want to think through first.
 func buildCodexInput(req codexInboundRequest) json.RawMessage {
-	var parts []string
-	if req.QuotedText != "" {
-		quoter := req.QuotedSender
-		if quoter == "" {
-			quoter = "之前的消息"
-		}
-		parts = append(parts, fmt.Sprintf("[引用 %s] %s", quoter, req.QuotedText))
-	}
-	if snip := fileTextSnippet(req.QuotedMediaType, req.QuotedMediaData, req.QuotedMediaFilename); snip != "" {
-		parts = append(parts, "[引用文件]"+snip)
-	}
-	if req.Text != "" {
-		parts = append(parts, req.Text)
-	}
-	if snip := fileTextSnippet(req.MediaType, req.MediaData, req.MediaFilename); snip != "" {
-		parts = append(parts, snip)
-	}
-	text := strings.Join(parts, "\n\n")
-	input := []map[string]any{
-		{"type": "text", "text": text},
-	}
+	var input []map[string]any
 	if item, ok := imageInputItem(req.QuotedMediaType, req.QuotedMediaData); ok {
 		input = append(input, item)
 	}
 	if item, ok := imageInputItem(req.MediaType, req.MediaData); ok {
 		input = append(input, item)
 	}
+	text := req.Text
+	if req.QuotedText != "" {
+		quoter := req.QuotedSender
+		if quoter == "" {
+			quoter = "之前的消息"
+		}
+		text = fmt.Sprintf("[引用 %s] %s\n%s", quoter, req.QuotedText, req.Text)
+	}
+	if text != "" {
+		input = append(input, map[string]any{"type": "text", "text": text})
+	}
 	wrapped := map[string]any{
 		"input": input,
 	}
 	b, _ := json.Marshal(wrapped)
 	return b
-}
-
-// fileMaxChars bounds the per-file content we inline into the text
-// input. Codex's MAX_USER_INPUT_TEXT_CHARS is 1 Mi (1<<20). Capping
-// each attached file at ~200K leaves room for the user's typed text,
-// quoted history, and a second attached file in the same turn before
-// the limit kicks in.
-const fileMaxChars = 200_000
-
-// fileTextSnippet returns a fenced-code block to append to the text
-// input for an attached file, IF the bytes sniff as text/* via
-// http.DetectContentType. Returns "" for binary files (caller leaves
-// imbridge's "[User sent a file: name]" marker in place) or invalid
-// input.
-//
-// Truncates content longer than fileMaxChars and appends a marker so
-// the LLM doesn't silently see a partial file.
-func fileTextSnippet(mediaType, base64Data, filename string) string {
-	if mediaType != "file" || base64Data == "" {
-		return ""
-	}
-	raw, err := base64.StdEncoding.DecodeString(base64Data)
-	if err != nil || len(raw) == 0 {
-		return ""
-	}
-	if !strings.HasPrefix(http.DetectContentType(raw), "text/") {
-		return ""
-	}
-	content := string(raw)
-	truncatedBytes := 0
-	if len(content) > fileMaxChars {
-		truncatedBytes = len(content) - fileMaxChars
-		content = content[:fileMaxChars]
-	}
-	label := filename
-	if label == "" {
-		label = "file"
-	}
-	snippet := fmt.Sprintf("[Attached file: %s]\n```\n%s\n```", label, content)
-	if truncatedBytes > 0 {
-		snippet += fmt.Sprintf("\n[truncated %d bytes; original was %d bytes total]", truncatedBytes, len(raw))
-	}
-	return snippet
 }
 
 // imageInputItem returns a codex v2 UserInput::Image item for the given

--- a/internal/server/codex_im_inbound.go
+++ b/internal/server/codex_im_inbound.go
@@ -287,30 +287,50 @@ func transportToUserMessage(t *CodexTransportError) string {
 }
 
 // buildCodexInput constructs the codex turn/start params.input from the
-// inbound WeChat message. Text + image media are forwarded; non-image
-// attachments are described in the text fallback by imbridge already
-// (describeWeixinMedia).
+// inbound WeChat message. Text + image media + text-file content are
+// forwarded.
 //
-// Image bytes are encoded as data: URLs and emitted as UserInput::Image.
-// Codex v2 protocol accepts data:// in the `url` field (see
-// codex-rs/app-server-protocol/src/protocol/v2/tests.rs:3254).
-// Image inputs do NOT count toward MAX_USER_INPUT_TEXT_CHARS
-// (turn.rs:text_char_count returns 0 for non-text variants).
+// Codex v2 UserInput supports only Text / Image / LocalImage / Skill /
+// Mention — there's no `File` variant. So file attachments are routed
+// as follows:
+//
+//   - image bytes → UserInput::Image as a `data:<mime>;base64,...` URL.
+//     Codex test suite covers this shape at v2/tests.rs:3254. Images
+//     do NOT count toward MAX_USER_INPUT_TEXT_CHARS (text_char_count
+//     returns 0 for non-Text variants).
+//   - text-detectable file content (sniffed as text/*) → fenced-code
+//     block appended to the Text input. Truncated to fileMaxChars
+//     so a giant log doesn't blow the codex input limit (1 Mi chars
+//     per protocol/src/user_input.rs).
+//   - binary files → no content forwarded. imbridge already injected
+//     "[User sent a file: name]" via describeWeixinMedia when the
+//     user sent a file without a caption, so the LLM at least knows
+//     a file arrived.
+//
+// Quoted (older) media is placed before current media to preserve
+// chronological order as the user sees it.
 func buildCodexInput(req codexInboundRequest) json.RawMessage {
-	text := req.Text
+	var parts []string
 	if req.QuotedText != "" {
 		quoter := req.QuotedSender
 		if quoter == "" {
 			quoter = "之前的消息"
 		}
-		text = fmt.Sprintf("[引用 %s] %s\n%s", quoter, req.QuotedText, req.Text)
+		parts = append(parts, fmt.Sprintf("[引用 %s] %s", quoter, req.QuotedText))
 	}
+	if snip := fileTextSnippet(req.QuotedMediaType, req.QuotedMediaData, req.QuotedMediaFilename); snip != "" {
+		parts = append(parts, "[引用文件]"+snip)
+	}
+	if req.Text != "" {
+		parts = append(parts, req.Text)
+	}
+	if snip := fileTextSnippet(req.MediaType, req.MediaData, req.MediaFilename); snip != "" {
+		parts = append(parts, snip)
+	}
+	text := strings.Join(parts, "\n\n")
 	input := []map[string]any{
 		{"type": "text", "text": text},
 	}
-	// Inline quoted-message image first (chronologically older), then
-	// the current message's image. Mirrors how the user sees them in
-	// the WeChat thread.
 	if item, ok := imageInputItem(req.QuotedMediaType, req.QuotedMediaData); ok {
 		input = append(input, item)
 	}
@@ -322,6 +342,49 @@ func buildCodexInput(req codexInboundRequest) json.RawMessage {
 	}
 	b, _ := json.Marshal(wrapped)
 	return b
+}
+
+// fileMaxChars bounds the per-file content we inline into the text
+// input. Codex's MAX_USER_INPUT_TEXT_CHARS is 1 Mi (1<<20). Capping
+// each attached file at ~200K leaves room for the user's typed text,
+// quoted history, and a second attached file in the same turn before
+// the limit kicks in.
+const fileMaxChars = 200_000
+
+// fileTextSnippet returns a fenced-code block to append to the text
+// input for an attached file, IF the bytes sniff as text/* via
+// http.DetectContentType. Returns "" for binary files (caller leaves
+// imbridge's "[User sent a file: name]" marker in place) or invalid
+// input.
+//
+// Truncates content longer than fileMaxChars and appends a marker so
+// the LLM doesn't silently see a partial file.
+func fileTextSnippet(mediaType, base64Data, filename string) string {
+	if mediaType != "file" || base64Data == "" {
+		return ""
+	}
+	raw, err := base64.StdEncoding.DecodeString(base64Data)
+	if err != nil || len(raw) == 0 {
+		return ""
+	}
+	if !strings.HasPrefix(http.DetectContentType(raw), "text/") {
+		return ""
+	}
+	content := string(raw)
+	truncatedBytes := 0
+	if len(content) > fileMaxChars {
+		truncatedBytes = len(content) - fileMaxChars
+		content = content[:fileMaxChars]
+	}
+	label := filename
+	if label == "" {
+		label = "file"
+	}
+	snippet := fmt.Sprintf("[Attached file: %s]\n```\n%s\n```", label, content)
+	if truncatedBytes > 0 {
+		snippet += fmt.Sprintf("\n[truncated %d bytes; original was %d bytes total]", truncatedBytes, len(raw))
+	}
+	return snippet
 }
 
 // imageInputItem returns a codex v2 UserInput::Image item for the given

--- a/internal/server/codex_im_inbound.go
+++ b/internal/server/codex_im_inbound.go
@@ -288,22 +288,37 @@ func transportToUserMessage(t *CodexTransportError) string {
 	}
 }
 
-// buildCodexInput constructs the codex turn/start params.input from the
-// inbound WeChat message.
+// buildCodexInput constructs the codex turn/start params.input from
+// the inbound WeChat message.
 //
 // Codex v2 UserInput supports Text / Image / LocalImage / Skill /
-// Mention. We use Image only (LocalImage requires path access that the
-// cloud app-server can't satisfy). Images are encoded as
-// `data:<mime>;base64,...` URLs — codex test suite covers this shape
-// at v2/tests.rs:3254. Image inputs do NOT count toward
-// MAX_USER_INPUT_TEXT_CHARS (text_char_count returns 0 for non-Text
-// variants), so multi-MB photos pass.
+// Mention. We use Text + Image. LocalImage isn't viable in cloud (the
+// app-server runs in a separate pod from where the bytes live, so
+// path-based references break); Skill / Mention are codex-internal.
 //
-// Ordering matches codex's native TUI client: images first, text last
-// (chatwidget.rs builds items as remote/local images then Text). Quoted
-// (older) image is placed before the current image. Empty text is
-// dropped — TUI also skips the Text item when the user sends only
-// images.
+// Images are encoded as `data:<mime>;base64,...` URLs — codex test
+// suite covers this shape at v2/tests.rs:3254. Image inputs do NOT
+// count toward MAX_USER_INPUT_TEXT_CHARS (text_char_count returns 0
+// for non-Text variants), so multi-MB photos pass.
+//
+// Item ordering mirrors codex's native TUI:
+//   chatwidget.rs emits all image items, then the Text item, and
+//   skips the Text item entirely when text is empty.
+//
+// WeChat adds an "is a reply to" concept TUI doesn't have. We treat
+// it as a SECOND epoch placed BEFORE the current one in items:
+//
+//   [quoted image]   (if any)
+//   [quoted text]    "[引用 <sender>] <text>" or "[引用 <sender> 发送的图片]"
+//   [current image]  (if any)
+//   [current text]   (if any)
+//
+// Within each epoch we follow TUI's images-then-text rule, and across
+// epochs we order quoted (older) before current. The quoted Text item
+// is always present when there's ANY quoted content (text or image)
+// so the LLM can distinguish the prior image/text from the current
+// one — without a marker, two image items in a row look like two
+// attachments to the same current message.
 //
 // File attachments (MediaType="file"): no content forwarded today.
 // imbridge already injected "[User sent a file: name]" into req.Text
@@ -313,28 +328,51 @@ func transportToUserMessage(t *CodexTransportError) string {
 // files has ergonomics we want to think through first.
 func buildCodexInput(req codexInboundRequest) json.RawMessage {
 	var input []map[string]any
+
+	// Quoted epoch (chronologically older). Even quote-image-only
+	// gets a marker Text item so the LLM doesn't conflate it with
+	// the current image.
 	if item, ok := imageInputItem(req.QuotedMediaType, req.QuotedMediaData); ok {
 		input = append(input, item)
 	}
+	if marker := formatQuoteMarker(req.QuotedSender, req.QuotedText, req.QuotedMediaType); marker != "" {
+		input = append(input, map[string]any{"type": "text", "text": marker})
+	}
+
+	// Current epoch.
 	if item, ok := imageInputItem(req.MediaType, req.MediaData); ok {
 		input = append(input, item)
 	}
-	text := req.Text
-	if req.QuotedText != "" {
-		quoter := req.QuotedSender
-		if quoter == "" {
-			quoter = "之前的消息"
-		}
-		text = fmt.Sprintf("[引用 %s] %s\n%s", quoter, req.QuotedText, req.Text)
+	if req.Text != "" {
+		input = append(input, map[string]any{"type": "text", "text": req.Text})
 	}
-	if text != "" {
-		input = append(input, map[string]any{"type": "text", "text": text})
-	}
+
 	wrapped := map[string]any{
 		"input": input,
 	}
 	b, _ := json.Marshal(wrapped)
 	return b
+}
+
+// formatQuoteMarker returns the text content for the quoted Text item,
+// or "" if there's no quoted content. Always non-empty when the user's
+// WeChat message is a reply to another, even if the original was only
+// an image (in which case the marker stands alone as a label for the
+// preceding quoted image item).
+func formatQuoteMarker(sender, text, mediaType string) string {
+	quoter := sender
+	if quoter == "" {
+		quoter = "之前的消息"
+	}
+	switch {
+	case text != "":
+		return fmt.Sprintf("[引用 %s] %s", quoter, text)
+	case mediaType == "image":
+		return fmt.Sprintf("[引用 %s 发送的图片]", quoter)
+	default:
+		// No quoted content at all (no text and no image).
+		return ""
+	}
 }
 
 // imageInputItem returns a codex v2 UserInput::Image item for the given

--- a/internal/server/codex_im_inbound.go
+++ b/internal/server/codex_im_inbound.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -66,6 +67,16 @@ type codexInboundRequest struct {
 	Text         string `json:"text"`
 	QuotedText   string `json:"quoted_text,omitempty"`
 	QuotedSender string `json:"quoted_sender,omitempty"`
+	// Media fields mirror imbridge bridge.go's payload shape. MediaType
+	// is "image" / "file" (the bare token imbridge uses, not a MIME).
+	// MediaData is base64-encoded raw bytes; buildCodexInput sniffs the
+	// real MIME and forwards images to codex as data: URLs.
+	MediaType       string `json:"media_type,omitempty"`
+	MediaData       string `json:"media_data,omitempty"` // base64
+	MediaFilename   string `json:"media_filename,omitempty"`
+	QuotedMediaType     string `json:"quoted_media_type,omitempty"`
+	QuotedMediaData     string `json:"quoted_media_data,omitempty"` // base64
+	QuotedMediaFilename string `json:"quoted_media_filename,omitempty"`
 }
 
 func (h *codexInboundHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -276,8 +287,15 @@ func transportToUserMessage(t *CodexTransportError) string {
 }
 
 // buildCodexInput constructs the codex turn/start params.input from the
-// inbound WeChat message. MVP: text only. Quoted text is concatenated
-// into the same text item with a "引用:" prefix; image/media ignored.
+// inbound WeChat message. Text + image media are forwarded; non-image
+// attachments are described in the text fallback by imbridge already
+// (describeWeixinMedia).
+//
+// Image bytes are encoded as data: URLs and emitted as UserInput::Image.
+// Codex v2 protocol accepts data:// in the `url` field (see
+// codex-rs/app-server-protocol/src/protocol/v2/tests.rs:3254).
+// Image inputs do NOT count toward MAX_USER_INPUT_TEXT_CHARS
+// (turn.rs:text_char_count returns 0 for non-text variants).
 func buildCodexInput(req codexInboundRequest) json.RawMessage {
 	text := req.Text
 	if req.QuotedText != "" {
@@ -287,13 +305,52 @@ func buildCodexInput(req codexInboundRequest) json.RawMessage {
 		}
 		text = fmt.Sprintf("[引用 %s] %s\n%s", quoter, req.QuotedText, req.Text)
 	}
+	input := []map[string]any{
+		{"type": "text", "text": text},
+	}
+	// Inline quoted-message image first (chronologically older), then
+	// the current message's image. Mirrors how the user sees them in
+	// the WeChat thread.
+	if item, ok := imageInputItem(req.QuotedMediaType, req.QuotedMediaData); ok {
+		input = append(input, item)
+	}
+	if item, ok := imageInputItem(req.MediaType, req.MediaData); ok {
+		input = append(input, item)
+	}
 	wrapped := map[string]any{
-		"input": []map[string]any{
-			{"type": "text", "text": text},
-		},
+		"input": input,
 	}
 	b, _ := json.Marshal(wrapped)
 	return b
+}
+
+// imageInputItem returns a codex v2 UserInput::Image item for the given
+// (mediaType, base64-encoded bytes) pair, or (nil, false) if there are
+// no bytes or the bytes don't sniff as an image (e.g., MediaType=="file"
+// or upstream sent garbage). MediaType comes through as imbridge's
+// bare token ("image" / "file") rather than a MIME, so the real MIME
+// is detected from the first 512 bytes — covers JPEG/PNG/GIF/WebP,
+// which are the formats iLink delivers in practice.
+func imageInputItem(mediaType, base64Data string) (map[string]any, bool) {
+	if mediaType != "image" || base64Data == "" {
+		return nil, false
+	}
+	raw, err := base64.StdEncoding.DecodeString(base64Data)
+	if err != nil || len(raw) == 0 {
+		return nil, false
+	}
+	sniffed := http.DetectContentType(raw)
+	if !strings.HasPrefix(sniffed, "image/") {
+		// Upstream said "image" but bytes don't sniff that way — skip
+		// rather than feed codex a misdeclared data URL.
+		return nil, false
+	}
+	return map[string]any{
+		"type": "image",
+		// Reuse the already-base64-encoded payload verbatim to avoid a
+		// re-encode round-trip on multi-MB images.
+		"url": "data:" + sniffed + ";base64," + base64Data,
+	}, true
 }
 
 // sendText / sendError both POST /api/internal/imbridge/send. The

--- a/internal/server/codex_im_inbound_test.go
+++ b/internal/server/codex_im_inbound_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -402,5 +403,140 @@ func TestIsThreadNotFoundErr(t *testing.T) {
 		if got := isThreadNotFoundErr(in); got != want {
 			t.Errorf("isThreadNotFoundErr(%q) = %v, want %v", in, got, want)
 		}
+	}
+}
+
+// 1×1 transparent PNG — smallest valid PNG, just enough for
+// http.DetectContentType to return "image/png".
+const tinyPNGBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
+
+// TestBuildCodexInput_TextOnly pins the baseline: no media → exactly
+// one text item, no extra noise. Guards against accidentally emitting
+// an empty image item.
+func TestBuildCodexInput_TextOnly(t *testing.T) {
+	raw := buildCodexInput(codexInboundRequest{Text: "hello"})
+	var got struct {
+		Input []map[string]any `json:"input"`
+	}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Input) != 1 {
+		t.Fatalf("input items = %d, want 1", len(got.Input))
+	}
+	if got.Input[0]["type"] != "text" || got.Input[0]["text"] != "hello" {
+		t.Errorf("input[0] = %v, want text/hello", got.Input[0])
+	}
+}
+
+// TestBuildCodexInput_WithImage covers the main fix: image bytes from
+// imbridge become a UserInput::Image data URL in the codex turn input.
+func TestBuildCodexInput_WithImage(t *testing.T) {
+	raw := buildCodexInput(codexInboundRequest{
+		Text:      "look at this",
+		MediaType: "image",
+		MediaData: tinyPNGBase64,
+	})
+	var got struct {
+		Input []map[string]any `json:"input"`
+	}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Input) != 2 {
+		t.Fatalf("input items = %d, want 2 (text + image)", len(got.Input))
+	}
+	img := got.Input[1]
+	if img["type"] != "image" {
+		t.Errorf("input[1].type = %v, want image", img["type"])
+	}
+	url, _ := img["url"].(string)
+	if !strings.HasPrefix(url, "data:image/png;base64,") {
+		t.Errorf("input[1].url = %q, want data:image/png;base64,... prefix", url)
+	}
+	if !strings.HasSuffix(url, tinyPNGBase64) {
+		t.Errorf("input[1].url should round-trip the original base64 (no re-encode), got %q", url)
+	}
+}
+
+// TestBuildCodexInput_QuotedImageBeforeCurrent locks in chronological
+// order — the quoted (older) image must come before the current
+// message's image so the LLM sees them in conversation order.
+func TestBuildCodexInput_QuotedImageBeforeCurrent(t *testing.T) {
+	raw := buildCodexInput(codexInboundRequest{
+		Text:            "follow-up",
+		QuotedText:      "earlier msg",
+		QuotedSender:    "alice",
+		QuotedMediaType: "image",
+		QuotedMediaData: tinyPNGBase64,
+		MediaType:       "image",
+		MediaData:       tinyPNGBase64,
+	})
+	var got struct {
+		Input []map[string]any `json:"input"`
+	}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Input) != 3 {
+		t.Fatalf("input items = %d, want 3 (text + quoted-image + current-image)", len(got.Input))
+	}
+	if got.Input[0]["type"] != "text" {
+		t.Errorf("input[0].type = %v, want text", got.Input[0]["type"])
+	}
+	if got.Input[1]["type"] != "image" || got.Input[2]["type"] != "image" {
+		t.Errorf("input[1] and input[2] should both be image, got %v %v", got.Input[1]["type"], got.Input[2]["type"])
+	}
+}
+
+// TestImageInputItem_RejectsNonImageMediaType — imbridge sends "file"
+// for non-image attachments (PDF, etc.); we must NOT misclassify those
+// as images. codex has no File variant, so handling falls back to the
+// "user sent a file: X" text injected by imbridge's describeWeixinMedia.
+func TestImageInputItem_RejectsNonImageMediaType(t *testing.T) {
+	_, ok := imageInputItem("file", tinyPNGBase64)
+	if ok {
+		t.Error("expected file mediaType to be rejected")
+	}
+}
+
+// TestImageInputItem_RejectsBadBase64 — a typo / truncation upstream
+// shouldn't crash or generate a malformed data URL; just skip.
+func TestImageInputItem_RejectsBadBase64(t *testing.T) {
+	_, ok := imageInputItem("image", "not!!!valid$$$base64===")
+	if ok {
+		t.Error("expected garbage base64 to be rejected")
+	}
+}
+
+// TestImageInputItem_RejectsNonImageBytes — defense against an upstream
+// that misdeclares mediaType=image but ships text/binary. We don't want
+// to ship a malformed data URL to codex.
+func TestImageInputItem_RejectsNonImageBytes(t *testing.T) {
+	// "hello world" base64 — http.DetectContentType returns "text/plain".
+	_, ok := imageInputItem("image", "aGVsbG8gd29ybGQ=")
+	if ok {
+		t.Error("expected non-image bytes to be rejected even when mediaType=image")
+	}
+}
+
+// TestImageInputItem_DetectsJPEG covers another MIME the iLink CDN
+// actually returns. http.DetectContentType reads the first 512 bytes,
+// JPEG magic is the first 3 (FF D8 FF).
+func TestImageInputItem_DetectsJPEG(t *testing.T) {
+	// Minimal JPEG header: SOI (FF D8 FF) + APP0 marker (E0) + length (00 10)
+	// + JFIF magic + version + density. Enough for DetectContentType.
+	jpegBytes := []byte{
+		0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 'J', 'F', 'I', 'F', 0x00,
+		0x01, 0x01, 0x00, 0x00, 0x01, 0x00, 0x01, 0x00, 0x00,
+	}
+	jpegB64 := base64.StdEncoding.EncodeToString(jpegBytes)
+	item, ok := imageInputItem("image", jpegB64)
+	if !ok {
+		t.Fatal("expected JPEG to be accepted")
+	}
+	url := item["url"].(string)
+	if !strings.HasPrefix(url, "data:image/jpeg;base64,") {
+		t.Errorf("expected image/jpeg mime in data URL, got %q", url)
 	}
 }

--- a/internal/server/codex_im_inbound_test.go
+++ b/internal/server/codex_im_inbound_test.go
@@ -411,8 +411,7 @@ func TestIsThreadNotFoundErr(t *testing.T) {
 const tinyPNGBase64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8/5+hHgAHggJ/PchI7wAAAABJRU5ErkJggg=="
 
 // TestBuildCodexInput_TextOnly pins the baseline: no media → exactly
-// one text item, no extra noise. Guards against accidentally emitting
-// an empty image item.
+// one text item, no extra noise.
 func TestBuildCodexInput_TextOnly(t *testing.T) {
 	raw := buildCodexInput(codexInboundRequest{Text: "hello"})
 	var got struct {
@@ -431,6 +430,8 @@ func TestBuildCodexInput_TextOnly(t *testing.T) {
 
 // TestBuildCodexInput_WithImage covers the main fix: image bytes from
 // imbridge become a UserInput::Image data URL in the codex turn input.
+// Order matches codex TUI's native pattern: image FIRST, text last
+// (chatwidget.rs pushes images before the Text item).
 func TestBuildCodexInput_WithImage(t *testing.T) {
 	raw := buildCodexInput(codexInboundRequest{
 		Text:      "look at this",
@@ -444,24 +445,48 @@ func TestBuildCodexInput_WithImage(t *testing.T) {
 		t.Fatalf("decode: %v", err)
 	}
 	if len(got.Input) != 2 {
-		t.Fatalf("input items = %d, want 2 (text + image)", len(got.Input))
+		t.Fatalf("input items = %d, want 2 (image + text)", len(got.Input))
 	}
-	img := got.Input[1]
+	img := got.Input[0]
 	if img["type"] != "image" {
-		t.Errorf("input[1].type = %v, want image", img["type"])
+		t.Errorf("input[0].type = %v, want image (TUI ordering: images first)", img["type"])
 	}
 	url, _ := img["url"].(string)
 	if !strings.HasPrefix(url, "data:image/png;base64,") {
-		t.Errorf("input[1].url = %q, want data:image/png;base64,... prefix", url)
+		t.Errorf("input[0].url = %q, want data:image/png;base64,... prefix", url)
 	}
 	if !strings.HasSuffix(url, tinyPNGBase64) {
-		t.Errorf("input[1].url should round-trip the original base64 (no re-encode), got %q", url)
+		t.Errorf("input[0].url should round-trip the original base64 (no re-encode), got %q", url)
+	}
+	if got.Input[1]["type"] != "text" || got.Input[1]["text"] != "look at this" {
+		t.Errorf("input[1] = %v, want text/look at this", got.Input[1])
+	}
+}
+
+// TestBuildCodexInput_ImageOnlySkipsText — TUI skips the Text item
+// when the user submits only images (chatwidget.rs:
+// `if !text.is_empty() { items.push(Text) }`). We match.
+func TestBuildCodexInput_ImageOnlySkipsText(t *testing.T) {
+	raw := buildCodexInput(codexInboundRequest{
+		MediaType: "image",
+		MediaData: tinyPNGBase64,
+	})
+	var got struct {
+		Input []map[string]any `json:"input"`
+	}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Input) != 1 {
+		t.Fatalf("input items = %d, want 1 (image alone, no empty text)", len(got.Input))
+	}
+	if got.Input[0]["type"] != "image" {
+		t.Errorf("input[0].type = %v, want image", got.Input[0]["type"])
 	}
 }
 
 // TestBuildCodexInput_QuotedImageBeforeCurrent locks in chronological
-// order — the quoted (older) image must come before the current
-// message's image so the LLM sees them in conversation order.
+// order — quoted (older) image first, then current image, then text.
 func TestBuildCodexInput_QuotedImageBeforeCurrent(t *testing.T) {
 	raw := buildCodexInput(codexInboundRequest{
 		Text:            "follow-up",
@@ -479,13 +504,13 @@ func TestBuildCodexInput_QuotedImageBeforeCurrent(t *testing.T) {
 		t.Fatalf("decode: %v", err)
 	}
 	if len(got.Input) != 3 {
-		t.Fatalf("input items = %d, want 3 (text + quoted-image + current-image)", len(got.Input))
+		t.Fatalf("input items = %d, want 3 (quoted-image + current-image + text)", len(got.Input))
 	}
-	if got.Input[0]["type"] != "text" {
-		t.Errorf("input[0].type = %v, want text", got.Input[0]["type"])
+	if got.Input[0]["type"] != "image" || got.Input[1]["type"] != "image" {
+		t.Errorf("input[0] and input[1] should both be image (quoted then current), got %v %v", got.Input[0]["type"], got.Input[1]["type"])
 	}
-	if got.Input[1]["type"] != "image" || got.Input[2]["type"] != "image" {
-		t.Errorf("input[1] and input[2] should both be image, got %v %v", got.Input[1]["type"], got.Input[2]["type"])
+	if got.Input[2]["type"] != "text" {
+		t.Errorf("input[2].type = %v, want text (last per TUI ordering)", got.Input[2]["type"])
 	}
 }
 
@@ -541,77 +566,16 @@ func TestImageInputItem_DetectsJPEG(t *testing.T) {
 	}
 }
 
-// TestFileTextSnippet_TextFileInlined covers the main file fix: text
-// files (code, configs, plain) get inlined into the text input.
-func TestFileTextSnippet_TextFileInlined(t *testing.T) {
-	content := "package main\nfunc main() { println(\"hi\") }\n"
-	b64 := base64.StdEncoding.EncodeToString([]byte(content))
-	snip := fileTextSnippet("file", b64, "main.go")
-	if !strings.Contains(snip, "main.go") {
-		t.Errorf("snippet should name the file, got %q", snip)
-	}
-	if !strings.Contains(snip, content) {
-		t.Errorf("snippet should embed file content verbatim, got %q", snip)
-	}
-	if !strings.Contains(snip, "```") {
-		t.Errorf("snippet should wrap content in a fenced code block, got %q", snip)
-	}
-}
-
-// TestFileTextSnippet_BinaryFileSkipped — PDFs, zips, etc. must NOT
-// have raw bytes inlined into text (would be unintelligible noise +
-// likely break UTF-8). Caller relies on imbridge's existing
-// "[User sent a file: X]" marker in that case.
-func TestFileTextSnippet_BinaryFileSkipped(t *testing.T) {
-	// PDF magic: "%PDF-"
-	pdf := []byte{'%', 'P', 'D', 'F', '-', '1', '.', '4', '\n', 0x00, 0x00, 0x00}
-	snip := fileTextSnippet("file", base64.StdEncoding.EncodeToString(pdf), "report.pdf")
-	if snip != "" {
-		t.Errorf("expected empty snippet for binary PDF, got %q", snip)
-	}
-}
-
-// TestFileTextSnippet_LargeTextTruncated guards the codex
-// MAX_USER_INPUT_TEXT_CHARS budget. A user dropping a 2 MB log
-// shouldn't blow the input limit.
-func TestFileTextSnippet_LargeTextTruncated(t *testing.T) {
-	large := strings.Repeat("ABCD\n", 60_000) // 300 KB of text
-	snip := fileTextSnippet("file", base64.StdEncoding.EncodeToString([]byte(large)), "big.log")
-	if !strings.Contains(snip, "truncated") {
-		t.Errorf("expected truncation marker, got %q", snip[:200])
-	}
-	// Snippet shouldn't carry the full original content.
-	if strings.Count(snip, "ABCD") >= 60_000 {
-		t.Errorf("snippet not truncated — got %d ABCD occurrences", strings.Count(snip, "ABCD"))
-	}
-}
-
-// TestFileTextSnippet_ImageMediaTypeSkipped — `image` mediaType is
-// handled by imageInputItem, not here. Avoid double-handling.
-func TestFileTextSnippet_ImageMediaTypeSkipped(t *testing.T) {
-	if snip := fileTextSnippet("image", tinyPNGBase64, "p.png"); snip != "" {
-		t.Errorf("image mediaType should be no-op for file snippet, got %q", snip)
-	}
-}
-
-// TestFileTextSnippet_NoFilenameUsesFallback — filename is optional in
-// some upstreams; ensure we emit a sensible default label.
-func TestFileTextSnippet_NoFilenameUsesFallback(t *testing.T) {
-	snip := fileTextSnippet("file", base64.StdEncoding.EncodeToString([]byte("hello")), "")
-	if !strings.Contains(snip, "file") {
-		t.Errorf("expected 'file' as default label, got %q", snip)
-	}
-}
-
-// TestBuildCodexInput_TextFileInlinedIntoText pins the user-visible
-// behavior: the file content appears inside the text input item, NOT
-// as a separate image item.
-func TestBuildCodexInput_TextFileInlinedIntoText(t *testing.T) {
+// TestBuildCodexInput_FileMediaTypeNoImageItem — file attachments
+// must NOT produce an image item (codex has no File variant, and the
+// inline-content path isn't designed yet). imbridge already injected
+// "[User sent a file: X]" into req.Text via describeWeixinMedia, so
+// the LLM sees the filename through that fallback alone.
+func TestBuildCodexInput_FileMediaTypeNoImageItem(t *testing.T) {
 	raw := buildCodexInput(codexInboundRequest{
-		Text:          "review this",
-		MediaType:     "file",
-		MediaData:     base64.StdEncoding.EncodeToString([]byte("hello world\n")),
-		MediaFilename: "notes.txt",
+		Text:      "[User sent a file: report.pdf]",
+		MediaType: "file",
+		MediaData: base64.StdEncoding.EncodeToString([]byte{'%', 'P', 'D', 'F', '-', '1'}),
 	})
 	var got struct {
 		Input []map[string]any `json:"input"`
@@ -620,13 +584,9 @@ func TestBuildCodexInput_TextFileInlinedIntoText(t *testing.T) {
 		t.Fatalf("decode: %v", err)
 	}
 	if len(got.Input) != 1 {
-		t.Fatalf("expected 1 input item (text only — files don't get their own item), got %d", len(got.Input))
+		t.Fatalf("expected 1 input item (text only), got %d", len(got.Input))
 	}
-	text, _ := got.Input[0]["text"].(string)
-	if !strings.Contains(text, "review this") {
-		t.Errorf("user text missing from combined input, got %q", text)
-	}
-	if !strings.Contains(text, "notes.txt") || !strings.Contains(text, "hello world") {
-		t.Errorf("file content/name missing from text, got %q", text)
+	if got.Input[0]["type"] != "text" {
+		t.Errorf("input[0].type = %v, want text", got.Input[0]["type"])
 	}
 }

--- a/internal/server/codex_im_inbound_test.go
+++ b/internal/server/codex_im_inbound_test.go
@@ -540,3 +540,93 @@ func TestImageInputItem_DetectsJPEG(t *testing.T) {
 		t.Errorf("expected image/jpeg mime in data URL, got %q", url)
 	}
 }
+
+// TestFileTextSnippet_TextFileInlined covers the main file fix: text
+// files (code, configs, plain) get inlined into the text input.
+func TestFileTextSnippet_TextFileInlined(t *testing.T) {
+	content := "package main\nfunc main() { println(\"hi\") }\n"
+	b64 := base64.StdEncoding.EncodeToString([]byte(content))
+	snip := fileTextSnippet("file", b64, "main.go")
+	if !strings.Contains(snip, "main.go") {
+		t.Errorf("snippet should name the file, got %q", snip)
+	}
+	if !strings.Contains(snip, content) {
+		t.Errorf("snippet should embed file content verbatim, got %q", snip)
+	}
+	if !strings.Contains(snip, "```") {
+		t.Errorf("snippet should wrap content in a fenced code block, got %q", snip)
+	}
+}
+
+// TestFileTextSnippet_BinaryFileSkipped — PDFs, zips, etc. must NOT
+// have raw bytes inlined into text (would be unintelligible noise +
+// likely break UTF-8). Caller relies on imbridge's existing
+// "[User sent a file: X]" marker in that case.
+func TestFileTextSnippet_BinaryFileSkipped(t *testing.T) {
+	// PDF magic: "%PDF-"
+	pdf := []byte{'%', 'P', 'D', 'F', '-', '1', '.', '4', '\n', 0x00, 0x00, 0x00}
+	snip := fileTextSnippet("file", base64.StdEncoding.EncodeToString(pdf), "report.pdf")
+	if snip != "" {
+		t.Errorf("expected empty snippet for binary PDF, got %q", snip)
+	}
+}
+
+// TestFileTextSnippet_LargeTextTruncated guards the codex
+// MAX_USER_INPUT_TEXT_CHARS budget. A user dropping a 2 MB log
+// shouldn't blow the input limit.
+func TestFileTextSnippet_LargeTextTruncated(t *testing.T) {
+	large := strings.Repeat("ABCD\n", 60_000) // 300 KB of text
+	snip := fileTextSnippet("file", base64.StdEncoding.EncodeToString([]byte(large)), "big.log")
+	if !strings.Contains(snip, "truncated") {
+		t.Errorf("expected truncation marker, got %q", snip[:200])
+	}
+	// Snippet shouldn't carry the full original content.
+	if strings.Count(snip, "ABCD") >= 60_000 {
+		t.Errorf("snippet not truncated — got %d ABCD occurrences", strings.Count(snip, "ABCD"))
+	}
+}
+
+// TestFileTextSnippet_ImageMediaTypeSkipped — `image` mediaType is
+// handled by imageInputItem, not here. Avoid double-handling.
+func TestFileTextSnippet_ImageMediaTypeSkipped(t *testing.T) {
+	if snip := fileTextSnippet("image", tinyPNGBase64, "p.png"); snip != "" {
+		t.Errorf("image mediaType should be no-op for file snippet, got %q", snip)
+	}
+}
+
+// TestFileTextSnippet_NoFilenameUsesFallback — filename is optional in
+// some upstreams; ensure we emit a sensible default label.
+func TestFileTextSnippet_NoFilenameUsesFallback(t *testing.T) {
+	snip := fileTextSnippet("file", base64.StdEncoding.EncodeToString([]byte("hello")), "")
+	if !strings.Contains(snip, "file") {
+		t.Errorf("expected 'file' as default label, got %q", snip)
+	}
+}
+
+// TestBuildCodexInput_TextFileInlinedIntoText pins the user-visible
+// behavior: the file content appears inside the text input item, NOT
+// as a separate image item.
+func TestBuildCodexInput_TextFileInlinedIntoText(t *testing.T) {
+	raw := buildCodexInput(codexInboundRequest{
+		Text:          "review this",
+		MediaType:     "file",
+		MediaData:     base64.StdEncoding.EncodeToString([]byte("hello world\n")),
+		MediaFilename: "notes.txt",
+	})
+	var got struct {
+		Input []map[string]any `json:"input"`
+	}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Input) != 1 {
+		t.Fatalf("expected 1 input item (text only — files don't get their own item), got %d", len(got.Input))
+	}
+	text, _ := got.Input[0]["text"].(string)
+	if !strings.Contains(text, "review this") {
+		t.Errorf("user text missing from combined input, got %q", text)
+	}
+	if !strings.Contains(text, "notes.txt") || !strings.Contains(text, "hello world") {
+		t.Errorf("file content/name missing from text, got %q", text)
+	}
+}

--- a/internal/server/codex_im_inbound_test.go
+++ b/internal/server/codex_im_inbound_test.go
@@ -485,9 +485,18 @@ func TestBuildCodexInput_ImageOnlySkipsText(t *testing.T) {
 	}
 }
 
-// TestBuildCodexInput_QuotedImageBeforeCurrent locks in chronological
-// order — quoted (older) image first, then current image, then text.
-func TestBuildCodexInput_QuotedImageBeforeCurrent(t *testing.T) {
+// TestBuildCodexInput_FullQuoteWithImageAndText pins the full
+// item layout when both quoted (text+image) and current (text+image)
+// are present:
+//
+//   [0] quoted image
+//   [1] quoted text  (with "[引用 alice] earlier msg" marker)
+//   [2] current image
+//   [3] current text
+//
+// Two epochs, each following TUI's images-then-text ordering. Quoted
+// epoch precedes current epoch chronologically.
+func TestBuildCodexInput_FullQuoteWithImageAndText(t *testing.T) {
 	raw := buildCodexInput(codexInboundRequest{
 		Text:            "follow-up",
 		QuotedText:      "earlier msg",
@@ -503,14 +512,101 @@ func TestBuildCodexInput_QuotedImageBeforeCurrent(t *testing.T) {
 	if err := json.Unmarshal(raw, &got); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
+	if len(got.Input) != 4 {
+		t.Fatalf("input items = %d, want 4 (quoted-image + quoted-text + current-image + current-text)", len(got.Input))
+	}
+	if got.Input[0]["type"] != "image" {
+		t.Errorf("input[0].type = %v, want image (quoted)", got.Input[0]["type"])
+	}
+	if got.Input[1]["type"] != "text" || !strings.Contains(got.Input[1]["text"].(string), "引用 alice") {
+		t.Errorf("input[1] = %v, want quoted-text with marker", got.Input[1])
+	}
+	if !strings.Contains(got.Input[1]["text"].(string), "earlier msg") {
+		t.Errorf("input[1].text should include quoted body, got %q", got.Input[1]["text"])
+	}
+	if got.Input[2]["type"] != "image" {
+		t.Errorf("input[2].type = %v, want image (current)", got.Input[2]["type"])
+	}
+	if got.Input[3]["type"] != "text" || got.Input[3]["text"] != "follow-up" {
+		t.Errorf("input[3] = %v, want current-text follow-up", got.Input[3])
+	}
+}
+
+// TestBuildCodexInput_QuotedImageOnly — user replied to an
+// image-only message with a text reply. The quoted image gets its
+// own image item AND a marker Text item so the LLM doesn't confuse
+// it with a current attachment.
+func TestBuildCodexInput_QuotedImageOnly(t *testing.T) {
+	raw := buildCodexInput(codexInboundRequest{
+		Text:            "what is this?",
+		QuotedSender:    "alice",
+		QuotedMediaType: "image",
+		QuotedMediaData: tinyPNGBase64,
+	})
+	var got struct {
+		Input []map[string]any `json:"input"`
+	}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
 	if len(got.Input) != 3 {
-		t.Fatalf("input items = %d, want 3 (quoted-image + current-image + text)", len(got.Input))
+		t.Fatalf("input items = %d, want 3 (quoted-image + marker + current-text)", len(got.Input))
 	}
-	if got.Input[0]["type"] != "image" || got.Input[1]["type"] != "image" {
-		t.Errorf("input[0] and input[1] should both be image (quoted then current), got %v %v", got.Input[0]["type"], got.Input[1]["type"])
+	if got.Input[0]["type"] != "image" {
+		t.Errorf("input[0].type = %v, want image", got.Input[0]["type"])
 	}
-	if got.Input[2]["type"] != "text" {
-		t.Errorf("input[2].type = %v, want text (last per TUI ordering)", got.Input[2]["type"])
+	marker, _ := got.Input[1]["text"].(string)
+	if !strings.Contains(marker, "引用") || !strings.Contains(marker, "图片") {
+		t.Errorf("input[1] marker should reference '引用' and '图片', got %q", marker)
+	}
+	if got.Input[2]["type"] != "text" || got.Input[2]["text"] != "what is this?" {
+		t.Errorf("input[2] = %v, want current-text", got.Input[2])
+	}
+}
+
+// TestBuildCodexInput_QuotedTextOnly — user replied to a text message
+// with a text reply. Quoted text item then current text item.
+func TestBuildCodexInput_QuotedTextOnly(t *testing.T) {
+	raw := buildCodexInput(codexInboundRequest{
+		Text:         "agree",
+		QuotedText:   "ship it",
+		QuotedSender: "bob",
+	})
+	var got struct {
+		Input []map[string]any `json:"input"`
+	}
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Input) != 2 {
+		t.Fatalf("input items = %d, want 2 (quoted-text + current-text)", len(got.Input))
+	}
+	q, _ := got.Input[0]["text"].(string)
+	if !strings.Contains(q, "引用 bob") || !strings.Contains(q, "ship it") {
+		t.Errorf("input[0] quoted marker = %q, want '引用 bob' + 'ship it'", q)
+	}
+	if got.Input[1]["text"] != "agree" {
+		t.Errorf("input[1] = %v, want current-text 'agree'", got.Input[1])
+	}
+}
+
+// TestBuildCodexInput_QuoteSenderFallback — empty QuotedSender uses
+// the "之前的消息" fallback so the marker still makes sense.
+func TestBuildCodexInput_QuoteSenderFallback(t *testing.T) {
+	raw := buildCodexInput(codexInboundRequest{
+		Text:       "hmm",
+		QuotedText: "yesterday's note",
+	})
+	var got struct {
+		Input []map[string]any `json:"input"`
+	}
+	_ = json.Unmarshal(raw, &got)
+	if len(got.Input) < 1 {
+		t.Fatal("expected at least one input item")
+	}
+	q, _ := got.Input[0]["text"].(string)
+	if !strings.Contains(q, "之前的消息") {
+		t.Errorf("expected '之前的消息' fallback in marker, got %q", q)
 	}
 }
 


### PR DESCRIPTION
## Summary

WeChat photos reach imbridge fine — \`weixin_provider.go\` downloads + decrypts the CDN-encrypted bytes — but \`forwardToCodex\` was text-only, so the bytes got dropped and codex never saw the image. NanoClaw routing (\`forwardToNanoClaw\`, same file) has always shipped media; the codex path was added without it.

## Item layout matches codex TUI

Codex TUI's \`chatwidget.rs\` builds the items list as: images first, then Text item, and skips the Text item entirely when text is empty. We mirror this — and extend it for WeChat's reply-with-quote concept (which TUI doesn't have) by treating the quoted material as a second epoch placed BEFORE the current epoch in items:

```
[0] quoted image    (if any quoted image)
[1] quoted text     "[引用 <sender>] <text>" or "[引用 <sender> 发送的图片]"
                    — always emitted when there's any quoted content
                    so the LLM can tell a quoted image apart from a
                    current attachment
[2] current image   (if any)
[3] current text    (if any current text)
```

Each epoch independently follows TUI's images-then-text rule. Empty text → no Text item.

## Wire format

\`codex-rs/app-server-protocol/src/protocol/v2/turn.rs:UserInput\` variants: Text / Image / LocalImage / Skill / Mention. We use Text + Image. LocalImage isn't viable in cloud (app-server is in a separate pod from where the bytes live). Image \`url\` accepts \`data:<mime>;base64,...\` (codex test suite covers this at \`v2/tests.rs:3254\`). Image inputs don't count toward \`MAX_USER_INPUT_TEXT_CHARS\`, so multi-MB photos pass.

## Wiring

- **imbridge/bridge.go forwardToCodex**: add \`media_data\` / \`media_type\` + \`quoted_media_*\` to the JSON payload. Mirrors forwardToNanoClaw's shape minus the filename (codex doesn't need it).
- **server/codex_im_inbound.go codexInboundRequest**: receive matching fields.
- **server/codex_im_inbound.go buildCodexInput**: two-epoch construction (quoted then current), images-then-text per epoch, Text items skipped when empty.
- **server/codex_im_inbound.go imageInputItem**: builds Image item from base64 bytes. \`http.DetectContentType\` sniffs MIME from first 512 bytes (JPEG/PNG/GIF/WebP — what iLink delivers). Rejects non-image MediaType / invalid base64 / non-image bytes. Reuses the original base64 verbatim — no decode+re-encode on multi-MB photos.
- **server/codex_im_inbound.go formatQuoteMarker**: builds the "[引用 …]" Text content; "之前的消息" sender fallback when missing.

## Test plan

- [x] \`TestBuildCodexInput_TextOnly\` — baseline (1 item)
- [x] \`TestBuildCodexInput_WithImage\` — image + text → image at [0], text at [1]
- [x] \`TestBuildCodexInput_ImageOnlySkipsText\` — image alone → 1 item, no empty Text
- [x] \`TestBuildCodexInput_FullQuoteWithImageAndText\` — 4 items, quoted epoch then current, image-then-text per epoch
- [x] \`TestBuildCodexInput_QuotedImageOnly\` — image + marker + current text
- [x] \`TestBuildCodexInput_QuotedTextOnly\` — quote marker + current text
- [x] \`TestBuildCodexInput_QuoteSenderFallback\` — empty sender → "之前的消息"
- [x] \`TestBuildCodexInput_FileMediaTypeNoImageItem\` — file mediaType produces no image item
- [x] \`TestImageInputItem_RejectsNonImageMediaType\` / \`RejectsBadBase64\` / \`RejectsNonImageBytes\` / \`DetectsJPEG\`
- [x] \`go test ./internal/server ./internal/imbridge -race\` clean
- [ ] Post-deploy: WeChat photo, image-only, reply-with-image, reply-with-text → LLM correctly understands what's the current message vs the quote

## Out of scope (followup)

- **File content forwarding** (text or binary). Codex has no File variant. Inlining text-file content into the Text item works but has ergonomics that need more thought (truncation policy, fenced-code rendering, etc.) — pulled from this PR so we can ship the image fix and design the file path separately.
- **Voice transcripts**: already routed via the \`[Voice message] <transcript>\` text fallback (iLink transcribes server-side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)