### PR TITLE
feat(codex-app-gateway): bump bundled codex 0.131.0 → 0.133.0

### DIFF
--- a/Dockerfile.codex-app-gateway
+++ b/Dockerfile.codex-app-gateway
@@ -11,7 +11,7 @@ RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' \
 # `codex app-server` per thread, so the runtime image must carry it.
 # Override at build time with --build-arg CODEX_VERSION=...
 FROM debian:trixie-slim AS codex
-ARG CODEX_VERSION=0.131.0
+ARG CODEX_VERSION=0.133.0
 ARG TARGETARCH
 RUN apt-get update \
  && apt-get install -y --no-install-recommends ca-certificates curl \

--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.7
-appVersion: "0.64.7"
+version: 0.64.8
+appVersion: "0.64.8"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
## Summary

Bumps the codex binary baked into the codex-app-gateway image from 0.131.0 → 0.133.0. Also bumps the chart 0.64.7 → 0.64.8 to ship it.

## Protocol diff (0.131 → 0.133) vs our consumption

- **app-server JSON-RPC**: 4 new methods (\`thread/settings/update\`, \`plugin/installed\`, \`permissionProfile/list\`, \`thread/settings/updated\`) — all pass-through. codex-app-gateway proxies frames untouched; the only places it inspects \`method\` are the approval allowlist (\`approvalfilter/filter.go\`) and the local-IO blocklist (\`intercept_local_io.go\`), neither of which match the new names.
- **exec-server (\`protocol.rs\`)**: 0 diff.
- **agent-identity / login**: 0 diff. JWKS / JWT / PKCE / device flow unchanged.
- **/cloud/executor/{id}/register → /cloud/environment/{id}/register**: already fixed in #160 (codex-exec-gateway now accepts both paths).

So bumping the spawned binary is safe with the in-tree codex-exec-gateway + codex-auth + codex-app-gateway as of #160.

## Files

- \`Dockerfile.codex-app-gateway\`: \`ARG CODEX_VERSION=0.131.0\` → \`0.133.0\`
- \`deploy/helm/agentserver/Chart.yaml\`: 0.64.7 → 0.64.8

## Test plan

- [ ] CI builds codex-app-gateway:0.64.8 from the new tag
- [ ] Manual smoke: thread/start → turn/start → turn/completed round-trip via the gateway against a 0.133 binary (same shape as 0.131; no expected change)
- [ ] No regression on /cloud/environment/{id}/register flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)