### PR TITLE
fix(helm): zero-downtime rolling restart for agentserver

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.8
-appVersion: "0.64.8"
+version: 0.64.9
+appVersion: "0.64.9"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/deploy/helm/agentserver/templates/deployment.yaml
+++ b/deploy/helm/agentserver/templates/deployment.yaml
@@ -12,6 +12,16 @@ metadata:
     app: {{ .Release.Name }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  # New pod must be Ready before the old one is removed. With the
+  # default 25%/25% on a 1-replica deployment, the old pod could be
+  # killed before the new one is serving — codex-exec-gateway then
+  # returns 401 from the validator round-trip and every codex client
+  # disconnects with `executor registry authentication error`.
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app: {{ .Release.Name }}
@@ -345,6 +355,18 @@ spec:
               port: 8080
             initialDelaySeconds: 3
             periodSeconds: 5
+          # On pod delete, sleep before the binary sees SIGTERM so kube
+          # endpoints controller has time to remove this pod from the
+          # Service backend list. Without this gap, in-flight requests
+          # (notably codex-exec-gateway's /internal/codex-auth/validate
+          # call) get RST'd mid-flight when the binary exits, surfacing
+          # as 401 to codex which then exits its register loop. 10s
+          # comfortably exceeds the worst-case endpoints propagation.
+          lifecycle:
+            preStop:
+              exec:
+                command: ["/bin/sh", "-c", "sleep 10"]
+      terminationGracePeriodSeconds: 30
 {{- if not .Values.externalDatabase.existingSecret }}
 ---
 apiVersion: v1


### PR DESCRIPTION
## Symptom
Every \`pulumi up\` / chart upgrade disconnects every codex client with:
\`executor registry authentication error: 401 Unauthorized\`

## Root cause
agentserver pod gap during rolling restart:

1. **replicaCount: 1** + default strategy (maxSurge=25%, maxUnavailable=25%) → on a 1-replica deployment that resolves to 1/1, so kubernetes may kill the old pod before the new one is Ready.
2. No preStop hook → old pod sees SIGTERM, immediately closes listening socket. In-flight \`/internal/codex-auth/validate\` requests from codex-exec-gateway get RST'd.
3. validate failure → cloud_register handler returns 401 → codex 0.132+ \`register_environment().await?\` exits the entire \`run_remote_environment\` function → ws drops → client gone.

## Fix
- Explicit \`strategy.rollingUpdate: { maxSurge: 1, maxUnavailable: 0 }\` — new pod must be Ready before old is removed.
- \`lifecycle.preStop: sleep 10s\` + \`terminationGracePeriodSeconds: 30\` — endpoints controller has time to drain the old pod from the Service backends before the binary exits.

Both are at the agentserver layer where this belongs, not papered over with retries in codex-exec-gateway.

## Chart
0.64.8 → 0.64.9

## Test plan
- [x] \`helm template\` renders strategy + preStop + termGrace correctly
- [ ] live: deploy 0.64.9 → trigger a rollout → keep a codex exec-server connected throughout → no 401, no disconnect