### PR TITLE
chore(chart): bump 0.64.12 → 0.64.13

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.12
-appVersion: "0.64.12"
+version: 0.64.13
+appVersion: "0.64.13"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
Release v0.64.13 ships:
- #173 codex-app-gateway public /api/turns via Bearer workspace API keys
- #175 secrets module unification (ask_/ast_ via base62 + CRC32 + HMAC pepper)

**Deploy gotchas:**
1. Set `SECRETS_PEPPER` env var on agentserver (32-byte random hex) — `openssl rand -hex 32`. Without it, hashes fall back to plain SHA-256 (functional, weaker defense-in-depth).
2. Migration 029 truncates `codex_remote_tokens` — existing `ast_*` tokens become invalid; users re-mint via CodexTokensPanel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)