### PR TITLE
chore(chart): bump 0.64.14 → 0.64.15 to ship #181

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.14
-appVersion: "0.64.14"
+version: 0.64.15
+appVersion: "0.64.15"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
Bumps chart and appVersion 0.64.14 → 0.64.15 to ship #181 (hide revoked API keys + drop Prefix column).