### PR TITLE
feat(openapi): Phase 1.b — Agent tag (15 endpoints)

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -7,6 +7,653 @@
     "version": "0.1.0"
   },
   "paths": {
+    "/api/agent/discovery/agents": {
+      "get": {
+        "tags": [
+          "Agent"
+        ],
+        "summary": "Discover agents in the calling agent's workspace (proxy_token auth)",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AgentCardItem"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/agent/discovery/cards": {
+      "post": {
+        "tags": [
+          "Agent"
+        ],
+        "summary": "Register or update an agent capability card",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentCardRegisterRequest"
+              }
+            }
+          },
+          "description": "Agent card info",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentCardRegisterResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/agent/mailbox/inbox": {
+      "get": {
+        "tags": [
+          "Agent"
+        ],
+        "summary": "Read messages from the calling agent's inbox",
+        "parameters": [
+          {
+            "description": "Max messages to return (default 10)",
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AgentMailboxMessage"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/agent/mailbox/send": {
+      "post": {
+        "tags": [
+          "Agent"
+        ],
+        "summary": "Send a message to another agent's mailbox",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentMailboxSendRequest"
+              }
+            }
+          },
+          "description": "Message payload",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentMailboxSendResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "target not in same workspace",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "target agent not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/agent/register": {
+      "post": {
+        "tags": [
+          "Agent"
+        ],
+        "summary": "Register an agent (obtain sandbox credentials)",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentRegisterRequest"
+              }
+            }
+          },
+          "description": "Agent registration info",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentRegisterResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "no permission",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/agent/tasks": {
+      "post": {
+        "tags": [
+          "Agent"
+        ],
+        "summary": "Create a delegated task (proxy_token auth)",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/AgentTaskCreateRequest"
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentTaskCreateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "target agent not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/agent/tasks/poll": {
+      "get": {
+        "tags": [
+          "Agent"
+        ],
+        "summary": "Poll for pending tasks (proxy_token auth)",
+        "parameters": [
+          {
+            "description": "Sandbox ID (defaults to token's sandbox)",
+            "name": "sandbox_id",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AgentTaskPollItem"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/agent/tasks/{id}": {
+      "get": {
+        "tags": [
+          "Agent"
+        ],
+        "summary": "Get a task by ID (proxy_token auth)",
+        "parameters": [
+          {
+            "description": "Task ID",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentTaskDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/agent/tasks/{id}/status": {
+      "put": {
+        "tags": [
+          "Agent"
+        ],
+        "summary": "Update task status (proxy_token auth)",
+        "parameters": [
+          {
+            "description": "Task ID",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentTaskStatusRequest"
+              }
+            }
+          },
+          "description": "Status update",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "bad request",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/agents/{sandboxId}": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Agent"
+        ],
+        "summary": "Get a single agent card by sandbox ID",
+        "parameters": [
+          {
+            "description": "Sandbox ID",
+            "name": "sandboxId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentCardItem"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/auth/check": {
       "get": {
         "security": [
@@ -1003,6 +1650,156 @@
           },
           "404": {
             "description": "sandbox not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tasks/{id}": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Agent"
+        ],
+        "summary": "Get a task by ID",
+        "parameters": [
+          {
+            "description": "Task ID",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Include output events",
+            "name": "include_output",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentTaskDetail"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/tasks/{id}/cancel": {
+      "post": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Agent"
+        ],
+        "summary": "Cancel a task",
+        "parameters": [
+          {
+            "description": "Task ID",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentTaskCancelResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "task already finished",
             "content": {
               "application/json": {
                 "schema": {
@@ -2362,6 +3159,75 @@
         }
       }
     },
+    "/api/workspaces/{wid}/agents": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Agent"
+        ],
+        "summary": "List agent cards in a workspace",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "name": "wid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AgentCardItem"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/workspaces/{wid}/browsers": {
       "get": {
         "security": [
@@ -2565,6 +3431,162 @@
           }
         }
       }
+    },
+    "/api/workspaces/{wid}/tasks": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Agent"
+        ],
+        "summary": "List delegated tasks for a workspace",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "name": "wid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AgentTaskItem"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Agent"
+        ],
+        "summary": "Create a delegated task in a workspace",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "name": "wid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/AgentTaskCreateRequest"
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentTaskCreateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "target agent not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "servers": [
@@ -2584,6 +3606,17 @@
         },
         "description": "Email and password",
         "required": true
+      },
+      "AgentTaskCreateRequest": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/AgentTaskCreateRequest"
+            }
+          }
+        },
+        "description": "Task details",
+        "required": true
       }
     },
     "securitySchemes": {
@@ -2595,6 +3628,73 @@
       }
     },
     "schemas": {
+      "AgentCardItem": {
+        "type": "object",
+        "required": [
+          "agent_id",
+          "agent_type",
+          "card",
+          "display_name",
+          "status",
+          "version"
+        ],
+        "properties": {
+          "agent_id": {
+            "type": "string"
+          },
+          "agent_type": {
+            "type": "string",
+            "example": "claudecode"
+          },
+          "card": {},
+          "description": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "example": "available"
+          },
+          "version": {
+            "type": "integer"
+          }
+        }
+      },
+      "AgentCardRegisterRequest": {
+        "type": "object",
+        "properties": {
+          "agent_type": {
+            "description": "optional; defaults to \"claudecode\"",
+            "type": "string",
+            "example": "claudecode"
+          },
+          "card": {
+            "description": "optional; arbitrary JSON"
+          },
+          "description": {
+            "type": "string",
+            "example": "A helpful coding agent"
+          },
+          "display_name": {
+            "type": "string",
+            "example": "My Agent"
+          }
+        }
+      },
+      "AgentCardRegisterResponse": {
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "example": "ok"
+          }
+        }
+      },
       "AgentInfo": {
         "type": "object",
         "required": [
@@ -2655,6 +3755,344 @@
           },
           "workdir": {
             "type": "string"
+          }
+        }
+      },
+      "AgentMailboxMessage": {
+        "type": "object",
+        "required": [
+          "created_at",
+          "from",
+          "id",
+          "msg_type",
+          "text"
+        ],
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "from": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "msg_type": {
+            "type": "string",
+            "example": "text"
+          },
+          "text": {
+            "type": "string"
+          }
+        }
+      },
+      "AgentMailboxSendRequest": {
+        "type": "object",
+        "required": [
+          "text",
+          "to"
+        ],
+        "properties": {
+          "msg_type": {
+            "type": "string",
+            "example": "text"
+          },
+          "text": {
+            "type": "string",
+            "example": "Hello from another agent"
+          },
+          "to": {
+            "type": "string",
+            "example": "sandbox-uuid-of-target"
+          }
+        }
+      },
+      "AgentMailboxSendResponse": {
+        "type": "object",
+        "required": [
+          "message_id",
+          "status"
+        ],
+        "properties": {
+          "message_id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "example": "sent"
+          }
+        }
+      },
+      "AgentRegisterRequest": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "example": "Local Agent"
+          },
+          "type": {
+            "description": "optional; defaults to \"opencode\"",
+            "type": "string",
+            "example": "opencode"
+          }
+        }
+      },
+      "AgentRegisterResponse": {
+        "type": "object",
+        "required": [
+          "proxy_token",
+          "sandbox_id",
+          "short_id",
+          "tunnel_token",
+          "workspace_id"
+        ],
+        "properties": {
+          "proxy_token": {
+            "type": "string"
+          },
+          "sandbox_id": {
+            "type": "string"
+          },
+          "short_id": {
+            "type": "string"
+          },
+          "tunnel_token": {
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        }
+      },
+      "AgentTaskCancelResponse": {
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "example": "cancelled"
+          }
+        }
+      },
+      "AgentTaskCreateRequest": {
+        "type": "object",
+        "required": [
+          "prompt",
+          "target_id"
+        ],
+        "properties": {
+          "delegation_chain": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "max_budget_usd": {
+            "type": "number",
+            "example": 1
+          },
+          "max_turns": {
+            "type": "integer",
+            "example": 50
+          },
+          "prompt": {
+            "type": "string",
+            "example": "Run the test suite"
+          },
+          "requester_id": {
+            "type": "string"
+          },
+          "skill": {
+            "type": "string",
+            "example": "testing"
+          },
+          "system_context": {
+            "type": "string"
+          },
+          "target_id": {
+            "type": "string",
+            "example": "sandbox-uuid"
+          },
+          "timeout_seconds": {
+            "type": "integer",
+            "example": 300
+          }
+        }
+      },
+      "AgentTaskCreateResponse": {
+        "type": "object",
+        "required": [
+          "status",
+          "task_id"
+        ],
+        "properties": {
+          "session_id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "example": "pending"
+          },
+          "task_id": {
+            "type": "string"
+          }
+        }
+      },
+      "AgentTaskDetail": {
+        "type": "object",
+        "required": [
+          "created_at",
+          "prompt",
+          "status",
+          "target_id",
+          "task_id",
+          "workspace_id"
+        ],
+        "properties": {
+          "completed_at": {
+            "type": "string",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "failure_reason": {
+            "type": "string",
+            "nullable": true
+          },
+          "num_turns": {
+            "type": "integer"
+          },
+          "prompt": {
+            "type": "string"
+          },
+          "requester_id": {
+            "type": "string"
+          },
+          "result": {
+            "nullable": true
+          },
+          "session_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "skill": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "example": "pending"
+          },
+          "target_id": {
+            "type": "string"
+          },
+          "task_id": {
+            "type": "string"
+          },
+          "total_cost_usd": {
+            "type": "number",
+            "nullable": true
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        }
+      },
+      "AgentTaskItem": {
+        "type": "object",
+        "required": [
+          "created_at",
+          "prompt",
+          "status",
+          "target_id",
+          "task_id"
+        ],
+        "properties": {
+          "completed_at": {
+            "type": "string",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "num_turns": {
+            "type": "integer"
+          },
+          "prompt": {
+            "type": "string"
+          },
+          "requester_id": {
+            "type": "string"
+          },
+          "skill": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "example": "pending"
+          },
+          "target_id": {
+            "type": "string"
+          },
+          "task_id": {
+            "type": "string"
+          },
+          "total_cost_usd": {
+            "type": "number",
+            "nullable": true
+          }
+        }
+      },
+      "AgentTaskPollItem": {
+        "type": "object",
+        "required": [
+          "prompt",
+          "task_id"
+        ],
+        "properties": {
+          "max_budget_usd": {
+            "type": "number"
+          },
+          "max_turns": {
+            "type": "integer"
+          },
+          "prompt": {
+            "type": "string"
+          },
+          "session_id": {
+            "type": "string"
+          },
+          "system_context": {
+            "type": "string"
+          },
+          "task_id": {
+            "type": "string"
+          }
+        }
+      },
+      "AgentTaskStatusRequest": {
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "properties": {
+          "failure_reason": {
+            "type": "string"
+          },
+          "num_turns": {
+            "type": "integer"
+          },
+          "result": {},
+          "status": {
+            "type": "string",
+            "example": "completed"
+          },
+          "total_cost_usd": {
+            "type": "number",
+            "nullable": true
           }
         }
       },

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -8,6 +8,397 @@ info:
   title: agentserver API
   version: 0.1.0
 paths:
+  /api/agent/discovery/agents:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: "#/components/schemas/AgentCardItem"
+                type: array
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      summary: Discover agents in the calling agent's workspace (proxy_token auth)
+      tags:
+        - Agent
+  /api/agent/discovery/cards:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AgentCardRegisterRequest"
+        description: Agent card info
+        required: true
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentCardRegisterResponse"
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                type: string
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      summary: Register or update an agent capability card
+      tags:
+        - Agent
+  /api/agent/mailbox/inbox:
+    get:
+      parameters:
+        - description: Max messages to return (default 10)
+          in: query
+          name: limit
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: "#/components/schemas/AgentMailboxMessage"
+                type: array
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      summary: Read messages from the calling agent's inbox
+      tags:
+        - Agent
+  /api/agent/mailbox/send:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AgentMailboxSendRequest"
+        description: Message payload
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentMailboxSendResponse"
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                type: string
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: target not in same workspace
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: target agent not found
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      summary: Send a message to another agent's mailbox
+      tags:
+        - Agent
+  /api/agent/register:
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AgentRegisterRequest"
+        description: Agent registration info
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentRegisterResponse"
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                type: string
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: no permission
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      summary: Register an agent (obtain sandbox credentials)
+      tags:
+        - Agent
+  /api/agent/tasks:
+    post:
+      requestBody:
+        $ref: "#/components/requestBodies/AgentTaskCreateRequest"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentTaskCreateResponse"
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                type: string
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: target agent not found
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      summary: Create a delegated task (proxy_token auth)
+      tags:
+        - Agent
+  "/api/agent/tasks/{id}":
+    get:
+      parameters:
+        - description: Task ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentTaskDetail"
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: not found
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      summary: Get a task by ID (proxy_token auth)
+      tags:
+        - Agent
+  "/api/agent/tasks/{id}/status":
+    put:
+      parameters:
+        - description: Task ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AgentTaskStatusRequest"
+        description: Status update
+        required: true
+      responses:
+        "200":
+          description: OK
+        "400":
+          description: bad request
+          content:
+            "*/*":
+              schema:
+                type: string
+        "401":
+          description: unauthorized
+          content:
+            "*/*":
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            "*/*":
+              schema:
+                type: string
+      summary: Update task status (proxy_token auth)
+      tags:
+        - Agent
+  /api/agent/tasks/poll:
+    get:
+      parameters:
+        - description: Sandbox ID (defaults to token's sandbox)
+          in: query
+          name: sandbox_id
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: "#/components/schemas/AgentTaskPollItem"
+                type: array
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      summary: Poll for pending tasks (proxy_token auth)
+      tags:
+        - Agent
+  "/api/agents/{sandboxId}":
+    get:
+      parameters:
+        - description: Sandbox ID
+          in: path
+          name: sandboxId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentCardItem"
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: not a member
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: not found
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Get a single agent card by sandbox ID
+      tags:
+        - Agent
   /api/auth/check:
     get:
       responses:
@@ -618,6 +1009,95 @@ paths:
       summary: Get sandbox usage stats
       tags:
         - Sandboxes
+  "/api/tasks/{id}":
+    get:
+      parameters:
+        - description: Task ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - description: Include output events
+          in: query
+          name: include_output
+          schema:
+            type: boolean
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentTaskDetail"
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: not found
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Get a task by ID
+      tags:
+        - Agent
+  "/api/tasks/{id}/cancel":
+    post:
+      parameters:
+        - description: Task ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentTaskCancelResponse"
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: not found
+          content:
+            application/json:
+              schema:
+                type: string
+        "409":
+          description: task already finished
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Cancel a task
+      tags:
+        - Agent
   /api/workspaces:
     get:
       responses:
@@ -1403,6 +1883,47 @@ paths:
       summary: Change a member's role (owner only)
       tags:
         - Workspaces
+  "/api/workspaces/{wid}/agents":
+    get:
+      parameters:
+        - description: Workspace ID
+          in: path
+          name: wid
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: "#/components/schemas/AgentCardItem"
+                type: array
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: not a member
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: List agent cards in a workspace
+      tags:
+        - Agent
   "/api/workspaces/{wid}/browsers":
     get:
       parameters:
@@ -1527,6 +2048,99 @@ paths:
       summary: Create a sandbox in a workspace
       tags:
         - Sandboxes
+  "/api/workspaces/{wid}/tasks":
+    get:
+      parameters:
+        - description: Workspace ID
+          in: path
+          name: wid
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: "#/components/schemas/AgentTaskItem"
+                type: array
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: not a member
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: List delegated tasks for a workspace
+      tags:
+        - Agent
+    post:
+      parameters:
+        - description: Workspace ID
+          in: path
+          name: wid
+          required: true
+          schema:
+            type: string
+      requestBody:
+        $ref: "#/components/requestBodies/AgentTaskCreateRequest"
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentTaskCreateResponse"
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                type: string
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: target agent not found
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Create a delegated task in a workspace
+      tags:
+        - Agent
   /api/workspaces/quota:
     get:
       responses:
@@ -1558,6 +2172,13 @@ components:
             $ref: "#/components/schemas/AuthCredentials"
       description: Email and password
       required: true
+    AgentTaskCreateRequest:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/AgentTaskCreateRequest"
+      description: Task details
+      required: true
   securitySchemes:
     CookieAuth:
       description: Session cookie set by POST /api/auth/login. All non-auth endpoints
@@ -1566,6 +2187,54 @@ components:
       name: agentserver-token
       type: apiKey
   schemas:
+    AgentCardItem:
+      properties:
+        agent_id:
+          type: string
+        agent_type:
+          example: claudecode
+          type: string
+        card: {}
+        description:
+          type: string
+        display_name:
+          type: string
+        status:
+          example: available
+          type: string
+        version:
+          type: integer
+      required:
+        - agent_id
+        - agent_type
+        - card
+        - display_name
+        - status
+        - version
+      type: object
+    AgentCardRegisterRequest:
+      properties:
+        agent_type:
+          description: optional; defaults to "claudecode"
+          example: claudecode
+          type: string
+        card:
+          description: optional; arbitrary JSON
+        description:
+          example: A helpful coding agent
+          type: string
+        display_name:
+          example: My Agent
+          type: string
+      type: object
+    AgentCardRegisterResponse:
+      properties:
+        status:
+          example: ok
+          type: string
+      required:
+        - status
+      type: object
     AgentInfo:
       properties:
         agent_version:
@@ -1611,6 +2280,244 @@ components:
         - platform_version
         - updated_at
         - workdir
+      type: object
+    AgentMailboxMessage:
+      properties:
+        created_at:
+          type: string
+        from:
+          type: string
+        id:
+          type: string
+        msg_type:
+          example: text
+          type: string
+        text:
+          type: string
+      required:
+        - created_at
+        - from
+        - id
+        - msg_type
+        - text
+      type: object
+    AgentMailboxSendRequest:
+      properties:
+        msg_type:
+          example: text
+          type: string
+        text:
+          example: Hello from another agent
+          type: string
+        to:
+          example: sandbox-uuid-of-target
+          type: string
+      required:
+        - text
+        - to
+      type: object
+    AgentMailboxSendResponse:
+      properties:
+        message_id:
+          type: string
+        status:
+          example: sent
+          type: string
+      required:
+        - message_id
+        - status
+      type: object
+    AgentRegisterRequest:
+      properties:
+        name:
+          example: Local Agent
+          type: string
+        type:
+          description: optional; defaults to "opencode"
+          example: opencode
+          type: string
+      type: object
+    AgentRegisterResponse:
+      properties:
+        proxy_token:
+          type: string
+        sandbox_id:
+          type: string
+        short_id:
+          type: string
+        tunnel_token:
+          type: string
+        workspace_id:
+          type: string
+      required:
+        - proxy_token
+        - sandbox_id
+        - short_id
+        - tunnel_token
+        - workspace_id
+      type: object
+    AgentTaskCancelResponse:
+      properties:
+        status:
+          example: cancelled
+          type: string
+      required:
+        - status
+      type: object
+    AgentTaskCreateRequest:
+      properties:
+        delegation_chain:
+          items:
+            type: string
+          type: array
+        max_budget_usd:
+          example: 1
+          type: number
+        max_turns:
+          example: 50
+          type: integer
+        prompt:
+          example: Run the test suite
+          type: string
+        requester_id:
+          type: string
+        skill:
+          example: testing
+          type: string
+        system_context:
+          type: string
+        target_id:
+          example: sandbox-uuid
+          type: string
+        timeout_seconds:
+          example: 300
+          type: integer
+      required:
+        - prompt
+        - target_id
+      type: object
+    AgentTaskCreateResponse:
+      properties:
+        session_id:
+          type: string
+        status:
+          example: pending
+          type: string
+        task_id:
+          type: string
+      required:
+        - status
+        - task_id
+      type: object
+    AgentTaskDetail:
+      properties:
+        completed_at:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+        failure_reason:
+          type: string
+          nullable: true
+        num_turns:
+          type: integer
+        prompt:
+          type: string
+        requester_id:
+          type: string
+        result:
+          nullable: true
+        session_id:
+          type: string
+          nullable: true
+        skill:
+          type: string
+          nullable: true
+        status:
+          example: pending
+          type: string
+        target_id:
+          type: string
+        task_id:
+          type: string
+        total_cost_usd:
+          type: number
+          nullable: true
+        workspace_id:
+          type: string
+      required:
+        - created_at
+        - prompt
+        - status
+        - target_id
+        - task_id
+        - workspace_id
+      type: object
+    AgentTaskItem:
+      properties:
+        completed_at:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+        num_turns:
+          type: integer
+        prompt:
+          type: string
+        requester_id:
+          type: string
+        skill:
+          type: string
+        status:
+          example: pending
+          type: string
+        target_id:
+          type: string
+        task_id:
+          type: string
+        total_cost_usd:
+          type: number
+          nullable: true
+      required:
+        - created_at
+        - prompt
+        - status
+        - target_id
+        - task_id
+      type: object
+    AgentTaskPollItem:
+      properties:
+        max_budget_usd:
+          type: number
+        max_turns:
+          type: integer
+        prompt:
+          type: string
+        session_id:
+          type: string
+        system_context:
+          type: string
+        task_id:
+          type: string
+      required:
+        - prompt
+        - task_id
+      type: object
+    AgentTaskStatusRequest:
+      properties:
+        failure_reason:
+          type: string
+        num_turns:
+          type: integer
+        result: {}
+        status:
+          example: completed
+          type: string
+        total_cost_usd:
+          type: number
+          nullable: true
+      required:
+        - status
       type: object
     AuthCredentials:
       properties:

--- a/docs/superpowers/plans/2026-05-22-openapi-phase-1b-agent.md
+++ b/docs/superpowers/plans/2026-05-22-openapi-phase-1b-agent.md
@@ -1,0 +1,124 @@
+# Phase 1.b — OpenAPI: Agent tag implementation plan
+
+**Branch:** `feat/openapi-phase-1b-agent`  
+**Stacks on:** PR #157 (Codex Browser Sessions)  
+**Date:** 2026-05-22
+
+## Recon summary
+
+Grep turned up **13 endpoints** across three sub-areas. All are pure REST CRUD — no
+WebSocket, no SSE, no `/api/internal/*` RPC. The sub-areas are:
+
+| # | Sub-area | Endpoint count |
+|---|----------|---------------|
+| 1 | Agent Discovery | 4 |
+| 2 | Agent Tasks | 7 |
+| 3 | Agent Mailbox | 2 |
+
+**Tag decision:** single `Agent` tag (swag `@Tags Agent`). Sub-area is already
+clear from the path prefix (`/discovery/`, `/tasks/`, `/mailbox/`). Three separate
+tags would create visual noise without adding navigability.
+
+---
+
+## Endpoint inventory
+
+### Discovery (4 endpoints)
+
+| Method | Path | Handler | Auth |
+|--------|------|---------|------|
+| POST | `/api/agent/register` | `handleAgentRegister` | Bearer (OAuth Hydra, `agent:register` scope) |
+| POST | `/api/agent/discovery/cards` | `handleRegisterAgentCard` | Bearer proxy\_token |
+| GET | `/api/workspaces/{wid}/agents` | `handleListAgentCards` | CookieAuth |
+| GET | `/api/agents/{sandboxId}` | `handleGetAgentCard` | CookieAuth |
+| GET | `/api/agent/discovery/agents` | `handleAgentDiscoverAgents` | Bearer proxy\_token |
+
+Discovery total: **5** (not 4 — recount after full read includes `handleAgentDiscoverAgents`).
+
+### Tasks (6 endpoints)
+
+| Method | Path | Handler | Auth |
+|--------|------|---------|------|
+| POST | `/api/workspaces/{wid}/tasks` | `handleCreateTask` | CookieAuth |
+| GET | `/api/workspaces/{wid}/tasks` | `handleListTasks` | CookieAuth |
+| GET | `/api/tasks/{id}` | `handleGetTask` | CookieAuth |
+| POST | `/api/tasks/{id}/cancel` | `handleCancelTask` | CookieAuth |
+| GET | `/api/agent/tasks/poll` | `handlePollTasks` | Bearer proxy\_token |
+| PUT | `/api/agent/tasks/{id}/status` | `handleUpdateTaskStatus` | Bearer proxy\_token |
+| POST | `/api/agent/tasks` | `handleAgentCreateTask` | Bearer proxy\_token |
+| GET | `/api/agent/tasks/{id}` | `handleAgentGetTask` | Bearer proxy\_token |
+
+Tasks total: **8** (includes the 2 proxy-token mirrors).
+
+### Mailbox (2 endpoints)
+
+| Method | Path | Handler | Auth |
+|--------|------|---------|------|
+| POST | `/api/agent/mailbox/send` | `handleSendMessage` | Bearer proxy\_token |
+| GET | `/api/agent/mailbox/inbox` | `handleReadInbox` | Bearer proxy\_token |
+
+**Grand total: 15 endpoints.**
+
+---
+
+## Tasks
+
+### Task 0 — Plan (this document)
+
+- [x] Recon all routes in `server.go`, handler files
+- [x] Commit plan as `docs(plan): Phase 1.b — Agent tag implementation plan`
+
+### Task 1 — DTOs in `api_types.go`
+
+Add three sub-sections after `--- Codex Browser Sessions ---`:
+
+**`// --- Agent Discovery ---`**
+- `AgentRegisterRequest` — body for `POST /api/agent/register`
+- `AgentRegisterResponse` — 201 body (sandbox\_id, tunnel\_token, proxy\_token, workspace\_id, short\_id)
+- `AgentCardRegisterRequest` — body for `POST /api/agent/discovery/cards`
+- `AgentCardRegisterResponse` — 200 body (`{"status":"ok"}`)
+- `AgentCardItem` — one entry in discovery/agents lists (agent\_id, display\_name, description, agent\_type, status, card, version)
+
+**`// --- Agent Tasks ---`**
+- `AgentTaskCreateRequest` — body for POST tasks (target\_id, skill, prompt, system\_context, max\_turns, max\_budget\_usd, timeout\_seconds, delegation\_chain, requester\_id)
+- `AgentTaskCreateResponse` — 201 body (task\_id, session\_id, status)
+- `AgentTaskItem` — one entry in task list (task\_id, target\_id, requester\_id, skill, status, prompt, num\_turns, total\_cost\_usd, created\_at, completed\_at)
+- `AgentTaskDetail` — full task (all fields including result, failure\_reason, output, workspace\_id, session\_id)
+- `AgentTaskStatusRequest` — body for `PUT /api/agent/tasks/{id}/status`
+- `AgentTaskCancelResponse` — body for cancel (`{"status":"cancelled"}`)
+- `AgentTaskPollItem` — one entry from poll (task\_id, prompt, system\_context, max\_turns, max\_budget\_usd, session\_id)
+
+**`// --- Agent Mailbox ---`**
+- `AgentMailboxSendRequest` — body for send (to, text, msg\_type)
+- `AgentMailboxSendResponse` — 201 body (message\_id, status)
+- `AgentMailboxMessage` — one message in inbox (id, from, text, msg\_type, created\_at)
+
+Commit: `feat(openapi): Agent DTOs in api_types.go`
+
+### Task 2 — Annotate handlers
+
+Files: `agent_register.go`, `agent_discovery.go`, `agent_proxy_routes.go`,
+`agent_tasks.go`, `agent_mailbox.go`.
+
+All get `@Tags Agent`. Inline structs replaced with named DTOs.  
+Regenerate: `make openapi`  
+Gate: `make openapi-check`
+
+Commit: `feat(openapi): annotate Agent handlers (15 endpoints)`
+
+### Task 3 — Frontend migration
+
+No existing agent/task/mailbox types found in `web/src/lib/api.ts` — **no migration
+needed.** The generated `apiClient` will provide fresh types for any future callers.
+
+Task 3 is effectively a no-op; skip the commit.
+
+### Task 4 — Verify + PR
+
+```
+make openapi-check
+go test ./internal/server/...
+cd web && pnpm build && git checkout -- dist/
+git push -u origin feat/openapi-phase-1b-agent
+gh pr create --title "feat(openapi): Phase 1.b — Agent tag (15 endpoints)" ...
+```

--- a/internal/server/agent_discovery.go
+++ b/internal/server/agent_discovery.go
@@ -11,6 +11,17 @@ import (
 
 // handleListAgentCards returns all agent cards in a workspace.
 // GET /api/workspaces/{wid}/agents
+//
+//	@Summary   List agent cards in a workspace
+//	@Tags      Agent
+//	@Produce   json
+//	@Param     wid  path      string  true  "Workspace ID"
+//	@Success   200  {array}   AgentCardItem
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "not a member"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{wid}/agents [get]
 func (s *Server) handleListAgentCards(w http.ResponseWriter, r *http.Request) {
 	wid := chi.URLParam(r, "wid")
 	cards, err := s.DB.ListAgentCardsByWorkspace(wid)
@@ -52,6 +63,18 @@ func (s *Server) handleListAgentCards(w http.ResponseWriter, r *http.Request) {
 
 // handleGetAgentCard returns a single agent card.
 // GET /api/agents/{sandboxId}
+//
+//	@Summary   Get a single agent card by sandbox ID
+//	@Tags      Agent
+//	@Produce   json
+//	@Param     sandboxId  path      string  true  "Sandbox ID"
+//	@Success   200        {object}  AgentCardItem
+//	@Failure   401        {string}  string  "unauthorized"
+//	@Failure   403        {string}  string  "not a member"
+//	@Failure   404        {string}  string  "not found"
+//	@Failure   500        {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/agents/{sandboxId} [get]
 func (s *Server) handleGetAgentCard(w http.ResponseWriter, r *http.Request) {
 	sandboxID := chi.URLParam(r, "sandboxId")
 	card, err := s.DB.GetAgentCard(sandboxID)
@@ -80,6 +103,17 @@ func (s *Server) handleGetAgentCard(w http.ResponseWriter, r *http.Request) {
 // handleRegisterAgentCard registers or updates an agent card.
 // POST /api/agent/discovery/cards
 // Auth: proxy_token (agent self-registration)
+//
+//	@Summary   Register or update an agent capability card
+//	@Tags      Agent
+//	@Accept    json
+//	@Produce   json
+//	@Param     body  body      AgentCardRegisterRequest   true  "Agent card info"
+//	@Success   200   {object}  AgentCardRegisterResponse
+//	@Failure   400   {string}  string  "bad request"
+//	@Failure   401   {string}  string  "unauthorized"
+//	@Failure   500   {string}  string  "internal error"
+//	@Router    /api/agent/discovery/cards [post]
 func (s *Server) handleRegisterAgentCard(w http.ResponseWriter, r *http.Request) {
 	// Authenticate via proxy_token.
 	token := r.Header.Get("Authorization")

--- a/internal/server/agent_mailbox.go
+++ b/internal/server/agent_mailbox.go
@@ -13,6 +13,19 @@ import (
 // handleSendMessage sends a message to another agent's mailbox.
 // POST /api/agent/mailbox/send
 // Auth: proxy_token (Bearer)
+//
+//	@Summary   Send a message to another agent's mailbox
+//	@Tags      Agent
+//	@Accept    json
+//	@Produce   json
+//	@Param     body  body      AgentMailboxSendRequest  true  "Message payload"
+//	@Success   201   {object}  AgentMailboxSendResponse
+//	@Failure   400   {string}  string  "bad request"
+//	@Failure   401   {string}  string  "unauthorized"
+//	@Failure   403   {string}  string  "target not in same workspace"
+//	@Failure   404   {string}  string  "target agent not found"
+//	@Failure   500   {string}  string  "internal error"
+//	@Router    /api/agent/mailbox/send [post]
 func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 	token := r.Header.Get("Authorization")
 	if len(token) > 7 && token[:7] == "Bearer " {
@@ -86,6 +99,15 @@ func (s *Server) handleSendMessage(w http.ResponseWriter, r *http.Request) {
 // handleReadInbox reads unread messages for the calling agent.
 // GET /api/agent/mailbox/inbox
 // Auth: proxy_token (Bearer)
+//
+//	@Summary   Read messages from the calling agent's inbox
+//	@Tags      Agent
+//	@Produce   json
+//	@Param     limit  query     int  false  "Max messages to return (default 10)"
+//	@Success   200    {array}   AgentMailboxMessage
+//	@Failure   401    {string}  string  "unauthorized"
+//	@Failure   500    {string}  string  "internal error"
+//	@Router    /api/agent/mailbox/inbox [get]
 func (s *Server) handleReadInbox(w http.ResponseWriter, r *http.Request) {
 	token := r.Header.Get("Authorization")
 	if len(token) > 7 && token[:7] == "Bearer " {

--- a/internal/server/agent_proxy_routes.go
+++ b/internal/server/agent_proxy_routes.go
@@ -28,6 +28,14 @@ func (s *Server) extractProxyTokenSandbox(w http.ResponseWriter, r *http.Request
 
 // handleAgentDiscoverAgents is the proxy_token-authed version of handleListAgentCards.
 // GET /api/agent/discovery/agents
+//
+//	@Summary   Discover agents in the calling agent's workspace (proxy_token auth)
+//	@Tags      Agent
+//	@Produce   json
+//	@Success   200  {array}   AgentCardItem
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   500  {string}  string  "internal error"
+//	@Router    /api/agent/discovery/agents [get]
 func (s *Server) handleAgentDiscoverAgents(w http.ResponseWriter, r *http.Request) {
 	sbx := s.extractProxyTokenSandbox(w, r)
 	if sbx == nil {
@@ -71,6 +79,19 @@ func (s *Server) handleAgentDiscoverAgents(w http.ResponseWriter, r *http.Reques
 
 // handleAgentCreateTask is the proxy_token-authed version of handleCreateTask.
 // POST /api/agent/tasks
+//
+//	@Summary   Create a delegated task (proxy_token auth)
+//	@Tags      Agent
+//	@Accept    json
+//	@Produce   json
+//	@Param     body  body      AgentTaskCreateRequest  true  "Task details"
+//	@Success   201   {object}  AgentTaskCreateResponse
+//	@Failure   400   {string}  string  "bad request"
+//	@Failure   401   {string}  string  "unauthorized"
+//	@Failure   403   {string}  string  "forbidden"
+//	@Failure   404   {string}  string  "target agent not found"
+//	@Failure   500   {string}  string  "internal error"
+//	@Router    /api/agent/tasks [post]
 func (s *Server) handleAgentCreateTask(w http.ResponseWriter, r *http.Request) {
 	sbx := s.extractProxyTokenSandbox(w, r)
 	if sbx == nil {
@@ -81,6 +102,16 @@ func (s *Server) handleAgentCreateTask(w http.ResponseWriter, r *http.Request) {
 
 // handleAgentGetTask is the proxy_token-authed version of handleGetTask.
 // GET /api/agent/tasks/{id}
+//
+//	@Summary   Get a task by ID (proxy_token auth)
+//	@Tags      Agent
+//	@Produce   json
+//	@Param     id  path      string  true  "Task ID"
+//	@Success   200  {object}  AgentTaskDetail
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   404  {string}  string  "not found"
+//	@Failure   500  {string}  string  "internal error"
+//	@Router    /api/agent/tasks/{id} [get]
 func (s *Server) handleAgentGetTask(w http.ResponseWriter, r *http.Request) {
 	sbx := s.extractProxyTokenSandbox(w, r)
 	if sbx == nil {

--- a/internal/server/agent_register.go
+++ b/internal/server/agent_register.go
@@ -12,6 +12,18 @@ import (
 
 // handleAgentRegister processes a CLI agent registration using an OAuth Bearer token.
 // The token must contain workspace_id and agent:register scope from the Hydra consent flow.
+//
+//	@Summary   Register an agent (obtain sandbox credentials)
+//	@Tags      Agent
+//	@Accept    json
+//	@Produce   json
+//	@Param     body  body      AgentRegisterRequest  true  "Agent registration info"
+//	@Success   201   {object}  AgentRegisterResponse
+//	@Failure   400   {string}  string  "bad request"
+//	@Failure   401   {string}  string  "unauthorized"
+//	@Failure   403   {string}  string  "no permission"
+//	@Failure   500   {string}  string  "internal error"
+//	@Router    /api/agent/register [post]
 func (s *Server) handleAgentRegister(w http.ResponseWriter, r *http.Request) {
 	// Extract Bearer token.
 	authHeader := r.Header.Get("Authorization")

--- a/internal/server/agent_tasks.go
+++ b/internal/server/agent_tasks.go
@@ -14,6 +14,21 @@ import (
 
 // handleCreateTask creates a new delegated task.
 // POST /api/workspaces/{wid}/tasks
+//
+//	@Summary   Create a delegated task in a workspace
+//	@Tags      Agent
+//	@Accept    json
+//	@Produce   json
+//	@Param     wid   path      string                  true  "Workspace ID"
+//	@Param     body  body      AgentTaskCreateRequest  true  "Task details"
+//	@Success   201   {object}  AgentTaskCreateResponse
+//	@Failure   400   {string}  string  "bad request"
+//	@Failure   401   {string}  string  "unauthorized"
+//	@Failure   403   {string}  string  "forbidden"
+//	@Failure   404   {string}  string  "target agent not found"
+//	@Failure   500   {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{wid}/tasks [post]
 func (s *Server) handleCreateTask(w http.ResponseWriter, r *http.Request) {
 	s.handleCreateTaskForWorkspace(w, r, chi.URLParam(r, "wid"))
 }
@@ -100,6 +115,17 @@ func (s *Server) handleCreateTaskForWorkspace(w http.ResponseWriter, r *http.Req
 
 // handleListTasks lists tasks for a workspace.
 // GET /api/workspaces/{wid}/tasks
+//
+//	@Summary   List delegated tasks for a workspace
+//	@Tags      Agent
+//	@Produce   json
+//	@Param     wid  path      string  true  "Workspace ID"
+//	@Success   200  {array}   AgentTaskItem
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "not a member"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{wid}/tasks [get]
 func (s *Server) handleListTasks(w http.ResponseWriter, r *http.Request) {
 	wid := chi.URLParam(r, "wid")
 	tasks, err := s.DB.ListAgentTasksByWorkspace(wid, 100)
@@ -153,6 +179,18 @@ func (s *Server) handleListTasks(w http.ResponseWriter, r *http.Request) {
 
 // handleGetTask returns a single task.
 // GET /api/tasks/{id}
+//
+//	@Summary   Get a task by ID
+//	@Tags      Agent
+//	@Produce   json
+//	@Param     id              path      string  true   "Task ID"
+//	@Param     include_output  query     bool    false  "Include output events"
+//	@Success   200             {object}  AgentTaskDetail
+//	@Failure   401             {string}  string  "unauthorized"
+//	@Failure   404             {string}  string  "not found"
+//	@Failure   500             {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/tasks/{id} [get]
 func (s *Server) handleGetTask(w http.ResponseWriter, r *http.Request) {
 	taskID := chi.URLParam(r, "id")
 	task, err := s.DB.GetAgentTask(taskID)
@@ -211,6 +249,16 @@ func (s *Server) handleGetTask(w http.ResponseWriter, r *http.Request) {
 // handlePollTasks returns pending tasks for a worker agent.
 // GET /api/agent/tasks/poll?sandbox_id=xxx
 // Auth: proxy_token
+//
+//	@Summary   Poll for pending tasks (proxy_token auth)
+//	@Tags      Agent
+//	@Produce   json
+//	@Param     sandbox_id  query     string  false  "Sandbox ID (defaults to token's sandbox)"
+//	@Success   200         {array}   AgentTaskPollItem
+//	@Failure   401         {string}  string  "unauthorized"
+//	@Failure   403         {string}  string  "forbidden"
+//	@Failure   500         {string}  string  "internal error"
+//	@Router    /api/agent/tasks/poll [get]
 func (s *Server) handlePollTasks(w http.ResponseWriter, r *http.Request) {
 	// Auth via proxy_token.
 	token := r.Header.Get("Authorization")
@@ -276,6 +324,17 @@ func (s *Server) handlePollTasks(w http.ResponseWriter, r *http.Request) {
 // handleUpdateTaskStatus updates task status from the worker.
 // PUT /api/agent/tasks/{id}/status
 // Auth: proxy_token
+//
+//	@Summary   Update task status (proxy_token auth)
+//	@Tags      Agent
+//	@Accept    json
+//	@Param     id    path  string                  true  "Task ID"
+//	@Param     body  body  AgentTaskStatusRequest  true  "Status update"
+//	@Success   200
+//	@Failure   400   {string}  string  "bad request"
+//	@Failure   401   {string}  string  "unauthorized"
+//	@Failure   500   {string}  string  "internal error"
+//	@Router    /api/agent/tasks/{id}/status [put]
 func (s *Server) handleUpdateTaskStatus(w http.ResponseWriter, r *http.Request) {
 	token := r.Header.Get("Authorization")
 	if len(token) > 7 && token[:7] == "Bearer " {
@@ -327,6 +386,18 @@ func (s *Server) handleUpdateTaskStatus(w http.ResponseWriter, r *http.Request) 
 
 // handleCancelTask cancels a running task.
 // POST /api/tasks/{id}/cancel
+//
+//	@Summary   Cancel a task
+//	@Tags      Agent
+//	@Produce   json
+//	@Param     id  path      string  true  "Task ID"
+//	@Success   200  {object}  AgentTaskCancelResponse
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   404  {string}  string  "not found"
+//	@Failure   409  {string}  string  "task already finished"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/tasks/{id}/cancel [post]
 func (s *Server) handleCancelTask(w http.ResponseWriter, r *http.Request) {
 	taskID := chi.URLParam(r, "id")
 	task, err := s.DB.GetAgentTask(taskID)

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -306,6 +306,171 @@ type CodexTokenListItem struct {
 	RevokedAt   *time.Time `json:"revoked_at,omitempty" extensions:"x-nullable=true"`
 } // @name CodexTokenListItem
 
+// --- Agent Discovery ---
+
+// AgentRegisterRequest is the body for POST /api/agent/register.
+// type defaults to "opencode" when omitted; valid values: opencode, claudecode, custom.
+type AgentRegisterRequest struct {
+	Name string `json:"name" example:"Local Agent"`
+	Type string `json:"type" example:"opencode"` // optional; defaults to "opencode"
+} // @name AgentRegisterRequest
+
+// AgentRegisterResponse is returned (201) by POST /api/agent/register.
+// proxy_token is the Bearer token used for subsequent agent-facing API calls.
+// tunnel_token is used by the tunnel transport (if applicable).
+type AgentRegisterResponse struct {
+	SandboxID   string `json:"sandbox_id" validate:"required"`
+	TunnelToken string `json:"tunnel_token" validate:"required"`
+	ProxyToken  string `json:"proxy_token" validate:"required"`
+	WorkspaceID string `json:"workspace_id" validate:"required"`
+	ShortID     string `json:"short_id" validate:"required"`
+} // @name AgentRegisterResponse
+
+// AgentCardRegisterRequest is the body for POST /api/agent/discovery/cards.
+// card is an arbitrary JSON capability descriptor; defaults to {} when omitted.
+type AgentCardRegisterRequest struct {
+	DisplayName string      `json:"display_name" example:"My Agent"`
+	Description string      `json:"description" example:"A helpful coding agent"`
+	AgentType   string      `json:"agent_type" example:"claudecode"` // optional; defaults to "claudecode"
+	Card        interface{} `json:"card"`                            // optional; arbitrary JSON
+} // @name AgentCardRegisterRequest
+
+// AgentCardRegisterResponse is the {"status":"ok"} body returned (200) by
+// POST /api/agent/discovery/cards.
+type AgentCardRegisterResponse struct {
+	Status string `json:"status" validate:"required" example:"ok"`
+} // @name AgentCardRegisterResponse
+
+// AgentCardItem is one entry in the agent card list returned by
+// GET /api/workspaces/{wid}/agents and GET /api/agent/discovery/agents.
+// card is the raw capability descriptor JSON submitted at registration time.
+type AgentCardItem struct {
+	AgentID     string      `json:"agent_id" validate:"required"`
+	DisplayName string      `json:"display_name" validate:"required"`
+	Description string      `json:"description"`
+	AgentType   string      `json:"agent_type" validate:"required" example:"claudecode"`
+	Status      string      `json:"status" validate:"required" example:"available"`
+	Card        interface{} `json:"card" validate:"required"`
+	Version     int         `json:"version" validate:"required"`
+} // @name AgentCardItem
+
+// --- Agent Tasks ---
+
+// AgentTaskCreateRequest is the body for POST /api/workspaces/{wid}/tasks
+// and POST /api/agent/tasks.
+// timeout_seconds defaults to 300 when omitted.
+type AgentTaskCreateRequest struct {
+	TargetID        string   `json:"target_id" validate:"required" example:"sandbox-uuid"`
+	Prompt          string   `json:"prompt" validate:"required" example:"Run the test suite"`
+	Skill           string   `json:"skill,omitempty" example:"testing"`
+	SystemContext   string   `json:"system_context,omitempty"`
+	MaxTurns        int      `json:"max_turns,omitempty" example:"50"`
+	MaxBudgetUSD    float64  `json:"max_budget_usd,omitempty" example:"1.0"`
+	TimeoutSeconds  int      `json:"timeout_seconds,omitempty" example:"300"`
+	DelegationChain []string `json:"delegation_chain,omitempty"`
+	RequesterID     string   `json:"requester_id,omitempty"`
+} // @name AgentTaskCreateRequest
+
+// AgentTaskCreateResponse is returned (201) by the task creation endpoints.
+// session_id is empty in the current implementation (bridge was removed).
+type AgentTaskCreateResponse struct {
+	TaskID    string `json:"task_id" validate:"required"`
+	SessionID string `json:"session_id"`
+	Status    string `json:"status" validate:"required" example:"pending"`
+} // @name AgentTaskCreateResponse
+
+// AgentTaskItem is one entry in the task list returned by
+// GET /api/workspaces/{wid}/tasks.
+// completed_at and total_cost_usd are null when not yet set.
+type AgentTaskItem struct {
+	TaskID      string   `json:"task_id" validate:"required"`
+	TargetID    string   `json:"target_id" validate:"required"`
+	RequesterID string   `json:"requester_id"`
+	Skill       string   `json:"skill,omitempty"`
+	Status      string   `json:"status" validate:"required" example:"pending"`
+	Prompt      string   `json:"prompt" validate:"required"`
+	NumTurns    int      `json:"num_turns"`
+	TotalCost   *float64 `json:"total_cost_usd,omitempty" extensions:"x-nullable=true"`
+	CreatedAt   string   `json:"created_at" validate:"required"`
+	CompletedAt *string  `json:"completed_at,omitempty" extensions:"x-nullable=true"`
+} // @name AgentTaskItem
+
+// AgentTaskDetail is the full task payload returned by GET /api/tasks/{id}
+// and GET /api/agent/tasks/{id}.
+// Optional fields are absent when not applicable.
+type AgentTaskDetail struct {
+	TaskID        string      `json:"task_id" validate:"required"`
+	WorkspaceID   string      `json:"workspace_id" validate:"required"`
+	RequesterID   string      `json:"requester_id"`
+	TargetID      string      `json:"target_id" validate:"required"`
+	Prompt        string      `json:"prompt" validate:"required"`
+	Status        string      `json:"status" validate:"required" example:"pending"`
+	NumTurns      int         `json:"num_turns"`
+	CreatedAt     string      `json:"created_at" validate:"required"`
+	SessionID     *string     `json:"session_id,omitempty" extensions:"x-nullable=true"`
+	Skill         *string     `json:"skill,omitempty" extensions:"x-nullable=true"`
+	TotalCostUSD  *float64    `json:"total_cost_usd,omitempty" extensions:"x-nullable=true"`
+	Result        interface{} `json:"result,omitempty" extensions:"x-nullable=true"`
+	FailureReason *string     `json:"failure_reason,omitempty" extensions:"x-nullable=true"`
+	CompletedAt   *string     `json:"completed_at,omitempty" extensions:"x-nullable=true"`
+} // @name AgentTaskDetail
+
+// AgentTaskStatusRequest is the body for PUT /api/agent/tasks/{id}/status.
+// Valid status values: running, completed, failed, cancelled.
+// failure_reason is required when status is "failed".
+// result and total_cost_usd are used when status is "completed".
+type AgentTaskStatusRequest struct {
+	Status        string      `json:"status" validate:"required" example:"completed"`
+	FailureReason string      `json:"failure_reason,omitempty"`
+	Result        interface{} `json:"result,omitempty"`
+	TotalCostUSD  *float64    `json:"total_cost_usd,omitempty" extensions:"x-nullable=true"`
+	NumTurns      int         `json:"num_turns,omitempty"`
+} // @name AgentTaskStatusRequest
+
+// AgentTaskCancelResponse is the {"status":"cancelled"} body returned (200)
+// by POST /api/tasks/{id}/cancel.
+type AgentTaskCancelResponse struct {
+	Status string `json:"status" validate:"required" example:"cancelled"`
+} // @name AgentTaskCancelResponse
+
+// AgentTaskPollItem is one entry in the list returned by
+// GET /api/agent/tasks/poll. Only the fields needed for immediate execution
+// are included (no cost/status/audit fields).
+type AgentTaskPollItem struct {
+	TaskID        string  `json:"task_id" validate:"required"`
+	Prompt        string  `json:"prompt" validate:"required"`
+	SystemContext string  `json:"system_context,omitempty"`
+	MaxTurns      int     `json:"max_turns,omitempty"`
+	MaxBudgetUSD  float64 `json:"max_budget_usd,omitempty"`
+	SessionID     string  `json:"session_id,omitempty"`
+} // @name AgentTaskPollItem
+
+// --- Agent Mailbox ---
+
+// AgentMailboxSendRequest is the body for POST /api/agent/mailbox/send.
+// msg_type defaults to "text" when omitted.
+type AgentMailboxSendRequest struct {
+	To      string `json:"to" validate:"required" example:"sandbox-uuid-of-target"`
+	Text    string `json:"text" validate:"required" example:"Hello from another agent"`
+	MsgType string `json:"msg_type,omitempty" example:"text"`
+} // @name AgentMailboxSendRequest
+
+// AgentMailboxSendResponse is returned (201) by POST /api/agent/mailbox/send.
+type AgentMailboxSendResponse struct {
+	MessageID string `json:"message_id" validate:"required"`
+	Status    string `json:"status" validate:"required" example:"sent"`
+} // @name AgentMailboxSendResponse
+
+// AgentMailboxMessage is one message in the inbox returned by
+// GET /api/agent/mailbox/inbox.
+type AgentMailboxMessage struct {
+	ID        string `json:"id" validate:"required"`
+	From      string `json:"from" validate:"required"`
+	Text      string `json:"text" validate:"required"`
+	MsgType   string `json:"msg_type" validate:"required" example:"text"`
+	CreatedAt string `json:"created_at" validate:"required"`
+} // @name AgentMailboxMessage
+
 // --- Codex Browser Sessions ---
 
 // CodexBrowserItem is one entry returned by GET /api/workspaces/{wid}/browsers.


### PR DESCRIPTION
## Summary

- Adds 15 named DTOs to `api_types.go` under `Agent Discovery`, `Agent Tasks`, and `Agent Mailbox` sub-sections
- Annotates all 15 endpoints in 5 handler files with `@Tags Agent` swag comments
- Regenerates `docs/api/openapi.{yaml,json}`; `make openapi-check` passes

## Endpoints annotated

| Method | Path | Auth |
|--------|------|------|
| POST | `/api/agent/register` | OAuth Bearer (agent:register scope) |
| POST | `/api/agent/discovery/cards` | Bearer proxy_token |
| GET | `/api/workspaces/{wid}/agents` | CookieAuth |
| GET | `/api/agents/{sandboxId}` | CookieAuth |
| GET | `/api/agent/discovery/agents` | Bearer proxy_token |
| POST | `/api/workspaces/{wid}/tasks` | CookieAuth |
| GET | `/api/workspaces/{wid}/tasks` | CookieAuth |
| GET | `/api/tasks/{id}` | CookieAuth |
| POST | `/api/tasks/{id}/cancel` | CookieAuth |
| GET | `/api/agent/tasks/poll` | Bearer proxy_token |
| PUT | `/api/agent/tasks/{id}/status` | Bearer proxy_token |
| POST | `/api/agent/tasks` | Bearer proxy_token |
| GET | `/api/agent/tasks/{id}` | Bearer proxy_token |
| POST | `/api/agent/mailbox/send` | Bearer proxy_token |
| GET | `/api/agent/mailbox/inbox` | Bearer proxy_token |

**Tag decision:** single `Agent` tag (not three sub-tags). Sub-area is already clear from the path prefix (`/discovery/`, `/tasks/`, `/mailbox/`).

**No frontend migration:** `web/src/lib/api.ts` had no existing agent/task/mailbox types to migrate.

## Test plan

- [x] `make openapi-check` passes (spec matches handler annotations)
- [x] `go test ./internal/server/...` passes
- [x] `pnpm build` succeeds

Stacks on PR #157 (Codex Browser Sessions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)