### PR TITLE
chore(chart): bump 0.64.6 → 0.64.7

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.6
-appVersion: "0.64.6"
+version: 0.64.7
+appVersion: "0.64.7"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
Ships #163 (Dockerfile fix for missing openapi:gen step). Versions 0.64.5 and 0.64.6 have unbuildable images on ghcr.io due to the same root cause; 0.64.7 is the first version with a working image since the Phase 1.a OpenAPI stack merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)