### PR TITLE
fix(docker): run pnpm openapi:gen before pnpm build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,12 @@ WORKDIR /app/web
 COPY web/package.json web/pnpm-lock.yaml web/pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 COPY web/ ./
+# Generate TypeScript types from the committed OpenAPI spec before tsc runs.
+# The output (src/lib/api-generated/schema.d.ts) is gitignored — without
+# this step `web/src/lib/api.ts` can't resolve its `components` import and
+# tsc fails with TS2307 + cascading TS7006 implicit-any errors.
+COPY docs/api/openapi.yaml /app/docs/api/openapi.yaml
+RUN pnpm openapi:gen
 RUN pnpm build
 
 # Stage 2: Build opencode frontend from submodule


### PR DESCRIPTION
## Summary

CI has been failing for v0.64.5 and v0.64.6 tag builds plus every main-push since the Phase 1.a OpenAPI infra landed in #152. Root cause: \`web/src/lib/api-generated/schema.d.ts\` is gitignored (regenerated from \`docs/api/openapi.yaml\` via openapi-typescript), but the Dockerfile's frontend stage never runs \`pnpm openapi:gen\` — so the import in \`web/src/lib/api.ts\` fails inside the container.

## Errors seen

\`\`\`
src/lib/api.ts(2,33): error TS2307: Cannot find module './api-generated/schema'
src/components/SandboxDetail.tsx(135,113): error TS7006: Parameter 'b' implicitly has an 'any' type.
src/components/WorkspaceDetail.tsx(759,40): error TS7006: Parameter 'm' implicitly has an 'any' type.
src/components/WorkspaceDetail.tsx(820,38): error TS7006: Parameter 'm' implicitly has an 'any' type.
\`\`\`

The 3 implicit-any errors are cascading from the missing module — once \`Sandbox[]\` / \`WorkspaceMember[]\` types resolve, callbacks regain their inferred types.

## Fix

Frontend stage now does:

\`\`\`dockerfile
COPY docs/api/openapi.yaml /app/docs/api/openapi.yaml
RUN pnpm openapi:gen
RUN pnpm build
\`\`\`

Same step local dev and CI's \`make openapi-check\` already run.

## Verification

Reproduced locally by removing \`web/src/lib/api-generated/\` then running \`pnpm openapi:gen && pnpm build\`. Both succeed; \`✓ built in 1.82s\`.

## Test plan

- [ ] Merge this PR; main push should produce a green CI run
- [ ] Bump chart (0.64.6 → 0.64.7) and tag v0.64.7 to get the fixed image

🤖 Generated with [Claude Code](https://claude.com/claude-code)