### PR TITLE
chore(chart): bump 0.64.4 → 0.64.5

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.4
-appVersion: "0.64.4"
+version: 0.64.5
+appVersion: "0.64.5"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
Release v0.64.5: ships the 8-PR OpenAPI organization stack (#152-#159).

## What's new in v0.64.5

- **OpenAPI 3.0 spec for the public REST API** (89 endpoints across 8 tags: Auth, Workspaces, Sandboxes, IM Channels, Codex Tokens, Codex Browser, Agent, Misc + Admin)
- swaggo → swagger2openapi → openapi-typescript pipeline + CI drift gate
- Frontend `apiClient.ts` fetch wrapper + `api.ts` helpers migrated to generated TypeScript types
- Wire-format preserved across all migrated endpoints (verified via cross-PR consistency review)

No behavior changes from v0.64.4 for end users — this release is infrastructure + spec generation.

## Test plan
- [x] All 8 stack PRs merged green
- [x] `make openapi-check` green on main
- [x] `pnpm build` green
- [ ] CI builds versioned images on tag push

🤖 Generated with [Claude Code](https://claude.com/claude-code)