### PR TITLE
fix: openapi codegen in Docker + bump spawned codex 0.131 → 0.133

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,12 @@ WORKDIR /app/web
 COPY web/package.json web/pnpm-lock.yaml web/pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile
 COPY web/ ./
+# Generate TypeScript types from the committed OpenAPI spec before tsc runs.
+# The output (src/lib/api-generated/schema.d.ts) is gitignored — without
+# this step `web/src/lib/api.ts` can't resolve its `components` import and
+# tsc fails with TS2307 + cascading TS7006 implicit-any errors.
+COPY docs/api/openapi.yaml /app/docs/api/openapi.yaml
+RUN pnpm openapi:gen
 RUN pnpm build
 
 # Stage 2: Build opencode frontend from submodule

--- a/Dockerfile.codex-app-gateway
+++ b/Dockerfile.codex-app-gateway
@@ -11,7 +11,7 @@ RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' \
 # `codex app-server` per thread, so the runtime image must carry it.
 # Override at build time with --build-arg CODEX_VERSION=...
 FROM debian:trixie-slim AS codex
-ARG CODEX_VERSION=0.131.0
+ARG CODEX_VERSION=0.133.0
 ARG TARGETARCH
 RUN apt-get update \
  && apt-get install -y --no-install-recommends ca-certificates curl \

--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.6
-appVersion: "0.64.6"
+version: 0.64.7
+appVersion: "0.64.7"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
Two fixes in one (both block v0.64.6 from publishing):

1. **Docker build**: \`pnpm openapi:gen\` was missing from frontend build stage. Generated \`web/src/lib/api-generated/schema.d.ts\` is gitignored, so in-container builds failed with TS2307 + cascading TS7006s. (Original fix by b5068f5.)

2. **Bump spawned codex**: codex-app-gateway's bundled codex binary 0.131.0 → 0.133.0. Protocol alignment check:
   - app-server JSON-RPC: new methods are pass-through (codex-app-gateway is a proxy)
   - exec-server protocol.rs: zero diff
   - agent-identity / login: zero diff
   - cloud/executor → cloud/environment: already handled in #160

Chart 0.64.6 → 0.64.7 (0.64.6 was never published — build-server failed on the openapi codegen issue).