### PR TITLE
feat(codex-app-gateway): bump spawned codex 0.131 → 0.133 + chart 0.64.8

### DIFF
--- a/Dockerfile.codex-app-gateway
+++ b/Dockerfile.codex-app-gateway
@@ -11,7 +11,7 @@ RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' \
 # `codex app-server` per thread, so the runtime image must carry it.
 # Override at build time with --build-arg CODEX_VERSION=...
 FROM debian:trixie-slim AS codex
-ARG CODEX_VERSION=0.131.0
+ARG CODEX_VERSION=0.133.0
 ARG TARGETARCH
 RUN apt-get update \
  && apt-get install -y --no-install-recommends ca-certificates curl \

--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.7
-appVersion: "0.64.7"
+version: 0.64.8
+appVersion: "0.64.8"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
## Protocol alignment audit (0.131 → 0.133)
| Module | Diff vs our consumption | Action |
|---|---|---|
| app-server JSON-RPC (codex-app-gateway proxy) | 4 new pass-through methods (thread/settings/update, plugin/installed, permissionProfile/list, thread/settings/updated) | none |
| exec-server/protocol.rs (codex-exec-gateway) | zero diff | none |
| agent-identity + login (JWKS/JWT/PKCE/device-flow) | zero diff | none |
| cloud register URL (executor → environment) | rename | handled in #160 |

Aligned. Safe to bump.

## Change
- \`Dockerfile.codex-app-gateway:14\`: \`CODEX_VERSION=0.131.0\` → \`0.133.0\`
- chart 0.64.7 → 0.64.8

## Test plan
- [ ] codex 0.133 client → \`codex --remote\` against bumped codex-app-gateway → initialize + thread/start work