### PR TITLE
feat(openapi): Phase 1.b — Workspaces tag (14 endpoints)

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -194,6 +194,848 @@
           }
         }
       }
+    },
+    "/api/workspaces": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "List workspaces for the current user",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Workspace"
+                  }
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "description": "Creator is auto-added as owner. May fail with 403 if the per-user workspace quota is exceeded.",
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Create a new workspace",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkspaceCreateRequest"
+              }
+            }
+          },
+          "description": "Workspace name",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Workspace"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request / empty name",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "workspace quota exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workspaces/quota": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Get per-user workspace quota",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceQuotaResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workspaces/{id}": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Get a workspace by id",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Workspace"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "workspace not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Delete a workspace (owner only; cascades to sandboxes + namespace)",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "403": {
+            "description": "owner only",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Rename a workspace",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkspaceRenameRequest"
+              }
+            }
+          },
+          "description": "New name",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Workspace"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "empty name",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "owner or maintainer required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workspaces/{id}/llm-config": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "description": "The returned api_key is masked (first 3 + \"...\" + last 4). updated_at is null when no config is set.",
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Get workspace LLM config (owner/maintainer)",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LLMConfigResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "description": "On update, omitting api_key retains the existing key.",
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Upsert workspace LLM config (owner/maintainer)",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LLMConfigUpsertRequest"
+              }
+            }
+          },
+          "description": "Config payload",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LLMConfigUpsertResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "validation error (invalid URL / missing field / too many models)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Delete workspace LLM config (owner/maintainer)",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "403": {
+            "description": "insufficient role",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workspaces/{id}/llm-quota": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Get the workspace's daily LLM request quota usage",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LLMQuotaResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workspaces/{id}/members": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "List members of a workspace",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/WorkspaceMember"
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "description": "Looks up the user by email. Default role is \"developer\" if omitted.",
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Add a member to a workspace",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MemberAddRequest"
+              }
+            }
+          },
+          "description": "Email and optional role",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceMember"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "owner or maintainer required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "user not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workspaces/{id}/members/{userId}": {
+      "put": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Change a member's role (owner only)",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "User id",
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MemberRoleUpdateRequest"
+              }
+            }
+          },
+          "description": "New role",
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "description": "empty role",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "owner only",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Workspaces"
+        ],
+        "summary": "Remove a member (owner only)",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "User id",
+            "name": "userId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "403": {
+            "description": "owner only",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "servers": [
@@ -295,6 +1137,223 @@
           "status": {
             "type": "string",
             "example": "ok"
+          }
+        }
+      },
+      "LLMConfigResponse": {
+        "type": "object",
+        "required": [
+          "configured"
+        ],
+        "properties": {
+          "api_key": {
+            "type": "string"
+          },
+          "base_url": {
+            "type": "string"
+          },
+          "configured": {
+            "type": "boolean"
+          },
+          "models": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LLMModel"
+            }
+          },
+          "updated_at": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "LLMConfigUpsertRequest": {
+        "type": "object",
+        "required": [
+          "base_url",
+          "models"
+        ],
+        "properties": {
+          "api_key": {
+            "description": "optional on update",
+            "type": "string",
+            "example": "sk-ant-..."
+          },
+          "base_url": {
+            "type": "string",
+            "example": "https://api.anthropic.com"
+          },
+          "models": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LLMModel"
+            }
+          }
+        }
+      },
+      "LLMConfigUpsertResponse": {
+        "type": "object",
+        "required": [
+          "ok"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          }
+        }
+      },
+      "LLMModel": {
+        "type": "object",
+        "required": [
+          "id",
+          "name"
+        ],
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "claude-opus-4-7"
+          },
+          "name": {
+            "type": "string",
+            "example": "Claude Opus 4.7"
+          }
+        }
+      },
+      "LLMQuotaResponse": {
+        "type": "object",
+        "required": [
+          "daily_limit",
+          "daily_used",
+          "resets_at",
+          "workspace_id"
+        ],
+        "properties": {
+          "daily_limit": {
+            "type": "integer"
+          },
+          "daily_used": {
+            "type": "integer"
+          },
+          "resets_at": {
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        }
+      },
+      "MemberAddRequest": {
+        "type": "object",
+        "required": [
+          "email"
+        ],
+        "properties": {
+          "email": {
+            "type": "string",
+            "example": "alice@example.com"
+          },
+          "role": {
+            "description": "optional; defaults to \"developer\"",
+            "type": "string",
+            "example": "developer"
+          }
+        }
+      },
+      "MemberRoleUpdateRequest": {
+        "type": "object",
+        "required": [
+          "role"
+        ],
+        "properties": {
+          "role": {
+            "type": "string",
+            "example": "maintainer"
+          }
+        }
+      },
+      "Workspace": {
+        "type": "object",
+        "required": [
+          "created_at",
+          "id",
+          "name",
+          "updated_at"
+        ],
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        }
+      },
+      "WorkspaceCreateRequest": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "My Workspace"
+          }
+        }
+      },
+      "WorkspaceMember": {
+        "type": "object",
+        "required": [
+          "email",
+          "role",
+          "user_id"
+        ],
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "picture": {
+            "type": "string",
+            "nullable": true
+          },
+          "role": {
+            "type": "string",
+            "example": "developer"
+          },
+          "user_id": {
+            "type": "string"
+          }
+        }
+      },
+      "WorkspaceQuotaResponse": {
+        "type": "object",
+        "required": [
+          "current",
+          "max"
+        ],
+        "properties": {
+          "current": {
+            "type": "integer"
+          },
+          "max": {
+            "type": "integer"
+          }
+        }
+      },
+      "WorkspaceRenameRequest": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "Renamed Workspace"
           }
         }
       }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1222,19 +1222,38 @@
       "LLMQuotaResponse": {
         "type": "object",
         "required": [
-          "daily_limit",
-          "daily_used",
-          "resets_at",
+          "default_max_rpd",
+          "today_request_count"
+        ],
+        "properties": {
+          "default_max_rpd": {
+            "type": "integer"
+          },
+          "today_request_count": {
+            "type": "integer"
+          },
+          "workspace_quota": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/LLMWorkspaceQuotaPart"
+              }
+            ],
+            "nullable": true
+          }
+        }
+      },
+      "LLMWorkspaceQuotaPart": {
+        "type": "object",
+        "required": [
+          "updated_at",
           "workspace_id"
         ],
         "properties": {
-          "daily_limit": {
-            "type": "integer"
+          "max_rpd": {
+            "type": "integer",
+            "nullable": true
           },
-          "daily_used": {
-            "type": "integer"
-          },
-          "resets_at": {
+          "updated_at": {
             "type": "string"
           },
           "workspace_id": {

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -122,6 +122,511 @@ paths:
       summary: Register a new user
       tags:
         - Auth
+  /api/workspaces:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: "#/components/schemas/Workspace"
+                type: array
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: List workspaces for the current user
+      tags:
+        - Workspaces
+    post:
+      description: Creator is auto-added as owner. May fail with 403 if the per-user
+        workspace quota is exceeded.
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkspaceCreateRequest"
+        description: Workspace name
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Workspace"
+        "400":
+          description: bad request / empty name
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: workspace quota exceeded
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Create a new workspace
+      tags:
+        - Workspaces
+  "/api/workspaces/{id}":
+    delete:
+      parameters:
+        - description: Workspace id
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: No Content
+        "403":
+          description: owner only
+          content:
+            "*/*":
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            "*/*":
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Delete a workspace (owner only; cascades to sandboxes + namespace)
+      tags:
+        - Workspaces
+    get:
+      parameters:
+        - description: Workspace id
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Workspace"
+        "403":
+          description: not a member
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: workspace not found
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Get a workspace by id
+      tags:
+        - Workspaces
+    patch:
+      parameters:
+        - description: Workspace id
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/WorkspaceRenameRequest"
+        description: New name
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Workspace"
+        "400":
+          description: empty name
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: owner or maintainer required
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Rename a workspace
+      tags:
+        - Workspaces
+  "/api/workspaces/{id}/llm-config":
+    delete:
+      parameters:
+        - description: Workspace id
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: No Content
+        "403":
+          description: insufficient role
+          content:
+            "*/*":
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            "*/*":
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Delete workspace LLM config (owner/maintainer)
+      tags:
+        - Workspaces
+    get:
+      description: The returned api_key is masked (first 3 + "..." + last 4).
+        updated_at is null when no config is set.
+      parameters:
+        - description: Workspace id
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LLMConfigResponse"
+        "403":
+          description: insufficient role
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Get workspace LLM config (owner/maintainer)
+      tags:
+        - Workspaces
+    put:
+      description: On update, omitting api_key retains the existing key.
+      parameters:
+        - description: Workspace id
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/LLMConfigUpsertRequest"
+        description: Config payload
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LLMConfigUpsertResponse"
+        "400":
+          description: validation error (invalid URL / missing field / too many models)
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: insufficient role
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Upsert workspace LLM config (owner/maintainer)
+      tags:
+        - Workspaces
+  "/api/workspaces/{id}/llm-quota":
+    get:
+      parameters:
+        - description: Workspace id
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LLMQuotaResponse"
+        "403":
+          description: insufficient role
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Get the workspace's daily LLM request quota usage
+      tags:
+        - Workspaces
+  "/api/workspaces/{id}/members":
+    get:
+      parameters:
+        - description: Workspace id
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: "#/components/schemas/WorkspaceMember"
+                type: array
+        "403":
+          description: not a member
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: List members of a workspace
+      tags:
+        - Workspaces
+    post:
+      description: Looks up the user by email. Default role is "developer" if omitted.
+      parameters:
+        - description: Workspace id
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MemberAddRequest"
+        description: Email and optional role
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkspaceMember"
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: owner or maintainer required
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: user not found
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Add a member to a workspace
+      tags:
+        - Workspaces
+  "/api/workspaces/{id}/members/{userId}":
+    delete:
+      parameters:
+        - description: Workspace id
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - description: User id
+          in: path
+          name: userId
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: No Content
+        "403":
+          description: owner only
+          content:
+            "*/*":
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            "*/*":
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Remove a member (owner only)
+      tags:
+        - Workspaces
+    put:
+      parameters:
+        - description: Workspace id
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - description: User id
+          in: path
+          name: userId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MemberRoleUpdateRequest"
+        description: New role
+        required: true
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: empty role
+          content:
+            "*/*":
+              schema:
+                type: string
+        "403":
+          description: owner only
+          content:
+            "*/*":
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            "*/*":
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Change a member's role (owner only)
+      tags:
+        - Workspaces
+  /api/workspaces/quota:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkspaceQuotaResponse"
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Get per-user workspace quota
+      tags:
+        - Workspaces
 servers:
   - url: /
 components:
@@ -192,4 +697,153 @@ components:
           type: string
       required:
         - status
+      type: object
+    LLMConfigResponse:
+      properties:
+        api_key:
+          type: string
+        base_url:
+          type: string
+        configured:
+          type: boolean
+        models:
+          items:
+            $ref: "#/components/schemas/LLMModel"
+          type: array
+        updated_at:
+          type: string
+          nullable: true
+      required:
+        - configured
+      type: object
+    LLMConfigUpsertRequest:
+      properties:
+        api_key:
+          description: optional on update
+          example: sk-ant-...
+          type: string
+        base_url:
+          example: https://api.anthropic.com
+          type: string
+        models:
+          items:
+            $ref: "#/components/schemas/LLMModel"
+          type: array
+      required:
+        - base_url
+        - models
+      type: object
+    LLMConfigUpsertResponse:
+      properties:
+        ok:
+          type: boolean
+      required:
+        - ok
+      type: object
+    LLMModel:
+      properties:
+        id:
+          example: claude-opus-4-7
+          type: string
+        name:
+          example: Claude Opus 4.7
+          type: string
+      required:
+        - id
+        - name
+      type: object
+    LLMQuotaResponse:
+      properties:
+        daily_limit:
+          type: integer
+        daily_used:
+          type: integer
+        resets_at:
+          type: string
+        workspace_id:
+          type: string
+      required:
+        - daily_limit
+        - daily_used
+        - resets_at
+        - workspace_id
+      type: object
+    MemberAddRequest:
+      properties:
+        email:
+          example: alice@example.com
+          type: string
+        role:
+          description: optional; defaults to "developer"
+          example: developer
+          type: string
+      required:
+        - email
+      type: object
+    MemberRoleUpdateRequest:
+      properties:
+        role:
+          example: maintainer
+          type: string
+      required:
+        - role
+      type: object
+    Workspace:
+      properties:
+        created_at:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        updated_at:
+          type: string
+      required:
+        - created_at
+        - id
+        - name
+        - updated_at
+      type: object
+    WorkspaceCreateRequest:
+      properties:
+        name:
+          example: My Workspace
+          type: string
+      required:
+        - name
+      type: object
+    WorkspaceMember:
+      properties:
+        email:
+          type: string
+        picture:
+          type: string
+          nullable: true
+        role:
+          example: developer
+          type: string
+        user_id:
+          type: string
+      required:
+        - email
+        - role
+        - user_id
+      type: object
+    WorkspaceQuotaResponse:
+      properties:
+        current:
+          type: integer
+        max:
+          type: integer
+      required:
+        - current
+        - max
+      type: object
+    WorkspaceRenameRequest:
+      properties:
+        name:
+          example: Renamed Workspace
+          type: string
+      required:
+        - name
       type: object

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -754,18 +754,29 @@ components:
       type: object
     LLMQuotaResponse:
       properties:
-        daily_limit:
+        default_max_rpd:
           type: integer
-        daily_used:
+        today_request_count:
           type: integer
-        resets_at:
+        workspace_quota:
+          allOf:
+            - $ref: "#/components/schemas/LLMWorkspaceQuotaPart"
+          nullable: true
+      required:
+        - default_max_rpd
+        - today_request_count
+      type: object
+    LLMWorkspaceQuotaPart:
+      properties:
+        max_rpd:
+          type: integer
+          nullable: true
+        updated_at:
           type: string
         workspace_id:
           type: string
       required:
-        - daily_limit
-        - daily_used
-        - resets_at
+        - updated_at
         - workspace_id
       type: object
     MemberAddRequest:

--- a/docs/superpowers/plans/2026-05-22-openapi-phase-1b-workspaces.md
+++ b/docs/superpowers/plans/2026-05-22-openapi-phase-1b-workspaces.md
@@ -1,0 +1,690 @@
+# OpenAPI Phase 1.b — Workspaces tag Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Annotate the 14 Workspaces REST endpoints with swaggo, regenerate the OpenAPI 3.0 spec, and migrate the corresponding helpers in `web/src/lib/api.ts` to use the apiClient + generated types.
+
+**Architecture:** Same pipeline as Phase 1.a — swag → swagger2openapi → openapi-typescript → typed helpers. This PR exercises the toolchain on a larger surface (14 endpoints, 3 sub-areas: workspace CRUD, members, LLM config) and is the template for the remaining 6 tag PRs.
+
+**Tech Stack:** Reuses everything from Phase 1.a; no new deps.
+
+**Prereq:** Phase 1.a (PR #152) must be merged first OR this PR is stacked on `feat/openapi-phase-1a-infra-auth` (will need rebase after merge).
+
+---
+
+## Endpoint surface (14)
+
+| Method | Path | Handler | Auth |
+|---|---|---|---|
+| GET | `/api/workspaces` | `handleListWorkspaces` server.go:1008 | cookie |
+| POST | `/api/workspaces` | `handleCreateWorkspace` server.go:1024 | cookie |
+| GET | `/api/workspaces/quota` | `handleGetWorkspacesQuota` server.go:990 | cookie |
+| GET | `/api/workspaces/{id}` | `handleGetWorkspace` server.go:1099 | cookie + member |
+| PATCH | `/api/workspaces/{id}` | `handleRenameWorkspace` server.go:1115 | cookie + owner/maintainer |
+| DELETE | `/api/workspaces/{id}` | `handleDeleteWorkspace` server.go:1141 | cookie + owner |
+| GET | `/api/workspaces/{id}/members` | `handleListMembers` server.go:1204 | cookie + member |
+| POST | `/api/workspaces/{id}/members` | `handleAddMember` server.go:1238 | cookie + owner/maintainer |
+| PUT | `/api/workspaces/{id}/members/{userId}` | `handleUpdateMemberRole` server.go:1278 | cookie + owner |
+| DELETE | `/api/workspaces/{id}/members/{userId}` | `handleRemoveMember` server.go:1302 | cookie + owner |
+| GET | `/api/workspaces/{id}/llm-quota` | `handleGetWorkspaceLLMQuota` server.go:1319 | cookie + any role |
+| GET | `/api/workspaces/{id}/llm-config` | `handleGetWorkspaceLLMConfig` server.go:1336 | cookie + owner/maintainer |
+| PUT | `/api/workspaces/{id}/llm-config` | `handleSetWorkspaceLLMConfig` server.go:1362 | cookie + owner/maintainer |
+| DELETE | `/api/workspaces/{id}/llm-config` | `handleDeleteWorkspaceLLMConfig` server.go:1418 | cookie + owner/maintainer |
+
+Line numbers are approximate (verify before editing — they will shift as we add doc comments).
+
+---
+
+## File Structure
+
+**Create:** none (api_types.go already exists from Phase 1.a)
+
+**Modify:**
+- `internal/server/api_types.go` — append Workspaces section (new named types for request/response shapes that were inline anonymous structs / inline maps)
+- `internal/server/server.go` — add swaggo doc-comment blocks above the 14 handlers; rewrite handlers that use inline anonymous structs to use the new named types
+- `docs/api/openapi.yaml` + `docs/api/openapi.json` — regenerated (drift gate enforces)
+- `web/src/lib/api.ts` — migrate workspace-related helpers to use `apiFetch` + generated types
+
+**Out of scope (other Phase 1.b PRs):**
+- Sandboxes (`/api/workspaces/{id}/sandboxes` etc.)
+- IM channels, codex tokens, codex browser sessions, agent endpoints, misc
+
+---
+
+### Task 1: Extend api_types.go with Workspaces DTOs
+
+**Files:**
+- Modify: `internal/server/api_types.go`
+
+Group the new types under a `// --- Workspaces ---` section, alphabetical within the group.
+
+- [ ] **Step 1: Confirm the existing `workspaceResponse` and `workspaceMemberResponse` types**
+
+```bash
+grep -n "type workspaceResponse\|type workspaceMemberResponse" /root/agentserver/internal/server/*.go
+```
+
+These already exist as named types (Phase 1.a-friendly). They need `@name` overrides + `validate:"required"` tags to flow through swag cleanly. Read their current definitions and report back so the next step can produce the exact edits.
+
+- [ ] **Step 2: Append DTOs to api_types.go**
+
+After the existing `// --- Auth ---` block, append:
+
+```go
+// --- Workspaces ---
+
+// WorkspaceRef is a workspace's primary fields, returned by list / get /
+// create / patch endpoints.
+//
+// Note: in handlers this type currently lives as `workspaceResponse`
+// (lowercase) — the @name override below exposes it as `Workspace` in
+// the OpenAPI spec without forcing a Go rename.
+//
+//	@name Workspace
+type WorkspaceRef struct {
+	ID        string `json:"id" validate:"required"`
+	Name      string `json:"name" validate:"required"`
+	Workdir   string `json:"workdir" validate:"required"`
+	CreatedAt string `json:"created_at" validate:"required"`
+	UpdatedAt string `json:"updated_at" validate:"required"`
+} // @name Workspace
+
+// WorkspaceMember describes a single member of a workspace.
+type WorkspaceMember struct {
+	UserID  string  `json:"user_id" validate:"required"`
+	Email   string  `json:"email" validate:"required"`
+	Role    string  `json:"role" validate:"required" example:"developer"`
+	Picture *string `json:"picture" extensions:"x-nullable=true"`
+} // @name WorkspaceMember
+
+// WorkspaceCreateRequest is the body for POST /api/workspaces.
+type WorkspaceCreateRequest struct {
+	Name string `json:"name" validate:"required" example:"My Workspace"`
+} // @name WorkspaceCreateRequest
+
+// WorkspaceRenameRequest is the body for PATCH /api/workspaces/{id}.
+type WorkspaceRenameRequest struct {
+	Name string `json:"name" validate:"required" example:"Renamed Workspace"`
+} // @name WorkspaceRenameRequest
+
+// WorkspaceQuotaResponse is the {"current": int, "max": int} envelope
+// returned by GET /api/workspaces/quota.
+type WorkspaceQuotaResponse struct {
+	Current int `json:"current" validate:"required"`
+	Max     int `json:"max" validate:"required"`
+} // @name WorkspaceQuotaResponse
+
+// MemberAddRequest is the body for POST /api/workspaces/{id}/members.
+type MemberAddRequest struct {
+	Email string `json:"email" validate:"required" example:"alice@example.com"`
+	Role  string `json:"role" example:"developer"` // optional; defaults to "developer"
+} // @name MemberAddRequest
+
+// MemberRoleUpdateRequest is the body for PUT /api/workspaces/{id}/members/{userId}.
+type MemberRoleUpdateRequest struct {
+	Role string `json:"role" validate:"required" example:"maintainer"`
+} // @name MemberRoleUpdateRequest
+
+// LLMQuotaResponse mirrors the body the LLM proxy returns from its
+// internal `/internal/quotas/{workspaceId}` endpoint. Fields not all
+// guaranteed by the proxy — they're documented as observed.
+type LLMQuotaResponse struct {
+	WorkspaceID    string `json:"workspace_id" validate:"required"`
+	DailyLimit     int    `json:"daily_limit" validate:"required"`
+	DailyUsed      int    `json:"daily_used" validate:"required"`
+	ResetsAt       string `json:"resets_at" validate:"required"`
+} // @name LLMQuotaResponse
+
+// LLMModel is one entry in a workspace's per-model LLM config.
+type LLMModel struct {
+	Name        string `json:"name" validate:"required" example:"claude-opus-4-7"`
+	DisplayName string `json:"display_name" example:"Claude Opus 4.7"`
+	MaxTokens   int    `json:"max_tokens" example:"200000"`
+} // @name LLMModel
+
+// LLMConfigResponse is the body returned by GET /api/workspaces/{id}/llm-config.
+// `api_key` is masked (first 3 + "..." + last 4 chars) and is empty
+// when no config exists.
+type LLMConfigResponse struct {
+	Configured bool       `json:"configured" validate:"required"`
+	BaseURL    string     `json:"base_url"`
+	APIKey     string     `json:"api_key"`
+	Models     []LLMModel `json:"models"`
+	UpdatedAt  *string    `json:"updated_at" extensions:"x-nullable=true"`
+} // @name LLMConfigResponse
+
+// LLMConfigUpsertRequest is the body for PUT /api/workspaces/{id}/llm-config.
+// All three fields are required for a fresh config; for an update,
+// omitting `api_key` retains the existing key.
+type LLMConfigUpsertRequest struct {
+	BaseURL string     `json:"base_url" validate:"required" example:"https://api.anthropic.com"`
+	APIKey  string     `json:"api_key" example:"sk-ant-..."` // optional on update
+	Models  []LLMModel `json:"models" validate:"required"`
+} // @name LLMConfigUpsertRequest
+
+// LLMConfigUpsertResponse is the body returned by the upsert endpoint.
+type LLMConfigUpsertResponse struct {
+	OK bool `json:"ok" validate:"required"`
+} // @name LLMConfigUpsertResponse
+```
+
+- [ ] **Step 3: Verify build**
+
+```bash
+cd /root/agentserver
+go build ./...
+```
+
+Should be silent.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/server/api_types.go
+git commit -m "feat(openapi): Workspaces DTOs in api_types.go"
+```
+
+---
+
+### Task 2: Refactor handlers to use the new named DTOs
+
+**Files:**
+- Modify: `internal/server/server.go` — Workspaces handlers + the inline `workspaceResponse` definition
+
+- [ ] **Step 1: Find the inline `workspaceResponse` and `workspaceMemberResponse` definitions**
+
+```bash
+grep -n "type workspaceResponse struct\|type workspaceMemberResponse struct\|workspaceResponse{" /root/agentserver/internal/server/server.go
+```
+
+These typically live near the top of `server.go` or near where they're returned. Read them.
+
+- [ ] **Step 2: Either delete the lowercase types and switch callers to `WorkspaceRef`/`WorkspaceMember`, OR add `@name` to the lowercase types**
+
+Recommended: **keep the lowercase Go names** (`workspaceResponse`, `workspaceMemberResponse`) for backwards compatibility with the surrounding code, just add the `@name Workspace` / `@name WorkspaceMember` swag overrides on their closing brace, and DROP the `WorkspaceRef`/`WorkspaceMember` types from Task 1's api_types.go. Rationale: minimal touch to server.go internals. Only the JSON wire / swag schema name changes; Go callers are untouched.
+
+Apply this: edit api_types.go, remove the duplicated `WorkspaceRef` and `WorkspaceMember` types. Then edit server.go to add `// @name Workspace` after the closing brace of `workspaceResponse` and `// @name WorkspaceMember` after `workspaceMemberResponse`. Also add `validate:"required"` to non-optional fields and `extensions:"x-nullable=true"` to `Picture`.
+
+(If the existing lowercase types lack JSON tags or have inconvenient field shapes, fall back to introducing the uppercase types and migrating callers. Report which path you chose.)
+
+- [ ] **Step 3: Refactor inline anonymous request structs in the 4 mutation endpoints**
+
+Endpoints that use `var req struct {...}` inline:
+- `handleCreateWorkspace` — replace with `var req WorkspaceCreateRequest`
+- `handleRenameWorkspace` — replace with `var req WorkspaceRenameRequest`
+- `handleAddMember` — replace with `var req MemberAddRequest`
+- `handleUpdateMemberRole` — replace with `var req MemberRoleUpdateRequest`
+- `handleSetWorkspaceLLMConfig` — replace with `var req LLMConfigUpsertRequest`
+
+For each, the rewrite is mechanical: replace the inline struct + the `var req` line with a single `var req <NamedType>`. Field access stays identical.
+
+- [ ] **Step 4: Refactor inline map responses to use named types**
+
+Endpoints that build inline `map[string]interface{}` or `map[string]int` responses:
+- `handleGetWorkspacesQuota` → return `WorkspaceQuotaResponse{Current: ..., Max: ...}`
+- `handleGetWorkspaceLLMConfig` → return `LLMConfigResponse{Configured: ..., BaseURL: ..., APIKey: ..., Models: ..., UpdatedAt: ...}`
+- `handleSetWorkspaceLLMConfig` → return `LLMConfigUpsertResponse{OK: true}`
+
+- [ ] **Step 5: Build + test**
+
+```bash
+cd /root/agentserver
+go build ./...
+go test ./internal/server/ -count=1 -timeout 120s
+```
+
+If tests assert exact JSON shapes of these responses, verify they still match the new typed encoding (field order in struct = field order in JSON, so as long as field order in the new types matches the order the inline map was constructed, the wire format is identical).
+
+If any test breaks, REPORT — do not modify the test without escalation.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/server/api_types.go internal/server/server.go
+git commit -m "refactor(server): Workspaces handlers use named DTOs"
+```
+
+---
+
+### Task 3: Add swag annotations to the 14 Workspaces handlers
+
+**Files:**
+- Modify: `internal/server/server.go`
+
+For each handler, add a doc-comment block ABOVE the func line with `@Summary`, `@Tags Workspaces`, `@Param`, `@Success`, `@Failure`, `@Router`, and `@Security CookieAuth` (all 14 require auth).
+
+- [ ] **Step 1: Annotate the 6 workspace-core handlers**
+
+Examples (verify line numbers first with `grep -n "func (s \*Server) handle\(List\|Create\|Get\|Rename\|Delete\)Workspace\b\|handleGetWorkspacesQuota\b" internal/server/server.go`):
+
+**Above `handleListWorkspaces`:**
+
+```go
+//	@Summary    List workspaces for the current user
+//	@Tags       Workspaces
+//	@Produce    json
+//	@Success    200  {array}   Workspace
+//	@Failure    500  {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces [get]
+```
+
+**Above `handleCreateWorkspace`:**
+
+```go
+//	@Summary    Create a new workspace
+//	@Description Creator is auto-added as owner. May fail with 403 if the per-user workspace quota is exceeded.
+//	@Tags       Workspaces
+//	@Accept     json
+//	@Produce    json
+//	@Param      body  body      WorkspaceCreateRequest  true  "Workspace name"
+//	@Success    201   {object}  Workspace
+//	@Failure    400   {string}  string  "bad request / empty name"
+//	@Failure    403   {string}  string  "workspace quota exceeded"
+//	@Failure    500   {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces [post]
+```
+
+**Above `handleGetWorkspacesQuota`:**
+
+```go
+//	@Summary    Get per-user workspace quota
+//	@Tags       Workspaces
+//	@Produce    json
+//	@Success    200  {object}  WorkspaceQuotaResponse
+//	@Failure    500  {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces/quota [get]
+```
+
+**Above `handleGetWorkspace`:**
+
+```go
+//	@Summary    Get a workspace by id
+//	@Tags       Workspaces
+//	@Produce    json
+//	@Param      id  path  string  true  "Workspace id"
+//	@Success    200  {object}  Workspace
+//	@Failure    403  {string}  string  "not a member"
+//	@Failure    404  {string}  string  "workspace not found"
+//	@Failure    500  {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces/{id} [get]
+```
+
+**Above `handleRenameWorkspace`:**
+
+```go
+//	@Summary    Rename a workspace
+//	@Tags       Workspaces
+//	@Accept     json
+//	@Produce    json
+//	@Param      id    path      string                  true  "Workspace id"
+//	@Param      body  body      WorkspaceRenameRequest  true  "New name"
+//	@Success    200   {object}  Workspace
+//	@Failure    400   {string}  string  "empty name"
+//	@Failure    403   {string}  string  "owner or maintainer required"
+//	@Failure    500   {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces/{id} [patch]
+```
+
+**Above `handleDeleteWorkspace`:**
+
+```go
+//	@Summary    Delete a workspace (owner only; cascades to sandboxes + namespace)
+//	@Tags       Workspaces
+//	@Param      id   path  string  true  "Workspace id"
+//	@Success    204
+//	@Failure    403  {string}  string  "owner only"
+//	@Failure    500  {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces/{id} [delete]
+```
+
+- [ ] **Step 2: Annotate the 4 members handlers**
+
+**Above `handleListMembers`:**
+
+```go
+//	@Summary    List members of a workspace
+//	@Tags       Workspaces
+//	@Produce    json
+//	@Param      id  path  string  true  "Workspace id"
+//	@Success    200  {array}   WorkspaceMember
+//	@Failure    403  {string}  string  "not a member"
+//	@Failure    500  {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces/{id}/members [get]
+```
+
+**Above `handleAddMember`:**
+
+```go
+//	@Summary    Add a member to a workspace
+//	@Description Looks up the user by email. Default role is "developer" if omitted.
+//	@Tags       Workspaces
+//	@Accept     json
+//	@Produce    json
+//	@Param      id    path      string            true  "Workspace id"
+//	@Param      body  body      MemberAddRequest  true  "Email and optional role"
+//	@Success    201   {object}  WorkspaceMember
+//	@Failure    400   {string}  string  "bad request"
+//	@Failure    403   {string}  string  "owner or maintainer required"
+//	@Failure    404   {string}  string  "user not found"
+//	@Failure    500   {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces/{id}/members [post]
+```
+
+**Above `handleUpdateMemberRole`:**
+
+```go
+//	@Summary    Change a member's role (owner only)
+//	@Tags       Workspaces
+//	@Accept     json
+//	@Param      id      path  string                   true  "Workspace id"
+//	@Param      userId  path  string                   true  "User id"
+//	@Param      body    body  MemberRoleUpdateRequest  true  "New role"
+//	@Success    204
+//	@Failure    400  {string}  string  "empty role"
+//	@Failure    403  {string}  string  "owner only"
+//	@Failure    500  {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces/{id}/members/{userId} [put]
+```
+
+**Above `handleRemoveMember`:**
+
+```go
+//	@Summary    Remove a member (owner only)
+//	@Tags       Workspaces
+//	@Param      id      path  string  true  "Workspace id"
+//	@Param      userId  path  string  true  "User id"
+//	@Success    204
+//	@Failure    403  {string}  string  "owner only"
+//	@Failure    500  {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces/{id}/members/{userId} [delete]
+```
+
+- [ ] **Step 3: Annotate the 4 LLM-config / LLM-quota handlers**
+
+**Above `handleGetWorkspaceLLMQuota`:**
+
+```go
+//	@Summary    Get the workspace's daily LLM request quota usage
+//	@Tags       Workspaces
+//	@Produce    json
+//	@Param      id  path  string  true  "Workspace id"
+//	@Success    200  {object}  LLMQuotaResponse
+//	@Failure    403  {string}  string  "insufficient role"
+//	@Failure    500  {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces/{id}/llm-quota [get]
+```
+
+**Above `handleGetWorkspaceLLMConfig`:**
+
+```go
+//	@Summary    Get workspace LLM config (owner/maintainer)
+//	@Description The returned api_key is masked (first 3 + "..." + last 4). updated_at is null when no config is set.
+//	@Tags       Workspaces
+//	@Produce    json
+//	@Param      id  path  string  true  "Workspace id"
+//	@Success    200  {object}  LLMConfigResponse
+//	@Failure    403  {string}  string  "insufficient role"
+//	@Failure    500  {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces/{id}/llm-config [get]
+```
+
+**Above `handleSetWorkspaceLLMConfig`:**
+
+```go
+//	@Summary    Upsert workspace LLM config (owner/maintainer)
+//	@Description On update, omitting api_key retains the existing key.
+//	@Tags       Workspaces
+//	@Accept     json
+//	@Produce    json
+//	@Param      id    path      string                  true  "Workspace id"
+//	@Param      body  body      LLMConfigUpsertRequest  true  "Config payload"
+//	@Success    200   {object}  LLMConfigUpsertResponse
+//	@Failure    400   {string}  string  "validation error (invalid URL / missing field / too many models)"
+//	@Failure    403   {string}  string  "insufficient role"
+//	@Failure    500   {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces/{id}/llm-config [put]
+```
+
+**Above `handleDeleteWorkspaceLLMConfig`:**
+
+```go
+//	@Summary    Delete workspace LLM config (owner/maintainer)
+//	@Tags       Workspaces
+//	@Param      id  path  string  true  "Workspace id"
+//	@Success    204
+//	@Failure    403  {string}  string  "insufficient role"
+//	@Failure    500  {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces/{id}/llm-config [delete]
+```
+
+- [ ] **Step 4: Regenerate spec + verify**
+
+```bash
+cd /root/agentserver
+make openapi
+grep -E "^  /api/workspaces" docs/api/openapi.yaml | sort
+make openapi-check
+```
+
+Expected: all 14 paths appear. Drift gate exits 0.
+
+Spot-check that schema names appear unprefixed:
+
+```bash
+grep -E "^\\s*(Workspace|WorkspaceMember|WorkspaceCreateRequest|WorkspaceRenameRequest|WorkspaceQuotaResponse|MemberAddRequest|MemberRoleUpdateRequest|LLMQuotaResponse|LLMModel|LLMConfigResponse|LLMConfigUpsertRequest|LLMConfigUpsertResponse):" docs/api/openapi.yaml | sort
+```
+
+Expected: 12 schema names listed without `server.` prefix.
+
+- [ ] **Step 5: Build + test**
+
+```bash
+go build ./...
+go test ./internal/server/ -count=1 -timeout 120s
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/server/server.go docs/api/openapi.yaml docs/api/openapi.json
+git commit -m "feat(openapi): annotate Workspaces handlers (14 endpoints, 3 sub-areas)"
+```
+
+---
+
+### Task 4: Migrate workspace helpers in `web/src/lib/api.ts`
+
+**Files:**
+- Modify: `web/src/lib/api.ts`
+
+- [ ] **Step 1: Regenerate frontend types**
+
+```bash
+cd /root/agentserver/web
+pnpm openapi:gen
+```
+
+Expected: `web/src/lib/api-generated/schema.d.ts` updated with new schemas.
+
+- [ ] **Step 2: Find the workspace-related helpers in api.ts**
+
+```bash
+grep -nE "export async function (listWorkspaces|createWorkspace|getWorkspace|renameWorkspace|deleteWorkspace|getWorkspacesQuota|listMembers|addMember|updateMemberRole|removeMember|getWorkspaceLLMQuota|getWorkspaceLLMConfig|setWorkspaceLLMConfig|deleteWorkspaceLLMConfig)" /root/agentserver/web/src/lib/api.ts
+```
+
+Identify the 14 (or fewer — some endpoints may not have frontend helpers yet) helpers. For each, rewrite the body to use `apiFetch` + `components['schemas']['<Name>']` from the generated schema. KEEP external signatures identical so all callers (`WorkspaceList.tsx`, `WorkspaceDetail.tsx`, `WorkspaceCreateModal.tsx`, …) work without changes.
+
+Template per helper (adapt to actual signatures):
+
+```typescript
+export async function listWorkspaces(): Promise<Workspace[]> {
+  return apiFetch<components['schemas']['Workspace'][]>({
+    method: 'GET',
+    path: '/api/workspaces',
+  })
+}
+
+export async function createWorkspace(name: string): Promise<Workspace> {
+  return apiFetch<components['schemas']['Workspace']>({
+    method: 'POST',
+    path: '/api/workspaces',
+    body: { name } satisfies components['schemas']['WorkspaceCreateRequest'],
+  })
+}
+```
+
+For mutation endpoints that previously caught errors and returned booleans (mirroring the Auth helpers' `boolean` pattern), preserve that contract:
+
+```typescript
+export async function renameWorkspace(id: string, name: string): Promise<boolean> {
+  try {
+    await apiFetch<components['schemas']['Workspace']>({
+      method: 'PATCH',
+      path: `/api/workspaces/${encodeURIComponent(id)}`,
+      body: { name } satisfies components['schemas']['WorkspaceRenameRequest'],
+    })
+    return true
+  } catch (err) {
+    if (err instanceof ApiError) return false
+    throw err
+  }
+}
+```
+
+If you find a helper whose return shape doesn't cleanly map to a single component schema (e.g. it currently builds a composite from multiple API calls), keep the helper's existing internal logic but switch the underlying fetch call to apiFetch + the relevant schema type.
+
+- [ ] **Step 3: Drop any local TypeScript types in api.ts that are now duplicated by `components['schemas']`**
+
+For example, if api.ts has its own `interface Workspace { id: string; name: string; ... }`, delete it and replace usages with `type Workspace = components['schemas']['Workspace']`. This removes a divergence vector. Re-export the alias if callers import the name directly:
+
+```typescript
+export type Workspace = components['schemas']['Workspace']
+export type WorkspaceMember = components['schemas']['WorkspaceMember']
+// ... etc.
+```
+
+If a local type has extra fields the spec doesn't declare, REPORT — that's a hidden divergence we should resolve before completing the migration.
+
+- [ ] **Step 4: Verify tsc + lint + build**
+
+```bash
+cd /root/agentserver/web
+pnpm tsc --noEmit
+pnpm lint
+pnpm build
+```
+
+Expected: tsc clean, no new lint errors, build succeeds.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /root/agentserver
+git add web/src/lib/api.ts
+git commit -m "refactor(web): migrate Workspaces helpers to apiClient + generated types"
+```
+
+---
+
+### Task 5: End-to-end verification + PR
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Drift gate sanity**
+
+```bash
+cd /root/agentserver
+make openapi-check
+```
+
+Expected: pass.
+
+- [ ] **Step 2: Full Go test suite**
+
+```bash
+go test ./internal/server/ -count=1 -timeout 120s
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Full frontend build**
+
+```bash
+cd /root/agentserver/web
+pnpm openapi:gen && pnpm build
+```
+
+Expected: pass; produces `dist/`.
+
+- [ ] **Step 4: Push the branch**
+
+```bash
+cd /root/agentserver
+git push -u github feat/openapi-phase-1b-workspaces
+```
+
+(Branch name assumes you branched off `feat/openapi-phase-1a-infra-auth` or `main`. If you stacked on 1.a and PR #152 has merged in the meantime, rebase first: `git rebase github/main`.)
+
+- [ ] **Step 5: Open PR**
+
+```bash
+gh pr create --base main --title "feat(openapi): Phase 1.b — Workspaces tag (14 endpoints)" --body "$(cat <<'EOF'
+## Summary
+
+Phase 1.b kickoff: annotates the 14 Workspaces REST endpoints with swaggo, regenerates `docs/api/openapi.{yaml,json}`, and migrates the corresponding frontend helpers in `web/src/lib/api.ts` to apiClient + generated types. External signatures of those helpers unchanged.
+
+Same shape as Phase 1.a (PR #152); this is the template for the remaining 6 tag PRs.
+
+Reference: spec `docs/superpowers/specs/2026-05-21-openapi-organization-design.md`, plan `docs/superpowers/plans/2026-05-22-openapi-phase-1b-workspaces.md`.
+
+## Endpoints
+
+- Workspace CRUD: list / create / get / rename / delete / quota
+- Members: list / add / update role / remove
+- LLM config: quota / get / upsert / delete
+
+## What changed
+
+- `internal/server/api_types.go` — added Workspaces section (10+ new DTOs)
+- `internal/server/server.go` — handlers refactored to use named DTOs; 14 swag annotation blocks added
+- `docs/api/openapi.{yaml,json}` — regenerated
+- `web/src/lib/api.ts` — workspace helpers migrated; old hand-written types replaced with `components['schemas']` aliases
+
+## Verification
+
+- `make openapi-check` green
+- `go test ./internal/server/` green
+- `cd web && pnpm tsc --noEmit && pnpm build` green
+
+## Next
+
+Sandboxes is the next tag in the queue (~8 endpoints).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 6: Verification done**
+
+---
+
+## Done when
+
+- PR opened against `main` with 4 commits (DTOs, refactor, annotate, frontend migration)
+- All 14 endpoints appear in `docs/api/openapi.yaml` under tag `Workspaces`
+- Frontend builds and existing workspace UI works (visually verified once dev server reloads)

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -77,13 +77,22 @@ type MemberRoleUpdateRequest struct {
 	Role string `json:"role" validate:"required" example:"maintainer"`
 } // @name MemberRoleUpdateRequest
 
+// LLMWorkspaceQuotaPart is the per-workspace quota override stored in the
+// LLM proxy DB. max_rpd is null when no custom limit is configured.
+type LLMWorkspaceQuotaPart struct {
+	WorkspaceID string  `json:"workspace_id" validate:"required"`
+	MaxRPD      *int    `json:"max_rpd" extensions:"x-nullable=true"`
+	UpdatedAt   string  `json:"updated_at" validate:"required"`
+} // @name LLMWorkspaceQuotaPart
+
 // LLMQuotaResponse mirrors the body the LLM proxy returns from its
-// internal /internal/quotas/{workspaceId} endpoint.
+// /internal/quotas/{workspaceId} endpoint, forwarded verbatim by
+// GET /api/workspaces/{id}/llm-quota.
+// workspace_quota is null when no per-workspace override is set.
 type LLMQuotaResponse struct {
-	WorkspaceID string `json:"workspace_id" validate:"required"`
-	DailyLimit  int    `json:"daily_limit" validate:"required"`
-	DailyUsed   int    `json:"daily_used" validate:"required"`
-	ResetsAt    string `json:"resets_at" validate:"required"`
+	DefaultMaxRPD     int                    `json:"default_max_rpd" validate:"required"`
+	TodayRequestCount int                    `json:"today_request_count" validate:"required"`
+	WorkspaceQuota    *LLMWorkspaceQuotaPart `json:"workspace_quota" extensions:"x-nullable=true"`
 } // @name LLMQuotaResponse
 
 // LLMModel is one entry in a workspace's per-model LLM config.

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -87,10 +87,10 @@ type LLMQuotaResponse struct {
 } // @name LLMQuotaResponse
 
 // LLMModel is one entry in a workspace's per-model LLM config.
+// id is the model identifier used in API calls; name is the human-readable label.
 type LLMModel struct {
-	Name        string `json:"name" validate:"required" example:"claude-opus-4-7"`
-	DisplayName string `json:"display_name" example:"Claude Opus 4.7"`
-	MaxTokens   int    `json:"max_tokens" example:"200000"`
+	ID   string `json:"id" validate:"required" example:"claude-opus-4-7"`
+	Name string `json:"name" validate:"required" example:"Claude Opus 4.7"`
 } // @name LLMModel
 
 // LLMConfigResponse is the body returned by GET /api/workspaces/{id}/llm-config.

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -46,3 +46,74 @@ type AuthMeResponse struct {
 	Picture *string `json:"picture" extensions:"x-nullable=true"`
 	Role    string  `json:"role" example:"developer" validate:"required"`
 } //@name AuthMeResponse
+
+// --- Workspaces ---
+
+// WorkspaceCreateRequest is the body for POST /api/workspaces.
+type WorkspaceCreateRequest struct {
+	Name string `json:"name" validate:"required" example:"My Workspace"`
+} // @name WorkspaceCreateRequest
+
+// WorkspaceRenameRequest is the body for PATCH /api/workspaces/{id}.
+type WorkspaceRenameRequest struct {
+	Name string `json:"name" validate:"required" example:"Renamed Workspace"`
+} // @name WorkspaceRenameRequest
+
+// WorkspaceQuotaResponse is the {"current": int, "max": int} envelope
+// returned by GET /api/workspaces/quota.
+type WorkspaceQuotaResponse struct {
+	Current int `json:"current" validate:"required"`
+	Max     int `json:"max" validate:"required"`
+} // @name WorkspaceQuotaResponse
+
+// MemberAddRequest is the body for POST /api/workspaces/{id}/members.
+type MemberAddRequest struct {
+	Email string `json:"email" validate:"required" example:"alice@example.com"`
+	Role  string `json:"role" example:"developer"` // optional; defaults to "developer"
+} // @name MemberAddRequest
+
+// MemberRoleUpdateRequest is the body for PUT /api/workspaces/{id}/members/{userId}.
+type MemberRoleUpdateRequest struct {
+	Role string `json:"role" validate:"required" example:"maintainer"`
+} // @name MemberRoleUpdateRequest
+
+// LLMQuotaResponse mirrors the body the LLM proxy returns from its
+// internal /internal/quotas/{workspaceId} endpoint.
+type LLMQuotaResponse struct {
+	WorkspaceID string `json:"workspace_id" validate:"required"`
+	DailyLimit  int    `json:"daily_limit" validate:"required"`
+	DailyUsed   int    `json:"daily_used" validate:"required"`
+	ResetsAt    string `json:"resets_at" validate:"required"`
+} // @name LLMQuotaResponse
+
+// LLMModel is one entry in a workspace's per-model LLM config.
+type LLMModel struct {
+	Name        string `json:"name" validate:"required" example:"claude-opus-4-7"`
+	DisplayName string `json:"display_name" example:"Claude Opus 4.7"`
+	MaxTokens   int    `json:"max_tokens" example:"200000"`
+} // @name LLMModel
+
+// LLMConfigResponse is the body returned by GET /api/workspaces/{id}/llm-config.
+// api_key is masked (first 3 + "..." + last 4 chars) and is empty
+// when no config exists.
+type LLMConfigResponse struct {
+	Configured bool       `json:"configured" validate:"required"`
+	BaseURL    string     `json:"base_url"`
+	APIKey     string     `json:"api_key"`
+	Models     []LLMModel `json:"models"`
+	UpdatedAt  *string    `json:"updated_at" extensions:"x-nullable=true"`
+} // @name LLMConfigResponse
+
+// LLMConfigUpsertRequest is the body for PUT /api/workspaces/{id}/llm-config.
+// All three fields are required for a fresh config; for an update,
+// omitting api_key retains the existing key.
+type LLMConfigUpsertRequest struct {
+	BaseURL string     `json:"base_url" validate:"required" example:"https://api.anthropic.com"`
+	APIKey  string     `json:"api_key" example:"sk-ant-..."` // optional on update
+	Models  []LLMModel `json:"models" validate:"required"`
+} // @name LLMConfigUpsertRequest
+
+// LLMConfigUpsertResponse is the body returned by the upsert endpoint.
+type LLMConfigUpsertResponse struct {
+	OK bool `json:"ok" validate:"required"`
+} // @name LLMConfigUpsertResponse

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -759,18 +759,18 @@ func (s *Server) handleMe(w http.ResponseWriter, r *http.Request) {
 // --- Response types ---
 
 type workspaceResponse struct {
-	ID        string `json:"id"`
-	Name      string `json:"name"`
-	CreatedAt string `json:"created_at"`
-	UpdatedAt string `json:"updated_at"`
-}
+	ID        string `json:"id" validate:"required"`
+	Name      string `json:"name" validate:"required"`
+	CreatedAt string `json:"created_at" validate:"required"`
+	UpdatedAt string `json:"updated_at" validate:"required"`
+} // @name Workspace
 
 type workspaceMemberResponse struct {
-	UserID  string  `json:"user_id"`
-	Email   string  `json:"email"`
-	Role    string  `json:"role"`
-	Picture *string `json:"picture,omitempty"`
-}
+	UserID  string  `json:"user_id" validate:"required"`
+	Email   string  `json:"email" validate:"required"`
+	Role    string  `json:"role" validate:"required" example:"developer"`
+	Picture *string `json:"picture" extensions:"x-nullable=true"`
+} // @name WorkspaceMember
 
 type agentInfoResponse struct {
 	Hostname        string `json:"hostname"`
@@ -1002,7 +1002,7 @@ func (s *Server) handleGetWorkspacesQuota(w http.ResponseWriter, r *http.Request
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]int{"current": current, "max": maxWs})
+	json.NewEncoder(w).Encode(WorkspaceQuotaResponse{Current: current, Max: maxWs})
 }
 
 func (s *Server) handleListWorkspaces(w http.ResponseWriter, r *http.Request) {
@@ -1042,9 +1042,7 @@ func (s *Server) handleCreateWorkspace(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var req struct {
-		Name string `json:"name"`
-	}
+	var req WorkspaceCreateRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		req.Name = "New Workspace"
 	}
@@ -1117,9 +1115,7 @@ func (s *Server) handleRenameWorkspace(w http.ResponseWriter, r *http.Request) {
 	if !s.requireWorkspaceRole(w, r, id, "owner", "maintainer") {
 		return
 	}
-	var req struct {
-		Name string `json:"name"`
-	}
+	var req WorkspaceRenameRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Name == "" {
 		http.Error(w, "name is required", http.StatusBadRequest)
 		return
@@ -1241,10 +1237,7 @@ func (s *Server) handleAddMember(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	var req struct {
-		Email string `json:"email"`
-		Role  string `json:"role"`
-	}
+	var req MemberAddRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
@@ -1282,9 +1275,7 @@ func (s *Server) handleUpdateMemberRole(w http.ResponseWriter, r *http.Request) 
 	}
 
 	targetUserID := chi.URLParam(r, "userId")
-	var req struct {
-		Role string `json:"role"`
-	}
+	var req MemberRoleUpdateRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Role == "" {
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
@@ -1346,16 +1337,21 @@ func (s *Server) handleGetWorkspaceLLMConfig(w http.ResponseWriter, r *http.Requ
 	}
 	if cfg == nil {
 		w.Header().Set("Content-Type", "application/json")
-		json.NewEncoder(w).Encode(map[string]interface{}{"configured": false})
+		json.NewEncoder(w).Encode(LLMConfigResponse{Configured: false})
 		return
 	}
+	cfgModels := make([]LLMModel, len(cfg.Models))
+	for i, m := range cfg.Models {
+		cfgModels[i] = LLMModel{ID: m.ID, Name: m.Name}
+	}
+	updatedAt := cfg.UpdatedAt.Format(time.RFC3339)
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{
-		"configured": true,
-		"base_url":   cfg.BaseURL,
-		"api_key":    maskAPIKey(cfg.APIKey),
-		"models":     cfg.Models,
-		"updated_at": cfg.UpdatedAt.Format(time.RFC3339),
+	json.NewEncoder(w).Encode(LLMConfigResponse{
+		Configured: true,
+		BaseURL:    cfg.BaseURL,
+		APIKey:     maskAPIKey(cfg.APIKey),
+		Models:     cfgModels,
+		UpdatedAt:  &updatedAt,
 	})
 }
 
@@ -1364,11 +1360,7 @@ func (s *Server) handleSetWorkspaceLLMConfig(w http.ResponseWriter, r *http.Requ
 	if !s.requireWorkspaceRole(w, r, wsID, "owner", "maintainer") {
 		return
 	}
-	var req struct {
-		BaseURL string     `json:"base_url"`
-		APIKey  string     `json:"api_key"`
-		Models  []db.LLMModel `json:"models"`
-	}
+	var req LLMConfigUpsertRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid request body", http.StatusBadRequest)
 		return
@@ -1406,13 +1398,17 @@ func (s *Server) handleSetWorkspaceLLMConfig(w http.ResponseWriter, r *http.Requ
 			return
 		}
 	}
-	if err := s.DB.SetWorkspaceLLMConfig(wsID, req.BaseURL, req.APIKey, req.Models); err != nil {
+	dbModels := make([]db.LLMModel, len(req.Models))
+	for i, m := range req.Models {
+		dbModels[i] = db.LLMModel{ID: m.ID, Name: m.Name}
+	}
+	if err := s.DB.SetWorkspaceLLMConfig(wsID, req.BaseURL, req.APIKey, dbModels); err != nil {
 		log.Printf("failed to set workspace llm config: %v", err)
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{"ok": true})
+	json.NewEncoder(w).Encode(LLMConfigUpsertResponse{OK: true})
 }
 
 func (s *Server) handleDeleteWorkspaceLLMConfig(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -987,6 +987,13 @@ func (s *Server) requireWorkspaceRole(w http.ResponseWriter, r *http.Request, wo
 
 // --- Workspace handlers ---
 
+//	@Summary    Get per-user workspace quota
+//	@Tags       Workspaces
+//	@Produce    json
+//	@Success    200  {object}  WorkspaceQuotaResponse
+//	@Failure    500  {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces/quota [get]
 func (s *Server) handleGetWorkspacesQuota(w http.ResponseWriter, r *http.Request) {
 	userID := auth.UserIDFromContext(r.Context())
 	maxWs, err := s.effectiveQuota(userID)
@@ -1005,6 +1012,13 @@ func (s *Server) handleGetWorkspacesQuota(w http.ResponseWriter, r *http.Request
 	json.NewEncoder(w).Encode(WorkspaceQuotaResponse{Current: current, Max: maxWs})
 }
 
+//	@Summary    List workspaces for the current user
+//	@Tags       Workspaces
+//	@Produce    json
+//	@Success    200  {array}   Workspace
+//	@Failure    500  {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces [get]
 func (s *Server) handleListWorkspaces(w http.ResponseWriter, r *http.Request) {
 	userID := auth.UserIDFromContext(r.Context())
 	workspaces, err := s.DB.ListWorkspacesByUser(userID)
@@ -1021,6 +1035,18 @@ func (s *Server) handleListWorkspaces(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(resp)
 }
 
+//	@Summary    Create a new workspace
+//	@Description Creator is auto-added as owner. May fail with 403 if the per-user workspace quota is exceeded.
+//	@Tags       Workspaces
+//	@Accept     json
+//	@Produce    json
+//	@Param      body  body      WorkspaceCreateRequest  true  "Workspace name"
+//	@Success    201   {object}  Workspace
+//	@Failure    400   {string}  string  "bad request / empty name"
+//	@Failure    403   {string}  string  "workspace quota exceeded"
+//	@Failure    500   {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces [post]
 func (s *Server) handleCreateWorkspace(w http.ResponseWriter, r *http.Request) {
 	userID := auth.UserIDFromContext(r.Context())
 
@@ -1094,6 +1120,16 @@ func (s *Server) handleCreateWorkspace(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(s.toWorkspaceResponse(ws))
 }
 
+//	@Summary    Get a workspace by id
+//	@Tags       Workspaces
+//	@Produce    json
+//	@Param      id  path  string  true  "Workspace id"
+//	@Success    200  {object}  Workspace
+//	@Failure    403  {string}  string  "not a member"
+//	@Failure    404  {string}  string  "workspace not found"
+//	@Failure    500  {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces/{id} [get]
 func (s *Server) handleGetWorkspace(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	if _, ok := s.requireWorkspaceMember(w, r, id); !ok {
@@ -1110,6 +1146,18 @@ func (s *Server) handleGetWorkspace(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(s.toWorkspaceResponse(ws))
 }
 
+//	@Summary    Rename a workspace
+//	@Tags       Workspaces
+//	@Accept     json
+//	@Produce    json
+//	@Param      id    path      string                  true  "Workspace id"
+//	@Param      body  body      WorkspaceRenameRequest  true  "New name"
+//	@Success    200   {object}  Workspace
+//	@Failure    400   {string}  string  "empty name"
+//	@Failure    403   {string}  string  "owner or maintainer required"
+//	@Failure    500   {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces/{id} [patch]
 func (s *Server) handleRenameWorkspace(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	if !s.requireWorkspaceRole(w, r, id, "owner", "maintainer") {
@@ -1134,6 +1182,14 @@ func (s *Server) handleRenameWorkspace(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(s.toWorkspaceResponse(ws))
 }
 
+//	@Summary    Delete a workspace (owner only; cascades to sandboxes + namespace)
+//	@Tags       Workspaces
+//	@Param      id   path  string  true  "Workspace id"
+//	@Success    204
+//	@Failure    403  {string}  string  "owner only"
+//	@Failure    500  {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces/{id} [delete]
 func (s *Server) handleDeleteWorkspace(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	if !s.requireWorkspaceRole(w, r, id, "owner") {
@@ -1197,6 +1253,15 @@ func (s *Server) handleDeleteWorkspace(w http.ResponseWriter, r *http.Request) {
 
 // --- Member handlers ---
 
+//	@Summary    List members of a workspace
+//	@Tags       Workspaces
+//	@Produce    json
+//	@Param      id  path  string  true  "Workspace id"
+//	@Success    200  {array}   WorkspaceMember
+//	@Failure    403  {string}  string  "not a member"
+//	@Failure    500  {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces/{id}/members [get]
 func (s *Server) handleListMembers(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "id")
 	if _, ok := s.requireWorkspaceMember(w, r, wsID); !ok {
@@ -1231,6 +1296,20 @@ func (s *Server) handleListMembers(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(resp)
 }
 
+//	@Summary    Add a member to a workspace
+//	@Description Looks up the user by email. Default role is "developer" if omitted.
+//	@Tags       Workspaces
+//	@Accept     json
+//	@Produce    json
+//	@Param      id    path      string            true  "Workspace id"
+//	@Param      body  body      MemberAddRequest  true  "Email and optional role"
+//	@Success    201   {object}  WorkspaceMember
+//	@Failure    400   {string}  string  "bad request"
+//	@Failure    403   {string}  string  "owner or maintainer required"
+//	@Failure    404   {string}  string  "user not found"
+//	@Failure    500   {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces/{id}/members [post]
 func (s *Server) handleAddMember(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "id")
 	if !s.requireWorkspaceRole(w, r, wsID, "owner", "maintainer") {
@@ -1268,6 +1347,18 @@ func (s *Server) handleAddMember(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+//	@Summary    Change a member's role (owner only)
+//	@Tags       Workspaces
+//	@Accept     json
+//	@Param      id      path  string                   true  "Workspace id"
+//	@Param      userId  path  string                   true  "User id"
+//	@Param      body    body  MemberRoleUpdateRequest  true  "New role"
+//	@Success    204
+//	@Failure    400  {string}  string  "empty role"
+//	@Failure    403  {string}  string  "owner only"
+//	@Failure    500  {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces/{id}/members/{userId} [put]
 func (s *Server) handleUpdateMemberRole(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "id")
 	if !s.requireWorkspaceRole(w, r, wsID, "owner") {
@@ -1290,6 +1381,15 @@ func (s *Server) handleUpdateMemberRole(w http.ResponseWriter, r *http.Request) 
 	w.WriteHeader(http.StatusNoContent)
 }
 
+//	@Summary    Remove a member (owner only)
+//	@Tags       Workspaces
+//	@Param      id      path  string  true  "Workspace id"
+//	@Param      userId  path  string  true  "User id"
+//	@Success    204
+//	@Failure    403  {string}  string  "owner only"
+//	@Failure    500  {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces/{id}/members/{userId} [delete]
 func (s *Server) handleRemoveMember(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "id")
 	if !s.requireWorkspaceRole(w, r, wsID, "owner") {
@@ -1306,6 +1406,15 @@ func (s *Server) handleRemoveMember(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+//	@Summary    Get the workspace's daily LLM request quota usage
+//	@Tags       Workspaces
+//	@Produce    json
+//	@Param      id  path  string  true  "Workspace id"
+//	@Success    200  {object}  LLMQuotaResponse
+//	@Failure    403  {string}  string  "insufficient role"
+//	@Failure    500  {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces/{id}/llm-quota [get]
 // handleGetWorkspaceLLMQuota returns the LLM RPD quota for a workspace (read-only for members).
 func (s *Server) handleGetWorkspaceLLMQuota(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "id")
@@ -1324,6 +1433,16 @@ func maskAPIKey(key string) string {
 	return key[:3] + "..." + key[len(key)-4:]
 }
 
+//	@Summary    Get workspace LLM config (owner/maintainer)
+//	@Description The returned api_key is masked (first 3 + "..." + last 4). updated_at is null when no config is set.
+//	@Tags       Workspaces
+//	@Produce    json
+//	@Param      id  path  string  true  "Workspace id"
+//	@Success    200  {object}  LLMConfigResponse
+//	@Failure    403  {string}  string  "insufficient role"
+//	@Failure    500  {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces/{id}/llm-config [get]
 func (s *Server) handleGetWorkspaceLLMConfig(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "id")
 	if !s.requireWorkspaceRole(w, r, wsID, "owner", "maintainer") {
@@ -1355,6 +1474,19 @@ func (s *Server) handleGetWorkspaceLLMConfig(w http.ResponseWriter, r *http.Requ
 	})
 }
 
+//	@Summary    Upsert workspace LLM config (owner/maintainer)
+//	@Description On update, omitting api_key retains the existing key.
+//	@Tags       Workspaces
+//	@Accept     json
+//	@Produce    json
+//	@Param      id    path      string                  true  "Workspace id"
+//	@Param      body  body      LLMConfigUpsertRequest  true  "Config payload"
+//	@Success    200   {object}  LLMConfigUpsertResponse
+//	@Failure    400   {string}  string  "validation error (invalid URL / missing field / too many models)"
+//	@Failure    403   {string}  string  "insufficient role"
+//	@Failure    500   {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces/{id}/llm-config [put]
 func (s *Server) handleSetWorkspaceLLMConfig(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "id")
 	if !s.requireWorkspaceRole(w, r, wsID, "owner", "maintainer") {
@@ -1411,6 +1543,14 @@ func (s *Server) handleSetWorkspaceLLMConfig(w http.ResponseWriter, r *http.Requ
 	json.NewEncoder(w).Encode(LLMConfigUpsertResponse{OK: true})
 }
 
+//	@Summary    Delete workspace LLM config (owner/maintainer)
+//	@Tags       Workspaces
+//	@Param      id  path  string  true  "Workspace id"
+//	@Success    204
+//	@Failure    403  {string}  string  "insufficient role"
+//	@Failure    500  {string}  string  "internal error"
+//	@Security   CookieAuth
+//	@Router     /api/workspaces/{id}/llm-config [delete]
 func (s *Server) handleDeleteWorkspaceLLMConfig(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "id")
 	if !s.requireWorkspaceRole(w, r, wsID, "owner", "maintainer") {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -243,16 +243,7 @@ export async function getWorkspaceDefaults(workspaceId: string): Promise<Workspa
   return res.json()
 }
 
-// NOTE: WorkspaceLLMQuota uses a local type rather than the generated LLMQuotaResponse
-// because the /llm-quota endpoint proxies an upstream LLM service whose actual response
-// shape (default_max_rpd, workspace_quota, today_request_count) differs from the
-// spec-declared LLMQuotaResponse (daily_limit, daily_used, resets_at, workspace_id).
-// Resolve by fixing the Go DTO + regenerating once the actual upstream API is confirmed.
-export interface WorkspaceLLMQuota {
-  default_max_rpd: number
-  workspace_quota: { workspace_id: string; max_rpd: number | null; updated_at: string } | null
-  today_request_count: number
-}
+export type WorkspaceLLMQuota = components['schemas']['LLMQuotaResponse']
 
 export async function getWorkspaceLLMQuota(workspaceId: string): Promise<WorkspaceLLMQuota> {
   return apiFetch<WorkspaceLLMQuota>({
@@ -935,11 +926,7 @@ export async function adminDeleteWorkspaceQuota(workspaceId: string): Promise<vo
 }
 
 // LLM Quota management (proxied to llmproxy)
-export interface LLMQuotaResponse {
-  default_max_rpd: number
-  workspace_quota: { workspace_id: string; max_rpd: number | null; updated_at: string } | null
-  today_request_count: number
-}
+export type LLMQuotaResponse = components['schemas']['LLMQuotaResponse']
 
 export async function adminGetWorkspaceLLMQuota(workspaceId: string): Promise<LLMQuotaResponse> {
   const res = await fetch(`/api/admin/workspaces/${workspaceId}/llm-quota`)

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -4,19 +4,10 @@ import type { components } from './api-generated/schema'
 export type SandboxStatus = 'creating' | 'running' | 'pausing' | 'paused' | 'resuming' | 'offline'
 export type WorkspaceRole = 'owner' | 'maintainer' | 'developer' | 'guest'
 
-export interface Workspace {
-  id: string
-  name: string
-  created_at: string
-  updated_at: string
-}
-
-export interface WorkspaceMember {
-  user_id: string
-  email: string
-  role: WorkspaceRole
-  picture?: string
-}
+export type Workspace = components['schemas']['Workspace']
+export type WorkspaceMember = components['schemas']['WorkspaceMember']
+export type LLMModel = components['schemas']['LLMModel']
+export type WorkspaceLLMConfig = components['schemas']['LLMConfigResponse']
 
 export interface WeixinBinding {
   bot_id: string
@@ -163,95 +154,77 @@ export async function logout(): Promise<void> {
 
 // Workspace API
 
-async function checkQuotaError(res: Response): Promise<QuotaExceededError | ResourceBudgetExceededError | null> {
-  if (res.status !== 403) return null
-  try {
-    const body = await res.json()
-    if (body.error === 'quota_exceeded') return body as QuotaExceededError
-    if (body.error === 'resource_budget_exceeded') return body as ResourceBudgetExceededError
-  } catch {
-    // not a quota error
-  }
-  return null
-}
-
 export async function listWorkspaces(): Promise<Workspace[]> {
-  const res = await fetch('/api/workspaces')
-  if (!res.ok) throw new Error('Failed to list workspaces')
-  return res.json()
+  return apiFetch<Workspace[]>({ method: 'GET', path: '/api/workspaces' })
 }
 
 export async function createWorkspace(name?: string): Promise<Workspace> {
-  const res = await fetch('/api/workspaces', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name: name || 'New Workspace' }),
-  })
-  if (!res.ok) {
-    const err = await checkQuotaError(res)
-    if (err) throw err
-    throw new Error('Failed to create workspace')
+  try {
+    return await apiFetch<Workspace>({
+      method: 'POST',
+      path: '/api/workspaces',
+      body: { name: name || 'New Workspace' } satisfies components['schemas']['WorkspaceCreateRequest'],
+    })
+  } catch (err) {
+    if (err instanceof ApiError) {
+      // Re-throw structured quota errors so callers can inspect .error / .message
+      const body = err.body as { error?: string; message?: string } | null | undefined
+      if (body?.error === 'quota_exceeded' || body?.error === 'resource_budget_exceeded') throw body
+    }
+    throw err
   }
-  return res.json()
 }
 
 export async function getWorkspace(id: string): Promise<Workspace> {
-  const res = await fetch(`/api/workspaces/${id}`)
-  if (!res.ok) throw new Error('Failed to get workspace')
-  return res.json()
+  return apiFetch<Workspace>({ method: 'GET', path: `/api/workspaces/${encodeURIComponent(id)}` })
 }
 
 export async function deleteWorkspace(id: string): Promise<void> {
-  const res = await fetch(`/api/workspaces/${id}`, { method: 'DELETE' })
-  if (!res.ok) throw new Error('Failed to delete workspace')
+  await apiFetch<void>({ method: 'DELETE', path: `/api/workspaces/${encodeURIComponent(id)}` })
 }
 
 export async function renameWorkspace(id: string, name: string): Promise<Workspace> {
-  const res = await fetch(`/api/workspaces/${id}`, {
+  return apiFetch<Workspace>({
     method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name }),
+    path: `/api/workspaces/${encodeURIComponent(id)}`,
+    body: { name } satisfies components['schemas']['WorkspaceRenameRequest'],
   })
-  if (!res.ok) throw new Error('Failed to rename workspace')
-  return res.json()
 }
 
-export async function getWorkspacesQuota(): Promise<WorkspacesQuota> {
-  const res = await fetch('/api/workspaces/quota')
-  if (!res.ok) throw new Error('Failed to get workspaces quota')
-  return res.json()
+export async function getWorkspacesQuota(): Promise<components['schemas']['WorkspaceQuotaResponse']> {
+  return apiFetch<components['schemas']['WorkspaceQuotaResponse']>({ method: 'GET', path: '/api/workspaces/quota' })
 }
 
 // Workspace member API
 
 export async function listMembers(workspaceId: string): Promise<WorkspaceMember[]> {
-  const res = await fetch(`/api/workspaces/${workspaceId}/members`)
-  if (!res.ok) throw new Error('Failed to list members')
-  return res.json()
+  return apiFetch<WorkspaceMember[]>({
+    method: 'GET',
+    path: `/api/workspaces/${encodeURIComponent(workspaceId)}/members`,
+  })
 }
 
 export async function addMember(workspaceId: string, email: string, role?: string): Promise<WorkspaceMember> {
-  const res = await fetch(`/api/workspaces/${workspaceId}/members`, {
+  return apiFetch<WorkspaceMember>({
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ email, role: role || 'developer' }),
+    path: `/api/workspaces/${encodeURIComponent(workspaceId)}/members`,
+    body: { email, role: role ?? 'developer' } satisfies components['schemas']['MemberAddRequest'],
   })
-  if (!res.ok) throw new Error('Failed to add member')
-  return res.json()
 }
 
 export async function updateMemberRole(workspaceId: string, userId: string, role: string): Promise<void> {
-  const res = await fetch(`/api/workspaces/${workspaceId}/members/${userId}`, {
+  await apiFetch<void>({
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ role }),
+    path: `/api/workspaces/${encodeURIComponent(workspaceId)}/members/${encodeURIComponent(userId)}`,
+    body: { role } satisfies components['schemas']['MemberRoleUpdateRequest'],
   })
-  if (!res.ok) throw new Error('Failed to update member role')
 }
 
 export async function removeMember(workspaceId: string, userId: string): Promise<void> {
-  const res = await fetch(`/api/workspaces/${workspaceId}/members/${userId}`, { method: 'DELETE' })
-  if (!res.ok) throw new Error('Failed to remove member')
+  await apiFetch<void>({
+    method: 'DELETE',
+    path: `/api/workspaces/${encodeURIComponent(workspaceId)}/members/${encodeURIComponent(userId)}`,
+  })
 }
 
 // Sandbox API
@@ -270,6 +243,11 @@ export async function getWorkspaceDefaults(workspaceId: string): Promise<Workspa
   return res.json()
 }
 
+// NOTE: WorkspaceLLMQuota uses a local type rather than the generated LLMQuotaResponse
+// because the /llm-quota endpoint proxies an upstream LLM service whose actual response
+// shape (default_max_rpd, workspace_quota, today_request_count) differs from the
+// spec-declared LLMQuotaResponse (daily_limit, daily_used, resets_at, workspace_id).
+// Resolve by fixing the Go DTO + regenerating once the actual upstream API is confirmed.
 export interface WorkspaceLLMQuota {
   default_max_rpd: number
   workspace_quota: { workspace_id: string; max_rpd: number | null; updated_at: string } | null
@@ -277,47 +255,37 @@ export interface WorkspaceLLMQuota {
 }
 
 export async function getWorkspaceLLMQuota(workspaceId: string): Promise<WorkspaceLLMQuota> {
-  const res = await fetch(`/api/workspaces/${workspaceId}/llm-quota`)
-  if (!res.ok) throw new Error('Failed to get LLM quota')
-  return res.json()
+  return apiFetch<WorkspaceLLMQuota>({
+    method: 'GET',
+    path: `/api/workspaces/${encodeURIComponent(workspaceId)}/llm-quota`,
+  })
 }
 
 // Workspace BYOK LLM config
 
-export interface LLMModel {
-  id: string
-  name: string
-}
-
-export interface WorkspaceLLMConfig {
-  configured: boolean
-  base_url?: string
-  api_key?: string
-  models?: LLMModel[]
-  updated_at?: string
-}
-
 export async function getWorkspaceLLMConfig(workspaceId: string): Promise<WorkspaceLLMConfig> {
-  const res = await fetch(`/api/workspaces/${workspaceId}/llm-config`)
-  if (!res.ok) throw new Error('Failed to get LLM config')
-  return res.json()
+  return apiFetch<WorkspaceLLMConfig>({
+    method: 'GET',
+    path: `/api/workspaces/${encodeURIComponent(workspaceId)}/llm-config`,
+  })
 }
 
 export async function setWorkspaceLLMConfig(
   workspaceId: string,
   config: { base_url: string; api_key: string; models: LLMModel[] }
 ): Promise<void> {
-  const res = await fetch(`/api/workspaces/${workspaceId}/llm-config`, {
+  await apiFetch<components['schemas']['LLMConfigUpsertResponse']>({
     method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(config),
+    path: `/api/workspaces/${encodeURIComponent(workspaceId)}/llm-config`,
+    body: config satisfies components['schemas']['LLMConfigUpsertRequest'],
   })
-  if (!res.ok) throw new Error('Failed to set LLM config')
 }
 
 export async function deleteWorkspaceLLMConfig(workspaceId: string): Promise<void> {
-  const res = await fetch(`/api/workspaces/${workspaceId}/llm-config`, { method: 'DELETE' })
-  if (!res.ok) throw new Error('Failed to delete LLM config')
+  await apiFetch<void>({
+    method: 'DELETE',
+    path: `/api/workspaces/${encodeURIComponent(workspaceId)}/llm-config`,
+  })
 }
 
 // ModelServer connection
@@ -338,6 +306,21 @@ export async function getModelserverStatus(workspaceId: string): Promise<Modelse
 export async function disconnectModelserver(workspaceId: string): Promise<void> {
   const res = await fetch(`/api/workspaces/${workspaceId}/modelserver/disconnect`, { method: 'DELETE' })
   if (!res.ok) throw new Error('Failed to disconnect')
+}
+
+// checkQuotaError parses a 403 response body and returns a structured
+// quota error if present, so non-apiFetch callers (e.g. createSandbox)
+// can rethrow structured errors for UI inspection.
+async function checkQuotaError(res: Response): Promise<QuotaExceededError | ResourceBudgetExceededError | null> {
+  if (res.status !== 403) return null
+  try {
+    const body = await res.json()
+    if (body.error === 'quota_exceeded') return body as QuotaExceededError
+    if (body.error === 'resource_budget_exceeded') return body as ResourceBudgetExceededError
+  } catch {
+    // not a quota error
+  }
+  return null
 }
 
 export async function listSandboxes(workspaceId: string): Promise<Sandbox[]> {
@@ -873,11 +856,6 @@ export interface QuotaExceededError {
 export interface ResourceBudgetExceededError {
   error: 'resource_budget_exceeded'
   message: string
-}
-
-export interface WorkspacesQuota {
-  current: number
-  max: number
 }
 
 // Admin quota API


### PR DESCRIPTION
## Summary

Phase 1.b kickoff: 14 Workspaces REST endpoints annotated with swaggo, spec regenerated, frontend helpers migrated to `apiClient` + generated types. Same toolchain as Phase 1.a (PR #152).

**Stacked on PR #152** — needs that merged first (or this branch rebased onto main once it lands).

Reference: spec `docs/superpowers/specs/2026-05-21-openapi-organization-design.md`, plan `docs/superpowers/plans/2026-05-22-openapi-phase-1b-workspaces.md`.

## Endpoints

| Sub-area | Endpoints |
|---|---|
| Workspace CRUD | list / create / get / rename / delete / quota |
| Members | list / add / update role / remove |
| LLM config | quota / get / upsert / delete |

## What changed

- `internal/server/api_types.go` — Workspaces section: 10 new DTOs (`WorkspaceCreateRequest`, `MemberAddRequest`, `LLMConfigUpsertRequest`, etc.). Existing lowercase types `workspaceResponse` and `workspaceMemberResponse` get `@name Workspace` / `@name WorkspaceMember` overrides (Go names untouched, spec emits clean names).
- `internal/server/server.go` — 14 swag annotation blocks added; 5 mutation handlers refactored from inline anonymous structs to named DTOs; 3 inline `map` responses replaced with typed structs.
- `docs/api/openapi.{yaml,json}` — regenerated, +12 schemas, +14 operations under tag `Workspaces`.
- `web/src/lib/api.ts` — 14 helpers migrated to `apiFetch` + `components['schemas'][...]`. Local TS types replaced with generated aliases. External signatures unchanged.

## Fixes uncovered while migrating

- **`LLMQuotaResponse` schema corrected**: original mapped to a guessed shape; corrected to match the LLM proxy's actual `{ default_max_rpd, today_request_count, workspace_quota }` payload (with nested `LLMWorkspaceQuotaPart`).
- **`workspaceMemberResponse.Picture`**: dropped `omitempty` and added `x-nullable=true` so the wire format stays `{picture: null}` instead of omitting the key — matches Phase 1.a's AuthMeResponse fix.

## Verification

- `make openapi-check` green
- `go test ./internal/server/ -count=1` green
- `cd web && pnpm tsc --noEmit && pnpm build` green
- Spec contains all 14 operations under tag `Workspaces`, 12 schemas, no `server.` prefix

## Next

Sandboxes is the next tag in the queue (~8 endpoints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)