### PR TITLE
feat(openapi): Phase 1.b — Codex Tokens tag (3 endpoints)

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -195,6 +195,236 @@
         }
       }
     },
+    "/api/codex/tokens": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Codex Tokens"
+        ],
+        "summary": "List Codex tokens for a workspace",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "name": "workspace_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Include revoked tokens (default false)",
+            "name": "include_revoked",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CodexTokenListItem"
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "workspace_id required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Codex Tokens"
+        ],
+        "summary": "Mint a Codex access token",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CodexTokenMintRequest"
+              }
+            }
+          },
+          "description": "Token parameters",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CodexTokenMintResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "invalid JSON",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a member of this workspace",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "workspace_id and name are required / ttl_days out of range",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/codex/tokens/{id}": {
+      "delete": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Codex Tokens"
+        ],
+        "summary": "Revoke a Codex token",
+        "parameters": [
+          {
+            "description": "Token id",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "forbidden",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/sandboxes/{id}": {
       "get": {
         "security": [
@@ -2430,6 +2660,95 @@
           "status": {
             "type": "string",
             "example": "ok"
+          }
+        }
+      },
+      "CodexTokenListItem": {
+        "type": "object",
+        "required": [
+          "created_at",
+          "expires_at",
+          "id",
+          "name",
+          "workspace_id"
+        ],
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "expires_at": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "last_used_at": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string"
+          },
+          "revoked": {
+            "type": "boolean"
+          },
+          "revoked_at": {
+            "type": "string",
+            "nullable": true
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        }
+      },
+      "CodexTokenMintRequest": {
+        "type": "object",
+        "required": [
+          "name",
+          "workspace_id"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "my mac"
+          },
+          "ttl_days": {
+            "type": "integer",
+            "example": 90
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        }
+      },
+      "CodexTokenMintResponse": {
+        "type": "object",
+        "required": [
+          "created_at",
+          "expires_at",
+          "id",
+          "name",
+          "token",
+          "workspace_id"
+        ],
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "expires_at": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "token": {
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
           }
         }
       },

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -122,6 +122,143 @@ paths:
       summary: Register a new user
       tags:
         - Auth
+  /api/codex/tokens:
+    get:
+      parameters:
+        - description: Workspace id
+          in: query
+          name: workspace_id
+          required: true
+          schema:
+            type: string
+        - description: Include revoked tokens (default false)
+          in: query
+          name: include_revoked
+          schema:
+            type: boolean
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: "#/components/schemas/CodexTokenListItem"
+                type: array
+        "400":
+          description: workspace_id required
+          content:
+            application/json:
+              schema:
+                type: string
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: not a member
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: List Codex tokens for a workspace
+      tags:
+        - Codex Tokens
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CodexTokenMintRequest"
+        description: Token parameters
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CodexTokenMintResponse"
+        "400":
+          description: invalid JSON
+          content:
+            application/json:
+              schema:
+                type: string
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: not a member of this workspace
+          content:
+            application/json:
+              schema:
+                type: string
+        "422":
+          description: workspace_id and name are required / ttl_days out of range
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Mint a Codex access token
+      tags:
+        - Codex Tokens
+  "/api/codex/tokens/{id}":
+    delete:
+      parameters:
+        - description: Token id
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: No Content
+        "401":
+          description: unauthorized
+          content:
+            "*/*":
+              schema:
+                type: string
+        "403":
+          description: forbidden
+          content:
+            "*/*":
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            "*/*":
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Revoke a Codex token
+      tags:
+        - Codex Tokens
   "/api/sandboxes/{id}":
     delete:
       parameters:
@@ -1485,6 +1622,69 @@ components:
           type: string
       required:
         - status
+      type: object
+    CodexTokenListItem:
+      properties:
+        created_at:
+          type: string
+        expires_at:
+          type: string
+        id:
+          type: string
+        last_used_at:
+          type: string
+          nullable: true
+        name:
+          type: string
+        revoked:
+          type: boolean
+        revoked_at:
+          type: string
+          nullable: true
+        workspace_id:
+          type: string
+      required:
+        - created_at
+        - expires_at
+        - id
+        - name
+        - workspace_id
+      type: object
+    CodexTokenMintRequest:
+      properties:
+        name:
+          example: my mac
+          type: string
+        ttl_days:
+          example: 90
+          type: integer
+        workspace_id:
+          type: string
+      required:
+        - name
+        - workspace_id
+      type: object
+    CodexTokenMintResponse:
+      properties:
+        created_at:
+          type: string
+        expires_at:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+        token:
+          type: string
+        workspace_id:
+          type: string
+      required:
+        - created_at
+        - expires_at
+        - id
+        - name
+        - token
+        - workspace_id
       type: object
     IMBinding:
       properties:

--- a/docs/superpowers/plans/2026-05-22-openapi-phase-1b-codex-tokens.md
+++ b/docs/superpowers/plans/2026-05-22-openapi-phase-1b-codex-tokens.md
@@ -1,0 +1,163 @@
+# OpenAPI Phase 1.b — Codex Tokens tag Implementation Plan
+
+**Goal:** Annotate 3 Codex Tokens REST endpoints at `/api/codex/tokens` (and
+`/api/codex/tokens/{id}`). The handlers are fully implemented in
+`internal/server/codex_tokens.go`; they already use named package-level structs
+(`mintCodexTokenReq`, etc.) but those structs are unexported and in the handler
+file, so they must be promoted to `api_types.go`.
+
+**Prereq:** Stacked on `feat/openapi-phase-1b-im-channels` (PR #155).
+
+**Reference spec:** `docs/superpowers/specs/` — no dedicated openapi-org spec
+found on the working tree; follow the same conventions as PR #152 (Auth),
+#153 (Workspaces), #154 (Sandboxes), #155 (IM Channels).
+
+---
+
+## Endpoints (3)
+
+| Method | Path | Handler | Auth | Notes |
+|---|---|---|---|---|
+| POST | `/api/codex/tokens` | `handleMintCodexToken` | cookie + workspace member (non-guest) | 201 Created, returns full token once |
+| GET | `/api/codex/tokens` | `handleListCodexTokens` | cookie + workspace member | `?workspace_id=` + `?include_revoked=true` query params; never returns raw `token` field |
+| DELETE | `/api/codex/tokens/{id}` | `handleRevokeCodexToken` | cookie + token owner or workspace admin | 204 No Content, idempotent |
+
+All three endpoints are registered in the main chi router at lines 449-451 of `internal/server/server.go`, guarded by the logged-in middleware.
+
+---
+
+## File Structure
+
+**Modify:**
+- `internal/server/api_types.go` — append `// --- Codex Tokens ---` section with 3 named types
+- `internal/server/codex_tokens.go` — replace inline `mintCodexTokenReq`, `mintCodexTokenResp`, `listCodexTokenItem` with exported DTOs; add swag annotation blocks on each handler
+- `docs/api/openapi.yaml` + `docs/api/openapi.json` — regenerated
+- `web/src/lib/api.ts` — migrate 3 helpers + drop 3 local interfaces
+
+**No new files needed** (direct annotation pattern, not wrapper pattern — handlers are self-contained, not proxied).
+
+---
+
+## Task Breakdown
+
+### Task 1: DTOs — `internal/server/api_types.go`
+
+Append after the `// --- IM Channels ---` block:
+
+```
+// --- Codex Tokens ---
+
+// CodexTokenMintRequest is the body for POST /api/codex/tokens.
+type CodexTokenMintRequest struct {
+    WorkspaceID string `json:"workspace_id" validate:"required"`
+    Name        string `json:"name" validate:"required" example:"my mac"`
+    TTLDays     int    `json:"ttl_days,omitempty" example:"90"`
+} // @name CodexTokenMintRequest
+
+// CodexTokenMintResponse is returned (201) by POST /api/codex/tokens.
+// token is the full bearer value; it is shown only once.
+type CodexTokenMintResponse struct {
+    ID          string    `json:"id" validate:"required"`
+    Token       string    `json:"token" validate:"required"`
+    Name        string    `json:"name" validate:"required"`
+    WorkspaceID string    `json:"workspace_id" validate:"required"`
+    ExpiresAt   time.Time `json:"expires_at" validate:"required"`
+    CreatedAt   time.Time `json:"created_at" validate:"required"`
+} // @name CodexTokenMintResponse
+
+// CodexTokenListItem is one entry in the GET /api/codex/tokens response.
+// last_used_at and revoked_at are null when not set.
+type CodexTokenListItem struct {
+    ID          string     `json:"id" validate:"required"`
+    Name        string     `json:"name" validate:"required"`
+    WorkspaceID string     `json:"workspace_id" validate:"required"`
+    CreatedAt   time.Time  `json:"created_at" validate:"required"`
+    ExpiresAt   time.Time  `json:"expires_at" validate:"required"`
+    LastUsedAt  *time.Time `json:"last_used_at,omitempty" extensions:"x-nullable=true"`
+    Revoked     bool       `json:"revoked"`
+    RevokedAt   *time.Time `json:"revoked_at,omitempty" extensions:"x-nullable=true"`
+} // @name CodexTokenListItem
+```
+
+Note: `api_types.go` does not currently import `time`; will need to add the import.
+
+Commit: `feat(openapi): Codex Tokens DTOs in api_types.go`
+
+---
+
+### Task 2: Handler refactor + swag annotations
+
+In `internal/server/codex_tokens.go`:
+1. Replace local unexported structs with the exported DTOs from api_types.go
+2. Add swag annotation blocks to each of the 3 handlers
+3. Run `make openapi`, verify no `server.` prefixes in the spec
+4. Run `make openapi-check`
+
+Annotations:
+
+**POST /api/codex/tokens** → `handleMintCodexToken`
+- `@Tags Codex Tokens`
+- `@Param body body CodexTokenMintRequest true`
+- `@Success 201 {object} CodexTokenMintResponse`
+- `@Failure 400, 403, 422, 500`
+
+**GET /api/codex/tokens** → `handleListCodexTokens`
+- `@Tags Codex Tokens`
+- `@Param workspace_id query string true`
+- `@Param include_revoked query bool false`
+- `@Success 200 {array} CodexTokenListItem`
+- `@Failure 400, 403, 500`
+
+**DELETE /api/codex/tokens/{id}** → `handleRevokeCodexToken`
+- `@Tags Codex Tokens`
+- `@Param id path string true`
+- `@Success 204`
+- `@Failure 403, 500`
+
+Commit: `feat(openapi): annotate Codex Tokens handlers (3 endpoints)`
+
+---
+
+### Task 3: Frontend migration
+
+1. `cd web && pnpm openapi:gen`
+2. In `web/src/lib/api.ts`:
+   - Add type aliases:
+     ```typescript
+     export type CodexToken = components['schemas']['CodexTokenListItem']
+     export type CodexTokenMintRequest = components['schemas']['CodexTokenMintRequest']
+     export type CodexTokenMintResponse = components['schemas']['CodexTokenMintResponse']
+     ```
+   - Remove the 3 hand-written `export interface CodexToken / MintCodexTokenRequest / MintCodexTokenResponse`
+   - Migrate `listCodexTokens` to `apiFetch`
+   - Migrate `mintCodexToken` to `apiFetch`
+   - Migrate `revokeCodexToken` to `apiFetch` (DELETE, 204, return void)
+3. `pnpm tsc --noEmit && pnpm build`
+4. `git checkout -- web/dist/`
+
+Commit: `refactor(web): migrate Codex Tokens helpers to apiClient + generated types`
+
+---
+
+### Task 4: Verify + PR
+
+```bash
+make openapi-check
+go test ./internal/server/ -count=1 -timeout 120s
+cd web && pnpm openapi:gen && pnpm build && cd ..
+git checkout -- web/dist/ 2>/dev/null || true
+git push -u github feat/openapi-phase-1b-codex-tokens
+gh pr create --base feat/openapi-phase-1b-im-channels \
+  --title "feat(openapi): Phase 1.b — Codex Tokens tag (3 endpoints)" \
+  --body "..."
+```
+
+---
+
+## Done when
+
+- 3 endpoints under tag `Codex Tokens` in `docs/api/openapi.yaml`
+- `make openapi-check` passes
+- `go test ./internal/server/` passes (existing tests must still pass — they test exact HTTP shapes, so DTO promotion must be wire-compatible)
+- Frontend builds; existing Codex UI works
+- PR open against `feat/openapi-phase-1b-im-channels`

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -1,5 +1,7 @@
 package server
 
+import "time"
+
 // This file holds package-level request/response types for the
 // public REST API. swaggo annotations on handler funcs reference
 // these by name; inline `var req struct {...}` shapes can't be
@@ -268,3 +270,38 @@ type IMSandboxBindResponse struct {
 type IMSandboxUnbindResponse struct {
 	Status string `json:"status" validate:"required" example:"unbound"`
 } // @name IMSandboxUnbindResponse
+
+// --- Codex Tokens ---
+
+// CodexTokenMintRequest is the body for POST /api/codex/tokens.
+// ttl_days is optional; defaults to 90 (range: 1–365).
+type CodexTokenMintRequest struct {
+	WorkspaceID string `json:"workspace_id" validate:"required"`
+	Name        string `json:"name" validate:"required" example:"my mac"`
+	TTLDays     int    `json:"ttl_days,omitempty" example:"90"`
+} // @name CodexTokenMintRequest
+
+// CodexTokenMintResponse is returned (201) by POST /api/codex/tokens.
+// token is the full bearer value and is shown only once — store it securely.
+type CodexTokenMintResponse struct {
+	ID          string    `json:"id" validate:"required"`
+	Token       string    `json:"token" validate:"required"`
+	Name        string    `json:"name" validate:"required"`
+	WorkspaceID string    `json:"workspace_id" validate:"required"`
+	ExpiresAt   time.Time `json:"expires_at" validate:"required"`
+	CreatedAt   time.Time `json:"created_at" validate:"required"`
+} // @name CodexTokenMintResponse
+
+// CodexTokenListItem is one entry returned by GET /api/codex/tokens.
+// The raw token value is never included. last_used_at and revoked_at
+// are null when not applicable.
+type CodexTokenListItem struct {
+	ID          string     `json:"id" validate:"required"`
+	Name        string     `json:"name" validate:"required"`
+	WorkspaceID string     `json:"workspace_id" validate:"required"`
+	CreatedAt   time.Time  `json:"created_at" validate:"required"`
+	ExpiresAt   time.Time  `json:"expires_at" validate:"required"`
+	LastUsedAt  *time.Time `json:"last_used_at,omitempty" extensions:"x-nullable=true"`
+	Revoked     bool       `json:"revoked"`
+	RevokedAt   *time.Time `json:"revoked_at,omitempty" extensions:"x-nullable=true"`
+} // @name CodexTokenListItem

--- a/internal/server/codex_tokens.go
+++ b/internal/server/codex_tokens.go
@@ -18,39 +18,28 @@ const (
 	codexTokenMaxTTLDays     = 365
 )
 
-type mintCodexTokenReq struct {
-	WorkspaceID string `json:"workspace_id"`
-	Name        string `json:"name"`
-	TTLDays     int    `json:"ttl_days,omitempty"`
-}
-
-type mintCodexTokenResp struct {
-	ID          string    `json:"id"`
-	Token       string    `json:"token"`
-	Name        string    `json:"name"`
-	WorkspaceID string    `json:"workspace_id"`
-	ExpiresAt   time.Time `json:"expires_at"`
-	CreatedAt   time.Time `json:"created_at"`
-}
-
-type listCodexTokenItem struct {
-	ID          string     `json:"id"`
-	Name        string     `json:"name"`
-	WorkspaceID string     `json:"workspace_id"`
-	CreatedAt   time.Time  `json:"created_at"`
-	ExpiresAt   time.Time  `json:"expires_at"`
-	LastUsedAt  *time.Time `json:"last_used_at,omitempty"`
-	Revoked     bool       `json:"revoked"`
-	RevokedAt   *time.Time `json:"revoked_at,omitempty"`
-}
-
+// handleMintCodexToken issues a new long-lived bearer token for codex CLI access.
+//
+//	@Summary   Mint a Codex access token
+//	@Tags      Codex Tokens
+//	@Accept    json
+//	@Produce   json
+//	@Param     body  body  CodexTokenMintRequest  true  "Token parameters"
+//	@Success   201  {object}  CodexTokenMintResponse
+//	@Failure   400  {string}  string  "invalid JSON"
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "not a member of this workspace"
+//	@Failure   422  {string}  string  "workspace_id and name are required / ttl_days out of range"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/codex/tokens [post]
 func (s *Server) handleMintCodexToken(w http.ResponseWriter, r *http.Request) {
 	userID := auth.UserIDFromContext(r.Context())
 	if userID == "" {
 		http.Error(w, "unauthorized", http.StatusUnauthorized)
 		return
 	}
-	var req mintCodexTokenReq
+	var req CodexTokenMintRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "invalid JSON", http.StatusBadRequest)
 		return
@@ -98,12 +87,26 @@ func (s *Server) handleMintCodexToken(w http.ResponseWriter, r *http.Request) {
 
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusCreated)
-	_ = json.NewEncoder(w).Encode(mintCodexTokenResp{
+	_ = json.NewEncoder(w).Encode(CodexTokenMintResponse{
 		ID: id, Token: full, Name: req.Name, WorkspaceID: req.WorkspaceID,
 		ExpiresAt: exp, CreatedAt: time.Now().UTC(),
 	})
 }
 
+// handleListCodexTokens returns all codex tokens for a workspace.
+//
+//	@Summary   List Codex tokens for a workspace
+//	@Tags      Codex Tokens
+//	@Produce   json
+//	@Param     workspace_id     query  string  true   "Workspace id"
+//	@Param     include_revoked  query  bool    false  "Include revoked tokens (default false)"
+//	@Success   200  {array}   CodexTokenListItem
+//	@Failure   400  {string}  string  "workspace_id required"
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "not a member"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/codex/tokens [get]
 func (s *Server) handleListCodexTokens(w http.ResponseWriter, r *http.Request) {
 	userID := auth.UserIDFromContext(r.Context())
 	if userID == "" {
@@ -130,9 +133,9 @@ func (s *Server) handleListCodexTokens(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
-	out := make([]listCodexTokenItem, 0, len(rows))
+	out := make([]CodexTokenListItem, 0, len(rows))
 	for _, t := range rows {
-		out = append(out, listCodexTokenItem{
+		out = append(out, CodexTokenListItem{
 			ID: t.ID, Name: t.Name, WorkspaceID: t.WorkspaceID,
 			CreatedAt: t.CreatedAt, ExpiresAt: t.ExpiresAt,
 			LastUsedAt: t.LastUsedAt, Revoked: t.RevokedAt != nil, RevokedAt: t.RevokedAt,
@@ -142,6 +145,17 @@ func (s *Server) handleListCodexTokens(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(out)
 }
 
+// handleRevokeCodexToken revokes an existing codex token by id.
+//
+//	@Summary   Revoke a Codex token
+//	@Tags      Codex Tokens
+//	@Param     id  path  string  true  "Token id"
+//	@Success   204
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "forbidden"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/codex/tokens/{id} [delete]
 func (s *Server) handleRevokeCodexToken(w http.ResponseWriter, r *http.Request) {
 	userID := auth.UserIDFromContext(r.Context())
 	if userID == "" {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -25,6 +25,11 @@ export type IMMatrixConfigureRequest = components['schemas']['IMMatrixConfigureR
 export type IMMatrixConfigureResponse = components['schemas']['IMMatrixConfigureResponse']
 export type IMSandboxBindRequest = components['schemas']['IMSandboxBindRequest']
 
+// Codex Tokens — generated types from OpenAPI spec
+export type CodexToken = components['schemas']['CodexTokenListItem']
+export type MintCodexTokenRequest = components['schemas']['CodexTokenMintRequest']
+export type MintCodexTokenResponse = components['schemas']['CodexTokenMintResponse']
+
 export interface TelegramConfigureResult {
   connected: boolean
   bot_id: string
@@ -916,55 +921,28 @@ export async function submitOAuthConsent(
 }
 
 // Codex Token API
-
-export interface CodexToken {
-  id: string
-  name: string
-  workspace_id: string
-  created_at: string
-  expires_at: string
-  last_used_at?: string
-  revoked: boolean
-  revoked_at?: string
-}
-
-export interface MintCodexTokenRequest {
-  workspace_id: string
-  name: string
-  ttl_days?: number
-}
-
-export interface MintCodexTokenResponse {
-  id: string
-  token: string
-  name: string
-  workspace_id: string
-  expires_at: string
-  created_at: string
-}
+// Types are exported at the top of this file as generated aliases.
 
 export async function listCodexTokens(workspaceId: string): Promise<CodexToken[]> {
-  const res = await fetch(`/api/codex/tokens?workspace_id=${encodeURIComponent(workspaceId)}`)
-  if (!res.ok) throw new Error('Failed to list codex tokens')
-  return res.json()
+  return apiFetch<CodexToken[]>({
+    method: 'GET',
+    path: `/api/codex/tokens?workspace_id=${encodeURIComponent(workspaceId)}`,
+  })
 }
 
 export async function mintCodexToken(req: MintCodexTokenRequest): Promise<MintCodexTokenResponse> {
-  const res = await fetch('/api/codex/tokens', {
+  return apiFetch<MintCodexTokenResponse>({
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(req),
+    path: '/api/codex/tokens',
+    body: req satisfies components['schemas']['CodexTokenMintRequest'],
   })
-  if (!res.ok) {
-    const text = await res.text()
-    throw new Error(text || 'Failed to mint codex token')
-  }
-  return res.json()
 }
 
 export async function revokeCodexToken(id: string): Promise<void> {
-  const res = await fetch(`/api/codex/tokens/${encodeURIComponent(id)}`, { method: 'DELETE' })
-  if (!res.ok) throw new Error('Failed to revoke codex token')
+  await apiFetch<void>({
+    method: 'DELETE',
+    path: `/api/codex/tokens/${encodeURIComponent(id)}`,
+  })
 }
 
 // Remote Executor API


### PR DESCRIPTION
## Summary

Annotates the 3 Codex Tokens REST endpoints under the **Codex Tokens** OpenAPI tag, completing Phase 1.b of the OpenAPI organization effort.

- Adds named DTOs (`CodexTokenMintRequest`, `CodexTokenMintResponse`, `CodexTokenListItem`) to `internal/server/api_types.go`
- Promotes the previously unexported local structs in `codex_tokens.go` to the shared named DTOs (wire-shape unchanged — existing tests confirm)
- Adds swag annotation blocks to all 3 handlers (POST mint, GET list, DELETE revoke)
- Regenerates `docs/api/openapi.{yaml,json}`; `make openapi-check` passes
- Migrates 3 frontend helpers in `web/src/lib/api.ts` from raw `fetch` to `apiFetch` + generated types; drops 3 hand-written local interfaces

## Endpoints annotated

| Method | Path | Handler | Tag |
|---|---|---|---|
| POST | `/api/codex/tokens` | `handleMintCodexToken` | Codex Tokens |
| GET | `/api/codex/tokens` | `handleListCodexTokens` | Codex Tokens |
| DELETE | `/api/codex/tokens/{id}` | `handleRevokeCodexToken` | Codex Tokens |

## Implementation notes

- Unlike IM Channels (PR #155), the codex token handlers are self-contained (not a proxy), so no wrapper file was needed — annotations are placed directly on the handlers
- `api_types.go` required a `time` import (first in the file) for `time.Time` fields in the DTOs
- The `TTLDays` field is `omitempty` / optional on the request body (defaults to 90 server-side)

## Stack

This PR stacks on **PR #155** (`feat/openapi-phase-1b-im-channels`). Merge order: #152 Auth → #153 Workspaces → #154 Sandboxes → #155 IM Channels → **this PR**.

## Verification

- `make openapi-check` passes
- `go test ./internal/server/ -count=1 -timeout 120s` passes (all DB-dependent tests skip gracefully without `TEST_DATABASE_URL`)
- `cd web && pnpm openapi:gen && pnpm build` succeeds

## References

- Plan: `docs/superpowers/plans/2026-05-22-openapi-phase-1b-codex-tokens.md`