### PR TITLE
feat(openapi): Phase 1.b — Sandboxes tag (8 endpoints)

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1649,6 +1649,69 @@
       }
     },
     "schemas": {
+      "AgentInfo": {
+        "type": "object",
+        "required": [
+          "agent_version",
+          "cpu_count_logical",
+          "cpu_model_name",
+          "disk_free",
+          "disk_total",
+          "hostname",
+          "kernel_arch",
+          "memory_total",
+          "opencode_version",
+          "os",
+          "platform",
+          "platform_version",
+          "updated_at",
+          "workdir"
+        ],
+        "properties": {
+          "agent_version": {
+            "type": "string"
+          },
+          "cpu_count_logical": {
+            "type": "integer"
+          },
+          "cpu_model_name": {
+            "type": "string"
+          },
+          "disk_free": {
+            "type": "integer"
+          },
+          "disk_total": {
+            "type": "integer"
+          },
+          "hostname": {
+            "type": "string"
+          },
+          "kernel_arch": {
+            "type": "string"
+          },
+          "memory_total": {
+            "type": "integer"
+          },
+          "opencode_version": {
+            "type": "string"
+          },
+          "os": {
+            "type": "string"
+          },
+          "platform": {
+            "type": "string"
+          },
+          "platform_version": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "workdir": {
+            "type": "string"
+          }
+        }
+      },
       "AuthCredentials": {
         "type": "object",
         "required": [
@@ -1720,6 +1783,28 @@
           "status": {
             "type": "string",
             "example": "ok"
+          }
+        }
+      },
+      "IMBinding": {
+        "type": "object",
+        "required": [
+          "bot_id",
+          "bound_at",
+          "provider"
+        ],
+        "properties": {
+          "bot_id": {
+            "type": "string"
+          },
+          "bound_at": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "user_id": {
+            "type": "string"
           }
         }
       },
@@ -1886,7 +1971,7 @@
         ],
         "properties": {
           "agent_info": {
-            "$ref": "#/components/schemas/server.agentInfoResponse"
+            "$ref": "#/components/schemas/AgentInfo"
           },
           "claudecode_url": {
             "type": "string"
@@ -1909,7 +1994,7 @@
           "im_bindings": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/server.imBindingResponse"
+              "$ref": "#/components/schemas/IMBinding"
             }
           },
           "is_local": {
@@ -1957,7 +2042,7 @@
           "weixin_bindings": {
             "type": "array",
             "items": {
-              "$ref": "#/components/schemas/server.imBindingResponse"
+              "$ref": "#/components/schemas/IMBinding"
             }
           },
           "workspace_id": {
@@ -2162,70 +2247,6 @@
           "name": {
             "type": "string",
             "example": "Renamed Workspace"
-          }
-        }
-      },
-      "server.agentInfoResponse": {
-        "type": "object",
-        "properties": {
-          "agent_version": {
-            "type": "string"
-          },
-          "cpu_count_logical": {
-            "type": "integer"
-          },
-          "cpu_model_name": {
-            "type": "string"
-          },
-          "disk_free": {
-            "type": "integer"
-          },
-          "disk_total": {
-            "type": "integer"
-          },
-          "hostname": {
-            "type": "string"
-          },
-          "kernel_arch": {
-            "type": "string"
-          },
-          "memory_total": {
-            "type": "integer"
-          },
-          "opencode_version": {
-            "type": "string"
-          },
-          "os": {
-            "type": "string"
-          },
-          "platform": {
-            "type": "string"
-          },
-          "platform_version": {
-            "type": "string"
-          },
-          "updated_at": {
-            "type": "string"
-          },
-          "workdir": {
-            "type": "string"
-          }
-        }
-      },
-      "server.imBindingResponse": {
-        "type": "object",
-        "properties": {
-          "bot_id": {
-            "type": "string"
-          },
-          "bound_at": {
-            "type": "string"
-          },
-          "provider": {
-            "type": "string"
-          },
-          "user_id": {
-            "type": "string"
           }
         }
       }

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -195,6 +195,454 @@
         }
       }
     },
+    "/api/sandboxes/{id}": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Sandboxes"
+        ],
+        "summary": "Get a sandbox by id",
+        "parameters": [
+          {
+            "description": "Sandbox id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Sandbox"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "sandbox not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Sandboxes"
+        ],
+        "summary": "Delete a sandbox",
+        "parameters": [
+          {
+            "description": "Sandbox id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "403": {
+            "description": "not a member",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "sandbox not found",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Sandboxes"
+        ],
+        "summary": "Rename a sandbox",
+        "parameters": [
+          {
+            "description": "Sandbox id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SandboxRenameRequest"
+              }
+            }
+          },
+          "description": "New name",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Sandbox"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "name required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "sandbox not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/sandboxes/{id}/pause": {
+      "post": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "description": "Initiates pause transition; returns {\"status\":\"pausing\"}. Final state lands asynchronously.",
+        "tags": [
+          "Sandboxes"
+        ],
+        "summary": "Pause a sandbox (cloud sandboxes only)",
+        "parameters": [
+          {
+            "description": "Sandbox id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SandboxLifecycleStatusResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "local sandbox cannot be paused",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "sandbox not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "invalid state for pause",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/sandboxes/{id}/resume": {
+      "post": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "description": "Initiates resume transition; returns {\"status\":\"resuming\"}. Final state lands asynchronously.",
+        "tags": [
+          "Sandboxes"
+        ],
+        "summary": "Resume a paused sandbox (cloud sandboxes only)",
+        "parameters": [
+          {
+            "description": "Sandbox id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SandboxLifecycleStatusResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "local sandbox cannot be resumed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "sandbox not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "invalid state for resume",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/sandboxes/{id}/usage": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Sandboxes"
+        ],
+        "summary": "Get sandbox usage stats",
+        "parameters": [
+          {
+            "description": "Sandbox id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SandboxUsage"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "sandbox not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/workspaces": {
       "get": {
         "security": [
@@ -1036,6 +1484,141 @@
           }
         }
       }
+    },
+    "/api/workspaces/{wid}/sandboxes": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Sandboxes"
+        ],
+        "summary": "List sandboxes in a workspace",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "name": "wid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Sandbox"
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "description": "Validates type / CPU / memory / idle_timeout / quota / budget. Returns 201 immediately with status=\"provisioning\"; container starts asynchronously.",
+        "tags": [
+          "Sandboxes"
+        ],
+        "summary": "Create a sandbox in a workspace",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "name": "wid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SandboxCreateRequest"
+              }
+            }
+          },
+          "description": "Create payload",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Sandbox"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "validation error (type/cpu/memory/idle_timeout)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "insufficient role / quota / budget",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "servers": [
@@ -1290,6 +1873,212 @@
           }
         }
       },
+      "Sandbox": {
+        "type": "object",
+        "required": [
+          "created_at",
+          "id",
+          "is_local",
+          "name",
+          "status",
+          "type",
+          "workspace_id"
+        ],
+        "properties": {
+          "agent_info": {
+            "$ref": "#/components/schemas/server.agentInfoResponse"
+          },
+          "claudecode_url": {
+            "type": "string"
+          },
+          "cpu": {
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "custom_url": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "idle_timeout": {
+            "type": "integer"
+          },
+          "im_bindings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/server.imBindingResponse"
+            }
+          },
+          "is_local": {
+            "type": "boolean"
+          },
+          "jupyter_url": {
+            "type": "string"
+          },
+          "last_activity_at": {
+            "type": "string",
+            "nullable": true
+          },
+          "last_heartbeat_at": {
+            "type": "string"
+          },
+          "memory": {
+            "type": "integer"
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true
+          },
+          "name": {
+            "type": "string"
+          },
+          "openclaw_url": {
+            "type": "string"
+          },
+          "opencode_url": {
+            "type": "string"
+          },
+          "paused_at": {
+            "type": "string",
+            "nullable": true
+          },
+          "short_id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          },
+          "weixin_bindings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/server.imBindingResponse"
+            }
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        }
+      },
+      "SandboxCreateRequest": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "cpu": {
+            "description": "optional; millicores, e.g. 500 or 2000",
+            "type": "integer"
+          },
+          "idle_timeout": {
+            "description": "optional; seconds",
+            "type": "integer"
+          },
+          "memory": {
+            "description": "optional; bytes, e.g. 536870912 (512Mi)",
+            "type": "integer"
+          },
+          "metadata": {
+            "description": "optional; arbitrary key-value metadata",
+            "type": "object",
+            "additionalProperties": true
+          },
+          "name": {
+            "type": "string",
+            "example": "my-sandbox"
+          },
+          "type": {
+            "description": "optional; default \"opencode\"",
+            "type": "string",
+            "example": "opencode"
+          }
+        }
+      },
+      "SandboxLifecycleStatusResponse": {
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "example": "pausing"
+          }
+        }
+      },
+      "SandboxRenameRequest": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "renamed-sandbox"
+          }
+        }
+      },
+      "SandboxUsage": {
+        "type": "object",
+        "required": [
+          "usage"
+        ],
+        "properties": {
+          "since": {
+            "type": "string",
+            "example": "2026-01-01T00:00:00Z",
+            "nullable": true
+          },
+          "usage": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SandboxUsageSummary"
+            }
+          }
+        }
+      },
+      "SandboxUsageSummary": {
+        "type": "object",
+        "required": [
+          "cache_creation_input_tokens",
+          "cache_read_input_tokens",
+          "input_tokens",
+          "model",
+          "output_tokens",
+          "provider",
+          "request_count"
+        ],
+        "properties": {
+          "cache_creation_input_tokens": {
+            "type": "integer"
+          },
+          "cache_read_input_tokens": {
+            "type": "integer"
+          },
+          "input_tokens": {
+            "type": "integer"
+          },
+          "model": {
+            "type": "string",
+            "example": "claude-sonnet-4-6"
+          },
+          "output_tokens": {
+            "type": "integer"
+          },
+          "provider": {
+            "type": "string",
+            "example": "anthropic"
+          },
+          "request_count": {
+            "type": "integer"
+          }
+        }
+      },
       "Workspace": {
         "type": "object",
         "required": [
@@ -1373,6 +2162,70 @@
           "name": {
             "type": "string",
             "example": "Renamed Workspace"
+          }
+        }
+      },
+      "server.agentInfoResponse": {
+        "type": "object",
+        "properties": {
+          "agent_version": {
+            "type": "string"
+          },
+          "cpu_count_logical": {
+            "type": "integer"
+          },
+          "cpu_model_name": {
+            "type": "string"
+          },
+          "disk_free": {
+            "type": "integer"
+          },
+          "disk_total": {
+            "type": "integer"
+          },
+          "hostname": {
+            "type": "string"
+          },
+          "kernel_arch": {
+            "type": "string"
+          },
+          "memory_total": {
+            "type": "integer"
+          },
+          "opencode_version": {
+            "type": "string"
+          },
+          "os": {
+            "type": "string"
+          },
+          "platform": {
+            "type": "string"
+          },
+          "platform_version": {
+            "type": "string"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "workdir": {
+            "type": "string"
+          }
+        }
+      },
+      "server.imBindingResponse": {
+        "type": "object",
+        "properties": {
+          "bot_id": {
+            "type": "string"
+          },
+          "bound_at": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "user_id": {
+            "type": "string"
           }
         }
       }

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -998,6 +998,52 @@ components:
       name: agentserver-token
       type: apiKey
   schemas:
+    AgentInfo:
+      properties:
+        agent_version:
+          type: string
+        cpu_count_logical:
+          type: integer
+        cpu_model_name:
+          type: string
+        disk_free:
+          type: integer
+        disk_total:
+          type: integer
+        hostname:
+          type: string
+        kernel_arch:
+          type: string
+        memory_total:
+          type: integer
+        opencode_version:
+          type: string
+        os:
+          type: string
+        platform:
+          type: string
+        platform_version:
+          type: string
+        updated_at:
+          type: string
+        workdir:
+          type: string
+      required:
+        - agent_version
+        - cpu_count_logical
+        - cpu_model_name
+        - disk_free
+        - disk_total
+        - hostname
+        - kernel_arch
+        - memory_total
+        - opencode_version
+        - os
+        - platform
+        - platform_version
+        - updated_at
+        - workdir
+      type: object
     AuthCredentials:
       properties:
         email:
@@ -1049,6 +1095,21 @@ components:
           type: string
       required:
         - status
+      type: object
+    IMBinding:
+      properties:
+        bot_id:
+          type: string
+        bound_at:
+          type: string
+        provider:
+          type: string
+        user_id:
+          type: string
+      required:
+        - bot_id
+        - bound_at
+        - provider
       type: object
     LLMConfigResponse:
       properties:
@@ -1154,7 +1215,7 @@ components:
     Sandbox:
       properties:
         agent_info:
-          $ref: "#/components/schemas/server.agentInfoResponse"
+          $ref: "#/components/schemas/AgentInfo"
         claudecode_url:
           type: string
         cpu:
@@ -1169,7 +1230,7 @@ components:
           type: integer
         im_bindings:
           items:
-            $ref: "#/components/schemas/server.imBindingResponse"
+            $ref: "#/components/schemas/IMBinding"
           type: array
         is_local:
           type: boolean
@@ -1202,7 +1263,7 @@ components:
           type: string
         weixin_bindings:
           items:
-            $ref: "#/components/schemas/server.imBindingResponse"
+            $ref: "#/components/schemas/IMBinding"
           type: array
         workspace_id:
           type: string
@@ -1354,46 +1415,4 @@ components:
           type: string
       required:
         - name
-      type: object
-    server.agentInfoResponse:
-      properties:
-        agent_version:
-          type: string
-        cpu_count_logical:
-          type: integer
-        cpu_model_name:
-          type: string
-        disk_free:
-          type: integer
-        disk_total:
-          type: integer
-        hostname:
-          type: string
-        kernel_arch:
-          type: string
-        memory_total:
-          type: integer
-        opencode_version:
-          type: string
-        os:
-          type: string
-        platform:
-          type: string
-        platform_version:
-          type: string
-        updated_at:
-          type: string
-        workdir:
-          type: string
-      type: object
-    server.imBindingResponse:
-      properties:
-        bot_id:
-          type: string
-        bound_at:
-          type: string
-        provider:
-          type: string
-        user_id:
-          type: string
       type: object

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -122,6 +122,275 @@ paths:
       summary: Register a new user
       tags:
         - Auth
+  "/api/sandboxes/{id}":
+    delete:
+      parameters:
+        - description: Sandbox id
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: No Content
+        "403":
+          description: not a member
+          content:
+            "*/*":
+              schema:
+                type: string
+        "404":
+          description: sandbox not found
+          content:
+            "*/*":
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            "*/*":
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Delete a sandbox
+      tags:
+        - Sandboxes
+    get:
+      parameters:
+        - description: Sandbox id
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Sandbox"
+        "403":
+          description: not a member
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: sandbox not found
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Get a sandbox by id
+      tags:
+        - Sandboxes
+    patch:
+      parameters:
+        - description: Sandbox id
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SandboxRenameRequest"
+        description: New name
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Sandbox"
+        "400":
+          description: name required
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: not a member
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: sandbox not found
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Rename a sandbox
+      tags:
+        - Sandboxes
+  "/api/sandboxes/{id}/pause":
+    post:
+      description: Initiates pause transition; returns {"status":"pausing"}. Final
+        state lands asynchronously.
+      parameters:
+        - description: Sandbox id
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SandboxLifecycleStatusResponse"
+        "400":
+          description: local sandbox cannot be paused
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: not a member
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: sandbox not found
+          content:
+            application/json:
+              schema:
+                type: string
+        "409":
+          description: invalid state for pause
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Pause a sandbox (cloud sandboxes only)
+      tags:
+        - Sandboxes
+  "/api/sandboxes/{id}/resume":
+    post:
+      description: Initiates resume transition; returns {"status":"resuming"}. Final
+        state lands asynchronously.
+      parameters:
+        - description: Sandbox id
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SandboxLifecycleStatusResponse"
+        "400":
+          description: local sandbox cannot be resumed
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: not a member
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: sandbox not found
+          content:
+            application/json:
+              schema:
+                type: string
+        "409":
+          description: invalid state for resume
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Resume a paused sandbox (cloud sandboxes only)
+      tags:
+        - Sandboxes
+  "/api/sandboxes/{id}/usage":
+    get:
+      parameters:
+        - description: Sandbox id
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SandboxUsage"
+        "403":
+          description: not a member
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: sandbox not found
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Get sandbox usage stats
+      tags:
+        - Sandboxes
   /api/workspaces:
     get:
       responses:
@@ -607,6 +876,89 @@ paths:
       summary: Change a member's role (owner only)
       tags:
         - Workspaces
+  "/api/workspaces/{wid}/sandboxes":
+    get:
+      parameters:
+        - description: Workspace id
+          in: path
+          name: wid
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: "#/components/schemas/Sandbox"
+                type: array
+        "403":
+          description: not a member
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: List sandboxes in a workspace
+      tags:
+        - Sandboxes
+    post:
+      description: Validates type / CPU / memory / idle_timeout / quota / budget.
+        Returns 201 immediately with status="provisioning"; container starts
+        asynchronously.
+      parameters:
+        - description: Workspace id
+          in: path
+          name: wid
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SandboxCreateRequest"
+        description: Create payload
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Sandbox"
+        "400":
+          description: validation error (type/cpu/memory/idle_timeout)
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: insufficient role / quota / budget
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Create a sandbox in a workspace
+      tags:
+        - Sandboxes
   /api/workspaces/quota:
     get:
       responses:
@@ -799,6 +1151,151 @@ components:
       required:
         - role
       type: object
+    Sandbox:
+      properties:
+        agent_info:
+          $ref: "#/components/schemas/server.agentInfoResponse"
+        claudecode_url:
+          type: string
+        cpu:
+          type: integer
+        created_at:
+          type: string
+        custom_url:
+          type: string
+        id:
+          type: string
+        idle_timeout:
+          type: integer
+        im_bindings:
+          items:
+            $ref: "#/components/schemas/server.imBindingResponse"
+          type: array
+        is_local:
+          type: boolean
+        jupyter_url:
+          type: string
+        last_activity_at:
+          type: string
+          nullable: true
+        last_heartbeat_at:
+          type: string
+        memory:
+          type: integer
+        metadata:
+          additionalProperties: true
+          type: object
+        name:
+          type: string
+        openclaw_url:
+          type: string
+        opencode_url:
+          type: string
+        paused_at:
+          type: string
+          nullable: true
+        short_id:
+          type: string
+        status:
+          type: string
+        type:
+          type: string
+        weixin_bindings:
+          items:
+            $ref: "#/components/schemas/server.imBindingResponse"
+          type: array
+        workspace_id:
+          type: string
+      required:
+        - created_at
+        - id
+        - is_local
+        - name
+        - status
+        - type
+        - workspace_id
+      type: object
+    SandboxCreateRequest:
+      properties:
+        cpu:
+          description: optional; millicores, e.g. 500 or 2000
+          type: integer
+        idle_timeout:
+          description: optional; seconds
+          type: integer
+        memory:
+          description: optional; bytes, e.g. 536870912 (512Mi)
+          type: integer
+        metadata:
+          additionalProperties: true
+          description: optional; arbitrary key-value metadata
+          type: object
+        name:
+          example: my-sandbox
+          type: string
+        type:
+          description: optional; default "opencode"
+          example: opencode
+          type: string
+      required:
+        - name
+      type: object
+    SandboxLifecycleStatusResponse:
+      properties:
+        status:
+          example: pausing
+          type: string
+      required:
+        - status
+      type: object
+    SandboxRenameRequest:
+      properties:
+        name:
+          example: renamed-sandbox
+          type: string
+      required:
+        - name
+      type: object
+    SandboxUsage:
+      properties:
+        since:
+          example: 2026-01-01T00:00:00Z
+          type: string
+          nullable: true
+        usage:
+          items:
+            $ref: "#/components/schemas/SandboxUsageSummary"
+          type: array
+      required:
+        - usage
+      type: object
+    SandboxUsageSummary:
+      properties:
+        cache_creation_input_tokens:
+          type: integer
+        cache_read_input_tokens:
+          type: integer
+        input_tokens:
+          type: integer
+        model:
+          example: claude-sonnet-4-6
+          type: string
+        output_tokens:
+          type: integer
+        provider:
+          example: anthropic
+          type: string
+        request_count:
+          type: integer
+      required:
+        - cache_creation_input_tokens
+        - cache_read_input_tokens
+        - input_tokens
+        - model
+        - output_tokens
+        - provider
+        - request_count
+      type: object
     Workspace:
       properties:
         created_at:
@@ -857,4 +1354,46 @@ components:
           type: string
       required:
         - name
+      type: object
+    server.agentInfoResponse:
+      properties:
+        agent_version:
+          type: string
+        cpu_count_logical:
+          type: integer
+        cpu_model_name:
+          type: string
+        disk_free:
+          type: integer
+        disk_total:
+          type: integer
+        hostname:
+          type: string
+        kernel_arch:
+          type: string
+        memory_total:
+          type: integer
+        opencode_version:
+          type: string
+        os:
+          type: string
+        platform:
+          type: string
+        platform_version:
+          type: string
+        updated_at:
+          type: string
+        workdir:
+          type: string
+      type: object
+    server.imBindingResponse:
+      properties:
+        bot_id:
+          type: string
+        bound_at:
+          type: string
+        provider:
+          type: string
+        user_id:
+          type: string
       type: object

--- a/docs/superpowers/plans/2026-05-22-openapi-phase-1b-sandboxes.md
+++ b/docs/superpowers/plans/2026-05-22-openapi-phase-1b-sandboxes.md
@@ -1,0 +1,439 @@
+# OpenAPI Phase 1.b — Sandboxes tag Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Annotate the 9 Sandboxes REST endpoints with swaggo, regenerate the OpenAPI 3.0 spec, migrate the corresponding `web/src/lib/api.ts` helpers to apiClient + generated types.
+
+**Architecture:** Same toolchain as Phase 1.a/1.b Workspaces — swag → swagger2openapi → openapi-typescript.
+
+**Prereq:** Stacked on `feat/openapi-phase-1b-workspaces` (PR #153). Will rebase onto main when #152 + #153 merge.
+
+---
+
+## Endpoints (9)
+
+| Method | Path | Handler | Auth |
+|---|---|---|---|
+| GET | `/api/workspaces/{wid}/sandboxes` | `handleListSandboxes` server.go:1599 | cookie + member |
+| POST | `/api/workspaces/{wid}/sandboxes` | `handleCreateSandbox` server.go:1616 | cookie + owner/maintainer/developer |
+| GET | `/api/sandboxes/{id}` | `handleGetSandbox` server.go:1870 | cookie + member |
+| PATCH | `/api/sandboxes/{id}` | `handleRenameSandbox` server.go:1886 | cookie + member |
+| DELETE | `/api/sandboxes/{id}` | `handleDeleteSandbox` server.go:1913 | cookie + member |
+| POST | `/api/sandboxes/{id}/pause` | `handlePauseSandbox` server.go:1967 | cookie + member |
+| POST | `/api/sandboxes/{id}/resume` | `handleResumeSandbox` server.go:2016 | cookie + member |
+| GET | `/api/sandboxes/{id}/usage` | `handleSandboxUsage` server.go:2086 | cookie + member |
+
+(8 endpoints actually distinct — the count is wider when counting GETs but the table covers all that need annotating. Will re-confirm `handleSandboxUsage` line during work.)
+
+Line numbers are approximate; recon at the start of each task.
+
+---
+
+## File Structure
+
+**Modify:**
+- `internal/server/api_types.go` — append `// --- Sandboxes ---` section
+- `internal/server/server.go` — `@name` on existing `sandboxResponse` and `sandboxUsageResponse`; refactor inline request structs; add 9 annotations
+- `docs/api/openapi.{yaml,json}` — regenerated
+- `web/src/lib/api.ts` — migrate sandbox helpers
+
+---
+
+### Task 1: Sandboxes DTOs in api_types.go
+
+**Files:** modify `internal/server/api_types.go`
+
+- [ ] **Step 1: Recon existing types**
+
+```bash
+grep -nE "type sandboxResponse|type sandboxUsageResponse" /root/agentserver/internal/server/server.go
+```
+
+Read their definitions. They will get `@name Sandbox` and `@name SandboxUsage` overrides (added in Task 2 on the closing brace, not here).
+
+- [ ] **Step 2: Append to api_types.go after the `// --- Workspaces ---` block**
+
+```go
+// --- Sandboxes ---
+
+// SandboxCreateRequest is the body for POST /api/workspaces/{wid}/sandboxes.
+// All fields except name are optional and fall back to workspace/server defaults.
+type SandboxCreateRequest struct {
+	Name        string  `json:"name" validate:"required" example:"my-sandbox"`
+	Type        string  `json:"type" example:"opencode"`             // optional; default "opencode"
+	CPU         string  `json:"cpu" example:"1"`                     // optional; e.g. "500m" or "2"
+	Memory      string  `json:"memory" example:"2Gi"`                // optional; e.g. "512Mi" or "4Gi"
+	IdleTimeout string  `json:"idle_timeout" example:"30m"`          // optional; Go duration string
+	Metadata    *string `json:"metadata" extensions:"x-nullable=true"` // optional; JSON-encoded metadata
+} // @name SandboxCreateRequest
+
+// SandboxRenameRequest is the body for PATCH /api/sandboxes/{id}.
+type SandboxRenameRequest struct {
+	Name string `json:"name" validate:"required" example:"renamed-sandbox"`
+} // @name SandboxRenameRequest
+
+// SandboxLifecycleStatusResponse is the {"status": "pausing"} envelope returned
+// by POST /api/sandboxes/{id}/pause and /resume. The status reflects the
+// transition initiated, not the final state (those are async).
+type SandboxLifecycleStatusResponse struct {
+	Status string `json:"status" validate:"required" example:"pausing"`
+} // @name SandboxLifecycleStatusResponse
+```
+
+- [ ] **Step 3: Build + commit**
+
+```bash
+cd /root/agentserver
+go build ./...
+git add internal/server/api_types.go
+git commit -m "feat(openapi): Sandboxes DTOs in api_types.go"
+```
+
+---
+
+### Task 2: Augment `sandboxResponse`/`sandboxUsageResponse` + refactor handlers
+
+**Files:** modify `internal/server/server.go`
+
+- [ ] **Step 1: Add `@name` + tighten tags on the existing response types**
+
+For `sandboxResponse` (around line 799): add `// @name Sandbox` after the closing brace, add `validate:"required"` to fields that are always populated, add `extensions:"x-nullable=true"` to any `*T` field that should appear as null instead of omitted.
+
+For `sandboxUsageResponse`: add `// @name SandboxUsage` after the closing brace, add `validate:"required"` to required fields.
+
+**Read both struct definitions first.** Report which fields are pointers vs non-pointers. If a non-pointer field is sometimes empty (e.g. `Type: ""` for unset), it shouldn't be marked required — flag it.
+
+- [ ] **Step 2: Refactor `handleCreateSandbox` to use `SandboxCreateRequest`**
+
+Replace the inline `var req struct {...}` with `var req SandboxCreateRequest`. Field access stays identical.
+
+**Careful with `Metadata`:** in the inline struct it's likely a `string` (JSON-encoded payload). In the new type it's `*string` (nullable). Adjust call sites:
+
+```go
+metaStr := ""
+if req.Metadata != nil {
+    metaStr = *req.Metadata
+}
+// use metaStr where the old code used req.Metadata
+```
+
+(Verify the actual current type of `Metadata` in the inline struct first — if it's already `*string`, no change needed.)
+
+- [ ] **Step 3: Refactor `handleRenameSandbox` to use `SandboxRenameRequest`**
+
+Same pattern: `var req SandboxRenameRequest` instead of inline struct.
+
+- [ ] **Step 4: Refactor pause/resume to emit `SandboxLifecycleStatusResponse`**
+
+Replace `json.NewEncoder(w).Encode(map[string]string{"status": "pausing"})` with `json.NewEncoder(w).Encode(SandboxLifecycleStatusResponse{Status: "pausing"})` (and `"resuming"` for resume).
+
+- [ ] **Step 5: Build + test + regenerate spec**
+
+```bash
+cd /root/agentserver
+go build ./...
+go test ./internal/server/ -count=1 -timeout 120s
+make openapi
+make openapi-check
+```
+
+If a test breaks because of `Metadata` typing change or any wire-shape difference, REPORT — do NOT modify the test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/server/server.go internal/server/api_types.go docs/api/openapi.yaml docs/api/openapi.json
+git commit -m "refactor(server): Sandboxes handlers use named DTOs + @name overrides"
+```
+
+---
+
+### Task 3: Annotate the 8 Sandboxes handlers
+
+**Files:** modify `internal/server/server.go`
+
+Insert the following swag doc-comment blocks directly above each handler. Use TAB indent after `//` for the `@...` lines.
+
+- [ ] **Step 1: Annotate `handleListSandboxes`**
+
+```go
+//	@Summary   List sandboxes in a workspace
+//	@Tags      Sandboxes
+//	@Produce   json
+//	@Param     wid  path  string  true  "Workspace id"
+//	@Success   200  {array}   Sandbox
+//	@Failure   403  {string}  string  "not a member"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{wid}/sandboxes [get]
+```
+
+- [ ] **Step 2: Annotate `handleCreateSandbox`**
+
+```go
+//	@Summary     Create a sandbox in a workspace
+//	@Description Validates type / CPU / memory / idle_timeout / quota / budget. Returns 201 immediately with status="provisioning"; container starts asynchronously.
+//	@Tags        Sandboxes
+//	@Accept      json
+//	@Produce     json
+//	@Param       wid   path      string                true  "Workspace id"
+//	@Param       body  body      SandboxCreateRequest  true  "Create payload"
+//	@Success     201   {object}  Sandbox
+//	@Failure     400   {string}  string  "validation error (type/cpu/memory/idle_timeout)"
+//	@Failure     403   {string}  string  "insufficient role / quota / budget"
+//	@Failure     500   {string}  string  "internal error"
+//	@Security    CookieAuth
+//	@Router      /api/workspaces/{wid}/sandboxes [post]
+```
+
+- [ ] **Step 3: Annotate `handleGetSandbox`**
+
+```go
+//	@Summary   Get a sandbox by id
+//	@Tags      Sandboxes
+//	@Produce   json
+//	@Param     id  path  string  true  "Sandbox id"
+//	@Success   200  {object}  Sandbox
+//	@Failure   403  {string}  string  "not a member"
+//	@Failure   404  {string}  string  "sandbox not found"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/sandboxes/{id} [get]
+```
+
+- [ ] **Step 4: Annotate `handleRenameSandbox`**
+
+```go
+//	@Summary   Rename a sandbox
+//	@Tags      Sandboxes
+//	@Accept    json
+//	@Produce   json
+//	@Param     id    path      string                true  "Sandbox id"
+//	@Param     body  body      SandboxRenameRequest  true  "New name"
+//	@Success   200   {object}  Sandbox
+//	@Failure   400   {string}  string  "name required"
+//	@Failure   403   {string}  string  "not a member"
+//	@Failure   404   {string}  string  "sandbox not found"
+//	@Failure   500   {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/sandboxes/{id} [patch]
+```
+
+- [ ] **Step 5: Annotate `handleDeleteSandbox`**
+
+```go
+//	@Summary   Delete a sandbox
+//	@Tags      Sandboxes
+//	@Param     id  path  string  true  "Sandbox id"
+//	@Success   204
+//	@Failure   403  {string}  string  "not a member"
+//	@Failure   404  {string}  string  "sandbox not found"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/sandboxes/{id} [delete]
+```
+
+- [ ] **Step 6: Annotate `handlePauseSandbox`**
+
+```go
+//	@Summary     Pause a sandbox (cloud sandboxes only)
+//	@Description Initiates pause transition; returns {"status":"pausing"}. Final state lands asynchronously.
+//	@Tags        Sandboxes
+//	@Produce     json
+//	@Param       id  path  string  true  "Sandbox id"
+//	@Success     200  {object}  SandboxLifecycleStatusResponse
+//	@Failure     400  {string}  string  "local sandbox cannot be paused"
+//	@Failure     403  {string}  string  "not a member"
+//	@Failure     404  {string}  string  "sandbox not found"
+//	@Failure     409  {string}  string  "invalid state for pause"
+//	@Failure     500  {string}  string  "internal error"
+//	@Security    CookieAuth
+//	@Router      /api/sandboxes/{id}/pause [post]
+```
+
+- [ ] **Step 7: Annotate `handleResumeSandbox`**
+
+```go
+//	@Summary     Resume a paused sandbox (cloud sandboxes only)
+//	@Description Initiates resume transition; returns {"status":"resuming"}. Final state lands asynchronously.
+//	@Tags        Sandboxes
+//	@Produce     json
+//	@Param       id  path  string  true  "Sandbox id"
+//	@Success     200  {object}  SandboxLifecycleStatusResponse
+//	@Failure     400  {string}  string  "local sandbox cannot be resumed"
+//	@Failure     403  {string}  string  "not a member"
+//	@Failure     404  {string}  string  "sandbox not found"
+//	@Failure     409  {string}  string  "invalid state for resume"
+//	@Failure     500  {string}  string  "internal error"
+//	@Security    CookieAuth
+//	@Router      /api/sandboxes/{id}/resume [post]
+```
+
+- [ ] **Step 8: Annotate `handleSandboxUsage`**
+
+```go
+//	@Summary   Get sandbox usage stats
+//	@Tags      Sandboxes
+//	@Produce   json
+//	@Param     id  path  string  true  "Sandbox id"
+//	@Success   200  {object}  SandboxUsage
+//	@Failure   403  {string}  string  "not a member"
+//	@Failure   404  {string}  string  "sandbox not found"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/sandboxes/{id}/usage [get]
+```
+
+- [ ] **Step 9: Regenerate + verify**
+
+```bash
+cd /root/agentserver
+make openapi
+make openapi-check
+grep -E "^  ?(/api/workspaces/\{wid\}|/api/sandboxes)" docs/api/openapi.yaml | sort -u
+grep -E "^    (Sandbox|SandboxCreateRequest|SandboxRenameRequest|SandboxLifecycleStatusResponse|SandboxUsage):" docs/api/openapi.yaml | sort
+```
+
+Expected: 3 paths (workspace-scoped list/create + standalone get/patch/delete + pause + resume + usage), 5 schemas under components without `server.` prefix.
+
+- [ ] **Step 10: Build + test + commit**
+
+```bash
+go build ./...
+go test ./internal/server/ -count=1 -timeout 120s
+git add internal/server/server.go docs/api/openapi.yaml docs/api/openapi.json
+git commit -m "feat(openapi): annotate Sandboxes handlers (8 endpoints)"
+```
+
+---
+
+### Task 4: Migrate sandbox helpers in `web/src/lib/api.ts`
+
+**Files:** modify `web/src/lib/api.ts`
+
+- [ ] **Step 1: Regenerate types**
+
+```bash
+cd /root/agentserver/web
+pnpm openapi:gen
+```
+
+- [ ] **Step 2: Identify existing helpers**
+
+```bash
+grep -nE "export async function (listSandboxes|createSandbox|getSandbox|renameSandbox|deleteSandbox|pauseSandbox|resumeSandbox|sandboxUsage|getSandboxUsage)" /root/agentserver/web/src/lib/api.ts
+```
+
+There may be additional sandbox helpers (e.g. for tunneling/local-agent) that ARE NOT covered by this PR — leave those alone.
+
+- [ ] **Step 3: Migrate each present helper**
+
+Pattern (adapt to actual signatures):
+
+```typescript
+export type Sandbox = components['schemas']['Sandbox']
+export type SandboxUsage = components['schemas']['SandboxUsage']
+
+export async function listSandboxes(workspaceId: string): Promise<Sandbox[]> {
+  return apiFetch<Sandbox[]>({
+    method: 'GET',
+    path: `/api/workspaces/${encodeURIComponent(workspaceId)}/sandboxes`,
+  })
+}
+
+export async function createSandbox(
+  workspaceId: string,
+  body: components['schemas']['SandboxCreateRequest']
+): Promise<Sandbox> {
+  return apiFetch<Sandbox>({
+    method: 'POST',
+    path: `/api/workspaces/${encodeURIComponent(workspaceId)}/sandboxes`,
+    body,
+  })
+}
+```
+
+For pause/resume helpers, preserve any existing return-type contract (e.g. if they currently return `Promise<boolean>`, keep that).
+
+- [ ] **Step 4: Drop duplicate local types**
+
+Replace any local `interface Sandbox` / `interface SandboxUsage` / `interface CreateSandboxRequest` etc. with `type X = components['schemas']['X']` aliases. If a local type has extra fields the spec doesn't declare, REPORT.
+
+- [ ] **Step 5: Verify tsc + lint + build**
+
+```bash
+cd /root/agentserver/web
+pnpm tsc --noEmit
+pnpm lint
+pnpm build
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /root/agentserver
+git add web/src/lib/api.ts
+git commit -m "refactor(web): migrate Sandboxes helpers to apiClient + generated types"
+```
+
+---
+
+### Task 5: End-to-end verify + PR
+
+- [ ] **Step 1: Final verify**
+
+```bash
+cd /root/agentserver
+make openapi-check
+go test ./internal/server/ -count=1 -timeout 120s
+cd web && pnpm openapi:gen && pnpm build && cd ..
+git checkout -- web/dist/ 2>/dev/null || true
+git status --short | head -3
+```
+
+- [ ] **Step 2: Push branch**
+
+```bash
+git push -u github feat/openapi-phase-1b-sandboxes
+```
+
+- [ ] **Step 3: Open PR (stacked on #153)**
+
+```bash
+gh pr create --base main --title "feat(openapi): Phase 1.b — Sandboxes tag (8 endpoints)" --body "$(cat <<'EOF'
+## Summary
+
+Annotates the 8 Sandboxes REST endpoints with swaggo, regenerates the OpenAPI 3.0 spec, migrates the corresponding frontend helpers. Same toolchain as PRs #152 and #153.
+
+**Stacked on PR #153** — needs #152 + #153 merged first (or rebase after).
+
+Reference: spec `docs/superpowers/specs/2026-05-21-openapi-organization-design.md`, plan `docs/superpowers/plans/2026-05-22-openapi-phase-1b-sandboxes.md`.
+
+## Endpoints
+
+- List / Create / Get / Rename / Delete sandbox
+- Pause / Resume (lifecycle RPC)
+- Usage stats
+
+## Verification
+
+- `make openapi-check` green
+- `go test ./internal/server/` green
+- `cd web && pnpm tsc --noEmit && pnpm build` green
+
+## Next
+
+IM Channels (~8 endpoints).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+---
+
+## Done when
+
+- PR opened against `main` with 4 commits
+- 8 endpoints under tag `Sandboxes` in `docs/api/openapi.yaml`
+- Frontend builds; existing sandbox UI works

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -151,3 +151,24 @@ type SandboxRenameRequest struct {
 type SandboxLifecycleStatusResponse struct {
 	Status string `json:"status" validate:"required" example:"pausing"`
 } // @name SandboxLifecycleStatusResponse
+
+// SandboxUsageSummary is one row in the per-provider/model breakdown returned
+// by GET /api/sandboxes/{id}/usage. It mirrors llmproxy.UsageSummary.
+type SandboxUsageSummary struct {
+	Provider                 string `json:"provider" validate:"required" example:"anthropic"`
+	Model                    string `json:"model" validate:"required" example:"claude-sonnet-4-6"`
+	InputTokens              int64  `json:"input_tokens" validate:"required"`
+	OutputTokens             int64  `json:"output_tokens" validate:"required"`
+	CacheCreationInputTokens int64  `json:"cache_creation_input_tokens" validate:"required"`
+	CacheReadInputTokens     int64  `json:"cache_read_input_tokens" validate:"required"`
+	RequestCount             int64  `json:"request_count" validate:"required"`
+} // @name SandboxUsageSummary
+
+// SandboxUsageResponse mirrors the body the LLM proxy returns from its
+// /internal/usage?sandbox_id={id} endpoint, forwarded verbatim by
+// GET /api/sandboxes/{id}/usage. usage is the per-provider/model breakdown;
+// since is set only when the caller supplied a ?since= query param.
+type SandboxUsageResponse struct {
+	Usage []SandboxUsageSummary `json:"usage" validate:"required"`
+	Since *string               `json:"since,omitempty" extensions:"x-nullable=true" example:"2026-01-01T00:00:00Z"`
+} // @name SandboxUsage

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -126,3 +126,28 @@ type LLMConfigUpsertRequest struct {
 type LLMConfigUpsertResponse struct {
 	OK bool `json:"ok" validate:"required"`
 } // @name LLMConfigUpsertResponse
+
+// --- Sandboxes ---
+
+// SandboxCreateRequest is the body for POST /api/workspaces/{wid}/sandboxes.
+// All fields except name are optional and fall back to workspace/server defaults.
+type SandboxCreateRequest struct {
+	Name        string                 `json:"name" validate:"required" example:"my-sandbox"`
+	Type        string                 `json:"type" example:"opencode"`    // optional; default "opencode"
+	CPU         *int                   `json:"cpu"`                        // optional; millicores, e.g. 500 or 2000
+	Memory      *int64                 `json:"memory"`                     // optional; bytes, e.g. 536870912 (512Mi)
+	IdleTimeout *int                   `json:"idle_timeout"`               // optional; seconds
+	Metadata    map[string]interface{} `json:"metadata"`                   // optional; arbitrary key-value metadata
+} // @name SandboxCreateRequest
+
+// SandboxRenameRequest is the body for PATCH /api/sandboxes/{id}.
+type SandboxRenameRequest struct {
+	Name string `json:"name" validate:"required" example:"renamed-sandbox"`
+} // @name SandboxRenameRequest
+
+// SandboxLifecycleStatusResponse is the {"status": "pausing"} envelope returned
+// by POST /api/sandboxes/{id}/pause and /resume. The status reflects the
+// transition initiated, not the final state (those are async).
+type SandboxLifecycleStatusResponse struct {
+	Status string `json:"status" validate:"required" example:"pausing"`
+} // @name SandboxLifecycleStatusResponse

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1596,6 +1596,15 @@ func (s *Server) handleGetWorkspaceDefaults(w http.ResponseWriter, r *http.Reque
 	})
 }
 
+//	@Summary   List sandboxes in a workspace
+//	@Tags      Sandboxes
+//	@Produce   json
+//	@Param     wid  path  string  true  "Workspace id"
+//	@Success   200  {array}   Sandbox
+//	@Failure   403  {string}  string  "not a member"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{wid}/sandboxes [get]
 func (s *Server) handleListSandboxes(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "wid")
 	if _, ok := s.requireWorkspaceMember(w, r, wsID); !ok {
@@ -1613,6 +1622,19 @@ func (s *Server) handleListSandboxes(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(resp)
 }
 
+//	@Summary     Create a sandbox in a workspace
+//	@Description Validates type / CPU / memory / idle_timeout / quota / budget. Returns 201 immediately with status="provisioning"; container starts asynchronously.
+//	@Tags        Sandboxes
+//	@Accept      json
+//	@Produce     json
+//	@Param       wid   path      string                true  "Workspace id"
+//	@Param       body  body      SandboxCreateRequest  true  "Create payload"
+//	@Success     201   {object}  Sandbox
+//	@Failure     400   {string}  string  "validation error (type/cpu/memory/idle_timeout)"
+//	@Failure     403   {string}  string  "insufficient role / quota / budget"
+//	@Failure     500   {string}  string  "internal error"
+//	@Security    CookieAuth
+//	@Router      /api/workspaces/{wid}/sandboxes [post]
 func (s *Server) handleCreateSandbox(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "wid")
 	if !s.requireWorkspaceRole(w, r, wsID, "owner", "maintainer", "developer") {
@@ -1860,6 +1882,16 @@ func (s *Server) handleCreateSandbox(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(s.toSandboxResponse(r, sbx, authTokenFromRequest(r)))
 }
 
+//	@Summary   Get a sandbox by id
+//	@Tags      Sandboxes
+//	@Produce   json
+//	@Param     id  path  string  true  "Sandbox id"
+//	@Success   200  {object}  Sandbox
+//	@Failure   403  {string}  string  "not a member"
+//	@Failure   404  {string}  string  "sandbox not found"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/sandboxes/{id} [get]
 func (s *Server) handleGetSandbox(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	sbx, ok := s.Sandboxes.Get(id)
@@ -1876,6 +1908,19 @@ func (s *Server) handleGetSandbox(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(resp)
 }
 
+//	@Summary   Rename a sandbox
+//	@Tags      Sandboxes
+//	@Accept    json
+//	@Produce   json
+//	@Param     id    path      string                true  "Sandbox id"
+//	@Param     body  body      SandboxRenameRequest  true  "New name"
+//	@Success   200   {object}  Sandbox
+//	@Failure   400   {string}  string  "name required"
+//	@Failure   403   {string}  string  "not a member"
+//	@Failure   404   {string}  string  "sandbox not found"
+//	@Failure   500   {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/sandboxes/{id} [patch]
 func (s *Server) handleRenameSandbox(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	sbx, ok := s.Sandboxes.Get(id)
@@ -1901,6 +1946,15 @@ func (s *Server) handleRenameSandbox(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(s.toSandboxResponse(r, sbx, authTokenFromRequest(r)))
 }
 
+//	@Summary   Delete a sandbox
+//	@Tags      Sandboxes
+//	@Param     id  path  string  true  "Sandbox id"
+//	@Success   204
+//	@Failure   403  {string}  string  "not a member"
+//	@Failure   404  {string}  string  "sandbox not found"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/sandboxes/{id} [delete]
 func (s *Server) handleDeleteSandbox(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	sbx, ok := s.Sandboxes.Get(id)
@@ -1955,6 +2009,19 @@ func (s *Server) handleDeleteSandbox(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
+//	@Summary     Pause a sandbox (cloud sandboxes only)
+//	@Description Initiates pause transition; returns {"status":"pausing"}. Final state lands asynchronously.
+//	@Tags        Sandboxes
+//	@Produce     json
+//	@Param       id  path  string  true  "Sandbox id"
+//	@Success     200  {object}  SandboxLifecycleStatusResponse
+//	@Failure     400  {string}  string  "local sandbox cannot be paused"
+//	@Failure     403  {string}  string  "not a member"
+//	@Failure     404  {string}  string  "sandbox not found"
+//	@Failure     409  {string}  string  "invalid state for pause"
+//	@Failure     500  {string}  string  "internal error"
+//	@Security    CookieAuth
+//	@Router      /api/sandboxes/{id}/pause [post]
 func (s *Server) handlePauseSandbox(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	sbx, ok := s.Sandboxes.Get(id)
@@ -2004,6 +2071,19 @@ func (s *Server) handlePauseSandbox(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(SandboxLifecycleStatusResponse{Status: "pausing"})
 }
 
+//	@Summary     Resume a paused sandbox (cloud sandboxes only)
+//	@Description Initiates resume transition; returns {"status":"resuming"}. Final state lands asynchronously.
+//	@Tags        Sandboxes
+//	@Produce     json
+//	@Param       id  path  string  true  "Sandbox id"
+//	@Success     200  {object}  SandboxLifecycleStatusResponse
+//	@Failure     400  {string}  string  "local sandbox cannot be resumed"
+//	@Failure     403  {string}  string  "not a member"
+//	@Failure     404  {string}  string  "sandbox not found"
+//	@Failure     409  {string}  string  "invalid state for resume"
+//	@Failure     500  {string}  string  "internal error"
+//	@Security    CookieAuth
+//	@Router      /api/sandboxes/{id}/resume [post]
 func (s *Server) handleResumeSandbox(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	sbx, ok := s.Sandboxes.Get(id)
@@ -2074,6 +2154,16 @@ func (s *Server) handleResumeSandbox(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(SandboxLifecycleStatusResponse{Status: "resuming"})
 }
 
+//	@Summary   Get sandbox usage stats
+//	@Tags      Sandboxes
+//	@Produce   json
+//	@Param     id  path  string  true  "Sandbox id"
+//	@Success   200  {object}  SandboxUsage
+//	@Failure   403  {string}  string  "not a member"
+//	@Failure   404  {string}  string  "sandbox not found"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/sandboxes/{id}/usage [get]
 func (s *Server) handleSandboxUsage(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	sbx, ok := s.Sandboxes.Get(id)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -797,21 +797,21 @@ type imBindingResponse struct {
 }
 
 type sandboxResponse struct {
-	ID              string  `json:"id"`
+	ID              string  `json:"id" validate:"required"`
 	ShortID         string  `json:"short_id,omitempty"`
-	WorkspaceID     string  `json:"workspace_id"`
-	Name            string  `json:"name"`
-	Type            string  `json:"type"`
-	Status          string  `json:"status"`
+	WorkspaceID     string  `json:"workspace_id" validate:"required"`
+	Name            string  `json:"name" validate:"required"`
+	Type            string  `json:"type" validate:"required"`
+	Status          string  `json:"status" validate:"required"`
 	OpencodeURL     string  `json:"opencode_url,omitempty"`
 	OpenclawURL     string  `json:"openclaw_url,omitempty"`
 	ClaudeCodeURL   string  `json:"claudecode_url,omitempty"`
 	JupyterURL      string  `json:"jupyter_url,omitempty"`
 	CustomURL       string  `json:"custom_url,omitempty"`
-	CreatedAt       string  `json:"created_at"`
-	LastActivityAt  *string `json:"last_activity_at"`
-	PausedAt        *string `json:"paused_at"`
-	IsLocal         bool    `json:"is_local"`
+	CreatedAt       string  `json:"created_at" validate:"required"`
+	LastActivityAt  *string `json:"last_activity_at" extensions:"x-nullable=true"`
+	PausedAt        *string `json:"paused_at" extensions:"x-nullable=true"`
+	IsLocal         bool    `json:"is_local" validate:"required"`
 	LastHeartbeatAt *string `json:"last_heartbeat_at,omitempty"`
 	CPU             int     `json:"cpu,omitempty"`
 	Memory          int64   `json:"memory,omitempty"`
@@ -820,7 +820,7 @@ type sandboxResponse struct {
 	WeixinBindings  []imBindingResponse    `json:"weixin_bindings,omitempty"`
 	IMBindings      []imBindingResponse    `json:"im_bindings,omitempty"`
 	Metadata        map[string]interface{} `json:"metadata,omitempty"`
-}
+} // @name Sandbox
 
 func (s *Server) toWorkspaceResponse(ws *db.Workspace) workspaceResponse {
 	return workspaceResponse{
@@ -1648,14 +1648,7 @@ func (s *Server) handleCreateSandbox(w http.ResponseWriter, r *http.Request) {
 	cpuMillis := wd.MaxSandboxCPU   // already int millicores
 	memBytes := wd.MaxSandboxMemory // already int64 bytes
 
-	var req struct {
-		Name          string                 `json:"name"`
-		Type          string                 `json:"type"`
-		CPU           *int                   `json:"cpu"`
-		Memory        *int64                 `json:"memory"`
-		IdleTimeout   *int                   `json:"idle_timeout"`
-		Metadata      map[string]interface{} `json:"metadata"`
-	}
+	var req SandboxCreateRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		req.Name = "New Sandbox"
 	}
@@ -1893,9 +1886,7 @@ func (s *Server) handleRenameSandbox(w http.ResponseWriter, r *http.Request) {
 	if _, ok := s.requireWorkspaceMember(w, r, sbx.WorkspaceID); !ok {
 		return
 	}
-	var req struct {
-		Name string `json:"name"`
-	}
+	var req SandboxRenameRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Name == "" {
 		http.Error(w, "name is required", http.StatusBadRequest)
 		return
@@ -2010,7 +2001,7 @@ func (s *Server) handlePauseSandbox(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"status": "pausing"})
+	json.NewEncoder(w).Encode(SandboxLifecycleStatusResponse{Status: "pausing"})
 }
 
 func (s *Server) handleResumeSandbox(w http.ResponseWriter, r *http.Request) {
@@ -2080,7 +2071,7 @@ func (s *Server) handleResumeSandbox(w http.ResponseWriter, r *http.Request) {
 	}()
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]string{"status": "resuming"})
+	json.NewEncoder(w).Encode(SandboxLifecycleStatusResponse{Status: "resuming"})
 }
 
 func (s *Server) handleSandboxUsage(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -773,28 +773,28 @@ type workspaceMemberResponse struct {
 } // @name WorkspaceMember
 
 type agentInfoResponse struct {
-	Hostname        string `json:"hostname"`
-	OS              string `json:"os"`
-	Platform        string `json:"platform"`
-	PlatformVersion string `json:"platform_version"`
-	KernelArch      string `json:"kernel_arch"`
-	CPUModelName    string `json:"cpu_model_name"`
-	CPUCountLogical int    `json:"cpu_count_logical"`
-	MemoryTotal     int64  `json:"memory_total"`
-	DiskTotal       int64  `json:"disk_total"`
-	DiskFree        int64  `json:"disk_free"`
-	AgentVersion    string `json:"agent_version"`
-	OpencodeVersion string `json:"opencode_version"`
-	Workdir         string `json:"workdir"`
-	UpdatedAt       string `json:"updated_at"`
-}
+	Hostname        string `json:"hostname" validate:"required"`
+	OS              string `json:"os" validate:"required"`
+	Platform        string `json:"platform" validate:"required"`
+	PlatformVersion string `json:"platform_version" validate:"required"`
+	KernelArch      string `json:"kernel_arch" validate:"required"`
+	CPUModelName    string `json:"cpu_model_name" validate:"required"`
+	CPUCountLogical int    `json:"cpu_count_logical" validate:"required"`
+	MemoryTotal     int64  `json:"memory_total" validate:"required"`
+	DiskTotal       int64  `json:"disk_total" validate:"required"`
+	DiskFree        int64  `json:"disk_free" validate:"required"`
+	AgentVersion    string `json:"agent_version" validate:"required"`
+	OpencodeVersion string `json:"opencode_version" validate:"required"`
+	Workdir         string `json:"workdir" validate:"required"`
+	UpdatedAt       string `json:"updated_at" validate:"required"`
+} // @name AgentInfo
 
 type imBindingResponse struct {
-	Provider string `json:"provider"`
-	BotID    string `json:"bot_id"`
+	Provider string `json:"provider" validate:"required"`
+	BotID    string `json:"bot_id" validate:"required"`
 	UserID   string `json:"user_id,omitempty"`
-	BoundAt  string `json:"bound_at"`
-}
+	BoundAt  string `json:"bound_at" validate:"required"`
+} // @name IMBinding
 
 type sandboxResponse struct {
 	ID              string  `json:"id" validate:"required"`

--- a/web/src/components/SandboxDetail.tsx
+++ b/web/src/components/SandboxDetail.tsx
@@ -374,8 +374,8 @@ function AgentInfoSection({ info }: { info: AgentInfo }) {
     { icon: <Laptop size={14} />, label: 'OS', value: `${info.platform} ${info.platform_version}` },
     { icon: <Cpu size={14} />, label: 'Arch', value: info.kernel_arch },
     { icon: <Cpu size={14} />, label: 'CPU', value: info.cpu_model_name ? `${info.cpu_model_name} (${info.cpu_count_logical} cores)` : `${info.cpu_count_logical} cores` },
-    { icon: <MemoryStick size={14} />, label: 'Memory', value: formatBytes(info.memory_total) },
-    { icon: <HardDrive size={14} />, label: 'Disk', value: `${formatBytes(info.disk_free)} free / ${formatBytes(info.disk_total)}` },
+    { icon: <MemoryStick size={14} />, label: 'Memory', value: formatBytes(info.memory_total ?? 0) },
+    { icon: <HardDrive size={14} />, label: 'Disk', value: `${formatBytes(info.disk_free ?? 0)} free / ${formatBytes(info.disk_total ?? 0)}` },
   ]
   const versionItems = [
     { label: 'Agent', value: info.agent_version || 'Unknown' },
@@ -389,7 +389,7 @@ function AgentInfoSection({ info }: { info: AgentInfo }) {
           <span className="text-sm font-medium text-[var(--foreground)]">Agent Info</span>
         </div>
         <span className="text-[10px] text-[var(--muted-foreground)]">
-          Updated {new Date(info.updated_at).toLocaleString()}
+          Updated {info.updated_at ? new Date(info.updated_at).toLocaleString() : '-'}
         </span>
       </div>
       <div className="grid grid-cols-2 gap-4 p-5 sm:grid-cols-3">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -9,13 +9,9 @@ export type WorkspaceMember = components['schemas']['WorkspaceMember']
 export type LLMModel = components['schemas']['LLMModel']
 export type WorkspaceLLMConfig = components['schemas']['LLMConfigResponse']
 
-export interface WeixinBinding {
-  bot_id: string
-  user_id: string
-  bound_at: string
-}
+export type WeixinBinding = components['schemas']['IMBinding']
 
-export type IMBinding = components['schemas']['server.imBindingResponse']
+export type IMBinding = components['schemas']['IMBinding']
 
 export interface TelegramConfigureResult {
   connected: boolean
@@ -34,7 +30,7 @@ export type SandboxCreateRequest = components['schemas']['SandboxCreateRequest']
 export type SandboxUsage = components['schemas']['SandboxUsage']
 export type SandboxUsageSummary = components['schemas']['SandboxUsageSummary']
 
-export type AgentInfo = components['schemas']['server.agentInfoResponse']
+export type AgentInfo = components['schemas']['AgentInfo']
 
 export async function login(email: string, password: string): Promise<boolean> {
   try {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -15,12 +15,7 @@ export interface WeixinBinding {
   bound_at: string
 }
 
-export interface IMBinding {
-  provider: string
-  bot_id: string
-  user_id?: string
-  bound_at: string
-}
+export type IMBinding = components['schemas']['server.imBindingResponse']
 
 export interface TelegramConfigureResult {
   connected: boolean
@@ -34,46 +29,12 @@ export interface MatrixConfigureResult {
   user_id: string
 }
 
-export interface Sandbox {
-  id: string
-  workspace_id: string
-  name: string
-  type: string
-  status: SandboxStatus
-  opencode_url?: string
-  openclaw_url?: string
-  claudecode_url?: string
-  jupyter_url?: string
-  custom_url?: string
-  created_at: string
-  last_activity_at: string | null
-  paused_at: string | null
-  is_local: boolean
-  last_heartbeat_at?: string | null
-  cpu?: number
-  memory?: number
-  idle_timeout?: number
-  agent_info?: AgentInfo
-  weixin_bindings?: WeixinBinding[]
-  im_bindings?: IMBinding[]
-}
+export type Sandbox = components['schemas']['Sandbox']
+export type SandboxCreateRequest = components['schemas']['SandboxCreateRequest']
+export type SandboxUsage = components['schemas']['SandboxUsage']
+export type SandboxUsageSummary = components['schemas']['SandboxUsageSummary']
 
-export interface AgentInfo {
-  hostname: string
-  os: string
-  platform: string
-  platform_version: string
-  kernel_arch: string
-  cpu_model_name: string
-  cpu_count_logical: number
-  memory_total: number
-  disk_total: number
-  disk_free: number
-  agent_version: string
-  opencode_version: string
-  workdir: string
-  updated_at: string
-}
+export type AgentInfo = components['schemas']['server.agentInfoResponse']
 
 export async function login(email: string, password: string): Promise<boolean> {
   try {
@@ -299,25 +260,12 @@ export async function disconnectModelserver(workspaceId: string): Promise<void> 
   if (!res.ok) throw new Error('Failed to disconnect')
 }
 
-// checkQuotaError parses a 403 response body and returns a structured
-// quota error if present, so non-apiFetch callers (e.g. createSandbox)
-// can rethrow structured errors for UI inspection.
-async function checkQuotaError(res: Response): Promise<QuotaExceededError | ResourceBudgetExceededError | null> {
-  if (res.status !== 403) return null
-  try {
-    const body = await res.json()
-    if (body.error === 'quota_exceeded') return body as QuotaExceededError
-    if (body.error === 'resource_budget_exceeded') return body as ResourceBudgetExceededError
-  } catch {
-    // not a quota error
-  }
-  return null
-}
 
 export async function listSandboxes(workspaceId: string): Promise<Sandbox[]> {
-  const res = await fetch(`/api/workspaces/${workspaceId}/sandboxes`)
-  if (!res.ok) throw new Error('Failed to list sandboxes')
-  return res.json()
+  return apiFetch<Sandbox[]>({
+    method: 'GET',
+    path: `/api/workspaces/${encodeURIComponent(workspaceId)}/sandboxes`,
+  })
 }
 
 export async function createSandbox(
@@ -329,56 +277,64 @@ export async function createSandbox(
   idleTimeout?: number,
   metadata?: Record<string, unknown>,
 ): Promise<Sandbox> {
-  const body: Record<string, unknown> = {
+  const body: SandboxCreateRequest = {
     name: name || 'New Sandbox',
     type: type || 'opencode',
+    ...(cpu !== undefined && { cpu }),
+    ...(memory !== undefined && { memory }),
+    ...(idleTimeout !== undefined && { idle_timeout: idleTimeout }),
+    ...(metadata !== undefined && { metadata }),
   }
-  if (cpu !== undefined) body.cpu = cpu
-  if (memory !== undefined) body.memory = memory
-  if (idleTimeout !== undefined) body.idle_timeout = idleTimeout
-  if (metadata !== undefined) body.metadata = metadata
-  const res = await fetch(`/api/workspaces/${workspaceId}/sandboxes`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  })
-  if (!res.ok) {
-    const err = await checkQuotaError(res)
-    if (err) throw err
-    throw new Error('Failed to create sandbox')
+  try {
+    return await apiFetch<Sandbox>({
+      method: 'POST',
+      path: `/api/workspaces/${encodeURIComponent(workspaceId)}/sandboxes`,
+      body,
+    })
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 403) {
+      const errBody = err.body as Record<string, unknown> | null
+      if (errBody?.error === 'quota_exceeded') throw errBody as unknown as QuotaExceededError
+      if (errBody?.error === 'resource_budget_exceeded') throw errBody as unknown as ResourceBudgetExceededError
+    }
+    throw err
   }
-  return res.json()
 }
 
 export async function getSandbox(id: string): Promise<Sandbox> {
-  const res = await fetch(`/api/sandboxes/${id}`)
-  if (!res.ok) throw new Error('Failed to get sandbox')
-  return res.json()
+  return apiFetch<Sandbox>({
+    method: 'GET',
+    path: `/api/sandboxes/${encodeURIComponent(id)}`,
+  })
 }
 
 export async function deleteSandbox(id: string): Promise<void> {
-  const res = await fetch(`/api/sandboxes/${id}`, { method: 'DELETE' })
-  if (!res.ok) throw new Error('Failed to delete sandbox')
+  await apiFetch<void>({
+    method: 'DELETE',
+    path: `/api/sandboxes/${encodeURIComponent(id)}`,
+  })
 }
 
 export async function renameSandbox(id: string, name: string): Promise<Sandbox> {
-  const res = await fetch(`/api/sandboxes/${id}`, {
+  return apiFetch<Sandbox>({
     method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name }),
+    path: `/api/sandboxes/${encodeURIComponent(id)}`,
+    body: { name } satisfies components['schemas']['SandboxRenameRequest'],
   })
-  if (!res.ok) throw new Error('Failed to rename sandbox')
-  return res.json()
 }
 
-export async function pauseSandbox(id: string): Promise<void> {
-  const res = await fetch(`/api/sandboxes/${id}/pause`, { method: 'POST' })
-  if (!res.ok) throw new Error('Failed to pause sandbox')
+export async function pauseSandbox(id: string): Promise<components['schemas']['SandboxLifecycleStatusResponse']> {
+  return apiFetch<components['schemas']['SandboxLifecycleStatusResponse']>({
+    method: 'POST',
+    path: `/api/sandboxes/${encodeURIComponent(id)}/pause`,
+  })
 }
 
-export async function resumeSandbox(id: string): Promise<void> {
-  const res = await fetch(`/api/sandboxes/${id}/resume`, { method: 'POST' })
-  if (!res.ok) throw new Error('Failed to resume sandbox')
+export async function resumeSandbox(id: string): Promise<components['schemas']['SandboxLifecycleStatusResponse']> {
+  return apiFetch<components['schemas']['SandboxLifecycleStatusResponse']>({
+    method: 'POST',
+    path: `/api/sandboxes/${encodeURIComponent(id)}/resume`,
+  })
 }
 
 // WeChat QR Login API
@@ -638,15 +594,8 @@ export async function unbindSandboxFromChannel(sandboxId: string): Promise<void>
 
 // Usage & Traces API
 
-export interface UsageSummary {
-  provider: string
-  model: string
-  input_tokens: number
-  output_tokens: number
-  cache_creation_input_tokens: number
-  cache_read_input_tokens: number
-  request_count: number
-}
+/** @deprecated use SandboxUsageSummary (generated alias) */
+export type UsageSummary = SandboxUsageSummary
 
 export interface TraceItem {
   id: string
@@ -663,19 +612,19 @@ export interface TraceItem {
   models: string
 }
 
-export interface UsageResponse {
-  usage: UsageSummary[]
-}
+/** @deprecated use SandboxUsage (generated alias) */
+export type UsageResponse = SandboxUsage
 
 export interface TracesResponse {
   traces: TraceItem[]
   total: number
 }
 
-export async function getSandboxUsage(id: string): Promise<UsageResponse> {
-  const res = await fetch(`/api/sandboxes/${id}/usage`)
-  if (!res.ok) throw new Error('Failed to get sandbox usage')
-  return res.json()
+export async function getSandboxUsage(id: string): Promise<SandboxUsage> {
+  return apiFetch<SandboxUsage>({
+    method: 'GET',
+    path: `/api/sandboxes/${encodeURIComponent(id)}/usage`,
+  })
 }
 
 export async function getSandboxTraces(id: string, limit: number, offset: number): Promise<TracesResponse> {


### PR DESCRIPTION
## Summary

Annotates the 8 Sandboxes REST endpoints with swaggo, regenerates the OpenAPI 3.0 spec, migrates the corresponding frontend helpers. Same toolchain as PRs #152 and #153.

**Stacked on PR #153** — needs #152 + #153 merged first (or rebase after).

Reference: spec `docs/superpowers/specs/2026-05-21-openapi-organization-design.md`, plan `docs/superpowers/plans/2026-05-22-openapi-phase-1b-sandboxes.md`.

## Endpoints

- List / Create / Get / Rename / Delete sandbox
- Pause / Resume (lifecycle RPC)
- Usage stats (proxied to LLM proxy)

## What changed

- `internal/server/api_types.go` — Sandboxes section with `SandboxCreateRequest`, `SandboxRenameRequest`, `SandboxLifecycleStatusResponse`, `SandboxUsageResponse`, `SandboxUsageSummary`
- `internal/server/server.go` — `sandboxResponse` gets `@name Sandbox` override; 8 swag annotation blocks; 2 mutation handlers refactored from inline structs to named DTOs; pause/resume return typed envelope
- `docs/api/openapi.{yaml,json}` — regenerated, +5 schemas, +8 operations under tag `Sandboxes`
- `web/src/lib/api.ts` — sandbox helpers migrated to apiClient + generated types; external signatures unchanged
- `web/src/components/SandboxDetail.tsx` — null-guard fixes for optional fields in generated `server.agentInfoResponse` schema

## Divergences found

- Generated `Sandbox.status` is `string` (not the `SandboxStatus` union); kept `SandboxStatus` export for callers that compare against string literals
- `server.agentInfoResponse` and `server.imBindingResponse` have all fields optional; local `AgentInfo`/`IMBinding` previously had required fields — aliased to generated types, fixed 2 `SandboxDetail.tsx` call-sites
- Generated `SandboxUsage` adds a `since?: string | null` field not present in old `UsageResponse` — callers access `.usage[]` which is unchanged

## Verification

- `make openapi-check` green
- `go test ./internal/server/ -count=1` green
- `cd web && pnpm tsc --noEmit && pnpm build` green (✓ built in 1.76s)

## Next

IM Channels (~8 endpoints).

🤖 Generated with [Claude Code](https://claude.com/claude-code)