### PR TITLE
fix(imbridge,codex): bump turn timeouts 5min → 60min

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.11
-appVersion: "0.64.11"
+version: 0.64.12
+appVersion: "0.64.12"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/internal/codexappgateway/turn_api.go
+++ b/internal/codexappgateway/turn_api.go
@@ -45,7 +45,7 @@ type turnAPIHandler struct {
 	runner turnRunner
 }
 
-const defaultTurnTimeout = 5 * time.Minute
+const defaultTurnTimeout = 60 * time.Minute
 
 func (h *turnAPIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var req turnAPIRequest

--- a/internal/imbridge/bridge.go
+++ b/internal/imbridge/bridge.go
@@ -249,9 +249,9 @@ func (b *Bridge) startTypingForUser(binding BridgeBinding, msg InboundMessage) {
 
 	// Create context with timeout and register cancel in map BEFORE starting
 	// the typing goroutine, so StopTyping can find it even if a reply arrives
-	// quickly. The 5-minute timeout ensures goroutines don't leak if NanoClaw
+	// quickly. The 60-minute timeout ensures goroutines don't leak if NanoClaw
 	// never replies, and triggers an error notice to the user.
-	ctx, cancelFn := context.WithTimeout(context.Background(), 5*time.Minute)
+	ctx, cancelFn := context.WithTimeout(context.Background(), 60*time.Minute)
 
 	b.mu.Lock()
 	if existingCancel, exists := b.typingSessions[key]; exists {

--- a/internal/server/codex_client.go
+++ b/internal/server/codex_client.go
@@ -57,7 +57,7 @@ func NewCodexClient(baseURL, internalSecret string) *CodexClient {
 		secret:  internalSecret,
 		// Generous default — caller is the codex_im handler which has its
 		// own per-turn timeout coming from the request body.
-		http: &http.Client{Timeout: 6 * time.Minute},
+		http: &http.Client{Timeout: 61 * time.Minute},
 	}
 }
 


### PR DESCRIPTION
## Summary

- A long-running codex turn (53 stream items at the 5-min mark, observed today on weixin channel `1f7309fa-…` thread `019e4676-…`) was cut off by the broker hard cap and surfaced as "⚠️ 消息处理超时，请稍后重试" to the WeChat user. Codex itself was still actively producing items — the limit was ours, not codex's.
- Bumps all three layered timeouts to 60min so a genuinely slow but still-progressing turn can finish:
  - `internal/codexappgateway/turn_api.go`: `defaultTurnTimeout` 5min → **60min**
  - `internal/imbridge/bridge.go`: `startTypingForUser` ctx 5min → **60min**
  - `internal/server/codex_client.go`: agentserver→CXG `http.Client.Timeout` 6min → **61min** (must stay > broker cap)
- Self-heal behavior preserved: on timeout the broker still sends `turn/interrupt` and closes the ws conn (`conn.go:401-417`), so a truly hung codex doesn't pin the workspace's broker conn.

## Test plan

- [x] `go build ./...` passes
- [ ] No test fixtures hardcoded the old 5/6 minute values (`grep` confirmed)
- [ ] After deploy: confirm a long turn (>5min) completes and replies normally to the WeChat user instead of triggering the timeout notice
- [ ] After deploy: confirm a forced-hung turn still trips the 60-min broker cap and self-heals the conn (broker log: `TIMEOUT … codex never sent turn/completed` followed by next turn succeeding on a fresh conn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)