### PR TITLE
feat(codex-app-gateway): public /api/turns via Bearer workspace API keys

### DIFF
--- a/internal/codexappgateway/auth/api_key.go
+++ b/internal/codexappgateway/auth/api_key.go
@@ -1,0 +1,83 @@
+// Package auth — workspace API-key validator that forwards Bearer secrets
+// to agentserver's internal validate endpoint.
+package auth
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+// APIKeyValidator calls agentserver's /internal/workspace-api-keys/validate
+// to verify a Bearer secret and return the workspace_id + scopes it authorizes.
+type APIKeyValidator struct {
+	BaseURL        string // e.g. "http://agentserver.agentserver.svc:8080"
+	InternalSecret string
+	HTTPClient     *http.Client // optional; nil → default with 5s timeout
+}
+
+// ValidatedKey is the result of a successful Validate call.
+type ValidatedKey struct {
+	WorkspaceID string
+	KeyID       string
+	Scopes      []string
+}
+
+// NewAPIKeyValidator constructs a validator with sensible HTTP defaults.
+func NewAPIKeyValidator(baseURL, internalSecret string) *APIKeyValidator {
+	return &APIKeyValidator{
+		BaseURL:        baseURL,
+		InternalSecret: internalSecret,
+		HTTPClient:     &http.Client{Timeout: 5 * time.Second},
+	}
+}
+
+// Validate sends the secret to agentserver's internal validate RPC.
+// Returns the workspace and scopes authorized by the key, or an error
+// on any non-200 response (invalid key, revoked, wrong hash, etc.).
+func (v *APIKeyValidator) Validate(ctx context.Context, secret string) (*ValidatedKey, error) {
+	if v.BaseURL == "" {
+		return nil, fmt.Errorf("api key validator not configured (no BaseURL)")
+	}
+	body, _ := json.Marshal(map[string]string{"secret": secret})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost,
+		v.BaseURL+"/internal/workspace-api-keys/validate", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("api key validate: build request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Internal-Secret", v.InternalSecret)
+
+	client := v.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: 5 * time.Second}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("api key validate: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("api key validate: status %d", resp.StatusCode)
+	}
+
+	var out struct {
+		WorkspaceID string   `json:"workspace_id"`
+		KeyID       string   `json:"key_id"`
+		Scopes      []string `json:"scopes"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("api key validate: decode response: %w", err)
+	}
+	if out.WorkspaceID == "" {
+		return nil, fmt.Errorf("api key validate: empty workspace_id in response")
+	}
+	return &ValidatedKey{
+		WorkspaceID: out.WorkspaceID,
+		KeyID:       out.KeyID,
+		Scopes:      out.Scopes,
+	}, nil
+}

--- a/internal/codexappgateway/auth/api_key_test.go
+++ b/internal/codexappgateway/auth/api_key_test.go
@@ -1,0 +1,81 @@
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAPIKeyValidator_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Internal-Secret") != "test-secret" {
+			http.Error(w, "no", http.StatusUnauthorized)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"workspace_id": "ws-123",
+			"key_id":       "wak_abc",
+			"scopes":       []string{"turns:submit"},
+		})
+	}))
+	defer srv.Close()
+
+	v := NewAPIKeyValidator(srv.URL, "test-secret")
+	got, err := v.Validate(context.Background(), "wak_abc_xyz")
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if got.WorkspaceID != "ws-123" {
+		t.Errorf("WorkspaceID = %q, want %q", got.WorkspaceID, "ws-123")
+	}
+	if got.KeyID != "wak_abc" {
+		t.Errorf("KeyID = %q, want %q", got.KeyID, "wak_abc")
+	}
+	if len(got.Scopes) != 1 || got.Scopes[0] != "turns:submit" {
+		t.Errorf("Scopes = %v, want [turns:submit]", got.Scopes)
+	}
+}
+
+func TestAPIKeyValidator_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "no", http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	v := NewAPIKeyValidator(srv.URL, "x")
+	_, err := v.Validate(context.Background(), "wak_invalid")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestAPIKeyValidator_NilBaseURL(t *testing.T) {
+	v := NewAPIKeyValidator("", "secret")
+	_, err := v.Validate(context.Background(), "wak_abc_xyz")
+	if err == nil {
+		t.Fatal("expected error for empty BaseURL")
+	}
+}
+
+func TestAPIKeyValidator_ScopesPropagated(t *testing.T) {
+	scopes := []string{"turns:submit", "threads:read"}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"workspace_id": "ws-456",
+			"key_id":       "wak_def",
+			"scopes":       scopes,
+		})
+	}))
+	defer srv.Close()
+
+	v := NewAPIKeyValidator(srv.URL, "any")
+	got, err := v.Validate(context.Background(), "wak_def_something")
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if len(got.Scopes) != 2 || got.Scopes[0] != "turns:submit" || got.Scopes[1] != "threads:read" {
+		t.Errorf("Scopes = %v, want %v", got.Scopes, scopes)
+	}
+}

--- a/internal/codexappgateway/server.go
+++ b/internal/codexappgateway/server.go
@@ -32,6 +32,19 @@ type connectedClient interface {
 	Connected(ctx context.Context, workspaceID string) ([]execmodel.ConnectedExecutor, error)
 }
 
+// ctxKey is the unexported type for context values stashed by
+// requireInternalOrAPIKey so there are no collisions with other packages.
+type ctxKey int
+
+const (
+	// ctxKeyAuthorizedWorkspace holds the workspace_id the bearer key is
+	// scoped to. Set only on the bearer path; absent on X-Internal-Secret path.
+	ctxKeyAuthorizedWorkspace ctxKey = iota
+	// ctxKeyAuthorizedScopes holds the []string scopes granted by the bearer
+	// key. Set only on the bearer path; absent on X-Internal-Secret path.
+	ctxKeyAuthorizedScopes
+)
+
 // Server is the codex-app-gateway HTTP/WS server.
 type Server struct {
 	cfg  ServeConfig
@@ -39,6 +52,12 @@ type Server struct {
 	sup  *supervisor.Supervisor
 	homeMgr      *codexhome.Manager
 	logger       *slog.Logger
+
+	// apiKeyValidator validates Bearer wak_<...> tokens against agentserver's
+	// /internal/workspace-api-keys/validate RPC. May be nil in dev/test
+	// configurations that don't have agentserver wired up; when nil, bearer
+	// auth returns 401 (X-Internal-Secret still works).
+	apiKeyValidator *auth.APIKeyValidator
 
 	// buildConfig produces the per-spawn config + env vars (e.g. a
 	// workspace-scoped LLM API key). Receives the per-spawn loopback
@@ -94,13 +113,18 @@ func NewServer(cfg ServeConfig, codexBin, selfBin string, logger *slog.Logger) (
 	})
 	execClient := NewExecGatewayClient(cfg.ExecGatewayInternalURL, cfg.ExecGatewayInternalSecret)
 	wsTokenClient := NewWorkspaceTokenClient(cfg.AgentserverInternalURL, cfg.AgentserverInternalSecret)
+	var apiKeyVal *auth.APIKeyValidator
+	if cfg.AgentserverInternalURL != "" && cfg.AgentserverInternalSecret != "" {
+		apiKeyVal = auth.NewAPIKeyValidator(cfg.AgentserverInternalURL, cfg.AgentserverInternalSecret)
+	}
 	s := &Server{
-		cfg:  cfg,
-		auth: auth.NewRemoteVerifier(cfg.AgentserverInternalURL, cfg.AgentserverInternalSecret),
-		sup:  sup,
-		homeMgr:      mgr,
-		logger:       logger,
-		execClient:   execClient,
+		cfg:             cfg,
+		auth:            auth.NewRemoteVerifier(cfg.AgentserverInternalURL, cfg.AgentserverInternalSecret),
+		sup:             sup,
+		homeMgr:         mgr,
+		logger:          logger,
+		execClient:      execClient,
+		apiKeyValidator: apiKeyVal,
 	}
 	s.buildConfig = makeBuildConfig(cfg, execClient, wsTokenClient, selfBin, logger)
 	s.brokerPool = broker.NewPool(
@@ -257,7 +281,7 @@ func (s *Server) Routes() http.Handler {
 	turnHandler := &turnAPIHandler{
 		runner: newPoolRunner(s.brokerPool),
 	}
-	r.With(s.requireInternalSecret).Post("/api/turns", turnHandler.ServeHTTP)
+	r.With(s.requireInternalOrAPIKey).Post("/api/turns", turnHandler.ServeHTTP)
 	return r
 }
 
@@ -275,6 +299,72 @@ func (s *Server) requireInternalSecret(next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+// requireInternalOrAPIKey accepts EITHER X-Internal-Secret (legacy
+// in-cluster path; trusts body.workspaceId as-is, scope check bypassed)
+// OR Authorization: Bearer wak_<...> (public path; stashes the validated
+// workspace_id and scopes into the request context so the handler can
+// enforce consistency with the request body AND scope presence).
+//
+// X-Internal-Secret is checked first because it's a cheap constant
+// compare; Bearer adds an in-cluster HTTP roundtrip to agentserver.
+func (s *Server) requireInternalOrAPIKey(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Path A: trusted in-cluster caller (imbridge). Cheap compare first.
+		if s.cfg.AgentserverInternalSecret != "" &&
+			r.Header.Get("X-Internal-Secret") == s.cfg.AgentserverInternalSecret {
+			next.ServeHTTP(w, r)
+			return
+		}
+		// Path B: public Bearer wak_ token.
+		authz := r.Header.Get("Authorization")
+		if strings.HasPrefix(authz, "Bearer wak_") {
+			if s.apiKeyValidator == nil {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			secret := strings.TrimPrefix(authz, "Bearer ")
+			key, err := s.apiKeyValidator.Validate(r.Context(), secret)
+			if err != nil {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+			ctx := context.WithValue(r.Context(), ctxKeyAuthorizedWorkspace, key.WorkspaceID)
+			ctx = context.WithValue(ctx, ctxKeyAuthorizedScopes, key.Scopes)
+			next.ServeHTTP(w, r.WithContext(ctx))
+			return
+		}
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	})
+}
+
+// scopesFromContext returns the scopes the bearer key authorized, or nil
+// when the caller authenticated via X-Internal-Secret (scope check bypassed).
+func scopesFromContext(r *http.Request) []string {
+	v := r.Context().Value(ctxKeyAuthorizedScopes)
+	if v == nil {
+		return nil
+	}
+	scopes, _ := v.([]string)
+	return scopes
+}
+
+// requireBearerScope returns an error when the request was bearer-authenticated
+// and the scope list does not include `required`. Internal-secret callers
+// bypass (scopesFromContext returns nil → no enforcement).
+func requireBearerScope(r *http.Request, required string) error {
+	v := r.Context().Value(ctxKeyAuthorizedScopes)
+	if v == nil {
+		return nil // internal secret path — bypass scope enforcement
+	}
+	scopes, _ := v.([]string)
+	for _, s := range scopes {
+		if s == required {
+			return nil
+		}
+	}
+	return errors.New("missing scope: " + required)
 }
 
 // Close releases per-server resources. Must be called on shutdown.

--- a/internal/codexappgateway/turn_api.go
+++ b/internal/codexappgateway/turn_api.go
@@ -47,6 +47,12 @@ type turnAPIHandler struct {
 
 const defaultTurnTimeout = 60 * time.Minute
 
+// turnsSubmitScope is the API-key scope required to call POST /api/turns.
+// Mirrored from agentserver's internal/server/api_key_scopes.go — kept as
+// a local constant to avoid coupling codex-app-gateway to agentserver's
+// package layout. Keep in sync if the scope string ever changes.
+const turnsSubmitScope = "turns:submit"
+
 func (h *turnAPIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var req turnAPIRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
@@ -61,6 +67,23 @@ func (h *turnAPIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "params required", http.StatusBadRequest)
 		return
 	}
+
+	// Bearer-path: enforce that the API key's workspace matches the request body.
+	// X-Internal-Secret callers don't have ctxKeyAuthorizedWorkspace set; the
+	// check is a no-op for them (v is nil).
+	if v := r.Context().Value(ctxKeyAuthorizedWorkspace); v != nil {
+		authorizedWS, _ := v.(string)
+		if authorizedWS != "" && authorizedWS != req.WorkspaceID {
+			http.Error(w, "api key not authorized for workspace "+req.WorkspaceID, http.StatusForbidden)
+			return
+		}
+	}
+	// Bearer-path: enforce scope presence. Internal-secret callers bypass.
+	if err := requireBearerScope(r, turnsSubmitScope); err != nil {
+		http.Error(w, err.Error(), http.StatusForbidden)
+		return
+	}
+
 	timeout := defaultTurnTimeout
 	if req.TimeoutMs > 0 {
 		timeout = time.Duration(req.TimeoutMs) * time.Millisecond

--- a/internal/codexappgateway/turn_api_auth_test.go
+++ b/internal/codexappgateway/turn_api_auth_test.go
@@ -1,0 +1,136 @@
+package codexappgateway
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/agentserver/agentserver/internal/codexappgateway/auth"
+)
+
+// handlerWithContext builds a turnAPIHandler with a fakeBroker that returns
+// a successful turn. It is used across multiple auth-path subtests.
+func newSuccessHandler() *turnAPIHandler {
+	return &turnAPIHandler{
+		runner: &fakeBroker{
+			startThreadFn: func(_ context.Context, _ string) (string, error) {
+				return "thr-new", nil
+			},
+			turnFn: func(_ context.Context, _, _ string, _ json.RawMessage, _ time.Duration) (json.RawMessage, error) {
+				return json.RawMessage(`{"id":"trn-1","status":"completed"}`), nil
+			},
+		},
+	}
+}
+
+// makeBody returns a JSON-encoded turn request with the given workspaceId.
+func makeBody(workspaceID string) *bytes.Reader {
+	b, _ := json.Marshal(map[string]any{
+		"workspaceId": workspaceID,
+		"params":      map[string]any{"input": []any{}},
+	})
+	return bytes.NewReader(b)
+}
+
+// withBearerCtx injects bearer-path context values (workspace + scopes)
+// into r, simulating what requireInternalOrAPIKey sets when the bearer
+// token validates successfully.
+func withBearerCtx(r *http.Request, workspaceID string, scopes []string) *http.Request {
+	ctx := context.WithValue(r.Context(), ctxKeyAuthorizedWorkspace, workspaceID)
+	ctx = context.WithValue(ctx, ctxKeyAuthorizedScopes, scopes)
+	return r.WithContext(ctx)
+}
+
+// --- Handler-level tests (context values injected directly) ---
+
+func TestTurnAPI_BearerAuth_WorkspaceMatch(t *testing.T) {
+	h := newSuccessHandler()
+	r := httptest.NewRequest("POST", "/api/turns", makeBody("ws-A"))
+	r = withBearerCtx(r, "ws-A", []string{"turns:submit"})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestTurnAPI_BearerAuth_WorkspaceMismatch(t *testing.T) {
+	h := newSuccessHandler()
+	// Bearer key authorizes ws-A; body says ws-B → 403
+	r := httptest.NewRequest("POST", "/api/turns", makeBody("ws-B"))
+	r = withBearerCtx(r, "ws-A", []string{"turns:submit"})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestTurnAPI_BearerAuth_MissingScope(t *testing.T) {
+	h := newSuccessHandler()
+	// Bearer key has threads:read but not turns:submit → 403
+	r := httptest.NewRequest("POST", "/api/turns", makeBody("ws-A"))
+	r = withBearerCtx(r, "ws-A", []string{"threads:read"})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestTurnAPI_BearerAuth_EmptyScopes(t *testing.T) {
+	h := newSuccessHandler()
+	// Bearer key has no scopes → 403
+	r := httptest.NewRequest("POST", "/api/turns", makeBody("ws-A"))
+	r = withBearerCtx(r, "ws-A", []string{})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("want 403, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+func TestTurnAPI_InternalSecretAuth_BypassesScopeCheck(t *testing.T) {
+	h := newSuccessHandler()
+	// No context values set (internal-secret path) → handler runs without 403
+	r := httptest.NewRequest("POST", "/api/turns", makeBody("ws-A"))
+	// No ctxKeyAuthorizedWorkspace or ctxKeyAuthorizedScopes in context.
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d body=%s", w.Code, w.Body.String())
+	}
+}
+
+// --- Middleware-level test for invalid Bearer key → 401 ---
+
+func TestTurnAPI_BearerAuth_InvalidKey(t *testing.T) {
+	// Fake agentserver that always returns 401.
+	fakeSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+	}))
+	defer fakeSrv.Close()
+
+	validator := auth.NewAPIKeyValidator(fakeSrv.URL, "test-secret")
+	s := &Server{
+		cfg: ServeConfig{
+			AgentserverInternalSecret: "real-secret",
+		},
+		apiKeyValidator: validator,
+	}
+	mw := s.requireInternalOrAPIKey(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNoContent)
+	}))
+
+	r := httptest.NewRequest("POST", "/api/turns", makeBody("ws-A"))
+	r.Header.Set("Authorization", "Bearer wak_badbadbad_whatever")
+	w := httptest.NewRecorder()
+	mw.ServeHTTP(w, r)
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d body=%s", w.Code, w.Body.String())
+	}
+}


### PR DESCRIPTION
## Summary

PR 2 of 3 in the codex-app-gateway public-/api/turns stack. Builds on #171 (workspace API keys subsystem) by teaching codex-app-gateway to honor \`Authorization: Bearer wak_<...>\` in addition to the existing \`X-Internal-Secret\`. External integrators can now hit \`POST https://codex-app.agent.cs.ac.cn/api/turns\` directly.

Reference: spec \`docs/superpowers/specs/2026-05-22-codex-app-gateway-public-turns-design.md\`, plan \`docs/superpowers/plans/2026-05-22-codex-app-gateway-public-turns.md\`.

| PR | Status |
|---|---|
| 1 Workspace API keys subsystem (#171) | merged |
| **2 codex-app-gateway dual-auth on /api/turns (this PR)** | open |
| 3 codex-app-gateway OpenAPI spec | not yet branched |

## What lands

**Validator client** (\`internal/codexappgateway/auth/api_key.go\`):
- \`APIKeyValidator\` POSTs the bearer secret to agentserver's \`/internal/workspace-api-keys/validate\` and returns \`ValidatedKey{WorkspaceID, KeyID, Scopes}\`.

**Dual-auth middleware** (\`internal/codexappgateway/server.go\`):
- \`requireInternalOrAPIKey\` middleware checks X-Internal-Secret first (cheap), falls back to \`Authorization: Bearer wak_*\` validation against agentserver.
- Validated workspace + scopes stashed in request context for the handler.

**/api/turns enforcement** (\`internal/codexappgateway/turn_api.go\`):
- Bearer path: handler asserts \`body.workspaceId == key.workspace_id\` → 403 on mismatch.
- Bearer path: handler asserts \`turns:submit\` present in key scopes → 403 \`missing scope: turns:submit\`.
- X-Internal-Secret path: bypasses both checks (in-cluster trust, imbridge unchanged).

**Config**: reuses existing \`AgentserverInternalURL\` + \`AgentserverInternalSecret\` fields — no new plumbing.

## Verification

- \`go build ./...\` clean
- \`go test ./internal/codexappgateway/auth/ -run TestAPIKeyValidator\` — 4 PASS (Happy / Unauthorized / NilBaseURL / ScopesPropagated)
- \`go test ./internal/codexappgateway/ -run TestTurnAPI\` — 11 PASS, including all 6 new auth-path tests plus the original 5
- Existing \`requireInternalSecret\` middleware untouched and still applies to other internal endpoints

## Test plan

- [ ] After merge + tag: curl with a key minted via #171 against /api/turns on staging, with \`turns:submit\` granted → 200
- [ ] curl with a key WITHOUT \`turns:submit\` → 403 \`missing scope: turns:submit\`
- [ ] curl with a key for ws-A trying to send a turn to ws-B → 403 \`api key not authorized for workspace ws-B\`
- [ ] imbridge in-cluster call via X-Internal-Secret continues to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)