### PR TITLE
chore(chart): bump 0.64.3 → 0.64.4

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.3
-appVersion: "0.64.3"
+version: 0.64.4
+appVersion: "0.64.4"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
## Summary

Cumulative fixes since v0.64.3:

- #147 \`feat(codex-app-gateway): block client→app-server local IO RPCs\` — \`!\` shell, command/exec/*, fs/* at the ws boundary
- #149 \`feat(codex-im): forward WeChat images to codex (TUI-aligned)\` — photos reach the LLM via UserInput::Image (data: URL), per-epoch images-then-text ordering matches codex TUI, quoted-message handling treated as a second chronologically-prior epoch

## Follow-ups (out of this PR)

1. \`git tag v0.64.4 && git push --tags\` → CI builds versioned images (agentserver:0.64.4, codex-exec-gateway:0.64.4)
2. Update pulumi \`/root/k8s/stacks/agentserver.ts\`: chart 0.64.3 → 0.64.4, image.tag 0.64.3 → 0.64.4 for agentserver core + codex-exec-gateway
3. \`pulumi up --stack nj-prod\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)