### PR TITLE
feat(openapi): Phase 1.b — IM Channels tag (9 endpoints)

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -403,6 +403,157 @@
         }
       }
     },
+    "/api/sandboxes/{id}/im/bind": {
+      "post": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "IM Channels"
+        ],
+        "summary": "Bind a sandbox to an IM channel",
+        "parameters": [
+          {
+            "description": "Sandbox id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IMSandboxBindRequest"
+              }
+            }
+          },
+          "description": "Channel id",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IMSandboxBindResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "sandbox or channel not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "IM Channels"
+        ],
+        "summary": "Unbind a sandbox from its IM channel",
+        "parameters": [
+          {
+            "description": "Sandbox id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IMSandboxUnbindResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "sandbox not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/sandboxes/{id}/pause": {
       "post": {
         "security": [
@@ -958,6 +1109,502 @@
           },
           "500": {
             "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workspaces/{id}/im/channels": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "IM Channels"
+        ],
+        "summary": "List IM channels in a workspace",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IMChannelListResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workspaces/{id}/im/channels/{channelId}": {
+      "delete": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "IM Channels"
+        ],
+        "summary": "Delete an IM channel",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Channel id",
+            "name": "channelId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "403": {
+            "description": "not a member",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "channel not found",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "IM Channels"
+        ],
+        "summary": "Update IM channel settings",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Channel id",
+            "name": "channelId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IMChannelPatchRequest"
+              }
+            }
+          },
+          "description": "Settings patch",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IMChannelPatchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "channel not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workspaces/{id}/im/matrix/configure": {
+      "post": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "IM Channels"
+        ],
+        "summary": "Bind a Matrix account to a workspace",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IMMatrixConfigureRequest"
+              }
+            }
+          },
+          "description": "Matrix credentials",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IMMatrixConfigureResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid credentials",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workspaces/{id}/im/telegram/configure": {
+      "post": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "IM Channels"
+        ],
+        "summary": "Bind a Telegram bot to a workspace",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IMTelegramConfigureRequest"
+              }
+            }
+          },
+          "description": "Bot token",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IMTelegramConfigureResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid bot token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workspaces/{id}/im/weixin/qr-start": {
+      "post": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "description": "Returns a QR code URL the user scans in WeChat. Client should then long-poll qr-wait until the channel is bound.",
+        "tags": [
+          "IM Channels"
+        ],
+        "summary": "Start WeChat QR-code bind for a workspace",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IMWeixinQRStartResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "upstream error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workspaces/{id}/im/weixin/qr-wait": {
+      "post": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "description": "Polls for QR scan progress. Returns status \"wait\", \"scaned\", \"confirmed\", \"expired\", or other terminal states. On \"confirmed\", bot_id is set. On \"expired\", qrcode_url contains a refreshed code.",
+        "tags": [
+          "IM Channels"
+        ],
+        "summary": "Long-poll WeChat QR-code scan for a workspace",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IMWeixinQRWaitResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "no active session",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "upstream error",
             "content": {
               "application/json": {
                 "schema": {
@@ -1805,6 +2452,228 @@
           },
           "user_id": {
             "type": "string"
+          }
+        }
+      },
+      "IMChannel": {
+        "type": "object",
+        "required": [
+          "bot_id",
+          "bound_at",
+          "id",
+          "provider",
+          "routing_mode",
+          "workspace_id"
+        ],
+        "properties": {
+          "bot_id": {
+            "type": "string"
+          },
+          "bound_at": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "provider": {
+            "type": "string",
+            "example": "weixin"
+          },
+          "require_mention": {
+            "type": "boolean"
+          },
+          "routing_mode": {
+            "type": "string",
+            "example": "codex"
+          },
+          "user_id": {
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        }
+      },
+      "IMChannelListResponse": {
+        "type": "object",
+        "required": [
+          "channels"
+        ],
+        "properties": {
+          "channels": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/IMChannel"
+            }
+          }
+        }
+      },
+      "IMChannelPatchRequest": {
+        "type": "object",
+        "properties": {
+          "require_mention": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "routing_mode": {
+            "type": "string",
+            "example": "codex",
+            "nullable": true
+          }
+        }
+      },
+      "IMChannelPatchResponse": {
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "example": "updated"
+          }
+        }
+      },
+      "IMMatrixConfigureRequest": {
+        "type": "object",
+        "required": [
+          "access_token",
+          "homeserver_url"
+        ],
+        "properties": {
+          "access_token": {
+            "type": "string"
+          },
+          "homeserver_url": {
+            "type": "string",
+            "example": "https://matrix.example.com"
+          },
+          "recovery_key": {
+            "description": "optional, for E2EE",
+            "type": "string"
+          }
+        }
+      },
+      "IMMatrixConfigureResponse": {
+        "type": "object",
+        "required": [
+          "bot_id",
+          "connected"
+        ],
+        "properties": {
+          "bot_id": {
+            "type": "string"
+          },
+          "connected": {
+            "type": "boolean"
+          }
+        }
+      },
+      "IMSandboxBindRequest": {
+        "type": "object",
+        "required": [
+          "channel_id"
+        ],
+        "properties": {
+          "channel_id": {
+            "type": "string"
+          }
+        }
+      },
+      "IMSandboxBindResponse": {
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "example": "bound"
+          }
+        }
+      },
+      "IMSandboxUnbindResponse": {
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "example": "unbound"
+          }
+        }
+      },
+      "IMTelegramConfigureRequest": {
+        "type": "object",
+        "required": [
+          "bot_token"
+        ],
+        "properties": {
+          "bot_token": {
+            "type": "string",
+            "example": "123456:ABC-DEF..."
+          }
+        }
+      },
+      "IMTelegramConfigureResponse": {
+        "type": "object",
+        "required": [
+          "bot_id",
+          "connected"
+        ],
+        "properties": {
+          "bot_id": {
+            "type": "string"
+          },
+          "connected": {
+            "type": "boolean"
+          }
+        }
+      },
+      "IMWeixinQRStartResponse": {
+        "type": "object",
+        "required": [
+          "message",
+          "qrcode_url"
+        ],
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "qrcode_url": {
+            "type": "string"
+          }
+        }
+      },
+      "IMWeixinQRWaitResponse": {
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "properties": {
+          "bot_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "connected": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string",
+            "nullable": true
+          },
+          "qrcode_url": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "example": "wait"
+          },
+          "user_id": {
+            "type": "string",
+            "nullable": true
           }
         }
       },

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -246,6 +246,96 @@ paths:
       summary: Rename a sandbox
       tags:
         - Sandboxes
+  "/api/sandboxes/{id}/im/bind":
+    delete:
+      parameters:
+        - description: Sandbox id
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IMSandboxUnbindResponse"
+        "403":
+          description: not a member
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: sandbox not found
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Unbind a sandbox from its IM channel
+      tags:
+        - IM Channels
+    post:
+      parameters:
+        - description: Sandbox id
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/IMSandboxBindRequest"
+        description: Channel id
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IMSandboxBindResponse"
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: not a member
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: sandbox or channel not found
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Bind a sandbox to an IM channel
+      tags:
+        - IM Channels
   "/api/sandboxes/{id}/pause":
     post:
       description: Initiates pause transition; returns {"status":"pausing"}. Final
@@ -565,6 +655,306 @@ paths:
       summary: Rename a workspace
       tags:
         - Workspaces
+  "/api/workspaces/{id}/im/channels":
+    get:
+      parameters:
+        - description: Workspace id
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IMChannelListResponse"
+        "403":
+          description: not a member
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: List IM channels in a workspace
+      tags:
+        - IM Channels
+  "/api/workspaces/{id}/im/channels/{channelId}":
+    delete:
+      parameters:
+        - description: Workspace id
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - description: Channel id
+          in: path
+          name: channelId
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: No Content
+        "403":
+          description: not a member
+          content:
+            "*/*":
+              schema:
+                type: string
+        "404":
+          description: channel not found
+          content:
+            "*/*":
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            "*/*":
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Delete an IM channel
+      tags:
+        - IM Channels
+    patch:
+      parameters:
+        - description: Workspace id
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - description: Channel id
+          in: path
+          name: channelId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/IMChannelPatchRequest"
+        description: Settings patch
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IMChannelPatchResponse"
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: not a member
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: channel not found
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Update IM channel settings
+      tags:
+        - IM Channels
+  "/api/workspaces/{id}/im/matrix/configure":
+    post:
+      parameters:
+        - description: Workspace id
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/IMMatrixConfigureRequest"
+        description: Matrix credentials
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IMMatrixConfigureResponse"
+        "400":
+          description: invalid credentials
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: not a member
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Bind a Matrix account to a workspace
+      tags:
+        - IM Channels
+  "/api/workspaces/{id}/im/telegram/configure":
+    post:
+      parameters:
+        - description: Workspace id
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/IMTelegramConfigureRequest"
+        description: Bot token
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IMTelegramConfigureResponse"
+        "400":
+          description: invalid bot token
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: not a member
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Bind a Telegram bot to a workspace
+      tags:
+        - IM Channels
+  "/api/workspaces/{id}/im/weixin/qr-start":
+    post:
+      description: Returns a QR code URL the user scans in WeChat. Client should then
+        long-poll qr-wait until the channel is bound.
+      parameters:
+        - description: Workspace id
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IMWeixinQRStartResponse"
+        "403":
+          description: not a member
+          content:
+            application/json:
+              schema:
+                type: string
+        "502":
+          description: upstream error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Start WeChat QR-code bind for a workspace
+      tags:
+        - IM Channels
+  "/api/workspaces/{id}/im/weixin/qr-wait":
+    post:
+      description: Polls for QR scan progress. Returns status "wait", "scaned",
+        "confirmed", "expired", or other terminal states. On "confirmed", bot_id
+        is set. On "expired", qrcode_url contains a refreshed code.
+      parameters:
+        - description: Workspace id
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/IMWeixinQRWaitResponse"
+        "400":
+          description: no active session
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: not a member
+          content:
+            application/json:
+              schema:
+                type: string
+        "502":
+          description: upstream error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Long-poll WeChat QR-code scan for a workspace
+      tags:
+        - IM Channels
   "/api/workspaces/{id}/llm-config":
     delete:
       parameters:
@@ -1110,6 +1500,158 @@ components:
         - bot_id
         - bound_at
         - provider
+      type: object
+    IMChannel:
+      properties:
+        bot_id:
+          type: string
+        bound_at:
+          type: string
+        id:
+          type: string
+        provider:
+          example: weixin
+          type: string
+        require_mention:
+          type: boolean
+        routing_mode:
+          example: codex
+          type: string
+        user_id:
+          type: string
+        workspace_id:
+          type: string
+      required:
+        - bot_id
+        - bound_at
+        - id
+        - provider
+        - routing_mode
+        - workspace_id
+      type: object
+    IMChannelListResponse:
+      properties:
+        channels:
+          items:
+            $ref: "#/components/schemas/IMChannel"
+          type: array
+      required:
+        - channels
+      type: object
+    IMChannelPatchRequest:
+      properties:
+        require_mention:
+          type: boolean
+          nullable: true
+        routing_mode:
+          example: codex
+          type: string
+          nullable: true
+      type: object
+    IMChannelPatchResponse:
+      properties:
+        status:
+          example: updated
+          type: string
+      required:
+        - status
+      type: object
+    IMMatrixConfigureRequest:
+      properties:
+        access_token:
+          type: string
+        homeserver_url:
+          example: https://matrix.example.com
+          type: string
+        recovery_key:
+          description: optional, for E2EE
+          type: string
+      required:
+        - access_token
+        - homeserver_url
+      type: object
+    IMMatrixConfigureResponse:
+      properties:
+        bot_id:
+          type: string
+        connected:
+          type: boolean
+      required:
+        - bot_id
+        - connected
+      type: object
+    IMSandboxBindRequest:
+      properties:
+        channel_id:
+          type: string
+      required:
+        - channel_id
+      type: object
+    IMSandboxBindResponse:
+      properties:
+        status:
+          example: bound
+          type: string
+      required:
+        - status
+      type: object
+    IMSandboxUnbindResponse:
+      properties:
+        status:
+          example: unbound
+          type: string
+      required:
+        - status
+      type: object
+    IMTelegramConfigureRequest:
+      properties:
+        bot_token:
+          example: 123456:ABC-DEF...
+          type: string
+      required:
+        - bot_token
+      type: object
+    IMTelegramConfigureResponse:
+      properties:
+        bot_id:
+          type: string
+        connected:
+          type: boolean
+      required:
+        - bot_id
+        - connected
+      type: object
+    IMWeixinQRStartResponse:
+      properties:
+        message:
+          type: string
+        qrcode_url:
+          type: string
+      required:
+        - message
+        - qrcode_url
+      type: object
+    IMWeixinQRWaitResponse:
+      properties:
+        bot_id:
+          type: string
+          nullable: true
+        connected:
+          type: boolean
+        message:
+          type: string
+          nullable: true
+        qrcode_url:
+          type: string
+          nullable: true
+        status:
+          example: wait
+          type: string
+        user_id:
+          type: string
+          nullable: true
+      required:
+        - status
       type: object
     LLMConfigResponse:
       properties:

--- a/docs/superpowers/plans/2026-05-22-openapi-phase-1b-im-channels.md
+++ b/docs/superpowers/plans/2026-05-22-openapi-phase-1b-im-channels.md
@@ -1,0 +1,466 @@
+# OpenAPI Phase 1.b — IM Channels tag Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development.
+
+**Goal:** Annotate 9 IM Channels REST endpoints. All endpoints currently use a single shared `imbridgeProxy` handler that reverse-proxies to a separate `imbridge` service. Per-route swag annotations require per-route wrappers, so introduce thin wrappers in a new file.
+
+**Architecture:** Same swaggo pipeline. New file `internal/server/im_routes.go` holds wrappers like `handleIMChannelList(w, r) { s.imbridgeProxy(w, r) }`. Each wrapper has its own annotation block. Router (`server.go`) is updated to point at the wrappers.
+
+**Prereq:** Stacked on `feat/openapi-phase-1b-sandboxes` (PR #154).
+
+---
+
+## Endpoints (9)
+
+| Method | Path | Wrapper handler (new) | Auth |
+|---|---|---|---|
+| GET | `/api/workspaces/{id}/im/channels` | `handleIMChannelList` | cookie + member |
+| PATCH | `/api/workspaces/{id}/im/channels/{channelId}` | `handleIMChannelPatch` | cookie + member |
+| DELETE | `/api/workspaces/{id}/im/channels/{channelId}` | `handleIMChannelDelete` | cookie + member |
+| POST | `/api/workspaces/{id}/im/weixin/qr-start` | `handleIMWeixinQRStart` | cookie + member |
+| POST | `/api/workspaces/{id}/im/weixin/qr-wait` | `handleIMWeixinQRWait` | cookie + member |
+| POST | `/api/workspaces/{id}/im/telegram/configure` | `handleIMTelegramConfigure` | cookie + member |
+| POST | `/api/workspaces/{id}/im/matrix/configure` | `handleIMMatrixConfigure` | cookie + member |
+| POST | `/api/sandboxes/{id}/im/bind` | `handleIMSandboxBind` | cookie + member |
+| DELETE | `/api/sandboxes/{id}/im/bind` | `handleIMSandboxUnbind` | cookie + member |
+
+All routes are registered only when `s.IMBridgeURL != ""`.
+
+---
+
+## File Structure
+
+**Create:** `internal/server/im_routes.go` — 9 wrapper handlers with swag annotation blocks
+**Modify:** `internal/server/api_types.go` — append IM Channels DTOs
+**Modify:** `internal/server/server.go` — switch router from `s.imbridgeProxy` direct registration to the new wrappers
+**Modify:** `docs/api/openapi.{yaml,json}` (regenerated)
+**Modify:** `web/src/lib/api.ts` — migrate IM helpers if any exist
+
+---
+
+### Task 1: IM Channels DTOs in api_types.go
+
+**Files:** modify `internal/server/api_types.go`
+
+- [ ] **Step 1: Verify which shapes are actually in use**
+
+Read the imbridge handlers (`internal/imbridgesvc/handlers.go` and friends) to confirm exact request/response shapes. The shapes proxy-through, so getting them wrong means lying in the spec. Search:
+
+```bash
+grep -nE "json\\.NewEncoder|json\\.NewDecoder|http\\.Error" /root/agentserver/internal/imbridgesvc/*.go | head -40
+```
+
+For each endpoint listed in the plan, identify:
+- Request body fields (if any) and types
+- Success response body fields and types
+- Status code on success
+
+Cross-check by reading what the frontend (`web/src/lib/api.ts`) currently expects:
+
+```bash
+grep -nE "im/channels|im/weixin|im/telegram|im/matrix|sandboxes/.*im" /root/agentserver/web/src/lib/api.ts
+```
+
+- [ ] **Step 2: Append to api_types.go**
+
+After the existing `// --- Sandboxes ---` block, add:
+
+```go
+// --- IM Channels ---
+
+// IMChannelResponse mirrors workspace_im_channels rows surfaced via the
+// imbridge service. Fields not all required — bot_token is masked or
+// omitted by the server side.
+type IMChannelResponse struct {
+	ID             string `json:"id" validate:"required"`
+	WorkspaceID    string `json:"workspace_id" validate:"required"`
+	Provider       string `json:"provider" validate:"required" example:"weixin"`
+	BotID          string `json:"bot_id" validate:"required"`
+	UserID         string `json:"user_id" validate:"required"`
+	RequireMention bool   `json:"require_mention"`
+	RoutingMode    string `json:"routing_mode" validate:"required" example:"codex"`
+	BoundAt        string `json:"bound_at" validate:"required"`
+} // @name IMChannel
+
+// IMChannelListResponse is the {"channels": [...]} envelope.
+type IMChannelListResponse struct {
+	Channels []IMChannelResponse `json:"channels" validate:"required"`
+} // @name IMChannelListResponse
+
+// IMChannelPatchRequest is the body for PATCH /api/workspaces/{id}/im/channels/{channelId}.
+// Both fields optional — only the supplied keys are applied.
+type IMChannelPatchRequest struct {
+	RequireMention *bool   `json:"require_mention" extensions:"x-nullable=true"`
+	RoutingMode    *string `json:"routing_mode" extensions:"x-nullable=true" example:"codex"`
+} // @name IMChannelPatchRequest
+
+// IMWeixinQRStartResponse is returned by POST .../im/weixin/qr-start.
+type IMWeixinQRStartResponse struct {
+	QRCodeURL string `json:"qrcode_url" validate:"required"`
+	Message   string `json:"message"`
+} // @name IMWeixinQRStartResponse
+
+// IMWeixinQRWaitResponse is returned once the QR code is scanned and the
+// poller binds the channel.
+type IMWeixinQRWaitResponse struct {
+	ChannelID string `json:"channel_id" validate:"required"`
+	BotID     string `json:"bot_id" validate:"required"`
+} // @name IMWeixinQRWaitResponse
+
+// IMTelegramConfigureRequest is the body for POST .../im/telegram/configure.
+type IMTelegramConfigureRequest struct {
+	BotToken string `json:"bot_token" validate:"required" example:"123456:ABC-DEF..."`
+} // @name IMTelegramConfigureRequest
+
+// IMTelegramConfigureResponse is the body returned by the configure endpoint.
+type IMTelegramConfigureResponse struct {
+	Connected bool   `json:"connected" validate:"required"`
+	BotID     string `json:"bot_id" validate:"required"`
+} // @name IMTelegramConfigureResponse
+
+// IMMatrixConfigureRequest is the body for POST .../im/matrix/configure.
+type IMMatrixConfigureRequest struct {
+	HomeserverURL string `json:"homeserver_url" validate:"required" example:"https://matrix.example.com"`
+	AccessToken   string `json:"access_token" validate:"required"`
+	RecoveryKey   string `json:"recovery_key"` // optional, for E2EE
+} // @name IMMatrixConfigureRequest
+
+// IMMatrixConfigureResponse is the body returned by the matrix configure endpoint.
+type IMMatrixConfigureResponse struct {
+	Connected bool   `json:"connected" validate:"required"`
+	BotID     string `json:"bot_id" validate:"required"`
+} // @name IMMatrixConfigureResponse
+
+// IMSandboxBindRequest is the body for POST /api/sandboxes/{id}/im/bind.
+type IMSandboxBindRequest struct {
+	ChannelID string `json:"channel_id" validate:"required"`
+} // @name IMSandboxBindRequest
+```
+
+ADJUST field sets after Step 1's recon — these are best-effort guesses based on the Explore agent's report.
+
+- [ ] **Step 3: Build + commit**
+
+```bash
+cd /root/agentserver
+go build ./...
+git add internal/server/api_types.go
+git commit -m "feat(openapi): IM Channels DTOs in api_types.go"
+```
+
+---
+
+### Task 2: Create the wrapper handlers + rewire router
+
+**Files:**
+- Create: `internal/server/im_routes.go`
+- Modify: `internal/server/server.go` (router section + maybe drop direct `s.imbridgeProxy` registrations)
+
+- [ ] **Step 1: Recon current router registrations**
+
+```bash
+grep -n "imbridgeProxy\|/im/" /root/agentserver/internal/server/server.go | head -20
+```
+
+Identify the exact lines where `s.imbridgeProxy` is registered as the handler for each IM route. List them.
+
+- [ ] **Step 2: Create `internal/server/im_routes.go`**
+
+```go
+package server
+
+import "net/http"
+
+// This file holds thin per-route wrappers around s.imbridgeProxy so each
+// wrapper can carry its own swag annotation block. The wrappers are wired
+// up in server.go's router section when s.IMBridgeURL != "".
+//
+// The actual request handling all happens upstream in the imbridge service
+// (see internal/imbridgesvc/); these wrappers exist only for OpenAPI
+// documentation. Do NOT add per-route logic here — push it upstream.
+
+// handleIMChannelList lists IM channels bound to a workspace.
+//
+//	@Summary   List IM channels in a workspace
+//	@Tags      IM Channels
+//	@Produce   json
+//	@Param     id  path  string  true  "Workspace id"
+//	@Success   200  {object}  IMChannelListResponse
+//	@Failure   403  {string}  string  "not a member"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{id}/im/channels [get]
+func (s *Server) handleIMChannelList(w http.ResponseWriter, r *http.Request) {
+	s.imbridgeProxy(w, r)
+}
+
+// handleIMChannelPatch updates channel settings.
+//
+//	@Summary   Update IM channel settings
+//	@Tags      IM Channels
+//	@Accept    json
+//	@Param     id          path  string                 true  "Workspace id"
+//	@Param     channelId   path  string                 true  "Channel id"
+//	@Param     body        body  IMChannelPatchRequest  true  "Settings patch"
+//	@Success   204
+//	@Failure   400  {string}  string  "bad request"
+//	@Failure   403  {string}  string  "not a member"
+//	@Failure   404  {string}  string  "channel not found"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{id}/im/channels/{channelId} [patch]
+func (s *Server) handleIMChannelPatch(w http.ResponseWriter, r *http.Request) {
+	s.imbridgeProxy(w, r)
+}
+
+// handleIMChannelDelete removes a channel binding.
+//
+//	@Summary   Delete an IM channel
+//	@Tags      IM Channels
+//	@Param     id         path  string  true  "Workspace id"
+//	@Param     channelId  path  string  true  "Channel id"
+//	@Success   204
+//	@Failure   403  {string}  string  "not a member"
+//	@Failure   404  {string}  string  "channel not found"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{id}/im/channels/{channelId} [delete]
+func (s *Server) handleIMChannelDelete(w http.ResponseWriter, r *http.Request) {
+	s.imbridgeProxy(w, r)
+}
+
+// handleIMWeixinQRStart starts the WeChat/Weixin QR-code login flow.
+//
+//	@Summary     Start WeChat QR-code bind
+//	@Description Returns a QR code URL the user scans in WeChat. Client should then long-poll qr-wait until a channel is bound.
+//	@Tags        IM Channels
+//	@Produce     json
+//	@Param       id  path  string  true  "Workspace id"
+//	@Success     200  {object}  IMWeixinQRStartResponse
+//	@Failure     403  {string}  string  "not a member"
+//	@Failure     500  {string}  string  "internal error"
+//	@Security    CookieAuth
+//	@Router      /api/workspaces/{id}/im/weixin/qr-start [post]
+func (s *Server) handleIMWeixinQRStart(w http.ResponseWriter, r *http.Request) {
+	s.imbridgeProxy(w, r)
+}
+
+// handleIMWeixinQRWait long-polls for QR-code scan completion.
+//
+//	@Summary     Long-poll WeChat QR-code scan
+//	@Description Blocks until the user scans the QR code or the poll expires. On success returns the bound channel id.
+//	@Tags        IM Channels
+//	@Produce     json
+//	@Param       id  path  string  true  "Workspace id"
+//	@Success     200  {object}  IMWeixinQRWaitResponse
+//	@Failure     400  {string}  string  "poll expired / timeout"
+//	@Failure     403  {string}  string  "not a member"
+//	@Failure     500  {string}  string  "internal error"
+//	@Security    CookieAuth
+//	@Router      /api/workspaces/{id}/im/weixin/qr-wait [post]
+func (s *Server) handleIMWeixinQRWait(w http.ResponseWriter, r *http.Request) {
+	s.imbridgeProxy(w, r)
+}
+
+// handleIMTelegramConfigure validates a Telegram bot token and binds a channel.
+//
+//	@Summary     Bind a Telegram bot
+//	@Tags        IM Channels
+//	@Accept      json
+//	@Produce     json
+//	@Param       id    path  string                      true  "Workspace id"
+//	@Param       body  body  IMTelegramConfigureRequest  true  "Bot token"
+//	@Success     200   {object}  IMTelegramConfigureResponse
+//	@Failure     400   {string}  string  "invalid bot token"
+//	@Failure     403   {string}  string  "not a member"
+//	@Failure     500   {string}  string  "internal error"
+//	@Security    CookieAuth
+//	@Router      /api/workspaces/{id}/im/telegram/configure [post]
+func (s *Server) handleIMTelegramConfigure(w http.ResponseWriter, r *http.Request) {
+	s.imbridgeProxy(w, r)
+}
+
+// handleIMMatrixConfigure validates Matrix credentials and binds a channel.
+//
+//	@Summary     Bind a Matrix account
+//	@Tags        IM Channels
+//	@Accept      json
+//	@Produce     json
+//	@Param       id    path  string                    true  "Workspace id"
+//	@Param       body  body  IMMatrixConfigureRequest  true  "Matrix credentials"
+//	@Success     200   {object}  IMMatrixConfigureResponse
+//	@Failure     400   {string}  string  "invalid credentials"
+//	@Failure     403   {string}  string  "not a member"
+//	@Failure     500   {string}  string  "internal error"
+//	@Security    CookieAuth
+//	@Router      /api/workspaces/{id}/im/matrix/configure [post]
+func (s *Server) handleIMMatrixConfigure(w http.ResponseWriter, r *http.Request) {
+	s.imbridgeProxy(w, r)
+}
+
+// handleIMSandboxBind binds a sandbox to an IM channel.
+//
+//	@Summary     Bind a sandbox to an IM channel
+//	@Tags        IM Channels
+//	@Accept      json
+//	@Param       id    path  string                true  "Sandbox id"
+//	@Param       body  body  IMSandboxBindRequest  true  "Channel id"
+//	@Success     204
+//	@Failure     400  {string}  string  "bad request"
+//	@Failure     403  {string}  string  "not a member"
+//	@Failure     404  {string}  string  "sandbox not found"
+//	@Failure     500  {string}  string  "internal error"
+//	@Security    CookieAuth
+//	@Router      /api/sandboxes/{id}/im/bind [post]
+func (s *Server) handleIMSandboxBind(w http.ResponseWriter, r *http.Request) {
+	s.imbridgeProxy(w, r)
+}
+
+// handleIMSandboxUnbind removes a sandbox's IM channel binding.
+//
+//	@Summary     Unbind a sandbox from its IM channel
+//	@Tags        IM Channels
+//	@Param       id  path  string  true  "Sandbox id"
+//	@Success     204
+//	@Failure     403  {string}  string  "not a member"
+//	@Failure     404  {string}  string  "sandbox not found"
+//	@Failure     500  {string}  string  "internal error"
+//	@Security    CookieAuth
+//	@Router      /api/sandboxes/{id}/im/bind [delete]
+func (s *Server) handleIMSandboxUnbind(w http.ResponseWriter, r *http.Request) {
+	s.imbridgeProxy(w, r)
+}
+```
+
+- [ ] **Step 3: Update router in `internal/server/server.go`**
+
+Find the block (in the IM section guarded by `if s.IMBridgeURL != ""`) where each route is currently `r.<METHOD>(<path>, s.imbridgeProxy)`. Change each to use the new wrapper:
+
+```go
+r.Get("/api/workspaces/{id}/im/channels", s.handleIMChannelList)
+r.Patch("/api/workspaces/{id}/im/channels/{channelId}", s.handleIMChannelPatch)
+r.Delete("/api/workspaces/{id}/im/channels/{channelId}", s.handleIMChannelDelete)
+r.Post("/api/workspaces/{id}/im/weixin/qr-start", s.handleIMWeixinQRStart)
+r.Post("/api/workspaces/{id}/im/weixin/qr-wait", s.handleIMWeixinQRWait)
+r.Post("/api/workspaces/{id}/im/telegram/configure", s.handleIMTelegramConfigure)
+r.Post("/api/workspaces/{id}/im/matrix/configure", s.handleIMMatrixConfigure)
+r.Post("/api/sandboxes/{id}/im/bind", s.handleIMSandboxBind)
+r.Delete("/api/sandboxes/{id}/im/bind", s.handleIMSandboxUnbind)
+```
+
+Adjust method names (`r.Get`/`r.Patch`/etc.) to match chi's idioms in the file. Verify routes by reading the existing block first.
+
+If any IM route uses a wildcard/regex (`r.HandleFunc` etc.), keep the wildcard pattern but point at the new wrapper.
+
+- [ ] **Step 4: Build + tests + regenerate spec**
+
+```bash
+cd /root/agentserver
+go build ./...
+go test ./internal/server/ -count=1 -timeout 120s
+make openapi
+make openapi-check
+```
+
+Verify the new schemas + paths landed:
+
+```bash
+grep -E "^  /api/(workspaces/\{id\}/im|sandboxes/\{id\}/im)" docs/api/openapi.yaml | sort -u
+grep -E "^    (IMChannel|IMChannelList|IMChannelPatchRequest|IMWeixinQRStartResponse|IMWeixinQRWaitResponse|IMTelegramConfigure|IMMatrixConfigure|IMSandboxBindRequest):" docs/api/openapi.yaml | sort
+grep "server\\." docs/api/openapi.yaml | grep -v "^.*Public REST API for agentserver"  # should be empty
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/server/im_routes.go internal/server/server.go docs/api/openapi.yaml docs/api/openapi.json
+git commit -m "feat(openapi): annotate IM Channels handlers (9 endpoints via wrappers)"
+```
+
+---
+
+### Task 3: Migrate IM helpers in `web/src/lib/api.ts`
+
+**Files:** modify `web/src/lib/api.ts`
+
+- [ ] **Step 1: Regenerate types + find helpers**
+
+```bash
+cd /root/agentserver/web
+pnpm openapi:gen
+grep -nE "export async function .*(IMChannel|Weixin|Telegram|Matrix|bind.*[Ss]andbox|unbind.*[Ss]andbox|listIM|im/channels|im/weixin)" /root/agentserver/web/src/lib/api.ts
+```
+
+Some helpers may have non-obvious names — also check:
+
+```bash
+grep -nE "/api/workspaces/.*/(im|members)|api/sandboxes/.*/im" /root/agentserver/web/src/lib/api.ts
+```
+
+- [ ] **Step 2: Migrate present helpers**
+
+For each helper, rewrite the body to use `apiFetch` + the corresponding generated type. Keep signatures stable.
+
+Add type aliases:
+
+```typescript
+export type IMChannel = components['schemas']['IMChannel']
+export type IMChannelListResponse = components['schemas']['IMChannelListResponse']
+export type IMChannelPatchRequest = components['schemas']['IMChannelPatchRequest']
+// ... etc
+```
+
+Drop duplicate local types.
+
+- [ ] **Step 3: Verify**
+
+```bash
+cd /root/agentserver/web
+pnpm tsc --noEmit
+pnpm lint
+pnpm build
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /root/agentserver
+git checkout -- web/dist/ 2>/dev/null || true
+git add web/src/lib/api.ts
+git commit -m "refactor(web): migrate IM Channels helpers to apiClient + generated types"
+```
+
+---
+
+### Task 4: Final verify + PR
+
+- [ ] **Step 1: Gauntlet**
+
+```bash
+make openapi-check
+go test ./internal/server/ -count=1 -timeout 120s
+cd web && pnpm openapi:gen && pnpm build && cd ..
+git checkout -- web/dist/ 2>/dev/null || true
+git status --short
+```
+
+- [ ] **Step 2: Push + open PR (stacked on #154)**
+
+```bash
+git push -u github feat/openapi-phase-1b-im-channels
+gh pr create --base main --title "feat(openapi): Phase 1.b — IM Channels tag (9 endpoints)" --body "..."
+```
+
+PR body should explain:
+- Wrapper-pattern (per-route wrappers around shared `imbridgeProxy`) was introduced specifically for swag annotation; wrappers carry no logic
+- Stacked on PR #154
+
+---
+
+## Done when
+
+- 9 endpoints under tag `IM Channels` in `docs/api/openapi.yaml`
+- All 9 wrappers in `internal/server/im_routes.go` annotated
+- Router updated to use wrappers
+- Frontend builds; existing IM UI works
+- PR open against main

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -172,3 +172,99 @@ type SandboxUsageResponse struct {
 	Usage []SandboxUsageSummary `json:"usage" validate:"required"`
 	Since *string               `json:"since,omitempty" extensions:"x-nullable=true" example:"2026-01-01T00:00:00Z"`
 } // @name SandboxUsage
+
+// --- IM Channels ---
+
+// IMChannelResponse mirrors workspace_im_channels rows returned by
+// GET /api/workspaces/{id}/im/channels via the imbridge service.
+// user_id is omitted when not set (weixin sets it; telegram/matrix do not).
+type IMChannelResponse struct {
+	ID             string `json:"id" validate:"required"`
+	WorkspaceID    string `json:"workspace_id" validate:"required"`
+	Provider       string `json:"provider" validate:"required" example:"weixin"`
+	BotID          string `json:"bot_id" validate:"required"`
+	UserID         string `json:"user_id,omitempty"`
+	RequireMention bool   `json:"require_mention"`
+	RoutingMode    string `json:"routing_mode" validate:"required" example:"codex"`
+	BoundAt        string `json:"bound_at" validate:"required"`
+} // @name IMChannel
+
+// IMChannelListResponse is the {"channels": [...]} envelope returned by
+// GET /api/workspaces/{id}/im/channels.
+type IMChannelListResponse struct {
+	Channels []IMChannelResponse `json:"channels" validate:"required"`
+} // @name IMChannelListResponse
+
+// IMChannelPatchRequest is the body for PATCH /api/workspaces/{id}/im/channels/{channelId}.
+// Both fields are optional — only the supplied keys are applied.
+// routing_mode must be "nanoclaw" or "codex".
+type IMChannelPatchRequest struct {
+	RequireMention *bool   `json:"require_mention" extensions:"x-nullable=true"`
+	RoutingMode    *string `json:"routing_mode" extensions:"x-nullable=true" example:"codex"`
+} // @name IMChannelPatchRequest
+
+// IMChannelPatchResponse is the body returned on success by
+// PATCH /api/workspaces/{id}/im/channels/{channelId}.
+type IMChannelPatchResponse struct {
+	Status string `json:"status" validate:"required" example:"updated"`
+} // @name IMChannelPatchResponse
+
+// IMWeixinQRStartResponse is returned by POST .../im/weixin/qr-start.
+type IMWeixinQRStartResponse struct {
+	QRCodeURL string `json:"qrcode_url" validate:"required"`
+	Message   string `json:"message" validate:"required"`
+} // @name IMWeixinQRStartResponse
+
+// IMWeixinQRWaitResponse is the polymorphic response from POST .../im/weixin/qr-wait.
+// status values: "wait", "scaned", "confirmed", "expired", "binded_redirect",
+// "verify_code_blocked", "need_verifycode".
+// qrcode_url is only present when status is "expired" (new QR code generated).
+// bot_id and user_id are only present when status is "confirmed".
+type IMWeixinQRWaitResponse struct {
+	Connected  bool    `json:"connected"`
+	Status     string  `json:"status" validate:"required" example:"wait"`
+	Message    *string `json:"message,omitempty" extensions:"x-nullable=true"`
+	QRCodeURL  *string `json:"qrcode_url,omitempty" extensions:"x-nullable=true"`
+	BotID      *string `json:"bot_id,omitempty" extensions:"x-nullable=true"`
+	UserID     *string `json:"user_id,omitempty" extensions:"x-nullable=true"`
+} // @name IMWeixinQRWaitResponse
+
+// IMTelegramConfigureRequest is the body for POST .../im/telegram/configure.
+type IMTelegramConfigureRequest struct {
+	BotToken string `json:"bot_token" validate:"required" example:"123456:ABC-DEF..."`
+} // @name IMTelegramConfigureRequest
+
+// IMTelegramConfigureResponse is returned by POST .../im/telegram/configure.
+type IMTelegramConfigureResponse struct {
+	Connected bool   `json:"connected" validate:"required"`
+	BotID     string `json:"bot_id" validate:"required"`
+} // @name IMTelegramConfigureResponse
+
+// IMMatrixConfigureRequest is the body for POST .../im/matrix/configure.
+// recovery_key is optional and only used to enable E2EE.
+type IMMatrixConfigureRequest struct {
+	HomeserverURL string `json:"homeserver_url" validate:"required" example:"https://matrix.example.com"`
+	AccessToken   string `json:"access_token" validate:"required"`
+	RecoveryKey   string `json:"recovery_key"` // optional, for E2EE
+} // @name IMMatrixConfigureRequest
+
+// IMMatrixConfigureResponse is returned by POST .../im/matrix/configure.
+type IMMatrixConfigureResponse struct {
+	Connected bool   `json:"connected" validate:"required"`
+	BotID     string `json:"bot_id" validate:"required"`
+} // @name IMMatrixConfigureResponse
+
+// IMSandboxBindRequest is the body for POST /api/sandboxes/{id}/im/bind.
+type IMSandboxBindRequest struct {
+	ChannelID string `json:"channel_id" validate:"required"`
+} // @name IMSandboxBindRequest
+
+// IMSandboxBindResponse is returned on success by POST /api/sandboxes/{id}/im/bind.
+type IMSandboxBindResponse struct {
+	Status string `json:"status" validate:"required" example:"bound"`
+} // @name IMSandboxBindResponse
+
+// IMSandboxUnbindResponse is returned on success by DELETE /api/sandboxes/{id}/im/bind.
+type IMSandboxUnbindResponse struct {
+	Status string `json:"status" validate:"required" example:"unbound"`
+} // @name IMSandboxUnbindResponse

--- a/internal/server/im_routes.go
+++ b/internal/server/im_routes.go
@@ -1,0 +1,166 @@
+package server
+
+import "net/http"
+
+// This file holds thin per-route wrappers around s.imBridgeProxy so each
+// wrapper can carry its own swag annotation block. The wrappers are wired
+// up in server.go's router section when s.IMBridgeURL != "".
+//
+// The actual request handling all happens upstream in the imbridge service
+// (see internal/imbridgesvc/); these wrappers exist only for OpenAPI
+// documentation. Do NOT add per-route logic here — push it upstream.
+
+// handleIMChannelList lists IM channels bound to a workspace.
+//
+//	@Summary   List IM channels in a workspace
+//	@Tags      IM Channels
+//	@Produce   json
+//	@Param     id  path  string  true  "Workspace id"
+//	@Success   200  {object}  IMChannelListResponse
+//	@Failure   403  {string}  string  "not a member"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{id}/im/channels [get]
+func (s *Server) handleIMChannelList(w http.ResponseWriter, r *http.Request) {
+	s.imBridgeProxy(w, r)
+}
+
+// handleIMChannelPatch updates channel settings (require_mention and/or routing_mode).
+//
+//	@Summary   Update IM channel settings
+//	@Tags      IM Channels
+//	@Accept    json
+//	@Produce   json
+//	@Param     id         path  string                 true  "Workspace id"
+//	@Param     channelId  path  string                 true  "Channel id"
+//	@Param     body       body  IMChannelPatchRequest  true  "Settings patch"
+//	@Success   200  {object}  IMChannelPatchResponse
+//	@Failure   400  {string}  string  "bad request"
+//	@Failure   403  {string}  string  "not a member"
+//	@Failure   404  {string}  string  "channel not found"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{id}/im/channels/{channelId} [patch]
+func (s *Server) handleIMChannelPatch(w http.ResponseWriter, r *http.Request) {
+	s.imBridgeProxy(w, r)
+}
+
+// handleIMChannelDelete removes a channel binding and stops the associated poller.
+//
+//	@Summary   Delete an IM channel
+//	@Tags      IM Channels
+//	@Param     id         path  string  true  "Workspace id"
+//	@Param     channelId  path  string  true  "Channel id"
+//	@Success   204
+//	@Failure   403  {string}  string  "not a member"
+//	@Failure   404  {string}  string  "channel not found"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{id}/im/channels/{channelId} [delete]
+func (s *Server) handleIMChannelDelete(w http.ResponseWriter, r *http.Request) {
+	s.imBridgeProxy(w, r)
+}
+
+// handleIMWeixinQRStart starts the WeChat/Weixin QR-code login flow for a workspace.
+//
+//	@Summary     Start WeChat QR-code bind for a workspace
+//	@Description Returns a QR code URL the user scans in WeChat. Client should then long-poll qr-wait until the channel is bound.
+//	@Tags        IM Channels
+//	@Produce     json
+//	@Param       id  path  string  true  "Workspace id"
+//	@Success     200  {object}  IMWeixinQRStartResponse
+//	@Failure     403  {string}  string  "not a member"
+//	@Failure     502  {string}  string  "upstream error"
+//	@Security    CookieAuth
+//	@Router      /api/workspaces/{id}/im/weixin/qr-start [post]
+func (s *Server) handleIMWeixinQRStart(w http.ResponseWriter, r *http.Request) {
+	s.imBridgeProxy(w, r)
+}
+
+// handleIMWeixinQRWait long-polls for WeChat QR-code scan completion for a workspace.
+//
+//	@Summary     Long-poll WeChat QR-code scan for a workspace
+//	@Description Polls for QR scan progress. Returns status "wait", "scaned", "confirmed", "expired", or other terminal states. On "confirmed", bot_id is set. On "expired", qrcode_url contains a refreshed code.
+//	@Tags        IM Channels
+//	@Produce     json
+//	@Param       id  path  string  true  "Workspace id"
+//	@Success     200  {object}  IMWeixinQRWaitResponse
+//	@Failure     400  {string}  string  "no active session"
+//	@Failure     403  {string}  string  "not a member"
+//	@Failure     502  {string}  string  "upstream error"
+//	@Security    CookieAuth
+//	@Router      /api/workspaces/{id}/im/weixin/qr-wait [post]
+func (s *Server) handleIMWeixinQRWait(w http.ResponseWriter, r *http.Request) {
+	s.imBridgeProxy(w, r)
+}
+
+// handleIMTelegramConfigure validates a Telegram bot token and binds a channel to the workspace.
+//
+//	@Summary     Bind a Telegram bot to a workspace
+//	@Tags        IM Channels
+//	@Accept      json
+//	@Produce     json
+//	@Param       id    path  string                      true  "Workspace id"
+//	@Param       body  body  IMTelegramConfigureRequest  true  "Bot token"
+//	@Success     200   {object}  IMTelegramConfigureResponse
+//	@Failure     400   {string}  string  "invalid bot token"
+//	@Failure     403   {string}  string  "not a member"
+//	@Failure     500   {string}  string  "internal error"
+//	@Security    CookieAuth
+//	@Router      /api/workspaces/{id}/im/telegram/configure [post]
+func (s *Server) handleIMTelegramConfigure(w http.ResponseWriter, r *http.Request) {
+	s.imBridgeProxy(w, r)
+}
+
+// handleIMMatrixConfigure validates Matrix credentials and binds a channel to the workspace.
+//
+//	@Summary     Bind a Matrix account to a workspace
+//	@Tags        IM Channels
+//	@Accept      json
+//	@Produce     json
+//	@Param       id    path  string                    true  "Workspace id"
+//	@Param       body  body  IMMatrixConfigureRequest  true  "Matrix credentials"
+//	@Success     200   {object}  IMMatrixConfigureResponse
+//	@Failure     400   {string}  string  "invalid credentials"
+//	@Failure     403   {string}  string  "not a member"
+//	@Failure     500   {string}  string  "internal error"
+//	@Security    CookieAuth
+//	@Router      /api/workspaces/{id}/im/matrix/configure [post]
+func (s *Server) handleIMMatrixConfigure(w http.ResponseWriter, r *http.Request) {
+	s.imBridgeProxy(w, r)
+}
+
+// handleIMSandboxBind binds a sandbox to an existing workspace IM channel.
+//
+//	@Summary     Bind a sandbox to an IM channel
+//	@Tags        IM Channels
+//	@Accept      json
+//	@Produce     json
+//	@Param       id    path  string                true  "Sandbox id"
+//	@Param       body  body  IMSandboxBindRequest  true  "Channel id"
+//	@Success     200   {object}  IMSandboxBindResponse
+//	@Failure     400   {string}  string  "bad request"
+//	@Failure     403   {string}  string  "not a member"
+//	@Failure     404   {string}  string  "sandbox or channel not found"
+//	@Failure     500   {string}  string  "internal error"
+//	@Security    CookieAuth
+//	@Router      /api/sandboxes/{id}/im/bind [post]
+func (s *Server) handleIMSandboxBind(w http.ResponseWriter, r *http.Request) {
+	s.imBridgeProxy(w, r)
+}
+
+// handleIMSandboxUnbind removes a sandbox's IM channel binding.
+//
+//	@Summary     Unbind a sandbox from its IM channel
+//	@Tags        IM Channels
+//	@Produce     json
+//	@Param       id  path  string  true  "Sandbox id"
+//	@Success     200  {object}  IMSandboxUnbindResponse
+//	@Failure     403  {string}  string  "not a member"
+//	@Failure     404  {string}  string  "sandbox not found"
+//	@Failure     500  {string}  string  "internal error"
+//	@Security    CookieAuth
+//	@Router      /api/sandboxes/{id}/im/bind [delete]
+func (s *Server) handleIMSandboxUnbind(w http.ResponseWriter, r *http.Request) {
+	s.imBridgeProxy(w, r)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -99,6 +99,10 @@ type Server struct {
 	// codexHandler is set by Router() when CODEX_APP_GATEWAY_URL is
 	// configured. Kept here so Close() can stop its dispatcher.
 	codexHandler *codexInboundHandler
+
+	// imBridgeProxy is set by Router() when IMBridgeURL is non-empty.
+	// Stored here so per-route wrapper methods (im_routes.go) can call it.
+	imBridgeProxy http.HandlerFunc
 }
 
 func New(a *auth.Auth, oidcMgr *auth.OIDCManager, database *db.DB, sandboxStore *sbxstore.Store, processManager process.Manager, driveManager storage.DriveManager, nsMgr *namespace.Manager, tunnelReg *tunnel.Registry, staticFS fs.FS, passwordAuthEnabled bool) *Server {
@@ -284,10 +288,10 @@ func (s *Server) Router() http.Handler {
 
 	// IM bridge routes: proxy to standalone imbridge service when configured.
 	if s.IMBridgeURL != "" {
-		imbridgeProxy := newReverseProxy(s.IMBridgeURL)
+		s.imBridgeProxy = newReverseProxy(s.IMBridgeURL)
 		// Internal API for NanoClaw pods to send IM replies (auth via bridge secret).
-		r.Post("/api/internal/nanoclaw/{id}/im/send", imbridgeProxy)
-		r.Post("/api/internal/nanoclaw/{id}/weixin/send", imbridgeProxy) // legacy alias
+		r.Post("/api/internal/nanoclaw/{id}/im/send", s.imBridgeProxy)
+		r.Post("/api/internal/nanoclaw/{id}/weixin/send", s.imBridgeProxy) // legacy alias
 	}
 
 	// Codex routing path: WeChat (and other channels) with routing_mode="codex"
@@ -477,28 +481,27 @@ func (s *Server) Router() http.Handler {
 
 		// IM routes: proxy to standalone imbridge service.
 		if s.IMBridgeURL != "" {
-			imbridgeProxy := newReverseProxy(s.IMBridgeURL)
-			// Workspace IM channel management
-			r.Get("/api/workspaces/{id}/im/channels", imbridgeProxy)
-			r.Delete("/api/workspaces/{id}/im/channels/{channelId}", imbridgeProxy)
-			r.Patch("/api/workspaces/{id}/im/channels/{channelId}", imbridgeProxy)
-			r.Post("/api/workspaces/{id}/im/weixin/qr-start", imbridgeProxy)
-			r.Post("/api/workspaces/{id}/im/weixin/qr-wait", imbridgeProxy)
-			r.Post("/api/workspaces/{id}/im/telegram/configure", imbridgeProxy)
-			r.Post("/api/workspaces/{id}/im/matrix/configure", imbridgeProxy)
-			// Sandbox IM channel binding
-			r.Post("/api/sandboxes/{id}/im/bind", imbridgeProxy)
-			r.Delete("/api/sandboxes/{id}/im/bind", imbridgeProxy)
-			// Legacy sandbox-level IM routes
-			r.Post("/api/sandboxes/{id}/im/weixin/qr-start", imbridgeProxy)
-			r.Post("/api/sandboxes/{id}/im/weixin/qr-wait", imbridgeProxy)
-			r.Post("/api/sandboxes/{id}/im/telegram/configure", imbridgeProxy)
-			r.Delete("/api/sandboxes/{id}/im/telegram", imbridgeProxy)
-			r.Post("/api/sandboxes/{id}/im/matrix/configure", imbridgeProxy)
-			r.Delete("/api/sandboxes/{id}/im/matrix", imbridgeProxy)
-			r.Get("/api/sandboxes/{id}/im/bindings", imbridgeProxy)
-			r.Post("/api/sandboxes/{id}/weixin/qr-start", imbridgeProxy)
-			r.Post("/api/sandboxes/{id}/weixin/qr-wait", imbridgeProxy)
+			// Workspace IM channel management (annotated wrappers in im_routes.go).
+			r.Get("/api/workspaces/{id}/im/channels", s.handleIMChannelList)
+			r.Patch("/api/workspaces/{id}/im/channels/{channelId}", s.handleIMChannelPatch)
+			r.Delete("/api/workspaces/{id}/im/channels/{channelId}", s.handleIMChannelDelete)
+			r.Post("/api/workspaces/{id}/im/weixin/qr-start", s.handleIMWeixinQRStart)
+			r.Post("/api/workspaces/{id}/im/weixin/qr-wait", s.handleIMWeixinQRWait)
+			r.Post("/api/workspaces/{id}/im/telegram/configure", s.handleIMTelegramConfigure)
+			r.Post("/api/workspaces/{id}/im/matrix/configure", s.handleIMMatrixConfigure)
+			// Sandbox IM channel binding (annotated wrappers in im_routes.go).
+			r.Post("/api/sandboxes/{id}/im/bind", s.handleIMSandboxBind)
+			r.Delete("/api/sandboxes/{id}/im/bind", s.handleIMSandboxUnbind)
+			// Legacy sandbox-level IM routes (un-annotated, proxied directly).
+			r.Post("/api/sandboxes/{id}/im/weixin/qr-start", s.imBridgeProxy)
+			r.Post("/api/sandboxes/{id}/im/weixin/qr-wait", s.imBridgeProxy)
+			r.Post("/api/sandboxes/{id}/im/telegram/configure", s.imBridgeProxy)
+			r.Delete("/api/sandboxes/{id}/im/telegram", s.imBridgeProxy)
+			r.Post("/api/sandboxes/{id}/im/matrix/configure", s.imBridgeProxy)
+			r.Delete("/api/sandboxes/{id}/im/matrix", s.imBridgeProxy)
+			r.Get("/api/sandboxes/{id}/im/bindings", s.imBridgeProxy)
+			r.Post("/api/sandboxes/{id}/weixin/qr-start", s.imBridgeProxy)
+			r.Post("/api/sandboxes/{id}/weixin/qr-wait", s.imBridgeProxy)
 		}
 
 		// Agent discovery

--- a/web/src/components/WeixinLoginModal.tsx
+++ b/web/src/components/WeixinLoginModal.tsx
@@ -60,18 +60,18 @@ export function WeixinLoginModal({ sandboxId, workspaceId, onClose, onConnected 
 
           if (res.connected) {
             setPhase('connected')
-            setMessage(res.message)
+            setMessage(res.message ?? '')
             onConnected?.()
             return
           }
 
           if (res.status === 'scaned') {
             setPhase('scanned')
-            setMessage(res.message)
+            setMessage(res.message ?? '')
           } else if (res.status === 'expired' && res.qrcode_url) {
-            setQrUrl(res.qrcode_url)
+            setQrUrl(res.qrcode_url ?? '')
             setPhase('qr')
-            setMessage(res.message)
+            setMessage(res.message ?? '')
           }
           // "wait" → continue polling
         } catch {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -13,6 +13,18 @@ export type WeixinBinding = components['schemas']['IMBinding']
 
 export type IMBinding = components['schemas']['IMBinding']
 
+// IM Channels — generated types from OpenAPI spec
+export type IMChannel = components['schemas']['IMChannel']
+export type IMChannelListResponse = components['schemas']['IMChannelListResponse']
+export type IMChannelPatchRequest = components['schemas']['IMChannelPatchRequest']
+export type IMWeixinQRStartResponse = components['schemas']['IMWeixinQRStartResponse']
+export type IMWeixinQRWaitResponse = components['schemas']['IMWeixinQRWaitResponse']
+export type IMTelegramConfigureRequest = components['schemas']['IMTelegramConfigureRequest']
+export type IMTelegramConfigureResponse = components['schemas']['IMTelegramConfigureResponse']
+export type IMMatrixConfigureRequest = components['schemas']['IMMatrixConfigureRequest']
+export type IMMatrixConfigureResponse = components['schemas']['IMMatrixConfigureResponse']
+export type IMSandboxBindRequest = components['schemas']['IMSandboxBindRequest']
+
 export interface TelegramConfigureResult {
   connected: boolean
   bot_id: string
@@ -403,41 +415,32 @@ export async function listIMBindings(sandboxId: string): Promise<{ bindings: IMB
   return res.json()
 }
 
-// Workspace IM Channel types and API
+// Workspace IM Channel management API
 
-export interface IMChannel {
-  id: string
-  workspace_id: string
-  provider: string
-  bot_id: string
-  user_id: string
-  require_mention: boolean
-  routing_mode: string
-  bound_at: string
-}
-
-export async function listWorkspaceIMChannels(workspaceId: string): Promise<{ channels: IMChannel[] }> {
-  const res = await fetch(`/api/workspaces/${workspaceId}/im/channels`)
-  if (!res.ok) throw new Error('Failed to list IM channels')
-  return res.json()
+export async function listWorkspaceIMChannels(workspaceId: string): Promise<IMChannelListResponse> {
+  return apiFetch<IMChannelListResponse>({
+    method: 'GET',
+    path: `/api/workspaces/${encodeURIComponent(workspaceId)}/im/channels`,
+  })
 }
 
 export async function updateWorkspaceIMChannel(
   workspaceId: string,
   channelId: string,
-  settings: { require_mention?: boolean; routing_mode?: 'nanoclaw' | 'codex' },
+  settings: IMChannelPatchRequest,
 ): Promise<void> {
-  const res = await fetch(`/api/workspaces/${workspaceId}/im/channels/${channelId}`, {
+  await apiFetch<void>({
     method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(settings),
+    path: `/api/workspaces/${encodeURIComponent(workspaceId)}/im/channels/${encodeURIComponent(channelId)}`,
+    body: settings,
   })
-  if (!res.ok) throw new Error('Failed to update IM channel')
 }
 
 export async function deleteWorkspaceIMChannel(workspaceId: string, channelId: string): Promise<void> {
-  const res = await fetch(`/api/workspaces/${workspaceId}/im/channels/${channelId}`, { method: 'DELETE' })
-  if (!res.ok) throw new Error('Failed to delete IM channel')
+  await apiFetch<void>({
+    method: 'DELETE',
+    path: `/api/workspaces/${encodeURIComponent(workspaceId)}/im/channels/${encodeURIComponent(channelId)}`,
+  })
 }
 
 // Credential Bindings (kubeconfig / external API credentials)
@@ -527,65 +530,52 @@ export async function pollDeviceCodeComplete(
 }
 
 // Workspace-level WeChat QR login
-export async function workspaceWeixinQRStart(workspaceId: string): Promise<{ qrcode_url: string; message: string }> {
-  const res = await fetch(`/api/workspaces/${workspaceId}/im/weixin/qr-start`, { method: 'POST' })
-  if (!res.ok) throw new Error('Failed to start WeChat login')
-  return res.json()
+export async function workspaceWeixinQRStart(workspaceId: string): Promise<IMWeixinQRStartResponse> {
+  return apiFetch<IMWeixinQRStartResponse>({
+    method: 'POST',
+    path: `/api/workspaces/${encodeURIComponent(workspaceId)}/im/weixin/qr-start`,
+  })
 }
 
-export async function workspaceWeixinQRWait(workspaceId: string): Promise<any> {
-  const res = await fetch(`/api/workspaces/${workspaceId}/im/weixin/qr-wait`, { method: 'POST' })
-  if (!res.ok) {
-    const text = await res.text()
-    throw new Error(text || 'Failed to poll WeChat status')
-  }
-  return res.json()
+export async function workspaceWeixinQRWait(workspaceId: string): Promise<IMWeixinQRWaitResponse> {
+  return apiFetch<IMWeixinQRWaitResponse>({
+    method: 'POST',
+    path: `/api/workspaces/${encodeURIComponent(workspaceId)}/im/weixin/qr-wait`,
+  })
 }
 
 // Workspace-level Telegram configure
-export async function workspaceTelegramConfigure(workspaceId: string, botToken: string): Promise<{ connected: boolean; bot_id: string }> {
-  const res = await fetch(`/api/workspaces/${workspaceId}/im/telegram/configure`, {
+export async function workspaceTelegramConfigure(workspaceId: string, botToken: string): Promise<IMTelegramConfigureResponse> {
+  return apiFetch<IMTelegramConfigureResponse>({
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ bot_token: botToken }),
+    path: `/api/workspaces/${encodeURIComponent(workspaceId)}/im/telegram/configure`,
+    body: { bot_token: botToken } satisfies IMTelegramConfigureRequest,
   })
-  if (!res.ok) {
-    const text = await res.text()
-    throw new Error(text || 'Failed to configure Telegram')
-  }
-  return res.json()
 }
 
 // Workspace-level Matrix configure
-export async function workspaceMatrixConfigure(workspaceId: string, homeserverUrl: string, accessToken: string, recoveryKey?: string): Promise<{ connected: boolean; bot_id: string }> {
-  const res = await fetch(`/api/workspaces/${workspaceId}/im/matrix/configure`, {
+export async function workspaceMatrixConfigure(workspaceId: string, homeserverUrl: string, accessToken: string, recoveryKey?: string): Promise<IMMatrixConfigureResponse> {
+  return apiFetch<IMMatrixConfigureResponse>({
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ homeserver_url: homeserverUrl, access_token: accessToken, recovery_key: recoveryKey || '' }),
+    path: `/api/workspaces/${encodeURIComponent(workspaceId)}/im/matrix/configure`,
+    body: { homeserver_url: homeserverUrl, access_token: accessToken, recovery_key: recoveryKey || '' } satisfies IMMatrixConfigureRequest,
   })
-  if (!res.ok) {
-    const text = await res.text()
-    throw new Error(text || 'Failed to configure Matrix')
-  }
-  return res.json()
 }
 
 // Sandbox channel binding
 export async function bindSandboxToChannel(sandboxId: string, channelId: string): Promise<void> {
-  const res = await fetch(`/api/sandboxes/${sandboxId}/im/bind`, {
+  await apiFetch<void>({
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ channel_id: channelId }),
+    path: `/api/sandboxes/${encodeURIComponent(sandboxId)}/im/bind`,
+    body: { channel_id: channelId } satisfies IMSandboxBindRequest,
   })
-  if (!res.ok) {
-    const text = await res.text()
-    throw new Error(text || 'Failed to bind channel')
-  }
 }
 
 export async function unbindSandboxFromChannel(sandboxId: string): Promise<void> {
-  const res = await fetch(`/api/sandboxes/${sandboxId}/im/bind`, { method: 'DELETE' })
-  if (!res.ok) throw new Error('Failed to unbind channel')
+  await apiFetch<void>({
+    method: 'DELETE',
+    path: `/api/sandboxes/${encodeURIComponent(sandboxId)}/im/bind`,
+  })
 }
 
 // Usage & Traces API


### PR DESCRIPTION
## Summary

- Adds OpenAPI annotations for all 9 IM Channels endpoints, grouping them under the `IM Channels` tag in the generated spec
- Introduces thin per-route wrapper handlers (`internal/server/im_routes.go`) around the shared `imbridgeProxy` reverse-proxy — wrappers carry no logic, only swag annotation blocks; actual handling happens in the standalone imbridge service
- Migrates workspace-level IM helpers in `web/src/lib/api.ts` from raw `fetch` to `apiFetch` + generated types; drops duplicate `IMChannel` interface; adds 10 new type aliases from generated schemas

## Wrapper-pattern explanation

All 9 IM routes reverse-proxy to a standalone `imbridge` service when `s.IMBridgeURL` is configured. Previously they were all registered as `s.imbridgeProxy` directly — swag cannot emit distinct annotations for the same handler. This PR introduces `handleIMChannelList`, `handleIMChannelPatch`, etc. — each a one-liner that calls `s.imBridgeProxy(w, r)` — so each endpoint gets its own annotation block.

The shared proxy handle is now stored as `s.imBridgeProxy` (initialized once in `Router()`) rather than allocated as a local variable inside the `if` block.

## Recon findings (divergences from plan's best-effort guesses)

- `PATCH /im/channels/{channelId}` returns HTTP 200 `{"status":"updated"}` not 204 — added `IMChannelPatchResponse` DTO
- `POST /sandboxes/{id}/im/bind` returns HTTP 200 `{"status":"bound"}` not 204 — added `IMSandboxBindResponse` DTO  
- `DELETE /sandboxes/{id}/im/bind` returns HTTP 200 `{"status":"unbound"}` not 204 — added `IMSandboxUnbindResponse` DTO
- `IMWeixinQRWaitResponse` is polymorphic: `message`, `qrcode_url`, `bot_id`, `user_id` are all optional depending on `status`; the plan's `channel_id` + `bot_id` shape was incorrect — `WeixinLoginModal.tsx` required a small null-coalescing fix to match the correct optional types

## Stacked on

PR #154 (`feat/openapi-phase-1b-sandboxes`)

## Test plan

- [x] `make openapi-check` — green
- [x] `go test ./internal/server/ -count=1 -timeout 120s` — green
- [x] `cd web && pnpm openapi:gen && pnpm build` — green
- [x] `git status --short` — no tracked modifications
- [x] All 9 endpoints tagged `IM Channels` in `docs/api/openapi.yaml`
- [x] No `server.` prefix in schema refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)