### PR TITLE
chore(chart): bump 0.64.5 → 0.64.6 to ship #160

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.5
-appVersion: "0.64.5"
+version: 0.64.6
+appVersion: "0.64.6"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
PR #160 (codex 0.133 environment route) bumped chart 0.64.4 → 0.64.5, but PR #161 grabbed 0.64.5 first. This bumps 0.64.5 → 0.64.6 so the route fix actually ships.