### PR TITLE
chore(im): drop stateless_cc + default new channels to codex + match Connectors UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,8 @@ Browser ───────────▶ agentserver  ─┤    ┌───
                    sessions, mailboxes)
 
 Browser ──▶ sandboxproxy (:8082) ─▶ subdomain routing to sandbox services
-Browser ──▶ cc-broker          ───▶ stateless cc worker pool (Stage 3)
-Sandbox ──▶ executor-registry  ───▶ tool-call dispatch / executor lookup
+codex CLI ─▶ codex-exec-gateway ──▶ rendezvous for `codex exec --remote` executors
+codex app ─▶ codex-app-gateway  ──▶ per-workspace codex app-server subprocess pool
 ```
 
 | Service | Default Port | Role |
@@ -110,8 +110,8 @@ Sandbox ──▶ executor-registry  ───▶ tool-call dispatch / executor 
 | **sandboxproxy** | `:8082` | Subdomain-based routing to sandbox services |
 | **credentialproxy** | — | Server-side injection of provider credentials |
 | **imbridge** | — | IM channel bridge (WeChat / Weixin, Telegram) |
-| **cc-broker** | — | Stateless Claude Code / Codex worker pool (Stage 3) |
-| **executor-registry** | — | Tool-call dispatch / executor discovery (Stage 3) |
+| **codex-app-gateway** | `:8086` | Per-workspace codex app-server subprocess + ws bridge for codex desktop / web client |
+| **codex-exec-gateway** | `:6060` | Rendezvous endpoint for `codex exec --remote` executors (user-local processes) |
 
 ## Code of Conduct
 

--- a/internal/db/im_channels.go
+++ b/internal/db/im_channels.go
@@ -182,8 +182,9 @@ func (db *DB) UpdateIMChannelSettings(channelID string, requireMention bool) err
 
 // UpdateIMChannelRoutingMode updates the routing_mode column for a channel.
 // Caller is expected to validate `mode` before calling (valid values:
-// "nanoclaw", "stateless_cc"). Unknown values are accepted by the DB but
-// will cause forwardMessage to fall through to the default nanoclaw branch.
+// "nanoclaw", "codex"). Unknown values are accepted by the DB but will
+// cause forwardMessage to fall through to the default nanoclaw branch
+// (also captures legacy "stateless_cc" rows pre-#151 cleanup).
 func (db *DB) UpdateIMChannelRoutingMode(channelID, mode string) error {
 	_, err := db.Exec(
 		`UPDATE workspace_im_channels SET routing_mode = $1 WHERE id = $2`,

--- a/internal/db/migrations/027_im_routing_default_codex.sql
+++ b/internal/db/migrations/027_im_routing_default_codex.sql
@@ -1,0 +1,11 @@
+-- Switch new workspace_im_channels to default routing_mode='codex'
+-- instead of 'nanoclaw'. The nanoclaw sandbox path still works for
+-- existing rows but is no longer the recommended path — every new
+-- channel should land on the codex-app-gateway flow.
+--
+-- Existing rows are intentionally NOT updated: a workspace already
+-- bound to nanoclaw shouldn't have its routing silently flipped at
+-- migration time. Operators can toggle per-channel via the workspace
+-- detail UI or PATCH /api/workspaces/{id}/im/channels/{channelId}.
+ALTER TABLE workspace_im_channels
+    ALTER COLUMN routing_mode SET DEFAULT 'codex';

--- a/internal/imbridge/bridge.go
+++ b/internal/imbridge/bridge.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 	"os"
@@ -49,7 +48,7 @@ type BridgeBinding struct {
 	ChannelID   string // workspace_im_channels.id
 	Cursor      string
 	WorkspaceID string // workspace that owns this channel
-	RoutingMode string // "nanoclaw" (default) or "stateless_cc"
+	RoutingMode string // "nanoclaw" (default) or "codex"
 }
 
 // pollerEntry tracks an active poller so the bridge can both cancel it and
@@ -406,8 +405,12 @@ func (b *Bridge) pollLoop(ctx context.Context, binding BridgeBinding) {
 }
 
 // forwardMessage routes an inbound message based on the binding's RoutingMode.
-// "stateless_cc" forwards to the agentserver HTTP API; all other values
-// (including empty, for backward compatibility) forward to NanoClaw.
+// "codex" forwards to agentserver's codex-app-gateway path; all other
+// values (including empty, for backward compatibility) forward to
+// NanoClaw. "stateless_cc" used to route to a since-removed agentserver
+// /api/workspaces/{id}/im/inbound handler (purged in #135); that route
+// is no longer accepted by the API and any DB row still carrying it
+// falls through to NanoClaw here.
 func (b *Bridge) forwardMessage(ctx context.Context, binding BridgeBinding, msg InboundMessage) (bool, error) {
 	// In-memory routing mode (set via SetChannelRoutingMode) wins over
 	// the routing_mode captured at StartPoller time. Empty map value
@@ -417,53 +420,11 @@ func (b *Bridge) forwardMessage(ctx context.Context, binding BridgeBinding, msg 
 		mode = binding.RoutingMode
 	}
 	switch mode {
-	case "stateless_cc":
-		return b.forwardToAgentserver(ctx, binding, msg)
 	case "codex":
 		return b.forwardToCodex(ctx, binding, msg)
-	default: // "nanoclaw" or empty (backward compatible)
+	default: // "nanoclaw", "stateless_cc" (legacy), or empty
 		return b.forwardToNanoClaw(ctx, binding, msg)
 	}
-}
-
-// forwardToAgentserver sends a message to the agentserver IM inbound endpoint.
-func (b *Bridge) forwardToAgentserver(ctx context.Context, binding BridgeBinding, msg InboundMessage) (bool, error) {
-	payload := map[string]interface{}{
-		"chat_jid":    msg.FromUserID,
-		"sender_name": msg.SenderName,
-		"content":     msg.Text,
-		"provider":    binding.Provider.Name(),
-		"channel_id":  binding.ChannelID,
-	}
-	body, err := json.Marshal(payload)
-	if err != nil {
-		return false, fmt.Errorf("marshal message: %w", err)
-	}
-
-	url := fmt.Sprintf("%s/api/workspaces/%s/im/inbound", b.agentserverURL, binding.WorkspaceID)
-	ctx, cancel := context.WithTimeout(ctx, forwardTimeout)
-	defer cancel()
-
-	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
-	if err != nil {
-		return false, err
-	}
-	req.Header.Set("Content-Type", "application/json")
-	if secret := os.Getenv("INTERNAL_API_SECRET"); secret != "" {
-		req.Header.Set("X-Internal-Secret", secret)
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return false, fmt.Errorf("forward to agentserver: %w", err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusAccepted {
-		respBody, _ := io.ReadAll(resp.Body)
-		return false, fmt.Errorf("agentserver returned %d: %s", resp.StatusCode, respBody)
-	}
-	return true, nil
 }
 
 // forwardToCodex POSTs the inbound message to agentserver's

--- a/internal/imbridge/bridge_routing_test.go
+++ b/internal/imbridge/bridge_routing_test.go
@@ -20,15 +20,15 @@ func TestForwardMessageChannelRoutingOverridesBinding(t *testing.T) {
 		typingSessions:   map[string]func(){},
 	}
 
-	// Override with stateless_cc in the in-memory map.
-	b.SetChannelRoutingMode("ch-abc", "stateless_cc")
+	// Override with codex in the in-memory map.
+	b.SetChannelRoutingMode("ch-abc", "codex")
 
 	// Simulate forwardMessage's routing decision directly. We cannot
 	// invoke forwardMessage end-to-end here without a real provider /
 	// HTTP target, so we assert on the effective mode computation.
 	got := b.getChannelRoutingMode("ch-abc")
-	if got != "stateless_cc" {
-		t.Fatalf("expected in-memory routing=stateless_cc, got %q", got)
+	if got != "codex" {
+		t.Fatalf("expected in-memory routing=codex, got %q", got)
 	}
 
 	// Missing channel → empty string so forwardMessage falls back to
@@ -56,7 +56,7 @@ func TestSetChannelRoutingModeConcurrent(t *testing.T) {
 		wg.Add(2)
 		go func() {
 			defer wg.Done()
-			b.SetChannelRoutingMode("ch1", "stateless_cc")
+			b.SetChannelRoutingMode("ch1", "codex")
 		}()
 		go func() {
 			defer wg.Done()
@@ -65,7 +65,7 @@ func TestSetChannelRoutingModeConcurrent(t *testing.T) {
 	}
 	wg.Wait()
 
-	if b.getChannelRoutingMode("ch1") != "stateless_cc" {
-		t.Fatalf("expected stateless_cc after concurrent writes")
+	if b.getChannelRoutingMode("ch1") != "codex" {
+		t.Fatalf("expected codex after concurrent writes")
 	}
 }

--- a/internal/imbridgesvc/handlers.go
+++ b/internal/imbridgesvc/handlers.go
@@ -968,8 +968,11 @@ func (s *Server) handleUpdateWorkspaceIMChannel(w http.ResponseWriter, r *http.R
 
 	if req.RoutingMode != nil {
 		mode := *req.RoutingMode
-		if mode != "nanoclaw" && mode != "stateless_cc" && mode != "codex" {
-			http.Error(w, "invalid routing_mode: must be nanoclaw, stateless_cc, or codex", http.StatusBadRequest)
+		// stateless_cc is no longer accepted — the agentserver endpoint
+		// it pointed to (POST /api/workspaces/{id}/im/inbound) was
+		// removed in the #135 purge.
+		if mode != "nanoclaw" && mode != "codex" {
+			http.Error(w, "invalid routing_mode: must be nanoclaw or codex", http.StatusBadRequest)
 			return
 		}
 		if err := s.db.UpdateIMChannelRoutingMode(channelID, mode); err != nil {

--- a/web/src/components/WorkspaceDetail.tsx
+++ b/web/src/components/WorkspaceDetail.tsx
@@ -897,16 +897,15 @@ function IMTab({ workspaceId }: { workspaceId: string }) {
                       onChange={async (e) => {
                         try {
                           await updateWorkspaceIMChannel(workspaceId, ch.id, {
-                            routing_mode: e.target.value as 'nanoclaw' | 'stateless_cc' | 'codex',
+                            routing_mode: e.target.value as 'nanoclaw' | 'codex',
                           })
                           loadChannels()
                         } catch {}
                       }}
                       className="rounded border border-[var(--border)] bg-[var(--background)] px-1.5 py-0.5 text-[11px] text-[var(--foreground)]"
-                      title="Routing mode: nanoclaw = legacy NanoClaw sandbox; stateless_cc = new stateless Claude Code broker (Beta); codex = Codex via codex-app-gateway"
+                      title="Routing mode: nanoclaw = legacy NanoClaw sandbox; codex = Codex via codex-app-gateway"
                     >
                       <option value="nanoclaw">nanoclaw</option>
-                      <option value="stateless_cc">stateless_cc (Beta)</option>
                       <option value="codex">Codex (via codex-app-gateway)</option>
                     </select>
                     <label className="flex items-center gap-1.5 text-[11px] text-[var(--muted-foreground)] cursor-pointer" title="Only reply when @mentioned in group chats">

--- a/web/src/components/WorkspaceDetail.tsx
+++ b/web/src/components/WorkspaceDetail.tsx
@@ -860,105 +860,146 @@ function IMTab({ workspaceId }: { workspaceId: string }) {
 
   useEffect(() => { loadChannels() }, [loadChannels])
 
-  return (
-    <div className="max-w-2xl">
-      <h3 className="text-base font-semibold text-[var(--foreground)] mb-4">IM Channels</h3>
+  // Provider-token → display metadata. Unknown providers fall through
+  // to a neutral grey so a future provider added server-side without
+  // a UI bump still renders something sensible.
+  const providerMeta: Record<string, { label: string; badge: string }> = {
+    weixin: { label: 'WeChat', badge: 'bg-green-500/10 text-green-400' },
+    telegram: { label: 'Telegram', badge: 'bg-blue-500/10 text-blue-400' },
+    matrix: { label: 'Matrix', badge: 'bg-purple-500/10 text-purple-400' },
+  }
 
+  return (
+    <>
       <div className="rounded-lg border border-[var(--border)] bg-[var(--card)]">
         <div className="flex items-center justify-between border-b border-[var(--border)] px-5 py-3">
           <div className="flex items-center gap-2">
             <MessageSquare size={14} className="text-green-400" />
             <span className="text-sm font-medium text-[var(--foreground)]">IM Channels</span>
+            {imChannels.length > 0 && (
+              <span className="rounded-full bg-[var(--secondary)] px-2 py-0.5 text-[10px] text-[var(--muted-foreground)]">
+                {imChannels.length}
+              </span>
+            )}
           </div>
-        </div>
-        <div className="px-5 py-4">
-          {imChannels.length > 0 ? (
-            <div className="flex flex-col gap-2 mb-4">
-              {imChannels.map((ch) => (
-                <div key={ch.id} className="flex items-center justify-between rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2">
-                  <div className="flex items-center gap-3">
-                    <span className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium ${
-                      ch.provider === 'telegram'
-                        ? 'bg-blue-500/10 text-blue-400'
-                        : ch.provider === 'matrix'
-                          ? 'bg-purple-500/10 text-purple-400'
-                          : 'bg-green-500/10 text-green-400'
-                    }`}>
-                      {ch.provider === 'telegram' ? 'Telegram' : ch.provider === 'matrix' ? 'Matrix' : 'WeChat'}
-                    </span>
-                    <span className="text-xs font-mono text-[var(--foreground)]">{ch.bot_id}</span>
-                    <span className="text-[11px] text-[var(--muted-foreground)]">
-                      {new Date(ch.bound_at).toLocaleString()}
-                    </span>
-                  </div>
-                  <div className="flex items-center gap-2">
-                    <select
-                      value={ch.routing_mode || 'nanoclaw'}
-                      onChange={async (e) => {
-                        try {
-                          await updateWorkspaceIMChannel(workspaceId, ch.id, {
-                            routing_mode: e.target.value as 'nanoclaw' | 'codex',
-                          })
-                          loadChannels()
-                        } catch {}
-                      }}
-                      className="rounded border border-[var(--border)] bg-[var(--background)] px-1.5 py-0.5 text-[11px] text-[var(--foreground)]"
-                      title="Routing mode: nanoclaw = legacy NanoClaw sandbox; codex = Codex via codex-app-gateway"
-                    >
-                      <option value="nanoclaw">nanoclaw</option>
-                      <option value="codex">Codex (via codex-app-gateway)</option>
-                    </select>
-                    <label className="flex items-center gap-1.5 text-[11px] text-[var(--muted-foreground)] cursor-pointer" title="Only reply when @mentioned in group chats">
-                      <input
-                        type="checkbox"
-                        checked={ch.require_mention}
-                        onChange={async (e) => {
-                          try {
-                            await updateWorkspaceIMChannel(workspaceId, ch.id, { require_mention: e.target.checked })
-                            loadChannels()
-                          } catch {}
-                        }}
-                        className="rounded"
-                      />
-                      @mention
-                    </label>
-                    <button
-                      onClick={() => setConfirmDeleteChannel(ch)}
-                      className="rounded p-1 text-[var(--muted-foreground)] hover:bg-red-500/10 hover:text-red-400 transition-colors"
-                      title="Delete channel"
-                    >
-                      <Trash2 size={13} />
-                    </button>
-                  </div>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <p className="text-sm text-[var(--muted-foreground)] mb-4">No IM channels configured.</p>
-          )}
-          <div className="flex gap-2">
+          <div className="flex items-center gap-1.5">
             <button
               onClick={() => setShowWeixinLogin(true)}
-              className="inline-flex items-center gap-1.5 rounded-md border border-green-500/30 bg-green-500/10 px-3 py-1.5 text-xs font-medium text-green-400 hover:bg-green-500/20 transition-colors"
+              className="inline-flex items-center gap-1 rounded-md border border-green-500/30 bg-green-500/10 px-2.5 py-1 text-[11px] font-medium text-green-400 hover:bg-green-500/20 transition-colors"
             >
-              <MessageSquare size={13} />
+              <MessageSquare size={11} />
               WeChat
             </button>
             <button
               onClick={() => setShowTelegramConfig(true)}
-              className="inline-flex items-center gap-1.5 rounded-md border border-blue-500/30 bg-blue-500/10 px-3 py-1.5 text-xs font-medium text-blue-400 hover:bg-blue-500/20 transition-colors"
+              className="inline-flex items-center gap-1 rounded-md border border-blue-500/30 bg-blue-500/10 px-2.5 py-1 text-[11px] font-medium text-blue-400 hover:bg-blue-500/20 transition-colors"
             >
-              <Bot size={13} />
+              <Bot size={11} />
               Telegram
             </button>
             <button
               onClick={() => setShowMatrixConfig(true)}
-              className="inline-flex items-center gap-1.5 rounded-md border border-purple-500/30 bg-purple-500/10 px-3 py-1.5 text-xs font-medium text-purple-400 hover:bg-purple-500/20 transition-colors"
+              className="inline-flex items-center gap-1 rounded-md border border-purple-500/30 bg-purple-500/10 px-2.5 py-1 text-[11px] font-medium text-purple-400 hover:bg-purple-500/20 transition-colors"
             >
-              <Hash size={13} />
+              <Hash size={11} />
               Matrix
             </button>
           </div>
+        </div>
+
+        <div className="px-5 py-4">
+          {imChannels.length === 0 ? (
+            <div className="rounded-md border border-dashed border-[var(--border)] py-8 text-center text-xs italic text-[var(--muted-foreground)]">
+              No IM channels configured — bind a WeChat / Telegram / Matrix account above.
+            </div>
+          ) : (
+            <div className="overflow-hidden rounded-md border border-[var(--border)]">
+              <table className="w-full table-fixed border-collapse text-sm">
+                <thead className="bg-[var(--secondary)] text-[var(--muted-foreground)]">
+                  <tr>
+                    <th className="w-24 px-3 py-2 text-left font-medium">Provider</th>
+                    <th className="px-3 py-2 text-left font-medium">Bot</th>
+                    <th className="w-44 px-3 py-2 text-left font-medium">Routing</th>
+                    <th className="w-24 px-3 py-2 text-left font-medium">@mention</th>
+                    <th className="w-44 px-3 py-2 text-left font-medium">Bound at</th>
+                    <th className="w-16 px-3 py-2 text-right font-medium">Actions</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {imChannels.map((ch, i) => {
+                    const meta = providerMeta[ch.provider] ?? { label: ch.provider, badge: 'bg-gray-500/10 text-gray-400' }
+                    return (
+                      <tr
+                        key={ch.id}
+                        className={`border-t border-[var(--border)] ${i % 2 === 1 ? 'bg-[var(--background)]/40' : ''}`}
+                      >
+                        <td className="px-3 py-2">
+                          <span className={`inline-flex items-center rounded px-1.5 py-0.5 text-[10px] font-medium ${meta.badge}`}>
+                            {meta.label}
+                          </span>
+                        </td>
+                        <td className="px-3 py-2 truncate">
+                          <div className="truncate font-mono text-xs text-[var(--foreground)]" title={ch.bot_id}>
+                            {ch.bot_id}
+                          </div>
+                          {ch.user_id && (
+                            <div className="truncate text-[11px] text-[var(--muted-foreground)]" title={ch.user_id}>
+                              {ch.user_id}
+                            </div>
+                          )}
+                        </td>
+                        <td className="px-3 py-2">
+                          <select
+                            value={ch.routing_mode || 'nanoclaw'}
+                            onChange={async (e) => {
+                              try {
+                                await updateWorkspaceIMChannel(workspaceId, ch.id, {
+                                  routing_mode: e.target.value as 'nanoclaw' | 'codex',
+                                })
+                                loadChannels()
+                              } catch {}
+                            }}
+                            className="w-full rounded border border-[var(--border)] bg-[var(--background)] px-1.5 py-0.5 text-[11px] text-[var(--foreground)]"
+                            title="Routing mode: nanoclaw = legacy NanoClaw sandbox; codex = Codex via codex-app-gateway"
+                          >
+                            <option value="nanoclaw">nanoclaw</option>
+                            <option value="codex">codex</option>
+                          </select>
+                        </td>
+                        <td className="px-3 py-2">
+                          <input
+                            type="checkbox"
+                            checked={ch.require_mention}
+                            onChange={async (e) => {
+                              try {
+                                await updateWorkspaceIMChannel(workspaceId, ch.id, { require_mention: e.target.checked })
+                                loadChannels()
+                              } catch {}
+                            }}
+                            className="rounded"
+                            title="Only reply when @mentioned in group chats"
+                          />
+                        </td>
+                        <td className="px-3 py-2 text-[var(--muted-foreground)]">
+                          {new Date(ch.bound_at).toLocaleString()}
+                        </td>
+                        <td className="px-3 py-2 text-right">
+                          <button
+                            onClick={() => setConfirmDeleteChannel(ch)}
+                            className="rounded p-1 text-[var(--muted-foreground)] hover:bg-[var(--secondary)] hover:text-[var(--destructive)] transition-colors"
+                            aria-label="Delete channel"
+                            title="Delete channel"
+                          >
+                            <Trash2 size={14} />
+                          </button>
+                        </td>
+                      </tr>
+                    )
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
         </div>
       </div>
 
@@ -1000,7 +1041,7 @@ function IMTab({ workspaceId }: { workspaceId: string }) {
           onConnected={() => { loadChannels() }}
         />
       )}
-    </div>
+    </>
   )
 }
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -462,7 +462,7 @@ export async function listWorkspaceIMChannels(workspaceId: string): Promise<{ ch
 export async function updateWorkspaceIMChannel(
   workspaceId: string,
   channelId: string,
-  settings: { require_mention?: boolean; routing_mode?: 'nanoclaw' | 'stateless_cc' | 'codex' },
+  settings: { require_mention?: boolean; routing_mode?: 'nanoclaw' | 'codex' },
 ): Promise<void> {
   const res = await fetch(`/api/workspaces/${workspaceId}/im/channels/${channelId}`, {
     method: 'PATCH',


### PR DESCRIPTION
## Summary

Three related IM-channel cleanups bundled:

1. **Remove the \`stateless_cc\` routing leftover.** #135 purged the backend (cc-broker / executor-registry / TUI / bridge handler) but left imbridge's routing entry point pointing at a since-removed agentserver endpoint (\`POST /api/workspaces/{id}/im/inbound\`). Any channel still configured with \`routing_mode=stateless_cc\` would 404 on every poll → retry → log spam. UI also still advertised it as a "Beta" option.

2. **Default new IM channels to \`routing_mode='codex'\`** (migration 027). \`stateless_cc\` is fully gone and \`codex\` is now the recommended path, so making it the schema-level default avoids surprising operators who don't notice the dropdown.

3. **Match Connectors / Browsers list style for IM channels** (WorkspaceDetail.tsx). The IM tab rendered hand-rolled flex rows that looked nothing like the Connectors / Browsers tabs which already share the DeviceListPanel card+table look. Rebuild IMTab to follow the same shape: rounded card, header with icon + title + count badge + headerAction slot, table with proper columns (Provider / Bot / Routing / @mention / Bound at / Actions), dashed empty state, hover-destructive delete icon.

## Diff

**stateless_cc removal:**
- \`imbridge/bridge.go\`: drop \`case "stateless_cc"\` from \`forwardMessage\` + the entire \`forwardToAgentserver\` function (only caller). Default arm now catches legacy DB rows so they fall through to NanoClaw instead of 404-looping.
- \`imbridgesvc/handlers.go\`: PATCH IM channel validator narrows to \`{nanoclaw, codex}\`.
- \`imbridge/bridge_routing_test.go\`: swap incidental \`"stateless_cc"\` string in tests to \`"codex"\`.
- \`web/src/lib/api.ts\` + \`WorkspaceDetail.tsx\`: drop \`stateless_cc\` from type union + dropdown + tooltip.
- \`internal/db/im_channels.go\`: docstring updated.
- \`README.md\`: architecture diagram + service table replace cc-broker / executor-registry rows with codex-app-gateway / codex-exec-gateway.

**Codex default:**
- \`internal/db/migrations/027_im_routing_default_codex.sql\`: \`ALTER COLUMN routing_mode SET DEFAULT 'codex'\`. Existing rows intentionally untouched.

**UI redesign:**
- \`WorkspaceDetail.tsx\` \`IMTab\`: rebuilt around the DeviceListPanel shape; \`providerMeta\` factors out per-provider badge color + display label.

## Out of scope

- **\`agent_sessions.cc_thread_id\` DB column**: no live reader/writer; dropping it needs its own migration.
- **Historical-context comments** in \`server.go\` / \`agent_tasks.go\` / \`sysinfo.go\` / \`codex_im_inbound.go\` / applied DB migrations: audited and kept because they document why related endpoints/columns are gone.

## Test plan

- [x] \`go test ./internal/imbridge ./internal/db -race\` clean
- [x] \`go vet ./...\` clean
- [x] \`pnpm tsc --noEmit\` clean
- [x] No live code path references \`stateless_cc\` (audit grep confirmed)
- [ ] Post-deploy: bind a fresh WeChat channel → row gets \`routing_mode='codex'\` without an explicit value; PATCH attempt with \`stateless_cc\` returns 400; IM Channels page renders the new table layout matching Connectors / Browsers visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)