### PR TITLE
fix(codex-exec-gateway): add environment_id to register response (codex 0.133)

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.9
-appVersion: "0.64.9"
+version: 0.64.11
+appVersion: "0.64.11"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/internal/codexexecgateway/handlers/cloud_register.go
+++ b/internal/codexexecgateway/handlers/cloud_register.go
@@ -30,14 +30,19 @@ type clientMetaStore interface {
 }
 
 // cloudRegisterResponse mirrors the upstream codex exec-server registry
-// response shape. Codex v0.130 expects {id, executor_id, url}; main has
-// dropped `id`. We include all three so both shapes deserialize cleanly.
-// The `id` field is only used by upstream for log messages — we reuse
-// executor_id since we don't track per-attempt registration IDs.
+// response shape across versions:
+//   - codex v0.130: {id, executor_id, url}
+//   - codex 0.131-0.132: {executor_id, url}
+//   - codex 0.133+: {environment_id, url} (rename, hard-required)
+//
+// Emitting all three id fields lets both old and new clients deserialize
+// without a version-aware switch. The values are identical (our opaque
+// exe_* UUID).
 type cloudRegisterResponse struct {
-	ID         string `json:"id"`
-	ExecutorID string `json:"executor_id"`
-	URL        string `json:"url"`
+	ID            string `json:"id"`
+	ExecutorID    string `json:"executor_id"`
+	EnvironmentID string `json:"environment_id"`
+	URL           string `json:"url"`
 }
 
 // AgentserverValidator calls agentserver's /internal/codex-auth/validate
@@ -197,7 +202,10 @@ func respondWithWSURL(w http.ResponseWriter, r *http.Request, exeID, ticket, pub
 	}
 	wsURL := base + "/codex-exec/" + url.PathEscape(exeID) + "?token=" + url.QueryEscape(ticket)
 	writeJSON(w, http.StatusOK, cloudRegisterResponse{
-		ID: exeID, ExecutorID: exeID, URL: wsURL,
+		ID:            exeID,
+		ExecutorID:    exeID,
+		EnvironmentID: exeID,
+		URL:           wsURL,
 	})
 }
 

--- a/internal/codexexecgateway/handlers/cloud_register_test.go
+++ b/internal/codexexecgateway/handlers/cloud_register_test.go
@@ -167,6 +167,74 @@ func TestCloudRegister_AcceptsEnvIDParam(t *testing.T) {
 	}
 }
 
+// TestCloudRegister_ResponseDecodesAgainstCodexSchemas pins our response
+// shape against the literal upstream codex deserialization structs for
+// both the pre-0.133 (executor) and 0.133+ (environment) wire formats.
+// If codex renames a field again, this test fails before live testing.
+//
+// Codex sources (verbatim — keep in sync when bumping):
+//   v0.132 codex-rs/exec-server/src/remote.rs:
+//     struct ExecutorRegistryExecutorRegistrationResponse {
+//         pub executor_id: String,
+//         pub url: String,
+//     }
+//   v0.133 codex-rs/exec-server/src/remote.rs:
+//     struct EnvironmentRegistryEnvironmentRegistrationResponse {
+//         pub environment_id: String,
+//         pub url: String,
+//     }
+func TestCloudRegister_ResponseDecodesAgainstCodexSchemas(t *testing.T) {
+	agentSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]string{"user_id": "u-1"})
+	}))
+	defer agentSrv.Close()
+
+	store := newStoreWithExecutor(t, "exe_x", "u-1")
+	h := CloudRegister(store, "wss://test", AgentserverValidator{
+		BaseURL: agentSrv.URL, InternalSecret: "shh",
+	}, testTicketSecret)
+	req := httptest.NewRequest(http.MethodPost, "/cloud/environment/exe_x/register", nil)
+	req.Header.Set("Authorization", "Bearer any-token")
+	rctx := chi.NewRouteContext()
+	rctx.URLParams.Add("env_id", "exe_x")
+	req = req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+	rr := httptest.NewRecorder()
+	h(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d body=%s", rr.Code, rr.Body.String())
+	}
+
+	// codex 0.132 schema (struct fields are required — serde with no
+	// #[serde(default)] fails the whole decode if missing).
+	var v132 struct {
+		ExecutorID string `json:"executor_id"`
+		URL        string `json:"url"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &v132); err != nil {
+		t.Fatalf("codex 0.132 decode failed: %v body=%s", err, rr.Body.String())
+	}
+	if v132.ExecutorID == "" || v132.URL == "" {
+		t.Errorf("codex 0.132 fields missing: %+v", v132)
+	}
+
+	// codex 0.133 schema.
+	var v133 struct {
+		EnvironmentID string `json:"environment_id"`
+		URL           string `json:"url"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &v133); err != nil {
+		t.Fatalf("codex 0.133 decode failed: %v body=%s", err, rr.Body.String())
+	}
+	if v133.EnvironmentID == "" || v133.URL == "" {
+		t.Errorf("codex 0.133 fields missing: %+v", v133)
+	}
+
+	// Both id fields must carry the same opaque value.
+	if v132.ExecutorID != v133.EnvironmentID {
+		t.Errorf("executor_id (%q) != environment_id (%q)", v132.ExecutorID, v133.EnvironmentID)
+	}
+}
+
 // Both legacy `exe_id` and new `env_id` chi params resolve to the same
 // id when both happen to be set (defensive — production routes never
 // set both, but document the precedence).


### PR DESCRIPTION
## Symptom
codex 0.133 \`exec-server --remote\`:
\`Error: environment registry request failed: error decoding response body — missing field \`environment_id\`\`

## Root cause
PR #160 handled the URL rename (\`/cloud/executor/...\` → \`/cloud/environment/...\`) but missed the **response body** rename.

| codex version | required field |
|---|---|
| 0.130 | \`id\`, \`executor_id\` |
| 0.131-0.132 | \`executor_id\` |
| 0.133+ | \`environment_id\` |

## Fix
Emit all three (\`id\`, \`executor_id\`, \`environment_id\`) with the same opaque id value. Any client across versions deserializes successfully.

## Test that pins this
\`TestCloudRegister_ResponseDecodesAgainstCodexSchemas\` deserializes our actual response against the literal codex 0.132 + 0.133 \`#[derive(Deserialize)]\` struct definitions (copied verbatim into the test as Go structs). If codex renames again, this test fails locally before any live test cycle.

## Chart
0.64.8 → 0.64.10 (0.64.9 reserved for PR #169 rolling-update fix)