### PR TITLE
fix(codex-exec-gateway): accept codex 0.133 /cloud/environment/{id}/register path

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.4
-appVersion: "0.64.4"
+version: 0.64.5
+appVersion: "0.64.5"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/internal/codexexecgateway/handlers/cloud_register.go
+++ b/internal/codexexecgateway/handlers/cloud_register.go
@@ -96,7 +96,13 @@ func (v *AgentserverValidator) Validate(ctx context.Context, req map[string]stri
 // dev / direct in-cluster use.
 func CloudRegister(store CloudRegisterStore, publicWSBaseURL string, validator AgentserverValidator, wsTicketSecret string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
+		// codex 0.132 path: /cloud/executor/{exe_id}/register
+		// codex 0.133+ path: /cloud/environment/{env_id}/register
+		// Same handler, same id semantics — just two URL shapes.
 		exeID := chi.URLParam(r, "exe_id")
+		if exeID == "" {
+			exeID = chi.URLParam(r, "env_id")
+		}
 		if exeID == "" {
 			writeJSON(w, http.StatusBadRequest, map[string]string{"error": "exe_id required"})
 			return

--- a/internal/codexexecgateway/handlers/cloud_register_test.go
+++ b/internal/codexexecgateway/handlers/cloud_register_test.go
@@ -133,3 +133,63 @@ func TestCloudRegister_RejectsWithoutValidator(t *testing.T) {
 		t.Fatalf("want 401, got %d body=%s", rr.Code, rr.Body.String())
 	}
 }
+
+// Codex 0.133 renamed the URL param to `env_id` and the path to
+// /cloud/environment/{env_id}/register. The handler accepts either chi
+// param name so both the legacy and the new route resolve correctly.
+func TestCloudRegister_AcceptsEnvIDParam(t *testing.T) {
+	agentSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"user_id": "u-1"})
+	}))
+	defer agentSrv.Close()
+
+	store := newStoreWithExecutor(t, "exe_x", "u-1")
+	h := CloudRegister(store, "wss://test", AgentserverValidator{
+		BaseURL: agentSrv.URL, InternalSecret: "shh",
+	}, testTicketSecret)
+
+	req := httptest.NewRequest(http.MethodPost, "/cloud/environment/exe_x/register", nil)
+	req.Header.Set("Authorization", "Bearer any-token")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("env_id", "exe_x") // codex 0.133 path uses env_id
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rr := httptest.NewRecorder()
+	h(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	var resp cloudRegisterResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.ExecutorID != "exe_x" {
+		t.Fatalf("executor_id = %q", resp.ExecutorID)
+	}
+}
+
+// Both legacy `exe_id` and new `env_id` chi params resolve to the same
+// id when both happen to be set (defensive — production routes never
+// set both, but document the precedence).
+func TestCloudRegister_ExeIDTakesPrecedenceOverEnvID(t *testing.T) {
+	agentSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"user_id": "u-1"})
+	}))
+	defer agentSrv.Close()
+
+	store := newStoreWithExecutor(t, "exe_legacy", "u-1")
+	h := CloudRegister(store, "wss://test", AgentserverValidator{
+		BaseURL: agentSrv.URL, InternalSecret: "shh",
+	}, testTicketSecret)
+
+	req := httptest.NewRequest(http.MethodPost, "/cloud/executor/exe_legacy/register", nil)
+	req.Header.Set("Authorization", "Bearer any-token")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("exe_id", "exe_legacy")
+	rctx.URLParams.Add("env_id", "exe_new") // ignored when exe_id present
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rr := httptest.NewRecorder()
+	h(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+}

--- a/internal/codexexecgateway/server.go
+++ b/internal/codexexecgateway/server.go
@@ -165,15 +165,17 @@ func (s *Server) Routes() http.Handler {
 	r.Put("/relay/{ticket}", s.handleRelayPut)
 	r.Get("/relay/{ticket}", s.handleRelayGet)
 
-	// Upstream codex `exec-server --remote` compat: clients POST here
-	// with bearer auth, get back the ws URL above.
-	r.Post("/cloud/executor/{exe_id}/register",
-		handlers.CloudRegister(s.store, s.config.PublicWSBaseURL,
-			handlers.AgentserverValidator{
-				BaseURL:        s.config.AgentserverInternalURL,
-				InternalSecret: s.config.AgentserverInternalSecret,
-			},
-			s.config.AgentserverInternalSecret))
+	// Upstream codex `exec-server --remote` compat. Two paths because
+	// codex renamed the endpoint in 0.133 (executor → environment); the
+	// handler treats them identically.
+	cloudRegister := handlers.CloudRegister(s.store, s.config.PublicWSBaseURL,
+		handlers.AgentserverValidator{
+			BaseURL:        s.config.AgentserverInternalURL,
+			InternalSecret: s.config.AgentserverInternalSecret,
+		},
+		s.config.AgentserverInternalSecret)
+	r.Post("/cloud/executor/{exe_id}/register", cloudRegister)
+	r.Post("/cloud/environment/{env_id}/register", cloudRegister)
 
 	// *Store satisfies handlers.Store, handlers.BindingStore, and
 	// handlers.InternalConnectedStore directly — no adapter needed because

--- a/internal/codexexecgateway/server_test.go
+++ b/internal/codexexecgateway/server_test.go
@@ -66,3 +66,35 @@ func TestNewServer_RejectsZeroConfig(t *testing.T) {
 		t.Fatal("NewServer should reject zero-value Config")
 	}
 }
+
+// TestRoutes_BothCloudRegisterPaths confirms that the chi router mounts
+// the cloud_register handler at both the codex 0.132 path
+// (/cloud/executor/{exe_id}/register) and the codex 0.133+ path
+// (/cloud/environment/{env_id}/register). Without auth headers both
+// should fall through to the same 401 — the point is that neither
+// returns 404 (which would mean the route isn't mounted).
+func TestRoutes_BothCloudRegisterPaths(t *testing.T) {
+	srv, err := newServerNoStoreForTesting(Config{
+		CapTokenHMACSecret:        []byte("k"),
+		InternalSharedSecret:      "is",
+		AgentserverInternalSecret: "tic",
+	})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	for _, path := range []string{
+		"/cloud/executor/exe_x/register",    // codex 0.132
+		"/cloud/environment/exe_x/register", // codex 0.133+
+	} {
+		req := httptest.NewRequest(http.MethodPost, path, nil)
+		rr := httptest.NewRecorder()
+		srv.Routes().ServeHTTP(rr, req)
+		if rr.Code == http.StatusNotFound {
+			t.Errorf("%s: route not mounted (404)", path)
+			continue
+		}
+		if rr.Code != http.StatusUnauthorized {
+			t.Errorf("%s: got %d body=%s (want 401)", path, rr.Code, rr.Body.String())
+		}
+	}
+}

--- a/internal/server/codex_executors.go
+++ b/internal/server/codex_executors.go
@@ -157,7 +157,7 @@ func (s *Server) handleRegisterExecutor(w http.ResponseWriter, r *http.Request) 
 		issuer := s.CodexAuthIssuerURL
 		resp.ConnectCommands = ConnectCommands{
 			AgentIdentity: fmt.Sprintf(
-				"export CODEX_ACCESS_TOKEN='%s'\nexport CODEX_AGENT_IDENTITY_AUTHAPI_BASE_URL='%s'\ncodex -c chatgpt_base_url='%s' exec-server --remote '%s' --executor-id '%s' --name '%s' --use-agent-identity-auth",
+				"export CODEX_ACCESS_TOKEN='%s'\nexport CODEX_AGENT_IDENTITY_AUTHAPI_BASE_URL='%s'\ncodex -c chatgpt_base_url='%s' exec-server --remote '%s' --environment-id '%s' --name '%s' --use-agent-identity-auth",
 				aiResult.JWT, issuer, issuer, gatewayURL, reg.ExeID, req.Name),
 		}
 		resp.ConnectCommand = resp.ConnectCommands.AgentIdentity


### PR DESCRIPTION
## Problem
codex 0.133 renamed the exec-server registration endpoint:
- HTTP path: \`/cloud/executor/{exe_id}/register\` → \`/cloud/environment/{env_id}/register\`
- CLI flag: \`--executor-id\` → \`--environment-id\`

Hitting agentserver with 0.133 returns \`environment registry request failed (404 Not Found)\` and codex loops register-retry forever.

## Fix
- \`internal/codexexecgateway/server.go\`: mount the same handler at both URL shapes.
- \`internal/codexexecgateway/handlers/cloud_register.go\`: read whichever chi param is populated.
- \`internal/server/codex_executors.go\`: dashboard 'Add Connector' connect command emits \`--environment-id\` (0.133+ won't accept the old flag).

The id semantics are identical (still our opaque \`exe_*\` UUID), so nothing else changes.

## Chart
0.64.4 → 0.64.5

## Test plan
- [x] go test ./... (all passing)
- [ ] live: codex 0.133 exec-server --remote --environment-id ... --use-agent-identity-auth → register OK, ws connects