### PR TITLE
feat(openapi): Phase 1.b — Misc + Admin tags (34 endpoints)

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -8221,6 +8221,9 @@
           "traces"
         ],
         "properties": {
+          "total": {
+            "type": "integer"
+          },
           "traces": {
             "type": "array",
             "items": {
@@ -8234,8 +8237,13 @@
         "required": [
           "created_at",
           "id",
+          "request_count",
           "sandbox_id",
           "source",
+          "total_cache_creation_tokens",
+          "total_cache_read_tokens",
+          "total_input_tokens",
+          "total_output_tokens",
           "updated_at",
           "workspace_id"
         ],

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -2729,7 +2729,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TraceRecord"
+                  "$ref": "#/components/schemas/TraceDetailResponse"
                 }
               }
             }
@@ -6139,7 +6139,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/TraceRecord"
+                  "$ref": "#/components/schemas/TraceDetailResponse"
                 }
               }
             }
@@ -7734,6 +7734,7 @@
       "IMWeixinQRWaitResponse": {
         "type": "object",
         "required": [
+          "connected",
           "status"
         ],
         "properties": {
@@ -8215,6 +8216,24 @@
           }
         }
       },
+      "TraceDetailResponse": {
+        "type": "object",
+        "required": [
+          "requests",
+          "trace"
+        ],
+        "properties": {
+          "requests": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TraceRequest"
+            }
+          },
+          "trace": {
+            "$ref": "#/components/schemas/TraceRecord"
+          }
+        }
+      },
       "TraceListResponse": {
         "type": "object",
         "required": [
@@ -8281,6 +8300,69 @@
           },
           "updated_at": {
             "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        }
+      },
+      "TraceRequest": {
+        "type": "object",
+        "required": [
+          "cache_creation_input_tokens",
+          "cache_read_input_tokens",
+          "created_at",
+          "duration",
+          "id",
+          "input_tokens",
+          "model",
+          "output_tokens",
+          "provider",
+          "sandbox_id",
+          "workspace_id"
+        ],
+        "properties": {
+          "cache_creation_input_tokens": {
+            "type": "integer"
+          },
+          "cache_read_input_tokens": {
+            "type": "integer"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "duration": {
+            "type": "integer"
+          },
+          "id": {
+            "type": "string"
+          },
+          "input_tokens": {
+            "type": "integer"
+          },
+          "message_id": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "output_tokens": {
+            "type": "integer"
+          },
+          "provider": {
+            "type": "string"
+          },
+          "sandbox_id": {
+            "type": "string"
+          },
+          "streaming": {
+            "type": "boolean"
+          },
+          "trace_id": {
+            "type": "string"
+          },
+          "ttft": {
+            "type": "integer"
           },
           "workspace_id": {
             "type": "string"

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -7,6 +7,1001 @@
     "version": "0.1.0"
   },
   "paths": {
+    "/api/admin/quotas/defaults": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Get system-wide quota defaults (admin)",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminQuotaDefaultsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "admin role required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Update system-wide quota defaults (admin)",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminQuotaDefaultsUpdateRequest"
+              }
+            }
+          },
+          "description": "Quota fields to update (all optional)",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Updated defaults",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminQuotaDefaultsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "admin role required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/sandboxes": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Admin"
+        ],
+        "summary": "List all sandboxes (admin)",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AdminSandboxItem"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "admin role required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/users": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Admin"
+        ],
+        "summary": "List all users (admin)",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AdminUserItem"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "admin role required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/users/{id}/quota": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Get per-user quota override (admin)",
+        "parameters": [
+          {
+            "description": "User ID",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminUserQuotaResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "admin role required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Set per-user quota override (admin)",
+        "parameters": [
+          {
+            "description": "User ID",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminSetUserQuotaRequest"
+              }
+            }
+          },
+          "description": "Quota overrides",
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "saved"
+          },
+          "400": {
+            "description": "bad request",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "admin role required",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Delete per-user quota override (admin)",
+        "parameters": [
+          {
+            "description": "User ID",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "deleted"
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "admin role required",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/users/{id}/role": {
+      "put": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Update a user's role (admin)",
+        "parameters": [
+          {
+            "description": "User ID",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminUpdateUserRoleRequest"
+              }
+            }
+          },
+          "description": "New role (user or admin)",
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "updated"
+          },
+          "400": {
+            "description": "bad request / invalid role",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "admin role required",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/workspaces": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Admin"
+        ],
+        "summary": "List all workspaces (admin)",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AdminWorkspaceItem"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "admin role required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/workspaces/{id}/llm-quota": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Get workspace LLM quota (admin, proxied to llmproxy)",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LLMQuotaResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "admin role required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "llmproxy unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "llmproxy not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Set workspace LLM quota override (admin, proxied to llmproxy)",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "saved"
+          },
+          "400": {
+            "description": "bad request",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "admin role required",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "llmproxy unavailable",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "llmproxy not configured",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Delete workspace LLM quota override (admin, proxied to llmproxy)",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "deleted"
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "admin role required",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "llmproxy unavailable",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "llmproxy not configured",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/admin/workspaces/{id}/quota": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Get workspace quota override (admin)",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminWorkspaceQuotaResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "admin role required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Set workspace quota override (admin)",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminSetWorkspaceQuotaRequest"
+              }
+            }
+          },
+          "description": "Quota overrides (all optional, merged with existing)",
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "saved"
+          },
+          "400": {
+            "description": "bad request",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "admin role required",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Admin"
+        ],
+        "summary": "Delete workspace quota override (admin)",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "deleted"
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "admin role required",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/agent/discovery/agents": {
       "get": {
         "tags": [
@@ -1605,6 +2600,183 @@
         }
       }
     },
+    "/api/sandboxes/{id}/traces": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Misc"
+        ],
+        "summary": "List LLM traces for a sandbox",
+        "parameters": [
+          {
+            "description": "Sandbox ID",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Max entries to return",
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Pagination offset",
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TraceListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a workspace member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "sandbox not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "llmproxy not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/sandboxes/{id}/traces/{traceId}": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Misc"
+        ],
+        "summary": "Get a single LLM trace for a sandbox",
+        "parameters": [
+          {
+            "description": "Sandbox ID",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Trace ID",
+            "name": "traceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TraceRecord"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a workspace member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "sandbox not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "llmproxy not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/sandboxes/{id}/usage": {
       "get": {
         "security": [
@@ -2138,6 +3310,544 @@
             "description": "internal error",
             "content": {
               "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workspaces/{id}/credentials/{kind}": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Misc"
+        ],
+        "summary": "List credential bindings for a workspace",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Credential kind (e.g. kubernetes)",
+            "name": "kind",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/CredentialBindingItem"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "description": "On success returns 201 with the new binding. When the provider requires OIDC device code authentication returns 202 with verification_uri and user_code; poll device-complete to finalize.",
+        "tags": [
+          "Misc"
+        ],
+        "summary": "Create a credential binding for a workspace",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Credential kind (e.g. kubernetes)",
+            "name": "kind",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CredentialBindingCreateRequest"
+              }
+            }
+          },
+          "description": "Credential config",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Binding created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CredentialBindingCreateResponse"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "OIDC device code flow initiated",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CredentialBindingCreateResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "duplicate display_name",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workspaces/{id}/credentials/{kind}/{bindingId}": {
+      "delete": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Misc"
+        ],
+        "summary": "Delete a credential binding",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Credential kind",
+            "name": "kind",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Binding ID",
+            "name": "bindingId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "deleted"
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "cannot delete default binding while others exist",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Misc"
+        ],
+        "summary": "Patch a credential binding (rename)",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Credential kind",
+            "name": "kind",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Binding ID",
+            "name": "bindingId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CredentialBindingPatchRequest"
+              }
+            }
+          },
+          "description": "Fields to update",
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "updated"
+          },
+          "400": {
+            "description": "bad request",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "not found",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workspaces/{id}/credentials/{kind}/{bindingId}/device-complete": {
+      "post": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "description": "Long-polls until the user authorizes the device code. Returns 201 with the created binding on success.",
+        "tags": [
+          "Misc"
+        ],
+        "summary": "Complete an OIDC device code flow for a pending credential binding",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Credential kind",
+            "name": "kind",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Pending binding ID",
+            "name": "bindingId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Binding created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CredentialBindingCreateResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "device code authorization failed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "no pending device code flow found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "duplicate display_name or flow already being completed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "410": {
+            "description": "device code flow expired",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workspaces/{id}/credentials/{kind}/{bindingId}/set-default": {
+      "post": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Misc"
+        ],
+        "summary": "Set a credential binding as the default",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Credential kind",
+            "name": "kind",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Binding ID",
+            "name": "bindingId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "updated"
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "*/*": {
                 "schema": {
                   "type": "string"
                 }
@@ -3159,6 +4869,410 @@
         }
       }
     },
+    "/api/workspaces/{id}/modelserver/connect": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "description": "Redirects the browser to the ModelServer OAuth authorization URL. Returns 302.",
+        "tags": [
+          "Misc"
+        ],
+        "summary": "Initiate ModelServer OAuth connection for a workspace",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "302": {
+            "description": "redirect to ModelServer OAuth"
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "insufficient role (owner/maintainer required)",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "ModelServer OAuth not configured",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workspaces/{id}/modelserver/disconnect": {
+      "delete": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Misc"
+        ],
+        "summary": "Disconnect ModelServer from a workspace",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "disconnected"
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "insufficient role (owner/maintainer required)",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workspaces/{id}/modelserver/status": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Misc"
+        ],
+        "summary": "Get ModelServer connection status for a workspace",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelServerStatusResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a workspace member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workspaces/{id}/operations": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Misc"
+        ],
+        "summary": "List operations log entries for a workspace",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by environment ID",
+            "name": "env_id",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by tool name",
+            "name": "tool",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by source (e.g. codex)",
+            "name": "source",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Filter by error flag",
+            "name": "is_error",
+            "in": "query",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "description": "Return entries after this RFC3339 timestamp",
+            "name": "since",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Max rows to return",
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceOperationsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a workspace member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workspaces/{wid}/agent-interactions": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Misc"
+        ],
+        "summary": "List agent interaction audit trail for a workspace",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "name": "wid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Max entries (1–200, default 50)",
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Pagination offset",
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/AgentInteractionItem"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a workspace member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/workspaces/{wid}/agents": {
       "get": {
         "security": [
@@ -3288,6 +5402,324 @@
             "description": "internal error",
             "content": {
               "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workspaces/{wid}/defaults": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Misc"
+        ],
+        "summary": "Get workspace quota defaults and current sandbox count",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "name": "wid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceDefaultsResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "insufficient role",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workspaces/{wid}/executors": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Misc"
+        ],
+        "summary": "List codex remote executors for a workspace",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "name": "wid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ExecutorItem"
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a workspace member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "upstream gateway error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Misc"
+        ],
+        "summary": "Register a new codex remote executor for a workspace",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "name": "wid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExecutorRegisterRequest"
+              }
+            }
+          },
+          "description": "Executor registration payload",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExecutorRegisterResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request / invalid name",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "insufficient role (owner/maintainer required)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "upstream gateway error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "executors not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workspaces/{wid}/executors/{exe_id}": {
+      "delete": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Misc"
+        ],
+        "summary": "Remove a codex remote executor from a workspace",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "name": "wid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Executor ID",
+            "name": "exe_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "removed"
+          },
+          "400": {
+            "description": "bad request",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "insufficient role (owner/maintainer required)",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "upstream gateway error",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "executors not configured",
+            "content": {
+              "*/*": {
                 "schema": {
                   "type": "string"
                 }
@@ -3587,6 +6019,163 @@
           }
         }
       }
+    },
+    "/api/workspaces/{wid}/traces": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Misc"
+        ],
+        "summary": "List LLM traces for a workspace",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "name": "wid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Max entries to return",
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Pagination offset",
+            "name": "offset",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TraceListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a workspace member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "llmproxy not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/workspaces/{wid}/traces/{traceId}": {
+      "get": {
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "tags": [
+          "Misc"
+        ],
+        "summary": "Get a single LLM trace for a workspace",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "name": "wid",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Trace ID",
+            "name": "traceId",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TraceRecord"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "not a workspace member",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "llmproxy not configured",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "servers": [
@@ -3628,6 +6217,401 @@
       }
     },
     "schemas": {
+      "AdminOwnerInfo": {
+        "type": "object",
+        "required": [
+          "email",
+          "id"
+        ],
+        "properties": {
+          "email": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "picture": {
+            "type": "string",
+            "nullable": true
+          }
+        }
+      },
+      "AdminQuotaDefaultsResponse": {
+        "type": "object",
+        "required": [
+          "max_idle_timeout",
+          "max_sandbox_cpu",
+          "max_sandbox_memory",
+          "max_sandboxes_per_workspace",
+          "max_workspace_drive_size",
+          "max_workspaces_per_user",
+          "ws_max_idle_timeout",
+          "ws_max_total_cpu",
+          "ws_max_total_memory"
+        ],
+        "properties": {
+          "max_idle_timeout": {
+            "type": "integer"
+          },
+          "max_sandbox_cpu": {
+            "type": "integer"
+          },
+          "max_sandbox_memory": {
+            "type": "integer"
+          },
+          "max_sandboxes_per_workspace": {
+            "type": "integer"
+          },
+          "max_workspace_drive_size": {
+            "type": "integer"
+          },
+          "max_workspaces_per_user": {
+            "type": "integer"
+          },
+          "ws_max_idle_timeout": {
+            "type": "integer"
+          },
+          "ws_max_total_cpu": {
+            "type": "integer"
+          },
+          "ws_max_total_memory": {
+            "type": "integer"
+          }
+        }
+      },
+      "AdminQuotaDefaultsUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "max_idle_timeout": {
+            "type": "integer"
+          },
+          "max_sandbox_cpu": {
+            "type": "integer"
+          },
+          "max_sandbox_memory": {
+            "type": "integer"
+          },
+          "max_sandboxes_per_workspace": {
+            "type": "integer"
+          },
+          "max_workspace_drive_size": {
+            "type": "integer"
+          },
+          "max_workspaces_per_user": {
+            "type": "integer"
+          },
+          "ws_max_idle_timeout": {
+            "type": "integer"
+          },
+          "ws_max_total_cpu": {
+            "type": "integer"
+          },
+          "ws_max_total_memory": {
+            "type": "integer"
+          }
+        }
+      },
+      "AdminSandboxItem": {
+        "type": "object",
+        "required": [
+          "created_at",
+          "id",
+          "name",
+          "status",
+          "type",
+          "workspace_id"
+        ],
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "is_local": {
+            "type": "boolean"
+          },
+          "last_activity_at": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "example": "running"
+          },
+          "type": {
+            "type": "string",
+            "example": "opencode"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        }
+      },
+      "AdminSetUserQuotaRequest": {
+        "type": "object",
+        "properties": {
+          "max_workspaces": {
+            "type": "integer",
+            "nullable": true
+          }
+        }
+      },
+      "AdminSetWorkspaceQuotaRequest": {
+        "type": "object",
+        "properties": {
+          "max_drive_size": {
+            "type": "integer",
+            "nullable": true
+          },
+          "max_idle_timeout": {
+            "type": "integer",
+            "nullable": true
+          },
+          "max_sandbox_cpu": {
+            "type": "integer",
+            "nullable": true
+          },
+          "max_sandbox_memory": {
+            "type": "integer",
+            "nullable": true
+          },
+          "max_sandboxes": {
+            "type": "integer",
+            "nullable": true
+          },
+          "max_total_cpu": {
+            "type": "integer",
+            "nullable": true
+          },
+          "max_total_memory": {
+            "type": "integer",
+            "nullable": true
+          }
+        }
+      },
+      "AdminUpdateUserRoleRequest": {
+        "type": "object",
+        "required": [
+          "role"
+        ],
+        "properties": {
+          "role": {
+            "type": "string",
+            "example": "admin"
+          }
+        }
+      },
+      "AdminUserItem": {
+        "type": "object",
+        "required": [
+          "created_at",
+          "email",
+          "id",
+          "role"
+        ],
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "email": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "role": {
+            "type": "string",
+            "example": "user"
+          }
+        }
+      },
+      "AdminUserQuotaDefaults": {
+        "type": "object",
+        "required": [
+          "max_workspaces_per_user"
+        ],
+        "properties": {
+          "max_workspaces_per_user": {
+            "type": "integer"
+          }
+        }
+      },
+      "AdminUserQuotaOverrides": {
+        "type": "object",
+        "required": [
+          "updated_at"
+        ],
+        "properties": {
+          "max_workspaces": {
+            "type": "integer",
+            "nullable": true
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        }
+      },
+      "AdminUserQuotaResponse": {
+        "type": "object",
+        "required": [
+          "defaults"
+        ],
+        "properties": {
+          "defaults": {
+            "$ref": "#/components/schemas/AdminUserQuotaDefaults"
+          },
+          "overrides": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AdminUserQuotaOverrides"
+              }
+            ],
+            "nullable": true
+          }
+        }
+      },
+      "AdminWorkspaceItem": {
+        "type": "object",
+        "required": [
+          "created_at",
+          "id",
+          "name",
+          "updated_at"
+        ],
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "max_sandboxes": {
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "owner": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AdminOwnerInfo"
+              }
+            ],
+            "nullable": true
+          },
+          "sandbox_count": {
+            "type": "integer"
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        }
+      },
+      "AdminWorkspaceQuotaDefaults": {
+        "type": "object",
+        "required": [
+          "max_drive_size",
+          "max_idle_timeout",
+          "max_sandbox_cpu",
+          "max_sandbox_memory",
+          "max_sandboxes",
+          "max_total_cpu",
+          "max_total_memory"
+        ],
+        "properties": {
+          "max_drive_size": {
+            "type": "integer"
+          },
+          "max_idle_timeout": {
+            "type": "integer"
+          },
+          "max_sandbox_cpu": {
+            "type": "integer"
+          },
+          "max_sandbox_memory": {
+            "type": "integer"
+          },
+          "max_sandboxes": {
+            "type": "integer"
+          },
+          "max_total_cpu": {
+            "type": "integer"
+          },
+          "max_total_memory": {
+            "type": "integer"
+          }
+        }
+      },
+      "AdminWorkspaceQuotaOverrides": {
+        "type": "object",
+        "required": [
+          "updated_at"
+        ],
+        "properties": {
+          "max_drive_size": {
+            "type": "integer",
+            "nullable": true
+          },
+          "max_idle_timeout": {
+            "type": "integer",
+            "nullable": true
+          },
+          "max_sandbox_cpu": {
+            "type": "integer",
+            "nullable": true
+          },
+          "max_sandbox_memory": {
+            "type": "integer",
+            "nullable": true
+          },
+          "max_sandboxes": {
+            "type": "integer",
+            "nullable": true
+          },
+          "max_total_cpu": {
+            "type": "integer",
+            "nullable": true
+          },
+          "max_total_memory": {
+            "type": "integer",
+            "nullable": true
+          },
+          "updated_at": {
+            "type": "string"
+          }
+        }
+      },
+      "AdminWorkspaceQuotaResponse": {
+        "type": "object",
+        "required": [
+          "defaults"
+        ],
+        "properties": {
+          "defaults": {
+            "$ref": "#/components/schemas/AdminWorkspaceQuotaDefaults"
+          },
+          "overrides": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AdminWorkspaceQuotaOverrides"
+              }
+            ],
+            "nullable": true
+          }
+        }
+      },
       "AgentCardItem": {
         "type": "object",
         "required": [
@@ -3755,6 +6739,40 @@
           },
           "workdir": {
             "type": "string"
+          }
+        }
+      },
+      "AgentInteractionItem": {
+        "type": "object",
+        "required": [
+          "action",
+          "created_at",
+          "id",
+          "target_id",
+          "target_type"
+        ],
+        "properties": {
+          "action": {
+            "type": "string",
+            "example": "task.created"
+          },
+          "actor_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "detail": {},
+          "id": {
+            "type": "integer"
+          },
+          "target_id": {
+            "type": "string"
+          },
+          "target_type": {
+            "type": "string",
+            "example": "task"
           }
         }
       },
@@ -4311,6 +7329,195 @@
           }
         }
       },
+      "CredentialBindingCreateRequest": {
+        "type": "object",
+        "required": [
+          "config",
+          "display_name"
+        ],
+        "properties": {
+          "config": {
+            "type": "string",
+            "example": "{\"server\": \"https://...\"}"
+          },
+          "display_name": {
+            "type": "string",
+            "example": "My K8s Cluster"
+          }
+        }
+      },
+      "CredentialBindingCreateResponse": {
+        "type": "object",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "auth_type": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "expires_in": {
+            "type": "integer"
+          },
+          "id": {
+            "type": "string"
+          },
+          "is_default": {
+            "type": "boolean"
+          },
+          "server_url": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "example": "pending_device_code"
+          },
+          "user_code": {
+            "type": "string"
+          },
+          "verification_uri": {
+            "type": "string"
+          }
+        }
+      },
+      "CredentialBindingItem": {
+        "type": "object",
+        "required": [
+          "auth_type",
+          "created_at",
+          "display_name",
+          "id"
+        ],
+        "properties": {
+          "auth_type": {
+            "type": "string",
+            "example": "static"
+          },
+          "created_at": {
+            "type": "string"
+          },
+          "display_name": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "is_default": {
+            "type": "boolean"
+          },
+          "public_meta": {},
+          "server_url": {
+            "type": "string"
+          }
+        }
+      },
+      "CredentialBindingPatchRequest": {
+        "type": "object",
+        "properties": {
+          "display_name": {
+            "type": "string",
+            "example": "Renamed Cluster",
+            "nullable": true
+          }
+        }
+      },
+      "ExecutorConnectCommands": {
+        "type": "object",
+        "required": [
+          "agent_identity"
+        ],
+        "properties": {
+          "agent_identity": {
+            "type": "string"
+          }
+        }
+      },
+      "ExecutorItem": {
+        "type": "object",
+        "required": [
+          "exe_id",
+          "name"
+        ],
+        "properties": {
+          "client_ip": {
+            "type": "string"
+          },
+          "client_ua": {
+            "type": "string"
+          },
+          "codex_version": {
+            "type": "string"
+          },
+          "connected_at": {
+            "type": "string",
+            "nullable": true
+          },
+          "description": {
+            "type": "string"
+          },
+          "disconnected_at": {
+            "type": "string",
+            "nullable": true
+          },
+          "exe_id": {
+            "type": "string"
+          },
+          "is_default": {
+            "type": "boolean"
+          },
+          "is_online": {
+            "type": "boolean"
+          },
+          "last_seen_at": {
+            "type": "string",
+            "nullable": true
+          },
+          "name": {
+            "type": "string"
+          },
+          "os": {
+            "type": "string"
+          }
+        }
+      },
+      "ExecutorRegisterRequest": {
+        "type": "object",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "description": {
+            "type": "string",
+            "example": "Main development laptop"
+          },
+          "name": {
+            "type": "string",
+            "example": "my-dev-machine"
+          }
+        }
+      },
+      "ExecutorRegisterResponse": {
+        "type": "object",
+        "required": [
+          "exe_id"
+        ],
+        "properties": {
+          "agent_identity_jwt": {
+            "type": "string"
+          },
+          "connect_command": {
+            "type": "string"
+          },
+          "connect_commands": {
+            "$ref": "#/components/schemas/ExecutorConnectCommands"
+          },
+          "exe_id": {
+            "type": "string"
+          }
+        }
+      },
       "IMBinding": {
         "type": "object",
         "required": [
@@ -4705,6 +7912,103 @@
           }
         }
       },
+      "ModelServerStatusResponse": {
+        "type": "object",
+        "required": [
+          "connected"
+        ],
+        "properties": {
+          "connected": {
+            "type": "boolean"
+          },
+          "connected_at": {
+            "type": "string"
+          },
+          "models": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LLMModel"
+            }
+          },
+          "project_id": {
+            "type": "string"
+          },
+          "project_name": {
+            "type": "string"
+          }
+        }
+      },
+      "OperationRecord": {
+        "type": "object",
+        "required": [
+          "completed_at",
+          "duration_ms",
+          "env_id",
+          "id",
+          "source",
+          "started_at",
+          "tool",
+          "workspace_id"
+        ],
+        "properties": {
+          "arguments": {},
+          "arguments_meta": {},
+          "cell_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "completed_at": {
+            "type": "string"
+          },
+          "duration_ms": {
+            "type": "integer"
+          },
+          "env_id": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "is_error": {
+            "type": "boolean"
+          },
+          "notebook_path": {
+            "type": "string",
+            "nullable": true
+          },
+          "request_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "result_meta": {},
+          "result_summary": {
+            "type": "string",
+            "nullable": true
+          },
+          "source": {
+            "type": "string",
+            "example": "codex"
+          },
+          "started_at": {
+            "type": "string"
+          },
+          "thread_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "tool": {
+            "type": "string",
+            "example": "shell"
+          },
+          "user_id": {
+            "type": "string",
+            "nullable": true
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        }
+      },
       "Sandbox": {
         "type": "object",
         "required": [
@@ -4911,6 +8215,70 @@
           }
         }
       },
+      "TraceListResponse": {
+        "type": "object",
+        "required": [
+          "traces"
+        ],
+        "properties": {
+          "traces": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/TraceRecord"
+            }
+          }
+        }
+      },
+      "TraceRecord": {
+        "type": "object",
+        "required": [
+          "created_at",
+          "id",
+          "sandbox_id",
+          "source",
+          "updated_at",
+          "workspace_id"
+        ],
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "models": {
+            "type": "string"
+          },
+          "request_count": {
+            "type": "integer"
+          },
+          "sandbox_id": {
+            "type": "string"
+          },
+          "source": {
+            "type": "string",
+            "example": "codex"
+          },
+          "total_cache_creation_tokens": {
+            "type": "integer"
+          },
+          "total_cache_read_tokens": {
+            "type": "integer"
+          },
+          "total_input_tokens": {
+            "type": "integer"
+          },
+          "total_output_tokens": {
+            "type": "integer"
+          },
+          "updated_at": {
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        }
+      },
       "Workspace": {
         "type": "object",
         "required": [
@@ -4946,6 +8314,33 @@
           }
         }
       },
+      "WorkspaceDefaultsResponse": {
+        "type": "object",
+        "required": [
+          "current_sandboxes",
+          "max_idle_timeout",
+          "max_sandbox_cpu",
+          "max_sandbox_memory",
+          "max_sandboxes"
+        ],
+        "properties": {
+          "current_sandboxes": {
+            "type": "integer"
+          },
+          "max_idle_timeout": {
+            "type": "integer"
+          },
+          "max_sandbox_cpu": {
+            "type": "integer"
+          },
+          "max_sandbox_memory": {
+            "type": "integer"
+          },
+          "max_sandboxes": {
+            "type": "integer"
+          }
+        }
+      },
       "WorkspaceMember": {
         "type": "object",
         "required": [
@@ -4967,6 +8362,20 @@
           },
           "user_id": {
             "type": "string"
+          }
+        }
+      },
+      "WorkspaceOperationsResponse": {
+        "type": "object",
+        "required": [
+          "operations"
+        ],
+        "properties": {
+          "operations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/OperationRecord"
+            }
           }
         }
       },

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -8,6 +8,597 @@ info:
   title: agentserver API
   version: 0.1.0
 paths:
+  /api/admin/quotas/defaults:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminQuotaDefaultsResponse"
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: admin role required
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Get system-wide quota defaults (admin)
+      tags:
+        - Admin
+    put:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdminQuotaDefaultsUpdateRequest"
+        description: Quota fields to update (all optional)
+        required: true
+      responses:
+        "200":
+          description: Updated defaults
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminQuotaDefaultsResponse"
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                type: string
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: admin role required
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Update system-wide quota defaults (admin)
+      tags:
+        - Admin
+  /api/admin/sandboxes:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: "#/components/schemas/AdminSandboxItem"
+                type: array
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: admin role required
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: List all sandboxes (admin)
+      tags:
+        - Admin
+  /api/admin/users:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: "#/components/schemas/AdminUserItem"
+                type: array
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: admin role required
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: List all users (admin)
+      tags:
+        - Admin
+  "/api/admin/users/{id}/quota":
+    delete:
+      parameters:
+        - description: User ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: deleted
+        "401":
+          description: unauthorized
+          content:
+            "*/*":
+              schema:
+                type: string
+        "403":
+          description: admin role required
+          content:
+            "*/*":
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            "*/*":
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Delete per-user quota override (admin)
+      tags:
+        - Admin
+    get:
+      parameters:
+        - description: User ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminUserQuotaResponse"
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: admin role required
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Get per-user quota override (admin)
+      tags:
+        - Admin
+    put:
+      parameters:
+        - description: User ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdminSetUserQuotaRequest"
+        description: Quota overrides
+        required: true
+      responses:
+        "204":
+          description: saved
+        "400":
+          description: bad request
+          content:
+            "*/*":
+              schema:
+                type: string
+        "401":
+          description: unauthorized
+          content:
+            "*/*":
+              schema:
+                type: string
+        "403":
+          description: admin role required
+          content:
+            "*/*":
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            "*/*":
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Set per-user quota override (admin)
+      tags:
+        - Admin
+  "/api/admin/users/{id}/role":
+    put:
+      parameters:
+        - description: User ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdminUpdateUserRoleRequest"
+        description: New role (user or admin)
+        required: true
+      responses:
+        "204":
+          description: updated
+        "400":
+          description: bad request / invalid role
+          content:
+            "*/*":
+              schema:
+                type: string
+        "401":
+          description: unauthorized
+          content:
+            "*/*":
+              schema:
+                type: string
+        "403":
+          description: admin role required
+          content:
+            "*/*":
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            "*/*":
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Update a user's role (admin)
+      tags:
+        - Admin
+  /api/admin/workspaces:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: "#/components/schemas/AdminWorkspaceItem"
+                type: array
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: admin role required
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: List all workspaces (admin)
+      tags:
+        - Admin
+  "/api/admin/workspaces/{id}/llm-quota":
+    delete:
+      parameters:
+        - description: Workspace ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: deleted
+        "401":
+          description: unauthorized
+          content:
+            "*/*":
+              schema:
+                type: string
+        "403":
+          description: admin role required
+          content:
+            "*/*":
+              schema:
+                type: string
+        "502":
+          description: llmproxy unavailable
+          content:
+            "*/*":
+              schema:
+                type: string
+        "503":
+          description: llmproxy not configured
+          content:
+            "*/*":
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Delete workspace LLM quota override (admin, proxied to llmproxy)
+      tags:
+        - Admin
+    get:
+      parameters:
+        - description: Workspace ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/LLMQuotaResponse"
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: admin role required
+          content:
+            application/json:
+              schema:
+                type: string
+        "502":
+          description: llmproxy unavailable
+          content:
+            application/json:
+              schema:
+                type: string
+        "503":
+          description: llmproxy not configured
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Get workspace LLM quota (admin, proxied to llmproxy)
+      tags:
+        - Admin
+    put:
+      parameters:
+        - description: Workspace ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: saved
+        "400":
+          description: bad request
+          content:
+            "*/*":
+              schema:
+                type: string
+        "401":
+          description: unauthorized
+          content:
+            "*/*":
+              schema:
+                type: string
+        "403":
+          description: admin role required
+          content:
+            "*/*":
+              schema:
+                type: string
+        "502":
+          description: llmproxy unavailable
+          content:
+            "*/*":
+              schema:
+                type: string
+        "503":
+          description: llmproxy not configured
+          content:
+            "*/*":
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Set workspace LLM quota override (admin, proxied to llmproxy)
+      tags:
+        - Admin
+  "/api/admin/workspaces/{id}/quota":
+    delete:
+      parameters:
+        - description: Workspace ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: deleted
+        "401":
+          description: unauthorized
+          content:
+            "*/*":
+              schema:
+                type: string
+        "403":
+          description: admin role required
+          content:
+            "*/*":
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            "*/*":
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Delete workspace quota override (admin)
+      tags:
+        - Admin
+    get:
+      parameters:
+        - description: Workspace ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AdminWorkspaceQuotaResponse"
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: admin role required
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Get workspace quota override (admin)
+      tags:
+        - Admin
+    put:
+      parameters:
+        - description: Workspace ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/AdminSetWorkspaceQuotaRequest"
+        description: Quota overrides (all optional, merged with existing)
+        required: true
+      responses:
+        "204":
+          description: saved
+        "400":
+          description: bad request
+          content:
+            "*/*":
+              schema:
+                type: string
+        "401":
+          description: unauthorized
+          content:
+            "*/*":
+              schema:
+                type: string
+        "403":
+          description: admin role required
+          content:
+            "*/*":
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            "*/*":
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Set workspace quota override (admin)
+      tags:
+        - Admin
   /api/agent/discovery/agents:
     get:
       responses:
@@ -970,6 +1561,112 @@ paths:
       summary: Resume a paused sandbox (cloud sandboxes only)
       tags:
         - Sandboxes
+  "/api/sandboxes/{id}/traces":
+    get:
+      parameters:
+        - description: Sandbox ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - description: Max entries to return
+          in: query
+          name: limit
+          schema:
+            type: integer
+        - description: Pagination offset
+          in: query
+          name: offset
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TraceListResponse"
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: not a workspace member
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: sandbox not found
+          content:
+            application/json:
+              schema:
+                type: string
+        "503":
+          description: llmproxy not configured
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: List LLM traces for a sandbox
+      tags:
+        - Misc
+  "/api/sandboxes/{id}/traces/{traceId}":
+    get:
+      parameters:
+        - description: Sandbox ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - description: Trace ID
+          in: path
+          name: traceId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TraceRecord"
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: not a workspace member
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: sandbox not found
+          content:
+            application/json:
+              schema:
+                type: string
+        "503":
+          description: llmproxy not configured
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Get a single LLM trace for a sandbox
+      tags:
+        - Misc
   "/api/sandboxes/{id}/usage":
     get:
       parameters:
@@ -1272,6 +1969,337 @@ paths:
       summary: Rename a workspace
       tags:
         - Workspaces
+  "/api/workspaces/{id}/credentials/{kind}":
+    get:
+      parameters:
+        - description: Workspace ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - description: Credential kind (e.g. kubernetes)
+          in: path
+          name: kind
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: "#/components/schemas/CredentialBindingItem"
+                type: array
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: List credential bindings for a workspace
+      tags:
+        - Misc
+    post:
+      description: On success returns 201 with the new binding. When the provider
+        requires OIDC device code authentication returns 202 with
+        verification_uri and user_code; poll device-complete to finalize.
+      parameters:
+        - description: Workspace ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - description: Credential kind (e.g. kubernetes)
+          in: path
+          name: kind
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CredentialBindingCreateRequest"
+        description: Credential config
+        required: true
+      responses:
+        "201":
+          description: Binding created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CredentialBindingCreateResponse"
+        "202":
+          description: OIDC device code flow initiated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CredentialBindingCreateResponse"
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                type: string
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "409":
+          description: duplicate display_name
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Create a credential binding for a workspace
+      tags:
+        - Misc
+  "/api/workspaces/{id}/credentials/{kind}/{bindingId}":
+    delete:
+      parameters:
+        - description: Workspace ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - description: Credential kind
+          in: path
+          name: kind
+          required: true
+          schema:
+            type: string
+        - description: Binding ID
+          in: path
+          name: bindingId
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: deleted
+        "401":
+          description: unauthorized
+          content:
+            "*/*":
+              schema:
+                type: string
+        "404":
+          description: not found
+          content:
+            "*/*":
+              schema:
+                type: string
+        "409":
+          description: cannot delete default binding while others exist
+          content:
+            "*/*":
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            "*/*":
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Delete a credential binding
+      tags:
+        - Misc
+    patch:
+      parameters:
+        - description: Workspace ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - description: Credential kind
+          in: path
+          name: kind
+          required: true
+          schema:
+            type: string
+        - description: Binding ID
+          in: path
+          name: bindingId
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CredentialBindingPatchRequest"
+        description: Fields to update
+        required: true
+      responses:
+        "204":
+          description: updated
+        "400":
+          description: bad request
+          content:
+            "*/*":
+              schema:
+                type: string
+        "401":
+          description: unauthorized
+          content:
+            "*/*":
+              schema:
+                type: string
+        "404":
+          description: not found
+          content:
+            "*/*":
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            "*/*":
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Patch a credential binding (rename)
+      tags:
+        - Misc
+  "/api/workspaces/{id}/credentials/{kind}/{bindingId}/device-complete":
+    post:
+      description: Long-polls until the user authorizes the device code. Returns 201
+        with the created binding on success.
+      parameters:
+        - description: Workspace ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - description: Credential kind
+          in: path
+          name: kind
+          required: true
+          schema:
+            type: string
+        - description: Pending binding ID
+          in: path
+          name: bindingId
+          required: true
+          schema:
+            type: string
+      responses:
+        "201":
+          description: Binding created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CredentialBindingCreateResponse"
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: device code authorization failed
+          content:
+            application/json:
+              schema:
+                type: string
+        "404":
+          description: no pending device code flow found
+          content:
+            application/json:
+              schema:
+                type: string
+        "409":
+          description: duplicate display_name or flow already being completed
+          content:
+            application/json:
+              schema:
+                type: string
+        "410":
+          description: device code flow expired
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Complete an OIDC device code flow for a pending credential binding
+      tags:
+        - Misc
+  "/api/workspaces/{id}/credentials/{kind}/{bindingId}/set-default":
+    post:
+      parameters:
+        - description: Workspace ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - description: Credential kind
+          in: path
+          name: kind
+          required: true
+          schema:
+            type: string
+        - description: Binding ID
+          in: path
+          name: bindingId
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: updated
+        "401":
+          description: unauthorized
+          content:
+            "*/*":
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            "*/*":
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Set a credential binding as the default
+      tags:
+        - Misc
   "/api/workspaces/{id}/im/channels":
     get:
       parameters:
@@ -1883,6 +2911,249 @@ paths:
       summary: Change a member's role (owner only)
       tags:
         - Workspaces
+  "/api/workspaces/{id}/modelserver/connect":
+    get:
+      description: Redirects the browser to the ModelServer OAuth authorization URL.
+        Returns 302.
+      parameters:
+        - description: Workspace ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "302":
+          description: redirect to ModelServer OAuth
+        "401":
+          description: unauthorized
+          content:
+            "*/*":
+              schema:
+                type: string
+        "403":
+          description: insufficient role (owner/maintainer required)
+          content:
+            "*/*":
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            "*/*":
+              schema:
+                type: string
+        "501":
+          description: ModelServer OAuth not configured
+          content:
+            "*/*":
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Initiate ModelServer OAuth connection for a workspace
+      tags:
+        - Misc
+  "/api/workspaces/{id}/modelserver/disconnect":
+    delete:
+      parameters:
+        - description: Workspace ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: disconnected
+        "401":
+          description: unauthorized
+          content:
+            "*/*":
+              schema:
+                type: string
+        "403":
+          description: insufficient role (owner/maintainer required)
+          content:
+            "*/*":
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            "*/*":
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Disconnect ModelServer from a workspace
+      tags:
+        - Misc
+  "/api/workspaces/{id}/modelserver/status":
+    get:
+      parameters:
+        - description: Workspace ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ModelServerStatusResponse"
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: not a workspace member
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Get ModelServer connection status for a workspace
+      tags:
+        - Misc
+  "/api/workspaces/{id}/operations":
+    get:
+      parameters:
+        - description: Workspace ID
+          in: path
+          name: id
+          required: true
+          schema:
+            type: string
+        - description: Filter by environment ID
+          in: query
+          name: env_id
+          schema:
+            type: string
+        - description: Filter by tool name
+          in: query
+          name: tool
+          schema:
+            type: string
+        - description: Filter by source (e.g. codex)
+          in: query
+          name: source
+          schema:
+            type: string
+        - description: Filter by error flag
+          in: query
+          name: is_error
+          schema:
+            type: boolean
+        - description: Return entries after this RFC3339 timestamp
+          in: query
+          name: since
+          schema:
+            type: string
+        - description: Max rows to return
+          in: query
+          name: limit
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkspaceOperationsResponse"
+        "400":
+          description: bad request
+          content:
+            application/json:
+              schema:
+                type: string
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: not a workspace member
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: List operations log entries for a workspace
+      tags:
+        - Misc
+  "/api/workspaces/{wid}/agent-interactions":
+    get:
+      parameters:
+        - description: Workspace ID
+          in: path
+          name: wid
+          required: true
+          schema:
+            type: string
+        - description: Max entries (1–200, default 50)
+          in: query
+          name: limit
+          schema:
+            type: integer
+        - description: Pagination offset
+          in: query
+          name: offset
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: "#/components/schemas/AgentInteractionItem"
+                type: array
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: not a workspace member
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: List agent interaction audit trail for a workspace
+      tags:
+        - Misc
   "/api/workspaces/{wid}/agents":
     get:
       parameters:
@@ -1965,6 +3236,196 @@ paths:
       summary: List Codex browser sessions for a workspace
       tags:
         - Codex Browser Sessions
+  "/api/workspaces/{wid}/defaults":
+    get:
+      parameters:
+        - description: Workspace ID
+          in: path
+          name: wid
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WorkspaceDefaultsResponse"
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: insufficient role
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Get workspace quota defaults and current sandbox count
+      tags:
+        - Misc
+  "/api/workspaces/{wid}/executors":
+    get:
+      parameters:
+        - description: Workspace ID
+          in: path
+          name: wid
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                items:
+                  $ref: "#/components/schemas/ExecutorItem"
+                type: array
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: not a workspace member
+          content:
+            application/json:
+              schema:
+                type: string
+        "502":
+          description: upstream gateway error
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: List codex remote executors for a workspace
+      tags:
+        - Misc
+    post:
+      parameters:
+        - description: Workspace ID
+          in: path
+          name: wid
+          required: true
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ExecutorRegisterRequest"
+        description: Executor registration payload
+        required: true
+      responses:
+        "201":
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ExecutorRegisterResponse"
+        "400":
+          description: bad request / invalid name
+          content:
+            application/json:
+              schema:
+                type: string
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: insufficient role (owner/maintainer required)
+          content:
+            application/json:
+              schema:
+                type: string
+        "502":
+          description: upstream gateway error
+          content:
+            application/json:
+              schema:
+                type: string
+        "503":
+          description: executors not configured
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Register a new codex remote executor for a workspace
+      tags:
+        - Misc
+  "/api/workspaces/{wid}/executors/{exe_id}":
+    delete:
+      parameters:
+        - description: Workspace ID
+          in: path
+          name: wid
+          required: true
+          schema:
+            type: string
+        - description: Executor ID
+          in: path
+          name: exe_id
+          required: true
+          schema:
+            type: string
+      responses:
+        "204":
+          description: removed
+        "400":
+          description: bad request
+          content:
+            "*/*":
+              schema:
+                type: string
+        "401":
+          description: unauthorized
+          content:
+            "*/*":
+              schema:
+                type: string
+        "403":
+          description: insufficient role (owner/maintainer required)
+          content:
+            "*/*":
+              schema:
+                type: string
+        "502":
+          description: upstream gateway error
+          content:
+            "*/*":
+              schema:
+                type: string
+        "503":
+          description: executors not configured
+          content:
+            "*/*":
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Remove a codex remote executor from a workspace
+      tags:
+        - Misc
   "/api/workspaces/{wid}/sandboxes":
     get:
       parameters:
@@ -2141,6 +3602,100 @@ paths:
       summary: Create a delegated task in a workspace
       tags:
         - Agent
+  "/api/workspaces/{wid}/traces":
+    get:
+      parameters:
+        - description: Workspace ID
+          in: path
+          name: wid
+          required: true
+          schema:
+            type: string
+        - description: Max entries to return
+          in: query
+          name: limit
+          schema:
+            type: integer
+        - description: Pagination offset
+          in: query
+          name: offset
+          schema:
+            type: integer
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TraceListResponse"
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: not a workspace member
+          content:
+            application/json:
+              schema:
+                type: string
+        "503":
+          description: llmproxy not configured
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: List LLM traces for a workspace
+      tags:
+        - Misc
+  "/api/workspaces/{wid}/traces/{traceId}":
+    get:
+      parameters:
+        - description: Workspace ID
+          in: path
+          name: wid
+          required: true
+          schema:
+            type: string
+        - description: Trace ID
+          in: path
+          name: traceId
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/TraceRecord"
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: not a workspace member
+          content:
+            application/json:
+              schema:
+                type: string
+        "503":
+          description: llmproxy not configured
+          content:
+            application/json:
+              schema:
+                type: string
+      security:
+        - CookieAuth: []
+      summary: Get a single LLM trace for a workspace
+      tags:
+        - Misc
   /api/workspaces/quota:
     get:
       responses:
@@ -2187,6 +3742,277 @@ components:
       name: agentserver-token
       type: apiKey
   schemas:
+    AdminOwnerInfo:
+      properties:
+        email:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+          nullable: true
+        picture:
+          type: string
+          nullable: true
+      required:
+        - email
+        - id
+      type: object
+    AdminQuotaDefaultsResponse:
+      properties:
+        max_idle_timeout:
+          type: integer
+        max_sandbox_cpu:
+          type: integer
+        max_sandbox_memory:
+          type: integer
+        max_sandboxes_per_workspace:
+          type: integer
+        max_workspace_drive_size:
+          type: integer
+        max_workspaces_per_user:
+          type: integer
+        ws_max_idle_timeout:
+          type: integer
+        ws_max_total_cpu:
+          type: integer
+        ws_max_total_memory:
+          type: integer
+      required:
+        - max_idle_timeout
+        - max_sandbox_cpu
+        - max_sandbox_memory
+        - max_sandboxes_per_workspace
+        - max_workspace_drive_size
+        - max_workspaces_per_user
+        - ws_max_idle_timeout
+        - ws_max_total_cpu
+        - ws_max_total_memory
+      type: object
+    AdminQuotaDefaultsUpdateRequest:
+      properties:
+        max_idle_timeout:
+          type: integer
+        max_sandbox_cpu:
+          type: integer
+        max_sandbox_memory:
+          type: integer
+        max_sandboxes_per_workspace:
+          type: integer
+        max_workspace_drive_size:
+          type: integer
+        max_workspaces_per_user:
+          type: integer
+        ws_max_idle_timeout:
+          type: integer
+        ws_max_total_cpu:
+          type: integer
+        ws_max_total_memory:
+          type: integer
+      type: object
+    AdminSandboxItem:
+      properties:
+        created_at:
+          type: string
+        id:
+          type: string
+        is_local:
+          type: boolean
+        last_activity_at:
+          type: string
+          nullable: true
+        name:
+          type: string
+        status:
+          example: running
+          type: string
+        type:
+          example: opencode
+          type: string
+        workspace_id:
+          type: string
+      required:
+        - created_at
+        - id
+        - name
+        - status
+        - type
+        - workspace_id
+      type: object
+    AdminSetUserQuotaRequest:
+      properties:
+        max_workspaces:
+          type: integer
+          nullable: true
+      type: object
+    AdminSetWorkspaceQuotaRequest:
+      properties:
+        max_drive_size:
+          type: integer
+          nullable: true
+        max_idle_timeout:
+          type: integer
+          nullable: true
+        max_sandbox_cpu:
+          type: integer
+          nullable: true
+        max_sandbox_memory:
+          type: integer
+          nullable: true
+        max_sandboxes:
+          type: integer
+          nullable: true
+        max_total_cpu:
+          type: integer
+          nullable: true
+        max_total_memory:
+          type: integer
+          nullable: true
+      type: object
+    AdminUpdateUserRoleRequest:
+      properties:
+        role:
+          example: admin
+          type: string
+      required:
+        - role
+      type: object
+    AdminUserItem:
+      properties:
+        created_at:
+          type: string
+        email:
+          type: string
+        id:
+          type: string
+        name:
+          type: string
+          nullable: true
+        role:
+          example: user
+          type: string
+      required:
+        - created_at
+        - email
+        - id
+        - role
+      type: object
+    AdminUserQuotaDefaults:
+      properties:
+        max_workspaces_per_user:
+          type: integer
+      required:
+        - max_workspaces_per_user
+      type: object
+    AdminUserQuotaOverrides:
+      properties:
+        max_workspaces:
+          type: integer
+          nullable: true
+        updated_at:
+          type: string
+      required:
+        - updated_at
+      type: object
+    AdminUserQuotaResponse:
+      properties:
+        defaults:
+          $ref: "#/components/schemas/AdminUserQuotaDefaults"
+        overrides:
+          allOf:
+            - $ref: "#/components/schemas/AdminUserQuotaOverrides"
+          nullable: true
+      required:
+        - defaults
+      type: object
+    AdminWorkspaceItem:
+      properties:
+        created_at:
+          type: string
+        id:
+          type: string
+        max_sandboxes:
+          type: integer
+        name:
+          type: string
+        owner:
+          allOf:
+            - $ref: "#/components/schemas/AdminOwnerInfo"
+          nullable: true
+        sandbox_count:
+          type: integer
+        updated_at:
+          type: string
+      required:
+        - created_at
+        - id
+        - name
+        - updated_at
+      type: object
+    AdminWorkspaceQuotaDefaults:
+      properties:
+        max_drive_size:
+          type: integer
+        max_idle_timeout:
+          type: integer
+        max_sandbox_cpu:
+          type: integer
+        max_sandbox_memory:
+          type: integer
+        max_sandboxes:
+          type: integer
+        max_total_cpu:
+          type: integer
+        max_total_memory:
+          type: integer
+      required:
+        - max_drive_size
+        - max_idle_timeout
+        - max_sandbox_cpu
+        - max_sandbox_memory
+        - max_sandboxes
+        - max_total_cpu
+        - max_total_memory
+      type: object
+    AdminWorkspaceQuotaOverrides:
+      properties:
+        max_drive_size:
+          type: integer
+          nullable: true
+        max_idle_timeout:
+          type: integer
+          nullable: true
+        max_sandbox_cpu:
+          type: integer
+          nullable: true
+        max_sandbox_memory:
+          type: integer
+          nullable: true
+        max_sandboxes:
+          type: integer
+          nullable: true
+        max_total_cpu:
+          type: integer
+          nullable: true
+        max_total_memory:
+          type: integer
+          nullable: true
+        updated_at:
+          type: string
+      required:
+        - updated_at
+      type: object
+    AdminWorkspaceQuotaResponse:
+      properties:
+        defaults:
+          $ref: "#/components/schemas/AdminWorkspaceQuotaDefaults"
+        overrides:
+          allOf:
+            - $ref: "#/components/schemas/AdminWorkspaceQuotaOverrides"
+          nullable: true
+      required:
+        - defaults
+      type: object
     AgentCardItem:
       properties:
         agent_id:
@@ -2280,6 +4106,31 @@ components:
         - platform_version
         - updated_at
         - workdir
+      type: object
+    AgentInteractionItem:
+      properties:
+        action:
+          example: task.created
+          type: string
+        actor_id:
+          type: string
+          nullable: true
+        created_at:
+          type: string
+        detail: {}
+        id:
+          type: integer
+        target_id:
+          type: string
+        target_type:
+          example: task
+          type: string
+      required:
+        - action
+        - created_at
+        - id
+        - target_id
+        - target_type
       type: object
     AgentMailboxMessage:
       properties:
@@ -2670,6 +4521,135 @@ components:
         - token
         - workspace_id
       type: object
+    CredentialBindingCreateRequest:
+      properties:
+        config:
+          example: '{"server": "https://..."}'
+          type: string
+        display_name:
+          example: My K8s Cluster
+          type: string
+      required:
+        - config
+        - display_name
+      type: object
+    CredentialBindingCreateResponse:
+      properties:
+        auth_type:
+          type: string
+        display_name:
+          type: string
+        expires_in:
+          type: integer
+        id:
+          type: string
+        is_default:
+          type: boolean
+        server_url:
+          type: string
+        status:
+          example: pending_device_code
+          type: string
+        user_code:
+          type: string
+        verification_uri:
+          type: string
+      required:
+        - id
+      type: object
+    CredentialBindingItem:
+      properties:
+        auth_type:
+          example: static
+          type: string
+        created_at:
+          type: string
+        display_name:
+          type: string
+        id:
+          type: string
+        is_default:
+          type: boolean
+        public_meta: {}
+        server_url:
+          type: string
+      required:
+        - auth_type
+        - created_at
+        - display_name
+        - id
+      type: object
+    CredentialBindingPatchRequest:
+      properties:
+        display_name:
+          example: Renamed Cluster
+          type: string
+          nullable: true
+      type: object
+    ExecutorConnectCommands:
+      properties:
+        agent_identity:
+          type: string
+      required:
+        - agent_identity
+      type: object
+    ExecutorItem:
+      properties:
+        client_ip:
+          type: string
+        client_ua:
+          type: string
+        codex_version:
+          type: string
+        connected_at:
+          type: string
+          nullable: true
+        description:
+          type: string
+        disconnected_at:
+          type: string
+          nullable: true
+        exe_id:
+          type: string
+        is_default:
+          type: boolean
+        is_online:
+          type: boolean
+        last_seen_at:
+          type: string
+          nullable: true
+        name:
+          type: string
+        os:
+          type: string
+      required:
+        - exe_id
+        - name
+      type: object
+    ExecutorRegisterRequest:
+      properties:
+        description:
+          example: Main development laptop
+          type: string
+        name:
+          example: my-dev-machine
+          type: string
+      required:
+        - name
+      type: object
+    ExecutorRegisterResponse:
+      properties:
+        agent_identity_jwt:
+          type: string
+        connect_command:
+          type: string
+        connect_commands:
+          $ref: "#/components/schemas/ExecutorConnectCommands"
+        exe_id:
+          type: string
+      required:
+        - exe_id
+      type: object
     IMBinding:
       properties:
         bot_id:
@@ -2938,6 +4918,76 @@ components:
       required:
         - role
       type: object
+    ModelServerStatusResponse:
+      properties:
+        connected:
+          type: boolean
+        connected_at:
+          type: string
+        models:
+          items:
+            $ref: "#/components/schemas/LLMModel"
+          type: array
+        project_id:
+          type: string
+        project_name:
+          type: string
+      required:
+        - connected
+      type: object
+    OperationRecord:
+      properties:
+        arguments: {}
+        arguments_meta: {}
+        cell_id:
+          type: string
+          nullable: true
+        completed_at:
+          type: string
+        duration_ms:
+          type: integer
+        env_id:
+          type: string
+        id:
+          type: string
+        is_error:
+          type: boolean
+        notebook_path:
+          type: string
+          nullable: true
+        request_id:
+          type: string
+          nullable: true
+        result_meta: {}
+        result_summary:
+          type: string
+          nullable: true
+        source:
+          example: codex
+          type: string
+        started_at:
+          type: string
+        thread_id:
+          type: string
+          nullable: true
+        tool:
+          example: shell
+          type: string
+        user_id:
+          type: string
+          nullable: true
+        workspace_id:
+          type: string
+      required:
+        - completed_at
+        - duration_ms
+        - env_id
+        - id
+        - source
+        - started_at
+        - tool
+        - workspace_id
+      type: object
     Sandbox:
       properties:
         agent_info:
@@ -3083,6 +5133,50 @@ components:
         - provider
         - request_count
       type: object
+    TraceListResponse:
+      properties:
+        traces:
+          items:
+            $ref: "#/components/schemas/TraceRecord"
+          type: array
+      required:
+        - traces
+      type: object
+    TraceRecord:
+      properties:
+        created_at:
+          type: string
+        id:
+          type: string
+        models:
+          type: string
+        request_count:
+          type: integer
+        sandbox_id:
+          type: string
+        source:
+          example: codex
+          type: string
+        total_cache_creation_tokens:
+          type: integer
+        total_cache_read_tokens:
+          type: integer
+        total_input_tokens:
+          type: integer
+        total_output_tokens:
+          type: integer
+        updated_at:
+          type: string
+        workspace_id:
+          type: string
+      required:
+        - created_at
+        - id
+        - sandbox_id
+        - source
+        - updated_at
+        - workspace_id
+      type: object
     Workspace:
       properties:
         created_at:
@@ -3107,6 +5201,25 @@ components:
       required:
         - name
       type: object
+    WorkspaceDefaultsResponse:
+      properties:
+        current_sandboxes:
+          type: integer
+        max_idle_timeout:
+          type: integer
+        max_sandbox_cpu:
+          type: integer
+        max_sandbox_memory:
+          type: integer
+        max_sandboxes:
+          type: integer
+      required:
+        - current_sandboxes
+        - max_idle_timeout
+        - max_sandbox_cpu
+        - max_sandbox_memory
+        - max_sandboxes
+      type: object
     WorkspaceMember:
       properties:
         email:
@@ -3123,6 +5236,15 @@ components:
         - email
         - role
         - user_id
+      type: object
+    WorkspaceOperationsResponse:
+      properties:
+        operations:
+          items:
+            $ref: "#/components/schemas/OperationRecord"
+          type: array
+      required:
+        - operations
       type: object
     WorkspaceQuotaResponse:
       properties:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -1637,7 +1637,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TraceRecord"
+                $ref: "#/components/schemas/TraceDetailResponse"
         "401":
           description: unauthorized
           content:
@@ -3672,7 +3672,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/TraceRecord"
+                $ref: "#/components/schemas/TraceDetailResponse"
         "401":
           description: unauthorized
           content:
@@ -4815,6 +4815,7 @@ components:
           type: string
           nullable: true
       required:
+        - connected
         - status
       type: object
     LLMConfigResponse:
@@ -5133,6 +5134,18 @@ components:
         - provider
         - request_count
       type: object
+    TraceDetailResponse:
+      properties:
+        requests:
+          items:
+            $ref: "#/components/schemas/TraceRequest"
+          type: array
+        trace:
+          $ref: "#/components/schemas/TraceRecord"
+      required:
+        - requests
+        - trace
+      type: object
     TraceListResponse:
       properties:
         total:
@@ -5182,6 +5195,51 @@ components:
         - total_input_tokens
         - total_output_tokens
         - updated_at
+        - workspace_id
+      type: object
+    TraceRequest:
+      properties:
+        cache_creation_input_tokens:
+          type: integer
+        cache_read_input_tokens:
+          type: integer
+        created_at:
+          type: string
+        duration:
+          type: integer
+        id:
+          type: string
+        input_tokens:
+          type: integer
+        message_id:
+          type: string
+        model:
+          type: string
+        output_tokens:
+          type: integer
+        provider:
+          type: string
+        sandbox_id:
+          type: string
+        streaming:
+          type: boolean
+        trace_id:
+          type: string
+        ttft:
+          type: integer
+        workspace_id:
+          type: string
+      required:
+        - cache_creation_input_tokens
+        - cache_read_input_tokens
+        - created_at
+        - duration
+        - id
+        - input_tokens
+        - model
+        - output_tokens
+        - provider
+        - sandbox_id
         - workspace_id
       type: object
     Workspace:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -5135,6 +5135,8 @@ components:
       type: object
     TraceListResponse:
       properties:
+        total:
+          type: integer
         traces:
           items:
             $ref: "#/components/schemas/TraceRecord"
@@ -5172,8 +5174,13 @@ components:
       required:
         - created_at
         - id
+        - request_count
         - sandbox_id
         - source
+        - total_cache_creation_tokens
+        - total_cache_read_tokens
+        - total_input_tokens
+        - total_output_tokens
         - updated_at
         - workspace_id
       type: object

--- a/docs/superpowers/plans/2026-05-22-openapi-phase-1b-misc.md
+++ b/docs/superpowers/plans/2026-05-22-openapi-phase-1b-misc.md
@@ -1,0 +1,108 @@
+# Phase 1.b — Misc tag implementation plan
+
+**Date:** 2026-05-22
+**Branch:** `feat/openapi-phase-1b-misc`
+**Stacks on:** PR #158 (Agent tag)
+
+## Scope
+
+This is the final Phase 1.b PR — the Misc catchall for all public REST
+endpoints not covered by the preceding 7 PRs (Auth, Workspaces, Sandboxes,
+IM Channels, Codex Tokens, Codex Browser Sessions, Agent).
+
+## IN-scope endpoints
+
+### Credential Bindings (6)
+| Method | Path | Handler |
+|--------|------|---------|
+| GET    | /api/workspaces/{id}/credentials/{kind} | handleListCredentialBindings |
+| POST   | /api/workspaces/{id}/credentials/{kind} | handleCreateCredentialBinding |
+| PATCH  | /api/workspaces/{id}/credentials/{kind}/{bindingId} | handlePatchCredentialBinding |
+| DELETE | /api/workspaces/{id}/credentials/{kind}/{bindingId} | handleDeleteCredentialBinding |
+| POST   | /api/workspaces/{id}/credentials/{kind}/{bindingId}/set-default | handleSetDefaultCredentialBinding |
+| POST   | /api/workspaces/{id}/credentials/{kind}/{bindingId}/device-complete | handleDeviceCodeComplete |
+
+### Operations Log (1)
+| Method | Path | Handler |
+|--------|------|---------|
+| GET    | /api/workspaces/{id}/operations | getWorkspaceOperations |
+
+### Workspace Defaults (1)
+| Method | Path | Handler |
+|--------|------|---------|
+| GET    | /api/workspaces/{wid}/defaults | handleGetWorkspaceDefaults |
+
+### LLM Traces (4)
+| Method | Path | Handler |
+|--------|------|---------|
+| GET    | /api/sandboxes/{id}/traces | handleSandboxTraces |
+| GET    | /api/sandboxes/{id}/traces/{traceId} | handleTraceDetail |
+| GET    | /api/workspaces/{wid}/traces | handleWorkspaceTraces |
+| GET    | /api/workspaces/{wid}/traces/{traceId} | handleWorkspaceTraceDetail |
+
+### Codex Executors (3)
+| Method | Path | Handler |
+|--------|------|---------|
+| POST   | /api/workspaces/{wid}/executors | handleRegisterExecutor |
+| GET    | /api/workspaces/{wid}/executors | handleListExecutors |
+| DELETE | /api/workspaces/{wid}/executors/{exe_id} | handleUnbindExecutor |
+
+### ModelServer (3)
+| Method | Path | Handler |
+|--------|------|---------|
+| GET    | /api/workspaces/{id}/modelserver/connect | handleModelserverConnect |
+| DELETE | /api/workspaces/{id}/modelserver/disconnect | handleModelserverDisconnect |
+| GET    | /api/workspaces/{id}/modelserver/status | handleModelserverStatus |
+
+### Agent Interactions (1)
+| Method | Path | Handler |
+|--------|------|---------|
+| GET    | /api/workspaces/{wid}/agent-interactions | handleListInteractions |
+
+### Admin (11)
+| Method | Path | Handler |
+|--------|------|---------|
+| GET    | /api/admin/users | handleAdminListUsers |
+| GET    | /api/admin/workspaces | handleAdminListWorkspaces |
+| GET    | /api/admin/sandboxes | handleAdminListSandboxes |
+| PUT    | /api/admin/users/{id}/role | handleAdminUpdateUserRole |
+| GET    | /api/admin/quotas/defaults | handleAdminGetQuotaDefaults |
+| PUT    | /api/admin/quotas/defaults | handleAdminSetQuotaDefaults |
+| GET    | /api/admin/users/{id}/quota | handleAdminGetUserQuota |
+| PUT    | /api/admin/users/{id}/quota | handleAdminSetUserQuota |
+| DELETE | /api/admin/users/{id}/quota | handleAdminDeleteUserQuota |
+| GET    | /api/admin/workspaces/{id}/quota | handleAdminGetWorkspaceQuota |
+| PUT    | /api/admin/workspaces/{id}/quota | handleAdminSetWorkspaceQuota |
+| DELETE | /api/admin/workspaces/{id}/quota | handleAdminDeleteWorkspaceQuota |
+| GET    | /api/admin/workspaces/{id}/llm-quota | handleAdminGetWorkspaceLLMQuota |
+| PUT    | /api/admin/workspaces/{id}/llm-quota | handleAdminSetWorkspaceLLMQuota |
+| DELETE | /api/admin/workspaces/{id}/llm-quota | handleAdminDeleteWorkspaceLLMQuota |
+
+**Total IN-scope: 34 endpoints** (using two tags: `Misc` and `Admin`)
+
+## OUT of scope (explicitly excluded)
+- `/api/oauth2/*` — Hydra login/consent/device (Phase 2)
+- `/api/auth/oidc/*` — OIDC flows (Phase 2)
+- `GET /api/auth/modelserver/callback` — OAuth redirect, browser-facing, Phase 2
+- `/healthz` — operational probe, not REST CRUD
+- All `/internal/*` and `/api/internal/*` — server-internal auth
+- All WebSocket/SSE/proxy passthrough routes
+
+## Tasks
+
+1. **DTOs** — Add types under `// --- Misc ---` and `// --- Admin ---` in
+   `api_types.go`. Inline structs in credential_bindings.go, operations.go,
+   admin.go, agent_interactions.go need named counterparts.
+
+2. **Annotate handlers** — Add `@Tags Misc` (or `@Tags Admin`) + full swag
+   annotations to all 34 handlers. Regen spec with `make swag`, verify no
+   `server.` prefix drift.
+
+3. **Frontend migration** — Check `web/src/` for local types covering
+   credential bindings, operations, executors, modelserver, admin; alias to
+   `components['schemas']` via the generated client.
+
+4. **Verify + PR** — `make swag && go build ./...`, push, open PR titled
+   `feat(openapi): Phase 1.b — Misc tag (34 endpoints)` stacked on #158.
+   PR body notes this is the FINAL Phase 1.b PR completing the 8-PR stack
+   (#152–#159).

--- a/internal/server/admin.go
+++ b/internal/server/admin.go
@@ -31,6 +31,15 @@ func (s *Server) requireAdmin(next http.Handler) http.Handler {
 	})
 }
 
+//	@Summary   List all users (admin)
+//	@Tags      Admin
+//	@Produce   json
+//	@Success   200  {array}   AdminUserItem
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "admin role required"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/admin/users [get]
 func (s *Server) handleAdminListUsers(w http.ResponseWriter, r *http.Request) {
 	users, err := s.DB.ListAllUsers()
 	if err != nil {
@@ -39,17 +48,9 @@ func (s *Server) handleAdminListUsers(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	type adminUserResponse struct {
-		ID        string  `json:"id"`
-		Email     string  `json:"email"`
-		Name      *string `json:"name"`
-		Role      string  `json:"role"`
-		CreatedAt string  `json:"created_at"`
-	}
-
-	resp := make([]adminUserResponse, len(users))
+	resp := make([]AdminUserItem, len(users))
 	for i, u := range users {
-		resp[i] = adminUserResponse{
+		resp[i] = AdminUserItem{
 			ID:        u.ID,
 			Email:     u.Email,
 			Name:      u.Name,
@@ -62,6 +63,15 @@ func (s *Server) handleAdminListUsers(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(resp)
 }
 
+//	@Summary   List all workspaces (admin)
+//	@Tags      Admin
+//	@Produce   json
+//	@Success   200  {array}   AdminWorkspaceItem
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "admin role required"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/admin/workspaces [get]
 func (s *Server) handleAdminListWorkspaces(w http.ResponseWriter, r *http.Request) {
 	workspaces, err := s.DB.ListAllWorkspacesAdmin()
 	if err != nil {
@@ -72,25 +82,9 @@ func (s *Server) handleAdminListWorkspaces(w http.ResponseWriter, r *http.Reques
 
 	rd := s.getResourceDefaults()
 
-	type ownerInfo struct {
-		ID      string  `json:"id"`
-		Email   string  `json:"email"`
-		Name    *string `json:"name"`
-		Picture *string `json:"picture"`
-	}
-	type adminWorkspaceResponse struct {
-		ID            string    `json:"id"`
-		Name          string    `json:"name"`
-		CreatedAt     string    `json:"created_at"`
-		UpdatedAt     string    `json:"updated_at"`
-		Owner         *ownerInfo `json:"owner"`
-		SandboxCount  int       `json:"sandbox_count"`
-		MaxSandboxes  int       `json:"max_sandboxes"`
-	}
-
-	resp := make([]adminWorkspaceResponse, len(workspaces))
+	resp := make([]AdminWorkspaceItem, len(workspaces))
 	for i, ws := range workspaces {
-		r := adminWorkspaceResponse{
+		item := AdminWorkspaceItem{
 			ID:           ws.ID,
 			Name:         ws.Name,
 			CreatedAt:    ws.CreatedAt.Format(time.RFC3339),
@@ -103,7 +97,7 @@ func (s *Server) handleAdminListWorkspaces(w http.ResponseWriter, r *http.Reques
 			if ws.OwnerEmail != nil {
 				ownerEmail = *ws.OwnerEmail
 			}
-			r.Owner = &ownerInfo{
+			item.Owner = &AdminOwnerInfo{
 				ID:      *ws.OwnerID,
 				Email:   ownerEmail,
 				Name:    ws.OwnerName,
@@ -112,15 +106,24 @@ func (s *Server) handleAdminListWorkspaces(w http.ResponseWriter, r *http.Reques
 		}
 		// Check for workspace-level quota override.
 		if wq, err := s.DB.GetWorkspaceQuota(ws.ID); err == nil && wq != nil && wq.MaxSandboxes != nil {
-			r.MaxSandboxes = *wq.MaxSandboxes
+			item.MaxSandboxes = *wq.MaxSandboxes
 		}
-		resp[i] = r
+		resp[i] = item
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(resp)
 }
 
+//	@Summary   List all sandboxes (admin)
+//	@Tags      Admin
+//	@Produce   json
+//	@Success   200  {array}   AdminSandboxItem
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "admin role required"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/admin/sandboxes [get]
 func (s *Server) handleAdminListSandboxes(w http.ResponseWriter, r *http.Request) {
 	sandboxes, err := s.DB.ListAllSandboxes()
 	if err != nil {
@@ -129,20 +132,9 @@ func (s *Server) handleAdminListSandboxes(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	type adminSandboxResponse struct {
-		ID             string  `json:"id"`
-		Name           string  `json:"name"`
-		WorkspaceID    string  `json:"workspace_id"`
-		Type           string  `json:"type"`
-		Status         string  `json:"status"`
-		CreatedAt      string  `json:"created_at"`
-		LastActivityAt *string `json:"last_activity_at"`
-		IsLocal        bool    `json:"is_local"`
-	}
-
-	resp := make([]adminSandboxResponse, len(sandboxes))
+	resp := make([]AdminSandboxItem, len(sandboxes))
 	for i, sbx := range sandboxes {
-		r := adminSandboxResponse{
+		item := AdminSandboxItem{
 			ID:          sbx.ID,
 			Name:        sbx.Name,
 			WorkspaceID: sbx.WorkspaceID,
@@ -153,21 +145,31 @@ func (s *Server) handleAdminListSandboxes(w http.ResponseWriter, r *http.Request
 		}
 		if sbx.LastActivityAt.Valid {
 			s := sbx.LastActivityAt.Time.Format(time.RFC3339)
-			r.LastActivityAt = &s
+			item.LastActivityAt = &s
 		}
-		resp[i] = r
+		resp[i] = item
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(resp)
 }
 
+//	@Summary   Update a user's role (admin)
+//	@Tags      Admin
+//	@Accept    json
+//	@Param     id    path  string                      true  "User ID"
+//	@Param     body  body  AdminUpdateUserRoleRequest  true  "New role (user or admin)"
+//	@Success   204  "updated"
+//	@Failure   400  {string}  string  "bad request / invalid role"
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "admin role required"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/admin/users/{id}/role [put]
 func (s *Server) handleAdminUpdateUserRole(w http.ResponseWriter, r *http.Request) {
 	targetID := chi.URLParam(r, "id")
 
-	var req struct {
-		Role string `json:"role"`
-	}
+	var req AdminUpdateUserRoleRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Role == "" {
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
@@ -186,34 +188,44 @@ func (s *Server) handleAdminUpdateUserRole(w http.ResponseWriter, r *http.Reques
 	w.WriteHeader(http.StatusNoContent)
 }
 
+//	@Summary   Get system-wide quota defaults (admin)
+//	@Tags      Admin
+//	@Produce   json
+//	@Success   200  {object}  AdminQuotaDefaultsResponse
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "admin role required"
+//	@Security  CookieAuth
+//	@Router    /api/admin/quotas/defaults [get]
 func (s *Server) handleAdminGetQuotaDefaults(w http.ResponseWriter, r *http.Request) {
 	rd := s.getResourceDefaults()
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{
-		"max_workspaces_per_user":      rd.MaxWorkspacesPerUser,
-		"max_sandboxes_per_workspace":  rd.MaxSandboxesPerWorkspace,
-		"max_workspace_drive_size":     rd.MaxWorkspaceDriveSize,
-		"max_sandbox_cpu":              rd.MaxSandboxCPU,
-		"max_sandbox_memory":           rd.MaxSandboxMemory,
-		"max_idle_timeout":             rd.MaxIdleTimeout,
-		"ws_max_total_cpu":             rd.WsMaxTotalCPU,
-		"ws_max_total_memory":          rd.WsMaxTotalMemory,
-		"ws_max_idle_timeout":          rd.WsMaxIdleTimeout,
+	json.NewEncoder(w).Encode(AdminQuotaDefaultsResponse{
+		MaxWorkspacesPerUser:     rd.MaxWorkspacesPerUser,
+		MaxSandboxesPerWorkspace: rd.MaxSandboxesPerWorkspace,
+		MaxWorkspaceDriveSize:    rd.MaxWorkspaceDriveSize,
+		MaxSandboxCPU:            rd.MaxSandboxCPU,
+		MaxSandboxMemory:         rd.MaxSandboxMemory,
+		MaxIdleTimeout:           rd.MaxIdleTimeout,
+		WsMaxTotalCPU:            rd.WsMaxTotalCPU,
+		WsMaxTotalMemory:         rd.WsMaxTotalMemory,
+		WsMaxIdleTimeout:         rd.WsMaxIdleTimeout,
 	})
 }
 
+//	@Summary   Update system-wide quota defaults (admin)
+//	@Tags      Admin
+//	@Accept    json
+//	@Produce   json
+//	@Param     body  body  AdminQuotaDefaultsUpdateRequest  true  "Quota fields to update (all optional)"
+//	@Success   200  {object}  AdminQuotaDefaultsResponse  "Updated defaults"
+//	@Failure   400  {string}  string  "bad request"
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "admin role required"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/admin/quotas/defaults [put]
 func (s *Server) handleAdminSetQuotaDefaults(w http.ResponseWriter, r *http.Request) {
-	var req struct {
-		MaxWorkspacesPerUser     *int   `json:"max_workspaces_per_user"`
-		MaxSandboxesPerWorkspace *int   `json:"max_sandboxes_per_workspace"`
-		MaxWorkspaceDriveSize    *int64 `json:"max_workspace_drive_size"`
-		MaxSandboxCPU            *int   `json:"max_sandbox_cpu"`
-		MaxSandboxMemory         *int64 `json:"max_sandbox_memory"`
-		MaxIdleTimeout           *int   `json:"max_idle_timeout"`
-		WsMaxTotalCPU            *int   `json:"ws_max_total_cpu"`
-		WsMaxTotalMemory         *int64 `json:"ws_max_total_memory"`
-		WsMaxIdleTimeout         *int   `json:"ws_max_idle_timeout"`
-	}
+	var req AdminQuotaDefaultsUpdateRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
@@ -293,26 +305,33 @@ func (s *Server) handleAdminSetQuotaDefaults(w http.ResponseWriter, r *http.Requ
 
 	rd := s.getResourceDefaults()
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{
-		"max_workspaces_per_user":      rd.MaxWorkspacesPerUser,
-		"max_sandboxes_per_workspace":  rd.MaxSandboxesPerWorkspace,
-		"max_workspace_drive_size":     rd.MaxWorkspaceDriveSize,
-		"max_sandbox_cpu":              rd.MaxSandboxCPU,
-		"max_sandbox_memory":           rd.MaxSandboxMemory,
-		"max_idle_timeout":             rd.MaxIdleTimeout,
-		"ws_max_total_cpu":             rd.WsMaxTotalCPU,
-		"ws_max_total_memory":          rd.WsMaxTotalMemory,
-		"ws_max_idle_timeout":          rd.WsMaxIdleTimeout,
+	json.NewEncoder(w).Encode(AdminQuotaDefaultsResponse{
+		MaxWorkspacesPerUser:     rd.MaxWorkspacesPerUser,
+		MaxSandboxesPerWorkspace: rd.MaxSandboxesPerWorkspace,
+		MaxWorkspaceDriveSize:    rd.MaxWorkspaceDriveSize,
+		MaxSandboxCPU:            rd.MaxSandboxCPU,
+		MaxSandboxMemory:         rd.MaxSandboxMemory,
+		MaxIdleTimeout:           rd.MaxIdleTimeout,
+		WsMaxTotalCPU:            rd.WsMaxTotalCPU,
+		WsMaxTotalMemory:         rd.WsMaxTotalMemory,
+		WsMaxIdleTimeout:         rd.WsMaxIdleTimeout,
 	})
 }
 
+//	@Summary   Get per-user quota override (admin)
+//	@Tags      Admin
+//	@Produce   json
+//	@Param     id  path  string  true  "User ID"
+//	@Success   200  {object}  AdminUserQuotaResponse
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "admin role required"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/admin/users/{id}/quota [get]
 func (s *Server) handleAdminGetUserQuota(w http.ResponseWriter, r *http.Request) {
 	targetID := chi.URLParam(r, "id")
 
 	rd := s.getResourceDefaults()
-	defaults := map[string]interface{}{
-		"max_workspaces_per_user": rd.MaxWorkspacesPerUser,
-	}
 
 	uq, err := s.DB.GetUserQuota(targetID)
 	if err != nil {
@@ -321,27 +340,38 @@ func (s *Server) handleAdminGetUserQuota(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	var overrides interface{}
+	resp := AdminUserQuotaResponse{
+		Defaults: AdminUserQuotaDefaults{
+			MaxWorkspacesPerUser: rd.MaxWorkspacesPerUser,
+		},
+	}
 	if uq != nil {
-		overrides = map[string]interface{}{
-			"max_workspaces": uq.MaxWorkspaces,
-			"updated_at":     uq.UpdatedAt.Format(time.RFC3339),
+		resp.Overrides = &AdminUserQuotaOverrides{
+			MaxWorkspaces: uq.MaxWorkspaces,
+			UpdatedAt:     uq.UpdatedAt.Format(time.RFC3339),
 		}
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{
-		"defaults":  defaults,
-		"overrides": overrides,
-	})
+	json.NewEncoder(w).Encode(resp)
 }
 
+//	@Summary   Set per-user quota override (admin)
+//	@Tags      Admin
+//	@Accept    json
+//	@Param     id    path  string                    true  "User ID"
+//	@Param     body  body  AdminSetUserQuotaRequest  true  "Quota overrides"
+//	@Success   204  "saved"
+//	@Failure   400  {string}  string  "bad request"
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "admin role required"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/admin/users/{id}/quota [put]
 func (s *Server) handleAdminSetUserQuota(w http.ResponseWriter, r *http.Request) {
 	targetID := chi.URLParam(r, "id")
 
-	var req struct {
-		MaxWorkspaces *int `json:"max_workspaces"`
-	}
+	var req AdminSetUserQuotaRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
@@ -361,6 +391,15 @@ func (s *Server) handleAdminSetUserQuota(w http.ResponseWriter, r *http.Request)
 	w.WriteHeader(http.StatusNoContent)
 }
 
+//	@Summary   Delete per-user quota override (admin)
+//	@Tags      Admin
+//	@Param     id  path  string  true  "User ID"
+//	@Success   204  "deleted"
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "admin role required"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/admin/users/{id}/quota [delete]
 func (s *Server) handleAdminDeleteUserQuota(w http.ResponseWriter, r *http.Request) {
 	targetID := chi.URLParam(r, "id")
 
@@ -373,19 +412,20 @@ func (s *Server) handleAdminDeleteUserQuota(w http.ResponseWriter, r *http.Reque
 	w.WriteHeader(http.StatusNoContent)
 }
 
+//	@Summary   Get workspace quota override (admin)
+//	@Tags      Admin
+//	@Produce   json
+//	@Param     id  path  string  true  "Workspace ID"
+//	@Success   200  {object}  AdminWorkspaceQuotaResponse
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "admin role required"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/admin/workspaces/{id}/quota [get]
 func (s *Server) handleAdminGetWorkspaceQuota(w http.ResponseWriter, r *http.Request) {
 	workspaceID := chi.URLParam(r, "id")
 
 	rd := s.getResourceDefaults()
-	defaults := map[string]interface{}{
-		"max_sandboxes":      rd.MaxSandboxesPerWorkspace,
-		"max_sandbox_cpu":    rd.MaxSandboxCPU,
-		"max_sandbox_memory": rd.MaxSandboxMemory,
-		"max_idle_timeout":   rd.MaxIdleTimeout,
-		"max_total_cpu":      rd.WsMaxTotalCPU,
-		"max_total_memory":   rd.WsMaxTotalMemory,
-		"max_drive_size":     rd.MaxWorkspaceDriveSize,
-	}
 
 	wq, err := s.DB.GetWorkspaceQuota(workspaceID)
 	if err != nil {
@@ -394,39 +434,50 @@ func (s *Server) handleAdminGetWorkspaceQuota(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	var overrides interface{}
+	resp := AdminWorkspaceQuotaResponse{
+		Defaults: AdminWorkspaceQuotaDefaults{
+			MaxSandboxes:     rd.MaxSandboxesPerWorkspace,
+			MaxSandboxCPU:    rd.MaxSandboxCPU,
+			MaxSandboxMemory: rd.MaxSandboxMemory,
+			MaxIdleTimeout:   rd.MaxIdleTimeout,
+			MaxTotalCPU:      rd.WsMaxTotalCPU,
+			MaxTotalMemory:   rd.WsMaxTotalMemory,
+			MaxDriveSize:     rd.MaxWorkspaceDriveSize,
+		},
+	}
 	if wq != nil {
-		overrides = map[string]interface{}{
-			"max_sandboxes":      wq.MaxSandboxes,
-			"max_sandbox_cpu":    wq.MaxSandboxCPU,
-			"max_sandbox_memory": wq.MaxSandboxMemory,
-			"max_idle_timeout":   wq.MaxIdleTimeout,
-			"max_total_cpu":      wq.MaxTotalCPU,
-			"max_total_memory":   wq.MaxTotalMemory,
-			"max_drive_size":     wq.MaxDriveSize,
-			"updated_at":         wq.UpdatedAt.Format(time.RFC3339),
+		resp.Overrides = &AdminWorkspaceQuotaOverrides{
+			MaxSandboxes:     wq.MaxSandboxes,
+			MaxSandboxCPU:    wq.MaxSandboxCPU,
+			MaxSandboxMemory: wq.MaxSandboxMemory,
+			MaxIdleTimeout:   wq.MaxIdleTimeout,
+			MaxTotalCPU:      wq.MaxTotalCPU,
+			MaxTotalMemory:   wq.MaxTotalMemory,
+			MaxDriveSize:     wq.MaxDriveSize,
+			UpdatedAt:        wq.UpdatedAt.Format(time.RFC3339),
 		}
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{
-		"defaults":  defaults,
-		"overrides": overrides,
-	})
+	json.NewEncoder(w).Encode(resp)
 }
 
+//	@Summary   Set workspace quota override (admin)
+//	@Tags      Admin
+//	@Accept    json
+//	@Param     id    path  string                         true  "Workspace ID"
+//	@Param     body  body  AdminSetWorkspaceQuotaRequest  true  "Quota overrides (all optional, merged with existing)"
+//	@Success   204  "saved"
+//	@Failure   400  {string}  string  "bad request"
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "admin role required"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/admin/workspaces/{id}/quota [put]
 func (s *Server) handleAdminSetWorkspaceQuota(w http.ResponseWriter, r *http.Request) {
 	workspaceID := chi.URLParam(r, "id")
 
-	var req struct {
-		MaxSandboxes     *int   `json:"max_sandboxes"`
-		MaxSandboxCPU    *int   `json:"max_sandbox_cpu"`
-		MaxSandboxMemory *int64 `json:"max_sandbox_memory"`
-		MaxIdleTimeout   *int   `json:"max_idle_timeout"`
-		MaxTotalCPU      *int   `json:"max_total_cpu"`
-		MaxTotalMemory   *int64 `json:"max_total_memory"`
-		MaxDriveSize     *int64 `json:"max_drive_size"`
-	}
+	var req AdminSetWorkspaceQuotaRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		http.Error(w, "bad request", http.StatusBadRequest)
 		return
@@ -488,6 +539,15 @@ func (s *Server) handleAdminSetWorkspaceQuota(w http.ResponseWriter, r *http.Req
 	w.WriteHeader(http.StatusNoContent)
 }
 
+//	@Summary   Delete workspace quota override (admin)
+//	@Tags      Admin
+//	@Param     id  path  string  true  "Workspace ID"
+//	@Success   204  "deleted"
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "admin role required"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/admin/workspaces/{id}/quota [delete]
 func (s *Server) handleAdminDeleteWorkspaceQuota(w http.ResponseWriter, r *http.Request) {
 	workspaceID := chi.URLParam(r, "id")
 
@@ -528,11 +588,34 @@ func (s *Server) proxyLLMProxyRequest(w http.ResponseWriter, method, path string
 	io.Copy(w, resp.Body)
 }
 
+//	@Summary   Get workspace LLM quota (admin, proxied to llmproxy)
+//	@Tags      Admin
+//	@Produce   json
+//	@Param     id  path  string  true  "Workspace ID"
+//	@Success   200  {object}  LLMQuotaResponse
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "admin role required"
+//	@Failure   502  {string}  string  "llmproxy unavailable"
+//	@Failure   503  {string}  string  "llmproxy not configured"
+//	@Security  CookieAuth
+//	@Router    /api/admin/workspaces/{id}/llm-quota [get]
 func (s *Server) handleAdminGetWorkspaceLLMQuota(w http.ResponseWriter, r *http.Request) {
 	workspaceID := chi.URLParam(r, "id")
 	s.proxyLLMProxyRequest(w, http.MethodGet, "/internal/quotas/"+workspaceID, nil)
 }
 
+//	@Summary   Set workspace LLM quota override (admin, proxied to llmproxy)
+//	@Tags      Admin
+//	@Accept    json
+//	@Param     id  path  string  true  "Workspace ID"
+//	@Success   200  "saved"
+//	@Failure   400  {string}  string  "bad request"
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "admin role required"
+//	@Failure   502  {string}  string  "llmproxy unavailable"
+//	@Failure   503  {string}  string  "llmproxy not configured"
+//	@Security  CookieAuth
+//	@Router    /api/admin/workspaces/{id}/llm-quota [put]
 func (s *Server) handleAdminSetWorkspaceLLMQuota(w http.ResponseWriter, r *http.Request) {
 	workspaceID := chi.URLParam(r, "id")
 	body, err := io.ReadAll(r.Body)
@@ -543,6 +626,16 @@ func (s *Server) handleAdminSetWorkspaceLLMQuota(w http.ResponseWriter, r *http.
 	s.proxyLLMProxyRequest(w, http.MethodPut, "/internal/quotas/"+workspaceID, body)
 }
 
+//	@Summary   Delete workspace LLM quota override (admin, proxied to llmproxy)
+//	@Tags      Admin
+//	@Param     id  path  string  true  "Workspace ID"
+//	@Success   204  "deleted"
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "admin role required"
+//	@Failure   502  {string}  string  "llmproxy unavailable"
+//	@Failure   503  {string}  string  "llmproxy not configured"
+//	@Security  CookieAuth
+//	@Router    /api/admin/workspaces/{id}/llm-quota [delete]
 func (s *Server) handleAdminDeleteWorkspaceLLMQuota(w http.ResponseWriter, r *http.Request) {
 	workspaceID := chi.URLParam(r, "id")
 	s.proxyLLMProxyRequest(w, http.MethodDelete, "/internal/quotas/"+workspaceID, nil)

--- a/internal/server/agent_interactions.go
+++ b/internal/server/agent_interactions.go
@@ -12,6 +12,19 @@ import (
 
 // handleListInteractions returns the audit trail for a workspace.
 // GET /api/workspaces/{wid}/agent-interactions
+//
+//	@Summary   List agent interaction audit trail for a workspace
+//	@Tags      Misc
+//	@Produce   json
+//	@Param     wid     path   string  true  "Workspace ID"
+//	@Param     limit   query  int     false "Max entries (1–200, default 50)"
+//	@Param     offset  query  int     false "Pagination offset"
+//	@Success   200  {array}   AgentInteractionItem
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "not a workspace member"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{wid}/agent-interactions [get]
 func (s *Server) handleListInteractions(w http.ResponseWriter, r *http.Request) {
 	wid := chi.URLParam(r, "wid")
 	if _, ok := s.requireWorkspaceMember(w, r, wid); !ok {
@@ -41,18 +54,9 @@ func (s *Server) handleListInteractions(w http.ResponseWriter, r *http.Request) 
 		items = []db.AgentInteraction{}
 	}
 
-	type interactionResponse struct {
-		ID          int64            `json:"id"`
-		ActorID     *string          `json:"actor_id"`
-		Action      string           `json:"action"`
-		TargetID    string           `json:"target_id"`
-		TargetType  string           `json:"target_type"`
-		Detail      *json.RawMessage `json:"detail,omitempty"`
-		CreatedAt   string           `json:"created_at"`
-	}
-	result := make([]interactionResponse, len(items))
+	result := make([]AgentInteractionItem, len(items))
 	for i, item := range items {
-		result[i] = interactionResponse{
+		result[i] = AgentInteractionItem{
 			ID:         item.ID,
 			ActorID:    item.ActorID,
 			Action:     item.Action,

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -111,7 +111,7 @@ type LLMConfigResponse struct {
 	Configured bool       `json:"configured" validate:"required"`
 	BaseURL    string     `json:"base_url"`
 	APIKey     string     `json:"api_key"`
-	Models     []LLMModel `json:"models"`
+	Models     []LLMModel `json:"models,omitempty"`
 	UpdatedAt  *string    `json:"updated_at" extensions:"x-nullable=true"`
 } // @name LLMConfigResponse
 
@@ -223,7 +223,7 @@ type IMWeixinQRStartResponse struct {
 // qrcode_url is only present when status is "expired" (new QR code generated).
 // bot_id and user_id are only present when status is "confirmed".
 type IMWeixinQRWaitResponse struct {
-	Connected  bool    `json:"connected"`
+	Connected  bool    `json:"connected" validate:"required"`
 	Status     string  `json:"status" validate:"required" example:"wait"`
 	Message    *string `json:"message,omitempty" extensions:"x-nullable=true"`
 	QRCodeURL  *string `json:"qrcode_url,omitempty" extensions:"x-nullable=true"`
@@ -599,6 +599,33 @@ type TraceListResponse struct {
 	Traces []TraceRecord `json:"traces" validate:"required"`
 	Total  int64         `json:"total"`
 } // @name TraceListResponse
+
+// TraceRequest is one row in the requests array of TraceDetailResponse.
+// Fields mirror what the LLM proxy emits for a single API call (TokenUsage).
+type TraceRequest struct {
+	ID                       string `json:"id" validate:"required"`
+	TraceID                  string `json:"trace_id,omitempty"`
+	SandboxID                string `json:"sandbox_id" validate:"required"`
+	WorkspaceID              string `json:"workspace_id" validate:"required"`
+	Provider                 string `json:"provider" validate:"required"`
+	Model                    string `json:"model" validate:"required"`
+	MessageID                string `json:"message_id,omitempty"`
+	InputTokens              int64  `json:"input_tokens" validate:"required"`
+	OutputTokens             int64  `json:"output_tokens" validate:"required"`
+	CacheCreationInputTokens int64  `json:"cache_creation_input_tokens" validate:"required"`
+	CacheReadInputTokens     int64  `json:"cache_read_input_tokens" validate:"required"`
+	Streaming                bool   `json:"streaming"`
+	Duration                 int64  `json:"duration" validate:"required"`
+	TTFT                     int64  `json:"ttft"`
+	CreatedAt                string `json:"created_at" validate:"required"`
+} // @name TraceRequest
+
+// TraceDetailResponse is the body returned by /traces/{traceId} endpoints.
+// It pairs the trace metadata with the list of per-request records.
+type TraceDetailResponse struct {
+	Trace    TraceRecord    `json:"trace" validate:"required"`
+	Requests []TraceRequest `json:"requests" validate:"required"`
+} // @name TraceDetailResponse
 
 // ExecutorItem is one entry returned by GET /api/workspaces/{wid}/executors.
 // All session fields (client_ip, client_ua, codex_version, os,

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -641,12 +641,13 @@ type ExecutorRegisterResponse struct {
 
 // ModelServerStatusResponse is returned by GET /api/workspaces/{id}/modelserver/status.
 // When connected is false all other fields are absent.
+// models entries have the same {id, name} shape as LLMModel.
 type ModelServerStatusResponse struct {
-	Connected   bool     `json:"connected" validate:"required"`
-	ProjectID   string   `json:"project_id,omitempty"`
-	ProjectName string   `json:"project_name,omitempty"`
-	Models      []string `json:"models,omitempty"`
-	ConnectedAt string   `json:"connected_at,omitempty"`
+	Connected   bool       `json:"connected" validate:"required"`
+	ProjectID   string     `json:"project_id,omitempty"`
+	ProjectName string     `json:"project_name,omitempty"`
+	Models      []LLMModel `json:"models,omitempty"`
+	ConnectedAt string     `json:"connected_at,omitempty"`
 } // @name ModelServerStatusResponse
 
 // AgentInteractionItem is one entry in the audit trail returned by

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -585,17 +585,19 @@ type TraceRecord struct {
 	Source                   string `json:"source" validate:"required" example:"codex"`
 	CreatedAt                string `json:"created_at" validate:"required"`
 	UpdatedAt                string `json:"updated_at" validate:"required"`
-	RequestCount             int64  `json:"request_count"`
-	TotalInputTokens         int64  `json:"total_input_tokens"`
-	TotalOutputTokens        int64  `json:"total_output_tokens"`
-	TotalCacheReadTokens     int64  `json:"total_cache_read_tokens"`
-	TotalCacheCreationTokens int64  `json:"total_cache_creation_tokens"`
+	RequestCount             int64  `json:"request_count" validate:"required"`
+	TotalInputTokens         int64  `json:"total_input_tokens" validate:"required"`
+	TotalOutputTokens        int64  `json:"total_output_tokens" validate:"required"`
+	TotalCacheReadTokens     int64  `json:"total_cache_read_tokens" validate:"required"`
+	TotalCacheCreationTokens int64  `json:"total_cache_creation_tokens" validate:"required"`
 	Models                   string `json:"models,omitempty"`
 } // @name TraceRecord
 
 // TraceListResponse wraps a list of trace records.
+// total is the total count for pagination (set by llmproxy).
 type TraceListResponse struct {
 	Traces []TraceRecord `json:"traces" validate:"required"`
+	Total  int64         `json:"total"`
 } // @name TraceListResponse
 
 // ExecutorItem is one entry returned by GET /api/workspaces/{wid}/executors.

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -493,3 +493,313 @@ type CodexBrowserItem struct {
 	ConnectedAt    *time.Time `json:"connected_at,omitempty"`
 	DisconnectedAt *time.Time `json:"disconnected_at,omitempty"`
 } // @name CodexBrowserItem
+
+// --- Misc ---
+
+// CredentialBindingItem is one entry in the list returned by
+// GET /api/workspaces/{id}/credentials/{kind}.
+// public_meta is an arbitrary JSON object whose shape depends on the provider kind.
+type CredentialBindingItem struct {
+	ID          string          `json:"id" validate:"required"`
+	DisplayName string          `json:"display_name" validate:"required"`
+	ServerURL   string          `json:"server_url"`
+	AuthType    string          `json:"auth_type" validate:"required" example:"static"`
+	PublicMeta  interface{}     `json:"public_meta"`
+	IsDefault   bool            `json:"is_default"`
+	CreatedAt   string          `json:"created_at" validate:"required"`
+} // @name CredentialBindingItem
+
+// CredentialBindingCreateRequest is the body for POST /api/workspaces/{id}/credentials/{kind}.
+// config is a provider-specific JSON or YAML credential blob.
+type CredentialBindingCreateRequest struct {
+	DisplayName string `json:"display_name" validate:"required" example:"My K8s Cluster"`
+	Config      string `json:"config" validate:"required" example:"{\"server\": \"https://...\"}"`
+} // @name CredentialBindingCreateRequest
+
+// CredentialBindingCreateResponse is returned (201) by the create endpoint, or
+// (202) when the provider initiates an OIDC device code flow.
+// When status is "pending_device_code", verification_uri, user_code and expires_in
+// are set; the caller must long-poll the device-complete endpoint.
+type CredentialBindingCreateResponse struct {
+	ID              string `json:"id" validate:"required"`
+	DisplayName     string `json:"display_name,omitempty"`
+	ServerURL       string `json:"server_url,omitempty"`
+	AuthType        string `json:"auth_type,omitempty"`
+	IsDefault       bool   `json:"is_default"`
+	Status          string `json:"status,omitempty" example:"pending_device_code"`
+	VerificationURI string `json:"verification_uri,omitempty"`
+	UserCode        string `json:"user_code,omitempty"`
+	ExpiresIn       int    `json:"expires_in,omitempty"`
+} // @name CredentialBindingCreateResponse
+
+// CredentialBindingPatchRequest is the body for PATCH /api/workspaces/{id}/credentials/{kind}/{bindingId}.
+// Only display_name is patchable at present.
+type CredentialBindingPatchRequest struct {
+	DisplayName *string `json:"display_name" extensions:"x-nullable=true" example:"Renamed Cluster"`
+} // @name CredentialBindingPatchRequest
+
+// WorkspaceOperationsResponse is returned by GET /api/workspaces/{id}/operations.
+type WorkspaceOperationsResponse struct {
+	Operations []OperationRecord `json:"operations" validate:"required"`
+} // @name WorkspaceOperationsResponse
+
+// OperationRecord is a single entry in the operations log.
+// arguments, arguments_meta and result_meta are arbitrary JSON objects.
+type OperationRecord struct {
+	ID            string      `json:"id" validate:"required"`
+	WorkspaceID   string      `json:"workspace_id" validate:"required"`
+	UserID        *string     `json:"user_id,omitempty" extensions:"x-nullable=true"`
+	Source        string      `json:"source" validate:"required" example:"codex"`
+	ThreadID      *string     `json:"thread_id,omitempty" extensions:"x-nullable=true"`
+	RequestID     *string     `json:"request_id,omitempty" extensions:"x-nullable=true"`
+	EnvID         string      `json:"env_id" validate:"required"`
+	Tool          string      `json:"tool" validate:"required" example:"shell"`
+	Arguments     interface{} `json:"arguments,omitempty"`
+	ArgumentsMeta interface{} `json:"arguments_meta,omitempty"`
+	IsError       bool        `json:"is_error"`
+	ResultSummary *string     `json:"result_summary,omitempty" extensions:"x-nullable=true"`
+	ResultMeta    interface{} `json:"result_meta,omitempty"`
+	StartedAt     string      `json:"started_at" validate:"required"`
+	CompletedAt   string      `json:"completed_at" validate:"required"`
+	DurationMs    int32       `json:"duration_ms" validate:"required"`
+	NotebookPath  *string     `json:"notebook_path,omitempty" extensions:"x-nullable=true"`
+	CellID        *string     `json:"cell_id,omitempty" extensions:"x-nullable=true"`
+} // @name OperationRecord
+
+// WorkspaceDefaultsResponse is returned by GET /api/workspaces/{wid}/defaults.
+// It provides the effective quota limits for the workspace and the current sandbox count.
+type WorkspaceDefaultsResponse struct {
+	MaxSandboxCPU    int   `json:"max_sandbox_cpu" validate:"required"`
+	MaxSandboxMemory int64 `json:"max_sandbox_memory" validate:"required"`
+	MaxIdleTimeout   int   `json:"max_idle_timeout" validate:"required"`
+	MaxSandboxes     int   `json:"max_sandboxes" validate:"required"`
+	CurrentSandboxes int   `json:"current_sandboxes" validate:"required"`
+} // @name WorkspaceDefaultsResponse
+
+// TraceRecord is one entry in the LLM trace list returned by the traces endpoints.
+// All token/request count fields come from the llmproxy aggregation.
+type TraceRecord struct {
+	ID                       string `json:"id" validate:"required"`
+	SandboxID                string `json:"sandbox_id" validate:"required"`
+	WorkspaceID              string `json:"workspace_id" validate:"required"`
+	Source                   string `json:"source" validate:"required" example:"codex"`
+	CreatedAt                string `json:"created_at" validate:"required"`
+	UpdatedAt                string `json:"updated_at" validate:"required"`
+	RequestCount             int64  `json:"request_count"`
+	TotalInputTokens         int64  `json:"total_input_tokens"`
+	TotalOutputTokens        int64  `json:"total_output_tokens"`
+	TotalCacheReadTokens     int64  `json:"total_cache_read_tokens"`
+	TotalCacheCreationTokens int64  `json:"total_cache_creation_tokens"`
+	Models                   string `json:"models,omitempty"`
+} // @name TraceRecord
+
+// TraceListResponse wraps a list of trace records.
+type TraceListResponse struct {
+	Traces []TraceRecord `json:"traces" validate:"required"`
+} // @name TraceListResponse
+
+// ExecutorItem is one entry returned by GET /api/workspaces/{wid}/executors.
+// All session fields (client_ip, client_ua, codex_version, os,
+// connected_at, disconnected_at) come from the last seen connection;
+// they are omitted when the executor has never connected.
+type ExecutorItem struct {
+	ExeID          string     `json:"exe_id" validate:"required"`
+	Name           string     `json:"name" validate:"required"`
+	Description    string     `json:"description,omitempty"`
+	IsDefault      bool       `json:"is_default"`
+	IsOnline       bool       `json:"is_online"`
+	LastSeenAt     *time.Time `json:"last_seen_at,omitempty" extensions:"x-nullable=true"`
+	ClientIP       string     `json:"client_ip,omitempty"`
+	ClientUA       string     `json:"client_ua,omitempty"`
+	CodexVersion   string     `json:"codex_version,omitempty"`
+	OS             string     `json:"os,omitempty"`
+	ConnectedAt    *time.Time `json:"connected_at,omitempty" extensions:"x-nullable=true"`
+	DisconnectedAt *time.Time `json:"disconnected_at,omitempty" extensions:"x-nullable=true"`
+} // @name ExecutorItem
+
+// ExecutorRegisterRequest is the body for POST /api/workspaces/{wid}/executors.
+type ExecutorRegisterRequest struct {
+	Name        string `json:"name" validate:"required" example:"my-dev-machine"`
+	Description string `json:"description,omitempty" example:"Main development laptop"`
+} // @name ExecutorRegisterRequest
+
+// ExecutorConnectCommands holds the connect-command variants returned by the
+// register endpoint. At present only the agent_identity variant is surfaced.
+type ExecutorConnectCommands struct {
+	AgentIdentity string `json:"agent_identity" validate:"required"`
+} // @name ExecutorConnectCommands
+
+// ExecutorRegisterResponse is returned (201) by POST /api/workspaces/{wid}/executors.
+// agent_identity_jwt and connect_commands are only set when the codex auth shim is configured.
+// connect_command is a convenience alias for connect_commands.agent_identity.
+type ExecutorRegisterResponse struct {
+	ExeID            string                  `json:"exe_id" validate:"required"`
+	ConnectCommand   string                  `json:"connect_command,omitempty"`
+	AgentIdentityJWT string                  `json:"agent_identity_jwt,omitempty"`
+	ConnectCommands  ExecutorConnectCommands  `json:"connect_commands,omitempty"`
+} // @name ExecutorRegisterResponse
+
+// ModelServerStatusResponse is returned by GET /api/workspaces/{id}/modelserver/status.
+// When connected is false all other fields are absent.
+type ModelServerStatusResponse struct {
+	Connected   bool     `json:"connected" validate:"required"`
+	ProjectID   string   `json:"project_id,omitempty"`
+	ProjectName string   `json:"project_name,omitempty"`
+	Models      []string `json:"models,omitempty"`
+	ConnectedAt string   `json:"connected_at,omitempty"`
+} // @name ModelServerStatusResponse
+
+// AgentInteractionItem is one entry in the audit trail returned by
+// GET /api/workspaces/{wid}/agent-interactions.
+// detail is an arbitrary JSON object; it is absent when empty.
+type AgentInteractionItem struct {
+	ID         int64       `json:"id" validate:"required"`
+	ActorID    *string     `json:"actor_id" extensions:"x-nullable=true"`
+	Action     string      `json:"action" validate:"required" example:"task.created"`
+	TargetID   string      `json:"target_id" validate:"required"`
+	TargetType string      `json:"target_type" validate:"required" example:"task"`
+	Detail     interface{} `json:"detail,omitempty"`
+	CreatedAt  string      `json:"created_at" validate:"required"`
+} // @name AgentInteractionItem
+
+// --- Admin ---
+
+// AdminUserItem is one entry returned by GET /api/admin/users.
+type AdminUserItem struct {
+	ID        string  `json:"id" validate:"required"`
+	Email     string  `json:"email" validate:"required"`
+	Name      *string `json:"name" extensions:"x-nullable=true"`
+	Role      string  `json:"role" validate:"required" example:"user"`
+	CreatedAt string  `json:"created_at" validate:"required"`
+} // @name AdminUserItem
+
+// AdminOwnerInfo is the owner summary embedded in AdminWorkspaceItem.
+type AdminOwnerInfo struct {
+	ID      string  `json:"id" validate:"required"`
+	Email   string  `json:"email" validate:"required"`
+	Name    *string `json:"name" extensions:"x-nullable=true"`
+	Picture *string `json:"picture" extensions:"x-nullable=true"`
+} // @name AdminOwnerInfo
+
+// AdminWorkspaceItem is one entry returned by GET /api/admin/workspaces.
+type AdminWorkspaceItem struct {
+	ID           string          `json:"id" validate:"required"`
+	Name         string          `json:"name" validate:"required"`
+	CreatedAt    string          `json:"created_at" validate:"required"`
+	UpdatedAt    string          `json:"updated_at" validate:"required"`
+	Owner        *AdminOwnerInfo `json:"owner" extensions:"x-nullable=true"`
+	SandboxCount int             `json:"sandbox_count"`
+	MaxSandboxes int             `json:"max_sandboxes"`
+} // @name AdminWorkspaceItem
+
+// AdminSandboxItem is one entry returned by GET /api/admin/sandboxes.
+type AdminSandboxItem struct {
+	ID             string  `json:"id" validate:"required"`
+	Name           string  `json:"name" validate:"required"`
+	WorkspaceID    string  `json:"workspace_id" validate:"required"`
+	Type           string  `json:"type" validate:"required" example:"opencode"`
+	Status         string  `json:"status" validate:"required" example:"running"`
+	CreatedAt      string  `json:"created_at" validate:"required"`
+	LastActivityAt *string `json:"last_activity_at,omitempty" extensions:"x-nullable=true"`
+	IsLocal        bool    `json:"is_local"`
+} // @name AdminSandboxItem
+
+// AdminUpdateUserRoleRequest is the body for PUT /api/admin/users/{id}/role.
+type AdminUpdateUserRoleRequest struct {
+	Role string `json:"role" validate:"required" example:"admin"`
+} // @name AdminUpdateUserRoleRequest
+
+// AdminQuotaDefaultsResponse is returned by GET /api/admin/quotas/defaults
+// and PUT /api/admin/quotas/defaults.
+type AdminQuotaDefaultsResponse struct {
+	MaxWorkspacesPerUser     int   `json:"max_workspaces_per_user" validate:"required"`
+	MaxSandboxesPerWorkspace int   `json:"max_sandboxes_per_workspace" validate:"required"`
+	MaxWorkspaceDriveSize    int64 `json:"max_workspace_drive_size" validate:"required"`
+	MaxSandboxCPU            int   `json:"max_sandbox_cpu" validate:"required"`
+	MaxSandboxMemory         int64 `json:"max_sandbox_memory" validate:"required"`
+	MaxIdleTimeout           int   `json:"max_idle_timeout" validate:"required"`
+	WsMaxTotalCPU            int   `json:"ws_max_total_cpu" validate:"required"`
+	WsMaxTotalMemory         int64 `json:"ws_max_total_memory" validate:"required"`
+	WsMaxIdleTimeout         int   `json:"ws_max_idle_timeout" validate:"required"`
+} // @name AdminQuotaDefaultsResponse
+
+// AdminQuotaDefaultsUpdateRequest is the body for PUT /api/admin/quotas/defaults.
+// All fields are optional; only supplied keys are applied.
+type AdminQuotaDefaultsUpdateRequest struct {
+	MaxWorkspacesPerUser     *int   `json:"max_workspaces_per_user,omitempty"`
+	MaxSandboxesPerWorkspace *int   `json:"max_sandboxes_per_workspace,omitempty"`
+	MaxWorkspaceDriveSize    *int64 `json:"max_workspace_drive_size,omitempty"`
+	MaxSandboxCPU            *int   `json:"max_sandbox_cpu,omitempty"`
+	MaxSandboxMemory         *int64 `json:"max_sandbox_memory,omitempty"`
+	MaxIdleTimeout           *int   `json:"max_idle_timeout,omitempty"`
+	WsMaxTotalCPU            *int   `json:"ws_max_total_cpu,omitempty"`
+	WsMaxTotalMemory         *int64 `json:"ws_max_total_memory,omitempty"`
+	WsMaxIdleTimeout         *int   `json:"ws_max_idle_timeout,omitempty"`
+} // @name AdminQuotaDefaultsUpdateRequest
+
+// AdminUserQuotaDefaults is the system-default quota sub-object embedded in
+// AdminUserQuotaResponse.
+type AdminUserQuotaDefaults struct {
+	MaxWorkspacesPerUser int `json:"max_workspaces_per_user" validate:"required"`
+} // @name AdminUserQuotaDefaults
+
+// AdminUserQuotaOverrides is the per-user override sub-object embedded in
+// AdminUserQuotaResponse. null when no override is set.
+type AdminUserQuotaOverrides struct {
+	MaxWorkspaces *int   `json:"max_workspaces" extensions:"x-nullable=true"`
+	UpdatedAt     string `json:"updated_at" validate:"required"`
+} // @name AdminUserQuotaOverrides
+
+// AdminUserQuotaResponse is returned by GET /api/admin/users/{id}/quota.
+type AdminUserQuotaResponse struct {
+	Defaults  AdminUserQuotaDefaults   `json:"defaults" validate:"required"`
+	Overrides *AdminUserQuotaOverrides `json:"overrides" extensions:"x-nullable=true"`
+} // @name AdminUserQuotaResponse
+
+// AdminSetUserQuotaRequest is the body for PUT /api/admin/users/{id}/quota.
+type AdminSetUserQuotaRequest struct {
+	MaxWorkspaces *int `json:"max_workspaces" extensions:"x-nullable=true"`
+} // @name AdminSetUserQuotaRequest
+
+// AdminWorkspaceQuotaDefaults is the system-default quota sub-object embedded in
+// AdminWorkspaceQuotaResponse.
+type AdminWorkspaceQuotaDefaults struct {
+	MaxSandboxes     int   `json:"max_sandboxes" validate:"required"`
+	MaxSandboxCPU    int   `json:"max_sandbox_cpu" validate:"required"`
+	MaxSandboxMemory int64 `json:"max_sandbox_memory" validate:"required"`
+	MaxIdleTimeout   int   `json:"max_idle_timeout" validate:"required"`
+	MaxTotalCPU      int   `json:"max_total_cpu" validate:"required"`
+	MaxTotalMemory   int64 `json:"max_total_memory" validate:"required"`
+	MaxDriveSize     int64 `json:"max_drive_size" validate:"required"`
+} // @name AdminWorkspaceQuotaDefaults
+
+// AdminWorkspaceQuotaOverrides is the per-workspace override sub-object embedded in
+// AdminWorkspaceQuotaResponse. null when no override is set.
+type AdminWorkspaceQuotaOverrides struct {
+	MaxSandboxes     *int   `json:"max_sandboxes" extensions:"x-nullable=true"`
+	MaxSandboxCPU    *int   `json:"max_sandbox_cpu" extensions:"x-nullable=true"`
+	MaxSandboxMemory *int64 `json:"max_sandbox_memory" extensions:"x-nullable=true"`
+	MaxIdleTimeout   *int   `json:"max_idle_timeout" extensions:"x-nullable=true"`
+	MaxTotalCPU      *int   `json:"max_total_cpu" extensions:"x-nullable=true"`
+	MaxTotalMemory   *int64 `json:"max_total_memory" extensions:"x-nullable=true"`
+	MaxDriveSize     *int64 `json:"max_drive_size" extensions:"x-nullable=true"`
+	UpdatedAt        string `json:"updated_at" validate:"required"`
+} // @name AdminWorkspaceQuotaOverrides
+
+// AdminWorkspaceQuotaResponse is returned by GET /api/admin/workspaces/{id}/quota.
+type AdminWorkspaceQuotaResponse struct {
+	Defaults  AdminWorkspaceQuotaDefaults   `json:"defaults" validate:"required"`
+	Overrides *AdminWorkspaceQuotaOverrides `json:"overrides" extensions:"x-nullable=true"`
+} // @name AdminWorkspaceQuotaResponse
+
+// AdminSetWorkspaceQuotaRequest is the body for PUT /api/admin/workspaces/{id}/quota.
+// All fields are optional; only supplied keys are applied (merged with existing).
+type AdminSetWorkspaceQuotaRequest struct {
+	MaxSandboxes     *int   `json:"max_sandboxes,omitempty" extensions:"x-nullable=true"`
+	MaxSandboxCPU    *int   `json:"max_sandbox_cpu,omitempty" extensions:"x-nullable=true"`
+	MaxSandboxMemory *int64 `json:"max_sandbox_memory,omitempty" extensions:"x-nullable=true"`
+	MaxIdleTimeout   *int   `json:"max_idle_timeout,omitempty" extensions:"x-nullable=true"`
+	MaxTotalCPU      *int   `json:"max_total_cpu,omitempty" extensions:"x-nullable=true"`
+	MaxTotalMemory   *int64 `json:"max_total_memory,omitempty" extensions:"x-nullable=true"`
+	MaxDriveSize     *int64 `json:"max_drive_size,omitempty" extensions:"x-nullable=true"`
+} // @name AdminSetWorkspaceQuotaRequest

--- a/internal/server/codex_executors.go
+++ b/internal/server/codex_executors.go
@@ -60,6 +60,21 @@ type ConnectCommands struct {
 //
 // Returns the raw registration_token ONCE — UI must show it immediately
 // and let the user copy. agentserver does not store the raw token.
+//
+//	@Summary   Register a new codex remote executor for a workspace
+//	@Tags      Misc
+//	@Accept    json
+//	@Produce   json
+//	@Param     wid   path  string                   true  "Workspace ID"
+//	@Param     body  body  ExecutorRegisterRequest  true  "Executor registration payload"
+//	@Success   201  {object}  ExecutorRegisterResponse
+//	@Failure   400  {string}  string  "bad request / invalid name"
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "insufficient role (owner/maintainer required)"
+//	@Failure   502  {string}  string  "upstream gateway error"
+//	@Failure   503  {string}  string  "executors not configured"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{wid}/executors [post]
 func (s *Server) handleRegisterExecutor(w http.ResponseWriter, r *http.Request) {
 	userID := auth.UserIDFromContext(r.Context())
 	if userID == "" {
@@ -170,6 +185,17 @@ func (s *Server) handleRegisterExecutor(w http.ResponseWriter, r *http.Request) 
 
 // handleListExecutors returns executors bound to the workspace.
 // ACL: any workspace member.
+//
+//	@Summary   List codex remote executors for a workspace
+//	@Tags      Misc
+//	@Produce   json
+//	@Param     wid  path  string  true  "Workspace ID"
+//	@Success   200  {array}   ExecutorItem
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "not a workspace member"
+//	@Failure   502  {string}  string  "upstream gateway error"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{wid}/executors [get]
 func (s *Server) handleListExecutors(w http.ResponseWriter, r *http.Request) {
 	userID := auth.UserIDFromContext(r.Context())
 	if userID == "" {
@@ -199,6 +225,19 @@ func (s *Server) handleListExecutors(w http.ResponseWriter, r *http.Request) {
 
 // handleUnbindExecutor removes an executor from the workspace. ACL:
 // owner/maintainer of the workspace.
+//
+//	@Summary   Remove a codex remote executor from a workspace
+//	@Tags      Misc
+//	@Param     wid     path  string  true  "Workspace ID"
+//	@Param     exe_id  path  string  true  "Executor ID"
+//	@Success   204  "removed"
+//	@Failure   400  {string}  string  "bad request"
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "insufficient role (owner/maintainer required)"
+//	@Failure   502  {string}  string  "upstream gateway error"
+//	@Failure   503  {string}  string  "executors not configured"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{wid}/executors/{exe_id} [delete]
 func (s *Server) handleUnbindExecutor(w http.ResponseWriter, r *http.Request) {
 	userID := auth.UserIDFromContext(r.Context())
 	if userID == "" {

--- a/internal/server/credential_bindings.go
+++ b/internal/server/credential_bindings.go
@@ -53,6 +53,19 @@ type pendingDeviceFlow struct {
 	completing     sync.Once
 }
 
+// handleListCredentialBindings lists credential bindings for a workspace+kind.
+// GET /api/workspaces/{id}/credentials/{kind}
+//
+//	@Summary   List credential bindings for a workspace
+//	@Tags      Misc
+//	@Produce   json
+//	@Param     id    path  string  true  "Workspace ID"
+//	@Param     kind  path  string  true  "Credential kind (e.g. kubernetes)"
+//	@Success   200  {array}   CredentialBindingItem
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{id}/credentials/{kind} [get]
 func (s *Server) handleListCredentialBindings(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "id")
 	kind := chi.URLParam(r, "kind")
@@ -64,19 +77,9 @@ func (s *Server) handleListCredentialBindings(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	type bindingResp struct {
-		ID          string         `json:"id"`
-		DisplayName string         `json:"display_name"`
-		ServerURL   string         `json:"server_url"`
-		AuthType    string         `json:"auth_type"`
-		PublicMeta  json.RawMessage `json:"public_meta"`
-		IsDefault   bool           `json:"is_default"`
-		CreatedAt   string         `json:"created_at"`
-	}
-
-	result := make([]bindingResp, 0, len(bindings))
+	result := make([]CredentialBindingItem, 0, len(bindings))
 	for _, b := range bindings {
-		result = append(result, bindingResp{
+		result = append(result, CredentialBindingItem{
 			ID:          b.ID,
 			DisplayName: b.DisplayName,
 			ServerURL:   b.ServerURL,
@@ -91,6 +94,25 @@ func (s *Server) handleListCredentialBindings(w http.ResponseWriter, r *http.Req
 	json.NewEncoder(w).Encode(result)
 }
 
+// handleCreateCredentialBinding creates a new credential binding.
+// POST /api/workspaces/{id}/credentials/{kind}
+//
+//	@Summary   Create a credential binding for a workspace
+//	@Description On success returns 201 with the new binding. When the provider requires OIDC device code authentication returns 202 with verification_uri and user_code; poll device-complete to finalize.
+//	@Tags      Misc
+//	@Accept    json
+//	@Produce   json
+//	@Param     id    path  string                          true  "Workspace ID"
+//	@Param     kind  path  string                          true  "Credential kind (e.g. kubernetes)"
+//	@Param     body  body  CredentialBindingCreateRequest  true  "Credential config"
+//	@Success   201  {object}  CredentialBindingCreateResponse  "Binding created"
+//	@Success   202  {object}  CredentialBindingCreateResponse  "OIDC device code flow initiated"
+//	@Failure   400  {string}  string  "bad request"
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   409  {string}  string  "duplicate display_name"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{id}/credentials/{kind} [post]
 func (s *Server) handleCreateCredentialBinding(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "id")
 	kind := chi.URLParam(r, "kind")
@@ -200,6 +222,21 @@ func (s *Server) handleCreateCredentialBinding(w http.ResponseWriter, r *http.Re
 	})
 }
 
+// handleDeleteCredentialBinding deletes a credential binding.
+// DELETE /api/workspaces/{id}/credentials/{kind}/{bindingId}
+//
+//	@Summary   Delete a credential binding
+//	@Tags      Misc
+//	@Param     id         path  string  true  "Workspace ID"
+//	@Param     kind       path  string  true  "Credential kind"
+//	@Param     bindingId  path  string  true  "Binding ID"
+//	@Success   204  "deleted"
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   404  {string}  string  "not found"
+//	@Failure   409  {string}  string  "cannot delete default binding while others exist"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{id}/credentials/{kind}/{bindingId} [delete]
 func (s *Server) handleDeleteCredentialBinding(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "id")
 	kind := chi.URLParam(r, "kind")
@@ -239,6 +276,19 @@ func (s *Server) handleDeleteCredentialBinding(w http.ResponseWriter, r *http.Re
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// handleSetDefaultCredentialBinding sets a binding as the default for its kind.
+// POST /api/workspaces/{id}/credentials/{kind}/{bindingId}/set-default
+//
+//	@Summary   Set a credential binding as the default
+//	@Tags      Misc
+//	@Param     id         path  string  true  "Workspace ID"
+//	@Param     kind       path  string  true  "Credential kind"
+//	@Param     bindingId  path  string  true  "Binding ID"
+//	@Success   204  "updated"
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{id}/credentials/{kind}/{bindingId}/set-default [post]
 func (s *Server) handleSetDefaultCredentialBinding(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "id")
 	kind := chi.URLParam(r, "kind")
@@ -253,6 +303,23 @@ func (s *Server) handleSetDefaultCredentialBinding(w http.ResponseWriter, r *htt
 	w.WriteHeader(http.StatusNoContent)
 }
 
+// handlePatchCredentialBinding updates mutable fields of a credential binding.
+// PATCH /api/workspaces/{id}/credentials/{kind}/{bindingId}
+//
+//	@Summary   Patch a credential binding (rename)
+//	@Tags      Misc
+//	@Accept    json
+//	@Param     id         path  string                          true  "Workspace ID"
+//	@Param     kind       path  string                          true  "Credential kind"
+//	@Param     bindingId  path  string                          true  "Binding ID"
+//	@Param     body       body  CredentialBindingPatchRequest   true  "Fields to update"
+//	@Success   204  "updated"
+//	@Failure   400  {string}  string  "bad request"
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   404  {string}  string  "not found"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{id}/credentials/{kind}/{bindingId} [patch]
 func (s *Server) handlePatchCredentialBinding(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "id")
 	kind := chi.URLParam(r, "kind")
@@ -371,6 +438,24 @@ func (s *Server) handleCreateOIDCBinding(
 }
 
 // handleDeviceCodeComplete long-polls until the OIDC device code flow completes.
+// POST /api/workspaces/{id}/credentials/{kind}/{bindingId}/device-complete
+//
+//	@Summary   Complete an OIDC device code flow for a pending credential binding
+//	@Description Long-polls until the user authorizes the device code. Returns 201 with the created binding on success.
+//	@Tags      Misc
+//	@Produce   json
+//	@Param     id         path  string  true  "Workspace ID"
+//	@Param     kind       path  string  true  "Credential kind"
+//	@Param     bindingId  path  string  true  "Pending binding ID"
+//	@Success   201  {object}  CredentialBindingCreateResponse  "Binding created"
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "device code authorization failed"
+//	@Failure   404  {string}  string  "no pending device code flow found"
+//	@Failure   409  {string}  string  "duplicate display_name or flow already being completed"
+//	@Failure   410  {string}  string  "device code flow expired"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{id}/credentials/{kind}/{bindingId}/device-complete [post]
 func (s *Server) handleDeviceCodeComplete(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "id")
 	kind := chi.URLParam(r, "kind")

--- a/internal/server/modelserver_oauth.go
+++ b/internal/server/modelserver_oauth.go
@@ -29,6 +29,18 @@ const (
 
 // handleModelserverConnect initiates the OAuth flow to connect a workspace to a ModelServer project.
 // GET /api/workspaces/{id}/modelserver/connect
+//
+//	@Summary   Initiate ModelServer OAuth connection for a workspace
+//	@Description Redirects the browser to the ModelServer OAuth authorization URL. Returns 302.
+//	@Tags      Misc
+//	@Param     id  path  string  true  "Workspace ID"
+//	@Success   302  "redirect to ModelServer OAuth"
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "insufficient role (owner/maintainer required)"
+//	@Failure   501  {string}  string  "ModelServer OAuth not configured"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{id}/modelserver/connect [get]
 func (s *Server) handleModelserverConnect(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "id")
 	if !s.requireWorkspaceRole(w, r, wsID, "owner", "maintainer") {
@@ -342,6 +354,16 @@ func (s *Server) fetchModelserverModels(accessToken string) []db.LLMModel {
 
 // handleModelserverDisconnect removes the ModelServer connection for a workspace.
 // DELETE /api/workspaces/{id}/modelserver/disconnect
+//
+//	@Summary   Disconnect ModelServer from a workspace
+//	@Tags      Misc
+//	@Param     id  path  string  true  "Workspace ID"
+//	@Success   204  "disconnected"
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "insufficient role (owner/maintainer required)"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{id}/modelserver/disconnect [delete]
 func (s *Server) handleModelserverDisconnect(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "id")
 	if !s.requireWorkspaceRole(w, r, wsID, "owner", "maintainer") {
@@ -359,6 +381,17 @@ func (s *Server) handleModelserverDisconnect(w http.ResponseWriter, r *http.Requ
 
 // handleModelserverStatus returns the ModelServer connection status for a workspace.
 // GET /api/workspaces/{id}/modelserver/status
+//
+//	@Summary   Get ModelServer connection status for a workspace
+//	@Tags      Misc
+//	@Produce   json
+//	@Param     id  path  string  true  "Workspace ID"
+//	@Success   200  {object}  ModelServerStatusResponse
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "not a workspace member"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{id}/modelserver/status [get]
 func (s *Server) handleModelserverStatus(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "id")
 	if _, ok := s.requireWorkspaceMember(w, r, wsID); !ok {
@@ -374,17 +407,19 @@ func (s *Server) handleModelserverStatus(w http.ResponseWriter, r *http.Request)
 
 	w.Header().Set("Content-Type", "application/json")
 	if conn == nil {
-		json.NewEncoder(w).Encode(map[string]interface{}{
-			"connected": false,
-		})
+		json.NewEncoder(w).Encode(ModelServerStatusResponse{Connected: false})
 		return
 	}
 
-	json.NewEncoder(w).Encode(map[string]interface{}{
-		"connected":    true,
-		"project_id":   conn.ProjectID,
-		"project_name": conn.ProjectName,
-		"models":       conn.Models,
-		"connected_at": conn.CreatedAt.Format(time.RFC3339),
+	models := make([]LLMModel, len(conn.Models))
+	for i, m := range conn.Models {
+		models[i] = LLMModel{ID: m.ID, Name: m.Name}
+	}
+	json.NewEncoder(w).Encode(ModelServerStatusResponse{
+		Connected:   true,
+		ProjectID:   conn.ProjectID,
+		ProjectName: conn.ProjectName,
+		Models:      models,
+		ConnectedAt: conn.CreatedAt.Format(time.RFC3339),
 	})
 }

--- a/internal/server/operations.go
+++ b/internal/server/operations.go
@@ -174,6 +174,24 @@ func (s *Server) getInternalOperations(w http.ResponseWriter, r *http.Request) {
 // membership enforced. Filter query params are the same as
 // getInternalOperations; workspace_id is forced from the URL so a
 // caller can't query a workspace they're not a member of.
+//
+//	@Summary   List operations log entries for a workspace
+//	@Tags      Misc
+//	@Produce   json
+//	@Param     id      path   string  true   "Workspace ID"
+//	@Param     env_id  query  string  false  "Filter by environment ID"
+//	@Param     tool    query  string  false  "Filter by tool name"
+//	@Param     source  query  string  false  "Filter by source (e.g. codex)"
+//	@Param     is_error query bool   false  "Filter by error flag"
+//	@Param     since   query  string  false  "Return entries after this RFC3339 timestamp"
+//	@Param     limit   query  int     false  "Max rows to return"
+//	@Success   200  {object}  WorkspaceOperationsResponse
+//	@Failure   400  {string}  string  "bad request"
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "not a workspace member"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{id}/operations [get]
 func (s *Server) getWorkspaceOperations(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "id")
 	if wsID == "" {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1569,6 +1569,16 @@ func (s *Server) handleDeleteWorkspaceLLMConfig(w http.ResponseWriter, r *http.R
 
 // --- Sandbox handlers ---
 
+//	@Summary   Get workspace quota defaults and current sandbox count
+//	@Tags      Misc
+//	@Produce   json
+//	@Param     wid  path  string  true  "Workspace ID"
+//	@Success   200  {object}  WorkspaceDefaultsResponse
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "insufficient role"
+//	@Failure   500  {string}  string  "internal error"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{wid}/defaults [get]
 func (s *Server) handleGetWorkspaceDefaults(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "wid")
 	if !s.requireWorkspaceRole(w, r, wsID, "owner", "maintainer", "developer") {
@@ -1590,12 +1600,12 @@ func (s *Server) handleGetWorkspaceDefaults(w http.ResponseWriter, r *http.Reque
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(map[string]interface{}{
-		"max_sandbox_cpu":    wd.MaxSandboxCPU,
-		"max_sandbox_memory": wd.MaxSandboxMemory,
-		"max_idle_timeout":   wd.MaxIdleTimeout,
-		"max_sandboxes":      wd.MaxSandboxes,
-		"current_sandboxes":  currentSandboxes,
+	json.NewEncoder(w).Encode(WorkspaceDefaultsResponse{
+		MaxSandboxCPU:    wd.MaxSandboxCPU,
+		MaxSandboxMemory: wd.MaxSandboxMemory,
+		MaxIdleTimeout:   wd.MaxIdleTimeout,
+		MaxSandboxes:     wd.MaxSandboxes,
+		CurrentSandboxes: currentSandboxes,
 	})
 }
 
@@ -2185,6 +2195,19 @@ func (s *Server) handleSandboxUsage(w http.ResponseWriter, r *http.Request) {
 	s.proxyLLMRequest(w, proxyURL)
 }
 
+//	@Summary   List LLM traces for a sandbox
+//	@Tags      Misc
+//	@Produce   json
+//	@Param     id      path   string  true   "Sandbox ID"
+//	@Param     limit   query  int     false  "Max entries to return"
+//	@Param     offset  query  int     false  "Pagination offset"
+//	@Success   200  {object}  TraceListResponse
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "not a workspace member"
+//	@Failure   404  {string}  string  "sandbox not found"
+//	@Failure   503  {string}  string  "llmproxy not configured"
+//	@Security  CookieAuth
+//	@Router    /api/sandboxes/{id}/traces [get]
 func (s *Server) handleSandboxTraces(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	sbx, ok := s.Sandboxes.Get(id)
@@ -2209,6 +2232,18 @@ func (s *Server) handleSandboxTraces(w http.ResponseWriter, r *http.Request) {
 	s.proxyLLMRequest(w, proxyURL)
 }
 
+//	@Summary   Get a single LLM trace for a sandbox
+//	@Tags      Misc
+//	@Produce   json
+//	@Param     id       path  string  true  "Sandbox ID"
+//	@Param     traceId  path  string  true  "Trace ID"
+//	@Success   200  {object}  TraceRecord
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "not a workspace member"
+//	@Failure   404  {string}  string  "sandbox not found"
+//	@Failure   503  {string}  string  "llmproxy not configured"
+//	@Security  CookieAuth
+//	@Router    /api/sandboxes/{id}/traces/{traceId} [get]
 func (s *Server) handleTraceDetail(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	sbx, ok := s.Sandboxes.Get(id)
@@ -2228,6 +2263,18 @@ func (s *Server) handleTraceDetail(w http.ResponseWriter, r *http.Request) {
 	s.proxyLLMRequest(w, proxyURL)
 }
 
+//	@Summary   List LLM traces for a workspace
+//	@Tags      Misc
+//	@Produce   json
+//	@Param     wid     path   string  true   "Workspace ID"
+//	@Param     limit   query  int     false  "Max entries to return"
+//	@Param     offset  query  int     false  "Pagination offset"
+//	@Success   200  {object}  TraceListResponse
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "not a workspace member"
+//	@Failure   503  {string}  string  "llmproxy not configured"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{wid}/traces [get]
 func (s *Server) handleWorkspaceTraces(w http.ResponseWriter, r *http.Request) {
 	wid := chi.URLParam(r, "wid")
 	if _, ok := s.requireWorkspaceMember(w, r, wid); !ok {
@@ -2247,6 +2294,17 @@ func (s *Server) handleWorkspaceTraces(w http.ResponseWriter, r *http.Request) {
 	s.proxyLLMRequest(w, proxyURL)
 }
 
+//	@Summary   Get a single LLM trace for a workspace
+//	@Tags      Misc
+//	@Produce   json
+//	@Param     wid      path  string  true  "Workspace ID"
+//	@Param     traceId  path  string  true  "Trace ID"
+//	@Success   200  {object}  TraceRecord
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "not a workspace member"
+//	@Failure   503  {string}  string  "llmproxy not configured"
+//	@Security  CookieAuth
+//	@Router    /api/workspaces/{wid}/traces/{traceId} [get]
 func (s *Server) handleWorkspaceTraceDetail(w http.ResponseWriter, r *http.Request) {
 	wid := chi.URLParam(r, "wid")
 	if _, ok := s.requireWorkspaceMember(w, r, wid); !ok {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2237,7 +2237,7 @@ func (s *Server) handleSandboxTraces(w http.ResponseWriter, r *http.Request) {
 //	@Produce   json
 //	@Param     id       path  string  true  "Sandbox ID"
 //	@Param     traceId  path  string  true  "Trace ID"
-//	@Success   200  {object}  TraceRecord
+//	@Success   200  {object}  TraceDetailResponse
 //	@Failure   401  {string}  string  "unauthorized"
 //	@Failure   403  {string}  string  "not a workspace member"
 //	@Failure   404  {string}  string  "sandbox not found"
@@ -2299,7 +2299,7 @@ func (s *Server) handleWorkspaceTraces(w http.ResponseWriter, r *http.Request) {
 //	@Produce   json
 //	@Param     wid      path  string  true  "Workspace ID"
 //	@Param     traceId  path  string  true  "Trace ID"
-//	@Success   200  {object}  TraceRecord
+//	@Success   200  {object}  TraceDetailResponse
 //	@Failure   401  {string}  string  "unauthorized"
 //	@Failure   403  {string}  string  "not a workspace member"
 //	@Failure   503  {string}  string  "llmproxy not configured"

--- a/web/src/components/OperationsPanel.tsx
+++ b/web/src/components/OperationsPanel.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { RefreshCw, AlertCircle, X } from 'lucide-react'
 import {
   listOperations,
-  type Operation,
+  type OperationRecord,
   type ListOperationsFilters,
 } from '../lib/api'
 
@@ -12,15 +12,15 @@ interface Props {
 
 const AUTO_REFRESH_INTERVAL_MS = 30_000
 
-const SOURCES: Array<'' | 'sdk' | 'tui' | 'llm'> = ['', 'sdk', 'tui', 'llm']
+const SOURCES: string[] = ['', 'sdk', 'tui', 'llm']
 
 export default function OperationsPanel({ workspaceId }: Props) {
   const [filters, setFilters] = useState<ListOperationsFilters>({ limit: 100 })
-  const [ops, setOps] = useState<Operation[]>([])
+  const [ops, setOps] = useState<OperationRecord[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [autoRefresh, setAutoRefresh] = useState(false)
-  const [selected, setSelected] = useState<Operation | null>(null)
+  const [selected, setSelected] = useState<OperationRecord | null>(null)
 
   const refresh = useCallback(async () => {
     setLoading(true)
@@ -65,7 +65,7 @@ export default function OperationsPanel({ workspaceId }: Props) {
             onChange={(e) =>
               setFilters((f) => ({
                 ...f,
-                source: (e.target.value || undefined) as ListOperationsFilters['source'],
+                source: e.target.value || undefined,
               }))
             }
           >
@@ -199,7 +199,7 @@ function OperationDetailModal({
   op,
   onClose,
 }: {
-  op: Operation
+  op: OperationRecord
   onClose: () => void
 }) {
   return (
@@ -240,12 +240,16 @@ function OperationDetailModal({
               </pre>
             </div>
           )}
-          {op.arguments_meta && (
-            <div className="text-xs text-[var(--muted-foreground)]">
-              arguments truncated: {op.arguments_meta.size_bytes} bytes, sha256{' '}
-              <code className="text-[var(--foreground)]">{op.arguments_meta.sha256.slice(0, 12)}…</code>
-            </div>
-          )}
+          {op.arguments_meta != null && (() => {
+            const meta = op.arguments_meta as { truncated?: true; size_bytes?: number; sha256?: string }
+            if (meta.size_bytes === undefined) return null
+            return (
+              <div className="text-xs text-[var(--muted-foreground)]">
+                arguments truncated: {meta.size_bytes} bytes, sha256{' '}
+                <code className="text-[var(--foreground)]">{(meta.sha256 ?? '').slice(0, 12)}…</code>
+              </div>
+            )
+          })()}
           {op.result_summary && (
             <div>
               <div className="mb-1 text-xs text-[var(--muted-foreground)]">result_summary</div>
@@ -254,11 +258,15 @@ function OperationDetailModal({
               </pre>
             </div>
           )}
-          {op.result_meta && (
-            <div className="text-xs text-[var(--muted-foreground)]">
-              result truncated: total {op.result_meta.total_bytes} bytes
-            </div>
-          )}
+          {op.result_meta != null && (() => {
+            const meta = op.result_meta as { total_bytes?: number }
+            if (meta.total_bytes === undefined) return null
+            return (
+              <div className="text-xs text-[var(--muted-foreground)]">
+                result truncated: total {meta.total_bytes} bytes
+              </div>
+            )
+          })()}
         </div>
       </div>
     </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -920,28 +920,10 @@ export async function unbindRemoteExecutor(workspaceId: string, exeId: string): 
 
 // === Operations (Plan 3c) ===
 
-export interface Operation {
-  id: string
-  workspace_id: string
-  user_id?: string | null
-  source: 'sdk' | 'tui' | 'llm'
-  thread_id?: string | null
-  env_id: string
-  tool: string
-  arguments?: unknown
-  arguments_meta?: { truncated: true; size_bytes: number; sha256: string } | null
-  is_error: boolean
-  result_summary?: string | null
-  result_meta?: { truncated: true; total_bytes: number } | null
-  started_at: string  // RFC3339
-  completed_at: string
-  duration_ms: number
-}
-
 export interface ListOperationsFilters {
   env_id?: string
   tool?: string
-  source?: 'sdk' | 'tui' | 'llm'
+  source?: string
   is_error?: boolean
   since?: string  // RFC3339Nano
   limit?: number  // default 100, max 1000
@@ -949,18 +931,12 @@ export interface ListOperationsFilters {
 
 /**
  * List operations for a workspace, server-side filtered.
- *
- * Backend endpoint `GET /api/workspaces/{id}/operations` is a small
- * follow-up that lands AFTER Plan 2 (#84) and this PR merge. It wraps
- * Plan 2's internal endpoint with user-session auth + membership check.
- * Until that lands, this client returns the "X is not available" error
- * if the endpoint 404s.
  */
 export async function listOperations(
   workspaceId: string,
   filters: ListOperationsFilters = {},
-): Promise<Operation[]> {
-  const params = new URLSearchParams({ workspace_id: workspaceId })
+): Promise<OperationRecord[]> {
+  const params = new URLSearchParams()
   if (filters.env_id) params.set('env_id', filters.env_id)
   if (filters.tool) params.set('tool', filters.tool)
   if (filters.source) params.set('source', filters.source)
@@ -968,13 +944,8 @@ export async function listOperations(
   if (filters.since) params.set('since', filters.since)
   if (filters.limit) params.set('limit', String(filters.limit))
 
-  const res = await fetch(`/api/workspaces/${encodeURIComponent(workspaceId)}/operations?${params}`, {
-    credentials: 'include',
-  })
-  if (!res.ok) {
-    const body = await res.text()
-    throw new Error(`listOperations: ${res.status} ${body || res.statusText}`)
-  }
-  const data = await res.json()
+  const qs = params.toString()
+  const path = `/api/workspaces/${encodeURIComponent(workspaceId)}/operations${qs ? `?${qs}` : ''}`
+  const data = await apiFetch<WorkspaceOperationsResponse>({ method: 'GET', path })
   return data.operations ?? []
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -33,6 +33,33 @@ export type MintCodexTokenResponse = components['schemas']['CodexTokenMintRespon
 // Codex Browser Sessions — generated types from OpenAPI spec
 export type CodexBrowser = components['schemas']['CodexBrowserItem']
 
+// Misc — generated types from OpenAPI spec
+export type CredentialBinding = components['schemas']['CredentialBindingItem']
+export type CredentialBindingCreateRequest = components['schemas']['CredentialBindingCreateRequest']
+export type CredentialBindingCreateResponse = components['schemas']['CredentialBindingCreateResponse']
+export type CredentialBindingPatchRequest = components['schemas']['CredentialBindingPatchRequest']
+export type WorkspaceSandboxDefaults = components['schemas']['WorkspaceDefaultsResponse']
+export type ModelserverStatus = components['schemas']['ModelServerStatusResponse']
+export type TraceItem = components['schemas']['TraceRecord']
+export type TracesResponse = components['schemas']['TraceListResponse']
+export type ExecutorItem = components['schemas']['ExecutorItem']
+export type ExecutorRegisterResponse = components['schemas']['ExecutorRegisterResponse']
+export type AgentInteractionItem = components['schemas']['AgentInteractionItem']
+export type OperationRecord = components['schemas']['OperationRecord']
+export type WorkspaceOperationsResponse = components['schemas']['WorkspaceOperationsResponse']
+
+// Admin — generated types from OpenAPI spec
+export type AdminUser = components['schemas']['AdminUserItem']
+export type AdminWorkspaceOwner = components['schemas']['AdminOwnerInfo']
+export type AdminWorkspace = components['schemas']['AdminWorkspaceItem']
+export type AdminSandbox = components['schemas']['AdminSandboxItem']
+export type QuotaDefaults = components['schemas']['AdminQuotaDefaultsResponse']
+export type UserQuotaResponse = components['schemas']['AdminUserQuotaResponse']
+export type UserQuotaOverrides = components['schemas']['AdminUserQuotaOverrides']
+export type WorkspaceQuotaResponse = components['schemas']['AdminWorkspaceQuotaResponse']
+export type WorkspaceQuotaDefaults = components['schemas']['AdminWorkspaceQuotaDefaults']
+export type WorkspaceQuotaOverrides = components['schemas']['AdminWorkspaceQuotaOverrides']
+
 export interface TelegramConfigureResult {
   connected: boolean
   bot_id: string
@@ -206,14 +233,6 @@ export async function removeMember(workspaceId: string, userId: string): Promise
 
 // Sandbox API
 
-export interface WorkspaceSandboxDefaults {
-  max_sandbox_cpu: number    // millicores
-  max_sandbox_memory: number // bytes
-  max_idle_timeout: number   // seconds
-  max_sandboxes: number      // 0 = unlimited
-  current_sandboxes: number
-}
-
 export async function getWorkspaceDefaults(workspaceId: string): Promise<WorkspaceSandboxDefaults> {
   const res = await fetch(`/api/workspaces/${workspaceId}/defaults`)
   if (!res.ok) throw new Error('Failed to get workspace defaults')
@@ -257,14 +276,6 @@ export async function deleteWorkspaceLLMConfig(workspaceId: string): Promise<voi
 }
 
 // ModelServer connection
-export interface ModelserverStatus {
-  connected: boolean
-  project_id?: string
-  project_name?: string
-  models?: LLMModel[]
-  connected_at?: string
-}
-
 export async function getModelserverStatus(workspaceId: string): Promise<ModelserverStatus> {
   const res = await fetch(`/api/workspaces/${workspaceId}/modelserver/status`)
   if (!res.ok) throw new Error('Failed to fetch modelserver status')
@@ -453,22 +464,14 @@ export async function deleteWorkspaceIMChannel(workspaceId: string, channelId: s
 
 // Credential Bindings (kubeconfig / external API credentials)
 
-export interface CredentialBinding {
-  id: string
-  display_name: string
-  server_url: string
-  auth_type: string
-  public_meta: Record<string, any>
-  is_default: boolean
-  created_at: string
-}
-
 export async function listCredentialBindings(workspaceId: string, kind: string): Promise<CredentialBinding[]> {
   const res = await fetch(`/api/workspaces/${workspaceId}/credentials/${kind}`)
   if (!res.ok) throw new Error('Failed to list credential bindings')
   return res.json()
 }
 
+// DeviceCodeResponse is kept as a strict subtype of CredentialBindingCreateResponse
+// for callers that rely on user_code/verification_uri being non-optional.
 export interface DeviceCodeResponse {
   id: string
   status: 'pending_device_code'
@@ -591,28 +594,8 @@ export async function unbindSandboxFromChannel(sandboxId: string): Promise<void>
 /** @deprecated use SandboxUsageSummary (generated alias) */
 export type UsageSummary = SandboxUsageSummary
 
-export interface TraceItem {
-  id: string
-  sandbox_id: string
-  workspace_id: string
-  source: string
-  created_at: string
-  updated_at: string
-  request_count: number
-  total_input_tokens: number
-  total_output_tokens: number
-  total_cache_read_tokens: number
-  total_cache_creation_tokens: number
-  models: string
-}
-
 /** @deprecated use SandboxUsage (generated alias) */
 export type UsageResponse = SandboxUsage
-
-export interface TracesResponse {
-  traces: TraceItem[]
-  total: number
-}
 
 export async function getSandboxUsage(id: string): Promise<SandboxUsage> {
   return apiFetch<SandboxUsage>({
@@ -668,42 +651,6 @@ export async function getWorkspaceTraceDetail(workspaceId: string, traceId: stri
 
 // Admin API
 
-export interface AdminUser {
-  id: string
-  email: string
-  name: string | null
-  role: string
-  created_at: string
-}
-
-export interface AdminWorkspaceOwner {
-  id: string
-  email: string
-  name: string | null
-  picture: string | null
-}
-
-export interface AdminWorkspace {
-  id: string
-  name: string
-  created_at: string
-  updated_at: string
-  owner: AdminWorkspaceOwner | null
-  sandbox_count: number
-  max_sandboxes: number
-}
-
-export interface AdminSandbox {
-  id: string
-  name: string
-  workspace_id: string
-  type: string
-  status: string
-  created_at: string
-  last_activity_at: string | null
-  is_local: boolean
-}
-
 export async function adminListUsers(): Promise<AdminUser[]> {
   const res = await fetch('/api/admin/users')
   if (!res.ok) throw new Error('Failed to list users')
@@ -729,56 +676,6 @@ export async function adminUpdateUserRole(userId: string, role: string): Promise
     body: JSON.stringify({ role }),
   })
   if (!res.ok) throw new Error('Failed to update user role')
-}
-
-// Quota types
-
-export interface QuotaDefaults {
-  max_workspaces_per_user: number
-  max_sandboxes_per_workspace: number
-  max_workspace_drive_size: number   // bytes
-  max_sandbox_cpu: number           // millicores
-  max_sandbox_memory: number        // bytes
-  max_idle_timeout: number          // seconds
-  ws_max_total_cpu: number           // millicores
-  ws_max_total_memory: number        // bytes
-  ws_max_idle_timeout: number        // seconds
-}
-
-export interface UserQuotaOverrides {
-  max_workspaces: number | null
-  updated_at: string
-}
-
-export interface UserQuotaResponse {
-  defaults: { max_workspaces_per_user: number }
-  overrides: UserQuotaOverrides | null
-}
-
-export interface WorkspaceQuotaOverrides {
-  max_sandboxes: number | null
-  max_sandbox_cpu: number | null    // millicores
-  max_sandbox_memory: number | null // bytes
-  max_idle_timeout: number | null   // seconds
-  max_total_cpu: number | null      // millicores
-  max_total_memory: number | null   // bytes
-  max_drive_size: number | null     // bytes
-  updated_at: string
-}
-
-export interface WorkspaceQuotaDefaults {
-  max_sandboxes: number
-  max_sandbox_cpu: number           // millicores
-  max_sandbox_memory: number        // bytes
-  max_idle_timeout: number          // seconds
-  max_total_cpu: number             // millicores
-  max_total_memory: number          // bytes
-  max_drive_size: number            // bytes
-}
-
-export interface WorkspaceQuotaResponse {
-  defaults: WorkspaceQuotaDefaults
-  overrides: WorkspaceQuotaOverrides | null
 }
 
 export interface QuotaExceededError {


### PR DESCRIPTION
## Summary

This is the **final Phase 1.b PR**, completing the 8-PR OpenAPI annotation stack (#152–#159). After this lands, all public REST CRUD endpoints have swag annotations and are reflected in the generated `docs/api/openapi.yaml`.

Two new tags are introduced:

**Misc (19 endpoints)**
- Credential Bindings: `GET/POST /api/workspaces/{id}/credentials/{kind}` + patch/delete/set-default/device-complete per binding
- Operations Log: `GET /api/workspaces/{id}/operations`
- Workspace Defaults: `GET /api/workspaces/{wid}/defaults`
- LLM Traces (4): sandbox traces + trace detail, workspace traces + trace detail
- Codex Executors (3): register, list, unbind
- ModelServer (3): connect, disconnect, status
- Agent Interactions: `GET /api/workspaces/{wid}/agent-interactions`

**Admin (15 endpoints)**
- Users: list, update role, get/set/delete quota
- Workspaces: list, get/set/delete quota, get/set/delete llm-quota
- Sandboxes: list
- Quota defaults: get/set

### What's in this PR

- **34 named DTOs** in `api_types.go` under `// --- Misc ---` and `// --- Admin ---`
- **Handler annotations** on all 34 endpoints across `admin.go`, `agent_interactions.go`, `codex_executors.go`, `credential_bindings.go`, `modelserver_oauth.go`, `operations.go`, `server.go`
- **Inline struct refactoring** to named types throughout
- **Spec regenerated** — drift gate `make openapi-check` passes
- **Frontend migration** — 15 local interfaces in `web/src/lib/api.ts` replaced with `components['schemas']` aliases; web build clean

### Out of scope (Phase 2)
- `/api/oauth2/*` Hydra login/consent/device endpoints
- `/api/auth/oidc/*` OIDC flows
- `GET /api/auth/modelserver/callback` OAuth redirect

### Design spec
See `docs/superpowers/specs/2026-05-21-openapi-phase-1a-infra-auth.md` for the overall OpenAPI effort design.

### PR stack (#152–#159)
- #152 Phase 1.a: infra + auth
- #153 Phase 1.b: Workspaces
- #154 Phase 1.b: Sandboxes
- #155 Phase 1.b: IM Channels
- #156 Phase 1.b: Codex Tokens
- #157 Phase 1.b: Codex Browser Sessions
- #158 Phase 1.b: Agent
- **#159 Phase 1.b: Misc + Admin ← this PR (FINAL)**

## Test plan

- [ ] `go build ./...` — clean
- [ ] `go test ./...` — all pass
- [ ] `make openapi-check` — no drift
- [ ] `pnpm run build` in `web/` — clean (1761 modules, 0 errors)
- [ ] Spot-check generated spec: verify `Misc` and `Admin` tags appear, no `server.` prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)