### PR TITLE
fix(codex-exec-gateway): retry transient validator failures on register

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.8
-appVersion: "0.64.8"
+version: 0.64.9
+appVersion: "0.64.9"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/internal/codexexecgateway/handlers/cloud_register.go
+++ b/internal/codexexecgateway/handlers/cloud_register.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -48,8 +49,18 @@ type AgentserverValidator struct {
 	HTTPClient     *http.Client // optional; nil → default with 5s timeout
 }
 
+// ErrValidatorUnavailable is returned by Validate when the validator
+// itself is unreachable (network error, 5xx, or 408/429 transient
+// status). Callers should treat this as retryable — surface as 503 to
+// the codex client so it loops register-retry instead of bailing with
+// an auth error.
+var ErrValidatorUnavailable = fmt.Errorf("validator unavailable")
+
 // Validate POSTs the request body to agentserver and returns the
-// resolved user_id, or an error if validation fails.
+// resolved user_id, or an error if validation fails. Returns
+// ErrValidatorUnavailable (wrapped) for transient transport / 5xx
+// failures so callers can distinguish "auth said no" (401) from
+// "couldn't ask" (503 — retryable during rolling deploys).
 func (v *AgentserverValidator) Validate(ctx context.Context, req map[string]string) (userID string, err error) {
 	if v.BaseURL == "" {
 		return "", fmt.Errorf("validator not configured")
@@ -65,7 +76,9 @@ func (v *AgentserverValidator) Validate(ctx context.Context, req map[string]stri
 	}
 	resp, err := client.Do(httpReq)
 	if err != nil {
-		return "", fmt.Errorf("validate: %w", err)
+		// Network error: connection refused, DNS failure, timeout, etc.
+		// Treat as transient — the agentserver pod may be mid-restart.
+		return "", fmt.Errorf("%w: %v", ErrValidatorUnavailable, err)
 	}
 	defer resp.Body.Close()
 	var rb struct {
@@ -73,6 +86,9 @@ func (v *AgentserverValidator) Validate(ctx context.Context, req map[string]stri
 		Error  string `json:"error"`
 	}
 	json.NewDecoder(resp.Body).Decode(&rb)
+	if resp.StatusCode >= 500 || resp.StatusCode == http.StatusRequestTimeout || resp.StatusCode == http.StatusTooManyRequests {
+		return "", fmt.Errorf("%w: status=%d body=%q", ErrValidatorUnavailable, resp.StatusCode, rb.Error)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("validate: %s (status %d)", rb.Error, resp.StatusCode)
 	}
@@ -109,9 +125,22 @@ func CloudRegister(store CloudRegisterStore, publicWSBaseURL string, validator A
 		}
 
 		authHeader := r.Header.Get("Authorization")
-		userID, ok := classifyAndValidate(r.Context(), validator,
+		userID, vErr := classifyAndValidate(r.Context(), validator,
 			authHeader, r.Header.Get("ChatGPT-Account-ID"))
-		if !ok {
+		if vErr != nil {
+			// 503 for transient validator unavailability so codex keeps
+			// the register-retry loop alive across agentserver rolling
+			// restarts. 401/403 would make codex exit the loop with an
+			// auth error and drop the long-lived ws — every client
+			// connector would disconnect on every deploy.
+			if errors.Is(vErr, ErrValidatorUnavailable) {
+				writeJSON(w, http.StatusServiceUnavailable, map[string]string{"error": "validator unavailable, retry"})
+				return
+			}
+			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
+			return
+		}
+		if userID == "" {
 			writeJSON(w, http.StatusUnauthorized, map[string]string{"error": "unauthorized"})
 			return
 		}
@@ -137,36 +166,58 @@ func CloudRegister(store CloudRegisterStore, publicWSBaseURL string, validator A
 }
 
 // classifyAndValidate inspects the auth header and calls agentserver
-// with the appropriate scheme. Returns userID + ok=true on match.
-// Returns ok=false on any failure (legacy bcrypt path will then be tried).
-func classifyAndValidate(ctx context.Context, v AgentserverValidator, authHeader, accountID string) (string, bool) {
-	if strings.HasPrefix(authHeader, "Bearer ") {
-		token := strings.TrimPrefix(authHeader, "Bearer ")
-		// ChatGPT-mode bearer requests always come with the
-		// ChatGPT-Account-ID header (codex's BearerAuthProvider always
-		// adds it). Forward it so agentserver can cross-check the
-		// header against the token's owner.
-		// Legacy bcrypt tokens have similar shape; we always try
-		// delegating first and fall back to the bcrypt path on 401.
-		uid, err := v.Validate(ctx, map[string]string{
-			"scheme": "bearer", "token": token, "account_id": accountID,
-		})
-		if err == nil && uid != "" {
-			return uid, true
-		}
-		return "", false
+// with the appropriate scheme. Returns (userID, nil) on success,
+// (_, ErrValidatorUnavailable) when every retry to the validator was
+// unreachable, and (_, non-nil) for other auth failures (treat as 401).
+// An empty/unrecognized authHeader returns ("", nil) — caller treats
+// that as 401 too.
+//
+// Codex `register_environment(...).await?` exits run_remote_environment
+// on ANY non-2xx, so a 5xx during agentserver rolling restart would
+// disconnect every codex client. To hide the brief restart window we
+// retry transient validator failures here in-process; total wait stays
+// under ~3s so the codex client side doesn't time out.
+func classifyAndValidate(ctx context.Context, v AgentserverValidator, authHeader, accountID string) (string, error) {
+	var scheme, credKey, cred string
+	switch {
+	case strings.HasPrefix(authHeader, "Bearer "):
+		scheme = "bearer"
+		credKey = "token"
+		cred = strings.TrimPrefix(authHeader, "Bearer ")
+	case strings.HasPrefix(authHeader, "AgentAssertion "):
+		scheme = "agent_assertion"
+		credKey = "assertion"
+		cred = strings.TrimPrefix(authHeader, "AgentAssertion ")
+	default:
+		return "", nil
 	}
-	if strings.HasPrefix(authHeader, "AgentAssertion ") {
-		assertion := strings.TrimPrefix(authHeader, "AgentAssertion ")
-		uid, err := v.Validate(ctx, map[string]string{
-			"scheme": "agent_assertion", "assertion": assertion, "account_id": accountID,
-		})
-		if err == nil && uid != "" {
-			return uid, true
-		}
-		return "", false
+	body := map[string]string{
+		"scheme": scheme, credKey: cred, "account_id": accountID,
 	}
-	return "", false
+	// 5 attempts: 0ms, 300ms, 600ms, 1200ms, 2400ms — total ~4.5s, well
+	// over the kubelet rolling-restart RTT for an agentserver pod (1-2s).
+	var lastErr error
+	backoff := 300 * time.Millisecond
+	for attempt := 0; attempt < 5; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return "", ctx.Err()
+			case <-time.After(backoff):
+			}
+			backoff *= 2
+		}
+		uid, err := v.Validate(ctx, body)
+		if err == nil {
+			return uid, nil
+		}
+		lastErr = err
+		if !errors.Is(err, ErrValidatorUnavailable) {
+			// Hard auth failure — no point retrying.
+			return "", err
+		}
+	}
+	return "", lastErr
 }
 
 func assertExeOwnedByUser(ctx context.Context, store CloudRegisterStore, exeID, userID string) error {

--- a/internal/codexexecgateway/handlers/cloud_register_test.go
+++ b/internal/codexexecgateway/handlers/cloud_register_test.go
@@ -167,6 +167,72 @@ func TestCloudRegister_AcceptsEnvIDParam(t *testing.T) {
 	}
 }
 
+// Validator returning 502 (e.g. agentserver pod restarting) twice
+// before serving 200 — classifyAndValidate should retry and succeed
+// without surfacing the transient failure. Critical: codex
+// register-loop `?` would exit on any non-2xx from us, so dropping
+// every client every deploy is what we're preventing here.
+func TestCloudRegister_RetriesTransientValidatorErrors(t *testing.T) {
+	var attempts int
+	agentSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 3 {
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]string{"user_id": "u-1"})
+	}))
+	defer agentSrv.Close()
+
+	store := newStoreWithExecutor(t, "exe_x", "u-1")
+	h := CloudRegister(store, "wss://test", AgentserverValidator{
+		BaseURL: agentSrv.URL, InternalSecret: "shh",
+	}, testTicketSecret)
+	req := httptest.NewRequest(http.MethodPost, "/cloud/executor/exe_x/register", nil)
+	req.Header.Set("Authorization", "Bearer valid-bearer")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("exe_id", "exe_x")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rr := httptest.NewRecorder()
+	h(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200 after retries, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if attempts != 3 {
+		t.Errorf("validator called %d times, want 3 (two failures + one success)", attempts)
+	}
+}
+
+// Validator returns 401 — that's a hard auth failure, no retries.
+// Caller still gets 401 immediately (no extra wait).
+func TestCloudRegister_HardAuthFailureSkipsRetries(t *testing.T) {
+	var attempts int
+	agentSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]string{"error": "bad token"})
+	}))
+	defer agentSrv.Close()
+
+	store := newStoreWithExecutor(t, "exe_x", "u-1")
+	h := CloudRegister(store, "wss://test", AgentserverValidator{
+		BaseURL: agentSrv.URL, InternalSecret: "shh",
+	}, testTicketSecret)
+	req := httptest.NewRequest(http.MethodPost, "/cloud/executor/exe_x/register", nil)
+	req.Header.Set("Authorization", "Bearer bad-token")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("exe_id", "exe_x")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rr := httptest.NewRecorder()
+	h(rr, req)
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d body=%s", rr.Code, rr.Body.String())
+	}
+	if attempts != 1 {
+		t.Errorf("validator called %d times, want 1 (no retries on hard failure)", attempts)
+	}
+}
+
 // Both legacy `exe_id` and new `env_id` chi params resolve to the same
 // id when both happen to be set (defensive — production routes never
 // set both, but document the precedence).


### PR DESCRIPTION
## Symptom
During agentserver rolling restart, every connected codex client disconnects with:
\`executor registry authentication error: 401 Unauthorized\`

## Root cause
codex 0.133's register loop body is \`let r = client.register_environment(...).await?;\` — \`?\` exits the entire \`run_remote_environment\` function on **any** non-2xx, not just auth errors. When agentserver's pod is mid-restart, codex-exec-gateway's call to \`/internal/codex-auth/validate\` returns a transport error → handler returns 401 → codex exits → client gone.

Returning a 5xx instead of 401 wouldn't help — \`?\` exits regardless of status. Fixing client-side would require forking codex.

## Fix
Retry inside the handler so codex sees a single successful register.

- \`Validate()\` distinguishes transport / 5xx / 408 / 429 (returns \`ErrValidatorUnavailable\`) from real auth failures.
- \`classifyAndValidate()\` retries on \`ErrValidatorUnavailable\` up to 5×: 300ms / 600ms / 1.2s / 2.4s (~4.5s total). Real auth failures skip retries.

agentserver rolling-restart RTT is typically 1-2s, well inside the budget.

## Chart
0.64.8 → 0.64.9

## Tests
- success-after-2-failures (validator 502→502→200, classifyAndValidate retries, handler returns 200)
- no-retry-on-hard-401 (validator returns 401 once, handler immediately 401, no extra calls)