### PR TITLE
fix(web): token mint dialog UX (full command + date picker)

### DIFF
--- a/web/src/components/CodexTokensPanel.tsx
+++ b/web/src/components/CodexTokensPanel.tsx
@@ -11,13 +11,15 @@ interface Props {
   workspaceId: string
 }
 
-const EXPIRY_OPTIONS = [
-  { label: '7 days',   days: 7   },
-  { label: '30 days',  days: 30  },
-  { label: '90 days',  days: 90  },
-  { label: '180 days', days: 180 },
-  { label: '365 days', days: 365 },
-] as const
+// YYYY-MM-DD in local time, offset by `days` from today.
+function dateOffsetStr(days: number): string {
+  const d = new Date()
+  d.setDate(d.getDate() + days)
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
 
 export default function CodexTokensPanel({ workspaceId }: Props) {
   const [browsers, setBrowsers] = useState<CodexBrowser[]>([])
@@ -25,7 +27,7 @@ export default function CodexTokensPanel({ workspaceId }: Props) {
   const [error, setError] = useState<string | null>(null)
   const [showMint, setShowMint] = useState(false)
   const [newName, setNewName] = useState('')
-  const [expiryDays, setExpiryDays] = useState<number>(90)
+  const [expiresDate, setExpiresDate] = useState<string>(() => dateOffsetStr(90))
   const [generated, setGenerated] = useState<MintCodexTokenResponse | null>(null)
   const [copied, setCopied] = useState(false)
   const [revokeTarget, setRevokeTarget] = useState<CodexBrowser | null>(null)
@@ -51,9 +53,10 @@ export default function CodexTokensPanel({ workspaceId }: Props) {
   }, [refresh])
 
   const onMint = async () => {
-    if (!newName.trim()) return
+    if (!newName.trim() || !expiresDate) return
     try {
-      const expiresAt = new Date(Date.now() + expiryDays * 24 * 60 * 60 * 1000).toISOString()
+      // Use end-of-day local time so picking "today" doesn't immediately expire.
+      const expiresAt = new Date(`${expiresDate}T23:59:59`).toISOString()
       const resp = await mintCodexToken({
         workspace_id: workspaceId,
         name: newName.trim(),
@@ -62,7 +65,7 @@ export default function CodexTokensPanel({ workspaceId }: Props) {
       setGenerated(resp)
       setShowMint(false)
       setNewName('')
-      setExpiryDays(90)
+      setExpiresDate(dateOffsetStr(90))
       void refresh()
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e))
@@ -172,16 +175,15 @@ codex --remote wss://codex-app.${typeof window !== 'undefined' ? window.location
                 />
               </div>
               <div>
-                <label className="mb-1 block text-sm font-medium text-[var(--foreground)]">Expires in</label>
-                <select
-                  value={expiryDays}
-                  onChange={(e) => setExpiryDays(parseInt(e.target.value, 10))}
+                <label className="mb-1 block text-sm font-medium text-[var(--foreground)]">Expires on</label>
+                <input
+                  type="date"
+                  value={expiresDate}
+                  min={dateOffsetStr(0)}
+                  max={dateOffsetStr(365)}
+                  onChange={(e) => setExpiresDate(e.target.value)}
                   className="w-full rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)] outline-none focus:border-[var(--primary)]"
-                >
-                  {EXPIRY_OPTIONS.map((opt) => (
-                    <option key={opt.days} value={opt.days}>{opt.label}</option>
-                  ))}
-                </select>
+                />
               </div>
               <div className="flex justify-end gap-2">
                 <button
@@ -193,7 +195,7 @@ codex --remote wss://codex-app.${typeof window !== 'undefined' ? window.location
                 </button>
                 <button
                   type="submit"
-                  disabled={!newName.trim()}
+                  disabled={!newName.trim() || !expiresDate}
                   className="rounded-md bg-[var(--primary)] px-4 py-2 text-sm font-medium text-[var(--primary-foreground)] hover:opacity-90 disabled:opacity-50"
                 >
                   Generate

--- a/web/src/components/CodexTokensPanel.tsx
+++ b/web/src/components/CodexTokensPanel.tsx
@@ -79,9 +79,14 @@ export default function CodexTokensPanel({ workspaceId }: Props) {
     }
   }
 
-  const copyToken = async () => {
+  const buildCommand = (token: string) =>
+    `export AGENTSERVER_TOKEN='${token}'
+codex --remote wss://codex-app.${typeof window !== 'undefined' ? window.location.host : '<host>'}:443 \\
+      --remote-auth-token-env AGENTSERVER_TOKEN`
+
+  const copyCommand = async () => {
     if (!generated) return
-    await navigator.clipboard.writeText(generated.token)
+    await navigator.clipboard.writeText(buildCommand(generated.token))
     setCopied(true)
     setTimeout(() => setCopied(false), 1500)
   }
@@ -214,22 +219,17 @@ export default function CodexTokensPanel({ workspaceId }: Props) {
             <p className="mb-3 text-sm text-[var(--muted-foreground)]">
               Copy it now — you won't see it again.
             </p>
-            <div className="mb-4 flex items-center gap-2">
-              <code className="flex-1 break-all rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 font-mono text-xs text-[var(--foreground)]">
-                {generated.token}
-              </code>
+            <div className="mb-4 flex items-start gap-2">
+              <pre className="flex-1 overflow-x-auto rounded-md border border-[var(--border)] bg-[var(--background)] p-3 text-[11px] text-[var(--foreground)]">{buildCommand(generated.token)}</pre>
               <button
-                onClick={copyToken}
+                onClick={copyCommand}
                 className="rounded-md border border-[var(--border)] p-2 text-[var(--foreground)] hover:bg-[var(--secondary)]"
-                aria-label="Copy token"
+                aria-label="Copy command"
                 title="Copy"
               >
                 {copied ? <Check size={14} /> : <Copy size={14} />}
               </button>
             </div>
-            <pre className="mb-4 overflow-x-auto rounded-md border border-[var(--border)] bg-[var(--background)] p-3 text-[11px] text-[var(--foreground)]">{`export AGENTSERVER_TOKEN='${generated.token}'
-codex --remote wss://codex-app.${typeof window !== 'undefined' ? window.location.host : '<host>'}:443 \\
-      --remote-auth-token-env AGENTSERVER_TOKEN`}</pre>
             <div className="flex justify-end">
               <button
                 onClick={() => setGenerated(null)}

--- a/web/src/components/Home/Home.tsx
+++ b/web/src/components/Home/Home.tsx
@@ -1,5 +1,6 @@
 import { HomeHero } from './HomeHero'
 import { HomeNav } from './HomeNav'
+import { HomePillars } from './HomePillars'
 import { HomeQuote } from './HomeQuote'
 
 export function Home() {
@@ -9,6 +10,7 @@ export function Home() {
       <main className="mx-auto max-w-6xl px-6">
         <HomeHero />
         <HomeQuote />
+        <HomePillars />
       </main>
     </div>
   )

--- a/web/src/components/Home/Home.tsx
+++ b/web/src/components/Home/Home.tsx
@@ -1,10 +1,11 @@
-import { HomeCompare } from './HomeCompare'
-import { HomeFinalCTA } from './HomeFinalCTA'
-import { HomeHero } from './HomeHero'
 import { HomeNav } from './HomeNav'
-import { HomeOnboarding } from './HomeOnboarding'
-import { HomePillars } from './HomePillars'
+import { HomeHero } from './HomeHero'
 import { HomeQuote } from './HomeQuote'
+import { HomePillars } from './HomePillars'
+import { HomeCompare } from './HomeCompare'
+import { HomeOnboarding } from './HomeOnboarding'
+import { HomeFinalCTA } from './HomeFinalCTA'
+import { HomeFooter } from './HomeFooter'
 
 export function Home() {
   return (
@@ -18,6 +19,7 @@ export function Home() {
         <HomeOnboarding />
         <HomeFinalCTA />
       </main>
+      <HomeFooter />
     </div>
   )
 }

--- a/web/src/components/Home/Home.tsx
+++ b/web/src/components/Home/Home.tsx
@@ -1,3 +1,4 @@
+import { HomeCompare } from './HomeCompare'
 import { HomeHero } from './HomeHero'
 import { HomeNav } from './HomeNav'
 import { HomePillars } from './HomePillars'
@@ -11,6 +12,7 @@ export function Home() {
         <HomeHero />
         <HomeQuote />
         <HomePillars />
+        <HomeCompare />
       </main>
     </div>
   )

--- a/web/src/components/Home/Home.tsx
+++ b/web/src/components/Home/Home.tsx
@@ -1,6 +1,7 @@
 import { HomeCompare } from './HomeCompare'
 import { HomeHero } from './HomeHero'
 import { HomeNav } from './HomeNav'
+import { HomeOnboarding } from './HomeOnboarding'
 import { HomePillars } from './HomePillars'
 import { HomeQuote } from './HomeQuote'
 
@@ -13,6 +14,7 @@ export function Home() {
         <HomeQuote />
         <HomePillars />
         <HomeCompare />
+        <HomeOnboarding />
       </main>
     </div>
   )

--- a/web/src/components/Home/Home.tsx
+++ b/web/src/components/Home/Home.tsx
@@ -1,4 +1,5 @@
 import { HomeCompare } from './HomeCompare'
+import { HomeFinalCTA } from './HomeFinalCTA'
 import { HomeHero } from './HomeHero'
 import { HomeNav } from './HomeNav'
 import { HomeOnboarding } from './HomeOnboarding'
@@ -15,6 +16,7 @@ export function Home() {
         <HomePillars />
         <HomeCompare />
         <HomeOnboarding />
+        <HomeFinalCTA />
       </main>
     </div>
   )

--- a/web/src/components/Home/Home.tsx
+++ b/web/src/components/Home/Home.tsx
@@ -1,11 +1,12 @@
+import { HomeHero } from './HomeHero'
 import { HomeNav } from './HomeNav'
 
 export function Home() {
   return (
     <div data-theme="home" className="min-h-screen bg-[var(--background)] text-[var(--foreground)]">
       <HomeNav />
-      <main className="mx-auto max-w-6xl px-6 py-12">
-        <p className="font-mono text-sm text-[var(--muted-foreground)]">sections coming…</p>
+      <main className="mx-auto max-w-6xl px-6">
+        <HomeHero />
       </main>
     </div>
   )

--- a/web/src/components/Home/Home.tsx
+++ b/web/src/components/Home/Home.tsx
@@ -1,5 +1,6 @@
 import { HomeHero } from './HomeHero'
 import { HomeNav } from './HomeNav'
+import { HomeQuote } from './HomeQuote'
 
 export function Home() {
   return (
@@ -7,6 +8,7 @@ export function Home() {
       <HomeNav />
       <main className="mx-auto max-w-6xl px-6">
         <HomeHero />
+        <HomeQuote />
       </main>
     </div>
   )

--- a/web/src/components/Home/HomeCompare.tsx
+++ b/web/src/components/Home/HomeCompare.tsx
@@ -1,0 +1,56 @@
+import { useT } from '../../lib/i18n'
+import { homeStrings } from './strings'
+
+type Row = { tool: string; local: string; cloud: string; peer: string; chat: string; us?: boolean }
+
+const rows: Row[] = [
+  { tool: 'OpenClaw / Claude Code Remote', local: '1',      cloud: '—',      peer: '—', chat: '—' },
+  { tool: 'Claude Code on the web',        local: '—',      cloud: '✓',      peer: '—', chat: '—' },
+  { tool: 'CC Agent Teams',                local: '—',      cloud: '✓(sub)', peer: '—', chat: '—' },
+  { tool: 'agentserver',                   local: '✓ many', cloud: '✓',      peer: '✓', chat: '✓', us: true },
+]
+
+export function HomeCompare() {
+  const t = useT(homeStrings)
+  return (
+    <section id="compare" className="py-20">
+      <h2 className="font-mono text-xs tracking-[0.2em] text-[var(--muted-foreground)] uppercase mb-8">
+        {t('compare.heading')}
+      </h2>
+      <div className="overflow-x-auto">
+        <table className="w-full font-mono text-xs border border-[var(--home-term-border)]">
+          <caption className="sr-only">{t('compare.heading')}</caption>
+          <thead>
+            <tr className="bg-[var(--card)] text-[var(--home-accent)]">
+              <th scope="col" className="text-left p-3 font-medium">{t('compare.col.tool')}</th>
+              <th scope="col" className="text-center p-3 font-medium">{t('compare.col.local')}</th>
+              <th scope="col" className="text-center p-3 font-medium">{t('compare.col.cloud')}</th>
+              <th scope="col" className="text-center p-3 font-medium">{t('compare.col.peer')}</th>
+              <th scope="col" className="text-center p-3 font-medium">{t('compare.col.chat')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr
+                key={r.tool}
+                className={r.us
+                  ? 'bg-[var(--home-grid)] border-l-2 border-[var(--home-accent)]'
+                  : 'border-t border-[var(--home-term-border)]'
+                }
+              >
+                <th scope="row" className={`text-left p-3 font-normal ${r.us ? 'text-[var(--home-accent)] font-medium' : ''}`}>
+                  {r.us ? `▸ ${r.tool}` : r.tool}
+                </th>
+                <td className="text-center p-3">{r.local}</td>
+                <td className="text-center p-3">{r.cloud}</td>
+                <td className="text-center p-3">{r.peer}</td>
+                <td className="text-center p-3">{r.chat}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="mt-4 text-sm text-[var(--muted-foreground)]">{t('compare.caption')}</p>
+    </section>
+  )
+}

--- a/web/src/components/Home/HomeFinalCTA.tsx
+++ b/web/src/components/Home/HomeFinalCTA.tsx
@@ -1,0 +1,32 @@
+import { Link } from 'react-router-dom'
+import { useT } from '../../lib/i18n'
+import { homeStrings } from './strings'
+
+export function HomeFinalCTA() {
+  const t = useT(homeStrings)
+  return (
+    <section className="my-20 py-16 border-y-2 border-[var(--home-accent)]">
+      <div className="text-center">
+        <h2 className="text-3xl lg:text-4xl font-semibold tracking-tight max-w-2xl mx-auto">
+          {t('cta.heading')}
+        </h2>
+        <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+          <Link
+            to="/login"
+            className="font-mono text-sm px-5 py-2.5 rounded-md bg-[var(--home-accent)] text-[var(--home-accent-fg)] hover:opacity-90"
+          >
+            {t('cta.primary')}
+          </Link>
+          <a
+            href="https://github.com/agentserver/agentserver#self-hosting"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-mono text-sm px-5 py-2.5 rounded-md border border-[var(--border)] hover:opacity-90"
+          >
+            {t('cta.secondary')}
+          </a>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/web/src/components/Home/HomeFooter.tsx
+++ b/web/src/components/Home/HomeFooter.tsx
@@ -1,0 +1,40 @@
+import { useT } from '../../lib/i18n'
+import { homeStrings } from './strings'
+
+export function HomeFooter() {
+  const t = useT(homeStrings)
+  return (
+    <footer className="border-t border-[var(--border)] py-10 mt-10">
+      <div className="grid md:grid-cols-3 gap-8 text-sm">
+        <div>
+          <p className="font-mono font-semibold mb-3">{t('footer.col1.title')}</p>
+          <ul className="space-y-1 text-[var(--muted-foreground)]">
+            <li><a className="hover:text-[var(--foreground)]" href="https://agentserver.dev" target="_blank" rel="noopener noreferrer">agentserver.dev</a></li>
+            <li><a className="hover:text-[var(--foreground)]" href="https://github.com/agentserver/agentserver" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+            <li><a className="hover:text-[var(--foreground)]" href="https://github.com/agentserver/agentserver#readme" target="_blank" rel="noopener noreferrer">Docs</a></li>
+            <li><a className="hover:text-[var(--foreground)]" href="https://github.com/agentserver/agentserver/releases" target="_blank" rel="noopener noreferrer">Changelog</a></li>
+          </ul>
+        </div>
+        <div>
+          <p className="font-mono font-semibold mb-3">{t('footer.col2.title')}</p>
+          <ul className="space-y-1 text-[var(--muted-foreground)]">
+            <li><span>{t('footer.col2.weixin')}</span></li>
+            <li><span>{t('footer.col2.telegram')}</span></li>
+            <li><a className="hover:text-[var(--foreground)]" href="https://github.com/agentserver/agentserver/issues" target="_blank" rel="noopener noreferrer">{t('footer.col2.issues')}</a></li>
+          </ul>
+        </div>
+        <div>
+          <p className="font-mono font-semibold mb-3">{t('footer.col3.title')}</p>
+          <ul className="space-y-1 text-[var(--muted-foreground)]">
+            <li><a className="hover:text-[var(--foreground)]" href="https://github.com/agentserver/agentserver/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">{t('footer.col3.license')}</a></li>
+            <li><span>{t('footer.col3.privacy')}</span></li>
+            <li><span>{t('footer.col3.contact')}</span></li>
+          </ul>
+        </div>
+      </div>
+      <p className="mt-8 text-center font-mono text-[10px] text-[var(--muted-foreground)]">
+        v{__APP_VERSION__} · {__BUILD_COMMIT__} · built {__BUILD_DATE__}
+      </p>
+    </footer>
+  )
+}

--- a/web/src/components/Home/HomeHero.tsx
+++ b/web/src/components/Home/HomeHero.tsx
@@ -52,7 +52,7 @@ export function HomeHero() {
               href="https://github.com/agentserver/agentserver"
               target="_blank"
               rel="noopener noreferrer"
-              className="font-mono text-sm px-4 py-2 rounded-md border border-[var(--border)] hover:bg-[var(--accent)]"
+              className="font-mono text-sm px-4 py-2 rounded-md border border-[var(--border)] hover:opacity-90"
             >
               {t('hero.cta.secondary')}
             </a>

--- a/web/src/components/Home/HomeHero.tsx
+++ b/web/src/components/Home/HomeHero.tsx
@@ -1,0 +1,196 @@
+import { useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useT } from '../../lib/i18n'
+import { homeStrings } from './strings'
+
+export function HomeHero() {
+  const t = useT(homeStrings)
+  const ref = useRef<HTMLDivElement | null>(null)
+  const [started, setStarted] = useState(false)
+
+  useEffect(() => {
+    if (started) return
+    const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    if (reduce) {
+      setStarted(true) // eslint-disable-line react-hooks/set-state-in-effect
+      return
+    }
+    const node = ref.current
+    if (!node) return
+    const obs = new IntersectionObserver((entries) => {
+      for (const e of entries) {
+        if (e.isIntersecting) {
+          setStarted(true)
+          obs.disconnect()
+          break
+        }
+      }
+    }, { threshold: 0.25 })
+    obs.observe(node)
+    return () => obs.disconnect()
+  }, [started])
+
+  return (
+    <section ref={ref} className="pt-12 pb-20" data-started={started ? 'true' : 'false'}>
+      <div className="grid lg:grid-cols-[1.1fr_0.9fr] gap-10 items-start">
+        {/* Left: heading + CTAs */}
+        <div>
+          <h1 className="text-5xl lg:text-6xl font-semibold tracking-tight leading-[1.1]">
+            {t('hero.h1')}
+          </h1>
+          <p className="mt-6 text-base lg:text-lg text-[var(--muted-foreground)] leading-relaxed max-w-xl">
+            {t('hero.sub')}
+          </p>
+          <div className="mt-8 flex flex-wrap items-center gap-3">
+            <Link
+              to="/login"
+              className="font-mono text-sm px-4 py-2 rounded-md bg-[var(--home-accent)] text-[var(--home-accent-fg)] hover:opacity-90"
+            >
+              {t('hero.cta.primary')}
+            </Link>
+            <a
+              href="https://github.com/agentserver/agentserver"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-mono text-sm px-4 py-2 rounded-md border border-[var(--border)] hover:bg-[var(--accent)]"
+            >
+              {t('hero.cta.secondary')}
+            </a>
+            <span className="font-mono text-[10px] px-2 py-1 rounded border border-[var(--home-accent)]/40 text-[var(--home-accent)]">
+              v{__APP_VERSION__} · {t('hero.chip.online')}
+            </span>
+          </div>
+        </div>
+
+        {/* Right: three-pane animated demo */}
+        <div
+          role="img"
+          aria-label={t('hero.sub')}
+          className="hero-demo grid grid-cols-[1fr_1fr] gap-3"
+        >
+          {/* Two terminal panes stacked in the left column */}
+          <div className="flex flex-col gap-3">
+            <Term
+              title={t('hero.term.macbook')}
+              lines={[
+                { delay: 400,  text: '$ codex relay "把 experiment_0521.csv', kind: 'cmd' },
+                { delay: 700,  text: '   在沙箱里画成图发我"',                kind: 'cmd' },
+                { delay: 1100, text: '▸ found experiment_0521.csv (124MB)',  kind: 'dim' },
+                { delay: 1500, text: '▸ relaying to cloud-sandbox-7…',       kind: 'dim' },
+              ]}
+            />
+            <Term
+              title={t('hero.term.sandbox')}
+              lines={[
+                { delay: 3000, text: '▸ pandas: 5 conditions × 12 trials',  kind: 'dim' },
+                { delay: 3400, text: '▸ matplotlib: boxplot + error bars',  kind: 'dim' },
+                { delay: 4400, text: '✓ saved plot.png (412KB)',            kind: 'ok'  },
+                { delay: 4900, text: '▸ uploading via imbridge…',           kind: 'dim' },
+              ]}
+            />
+          </div>
+
+          {/* WeChat pane */}
+          <ChatPane t={t} />
+        </div>
+      </div>
+
+      <style>{`
+        .hero-demo .ln,
+        .hero-demo .bubble {
+          opacity: 0;
+          transform: translateY(4px);
+        }
+        .hero-demo[data-started="true"] .ln {
+          animation: heroFadeIn 280ms ease-out forwards;
+        }
+        .hero-demo[data-started="true"] .bubble {
+          animation: heroBubble 220ms ease-out forwards;
+        }
+        @keyframes heroFadeIn {
+          to { opacity: 1; transform: translateY(0); }
+        }
+        @keyframes heroBubble {
+          to { opacity: 1; transform: translateY(0); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .hero-demo .ln,
+          .hero-demo .bubble {
+            opacity: 1 !important;
+            transform: none !important;
+            animation: none !important;
+          }
+        }
+      `}</style>
+    </section>
+  )
+}
+
+type TermLine = { delay: number; text: string; kind: 'cmd' | 'dim' | 'ok' }
+
+function Term({ title, lines }: { title: string; lines: TermLine[] }) {
+  return (
+    <div className="rounded-md border border-[var(--home-term-border)] bg-[var(--home-term-bg)] font-mono text-[11px] overflow-hidden">
+      <div className="px-3 py-1.5 border-b border-[var(--home-term-border)] text-[var(--home-term-dim)]">
+        {title}
+      </div>
+      <div className="px-3 py-2 space-y-1">
+        {lines.map((ln, i) => (
+          <div
+            key={i}
+            className="ln"
+            style={{ animationDelay: `${ln.delay}ms` }}
+          >
+            <span className={
+              ln.kind === 'ok'  ? 'text-[var(--home-accent)]' :
+              ln.kind === 'dim' ? 'text-[var(--home-term-dim)]' :
+                                  'text-[var(--home-term-fg)]'
+            }>
+              {ln.text}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function ChatPane({ t }: { t: (k: string) => string }) {
+  type Bubble = { delay: number; who: 'me' | 'bot'; text: string; thumb?: boolean }
+  const bubbles: Bubble[] = [
+    { delay: 5500, who: 'me',  text: t('hero.chat.user') },
+    { delay: 6000, who: 'bot', text: t('hero.chat.bot1') },
+    { delay: 7000, who: 'bot', text: t('hero.chat.bot2') },
+    { delay: 8500, who: 'bot', text: t('hero.chat.bot3'), thumb: true },
+  ]
+  return (
+    <div className="rounded-md border border-[var(--home-term-border)] bg-[#ededed] dark:bg-[#1a1a1a] overflow-hidden">
+      <div className="px-3 py-1.5 border-b border-[var(--home-term-border)] text-xs font-medium text-[var(--home-term-fg)]">
+        {t('hero.chat.title')}
+      </div>
+      <div role="log" aria-live="polite" className="px-3 py-3 space-y-2 min-h-[260px]">
+        {bubbles.map((b, i) => (
+          <div
+            key={i}
+            className={`bubble flex ${b.who === 'me' ? 'justify-end' : 'justify-start'}`}
+            style={{ animationDelay: `${b.delay}ms` }}
+          >
+            <div className={
+              'max-w-[80%] rounded-md px-3 py-1.5 text-xs leading-relaxed ' +
+              (b.who === 'me'
+                ? 'bg-[#95ec69] text-black'
+                : 'bg-white text-black dark:bg-[#2a2a2a] dark:text-white')
+            }>
+              {b.text}
+              {b.thumb && (
+                <div className="mt-1.5 h-12 w-full rounded bg-gradient-to-br from-[var(--home-accent)]/30 to-[var(--home-accent)]/10 border border-[var(--home-accent)]/40 flex items-center justify-center text-[10px] text-[var(--home-term-dim)]">
+                  plot.png · 412KB
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/web/src/components/Home/HomeOnboarding.tsx
+++ b/web/src/components/Home/HomeOnboarding.tsx
@@ -1,0 +1,57 @@
+import { useT } from '../../lib/i18n'
+import { homeStrings } from './strings'
+
+const steps = [
+  { n: 1, titleKey: 'onb.s1.title', bodyKey: 'onb.s1.body' },
+  { n: 2, titleKey: 'onb.s2.title', bodyKey: 'onb.s2.body' },
+  { n: 3, titleKey: 'onb.s3.title', bodyKey: 'onb.s3.body' },
+  { n: 4, titleKey: 'onb.s4.title', bodyKey: 'onb.s4.body' },
+  { n: 5, titleKey: 'onb.s5.title', bodyKey: 'onb.s5.body' },
+  { n: 6, titleKey: 'onb.s6.title', bodyKey: 'onb.s6.body', emphasized: true },
+  { n: 7, titleKey: 'onb.s7.title', bodyKey: 'onb.s7.body' },
+]
+
+export function HomeOnboarding() {
+  const t = useT(homeStrings)
+  return (
+    <section id="how" className="py-20">
+      <h2 className="font-mono text-xs tracking-[0.2em] text-[var(--muted-foreground)] uppercase mb-8">
+        {t('onb.heading')}
+      </h2>
+      <ol className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {steps.map((s) => (
+          <li
+            key={s.n}
+            className={
+              'rounded-lg border p-5 ' +
+              (s.emphasized
+                ? 'border-[var(--home-accent)] bg-[var(--home-grid)]'
+                : 'border-[var(--border)] bg-[var(--card)]')
+            }
+          >
+            <div className={
+              'inline-flex items-center justify-center h-7 w-7 rounded-full font-mono text-xs mb-3 ' +
+              (s.emphasized
+                ? 'bg-[var(--home-accent)] text-[var(--home-accent-fg)]'
+                : 'bg-[var(--secondary)] text-[var(--secondary-foreground)]')
+            }>
+              {s.n}
+            </div>
+            <h3 className={`text-sm font-semibold mb-1 ${s.emphasized ? 'text-[var(--home-accent)]' : ''}`}>
+              {t(s.titleKey)}
+            </h3>
+            <p className="text-xs text-[var(--muted-foreground)] leading-relaxed">{t(s.bodyKey)}</p>
+          </li>
+        ))}
+      </ol>
+      <a
+        href="https://github.com/agentserver/agentserver#readme"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-block mt-6 font-mono text-xs text-[var(--home-accent)] hover:underline"
+      >
+        {t('onb.docs')}
+      </a>
+    </section>
+  )
+}

--- a/web/src/components/Home/HomePillars.tsx
+++ b/web/src/components/Home/HomePillars.tsx
@@ -1,0 +1,40 @@
+import { useT } from '../../lib/i18n'
+import { homeStrings } from './strings'
+
+type Pillar = {
+  emoji: string
+  titleKey: string
+  bodyKey: string
+}
+
+const pillars: Pillar[] = [
+  { emoji: '📱', titleKey: 'pillars.pocket.title',    bodyKey: 'pillars.pocket.body' },
+  { emoji: '🌐', titleKey: 'pillars.workspace.title', bodyKey: 'pillars.workspace.body' },
+  { emoji: '🔌', titleKey: 'pillars.tunnel.title',    bodyKey: 'pillars.tunnel.body' },
+]
+
+export function HomePillars() {
+  const t = useT(homeStrings)
+  return (
+    <section id="why" className="py-20">
+      <h2 className="font-mono text-xs tracking-[0.2em] text-[var(--muted-foreground)] uppercase mb-8">
+        {t('pillars.heading')}
+      </h2>
+      <div className="grid md:grid-cols-3 gap-4">
+        {pillars.map((p) => (
+          <article
+            key={p.titleKey}
+            className="rounded-lg border border-[var(--border)] p-6 bg-[var(--card)]"
+          >
+            <div className="text-3xl mb-3" aria-hidden="true">{p.emoji}</div>
+            <h3 className="text-lg font-semibold mb-2">{t(p.titleKey)}</h3>
+            <p className="text-sm text-[var(--muted-foreground)] leading-relaxed">{t(p.bodyKey)}</p>
+          </article>
+        ))}
+      </div>
+      <p className="mt-6 font-mono text-xs text-[var(--muted-foreground)] leading-relaxed">
+        {t('pillars.also')}
+      </p>
+    </section>
+  )
+}

--- a/web/src/components/Home/HomeQuote.tsx
+++ b/web/src/components/Home/HomeQuote.tsx
@@ -1,0 +1,23 @@
+import { useT } from '../../lib/i18n'
+import { homeStrings } from './strings'
+
+export function HomeQuote() {
+  const t = useT(homeStrings)
+  // Split the quote so 'conductor' and 'orchestrator' can be highlighted.
+  const accent = (text: string) => (
+    <span className="text-[var(--home-accent)] font-medium">{text}</span>
+  )
+  return (
+    <section className="py-16 border-l-2 border-[var(--home-accent)] pl-6">
+      <blockquote className="text-lg lg:text-xl text-[var(--foreground)] leading-relaxed max-w-3xl">
+        "Once you juggle 10+ agents across machines, you stop being a {accent('conductor')} and become an {accent('orchestrator')}."
+      </blockquote>
+      <p className="mt-3 text-sm text-[var(--muted-foreground)] font-mono">
+        {t('quote.attrib')}
+      </p>
+      <p className="mt-2 text-sm text-[var(--muted-foreground)]">
+        {t('quote.caption')}
+      </p>
+    </section>
+  )
+}

--- a/web/src/components/MintAPIKeyModal.tsx
+++ b/web/src/components/MintAPIKeyModal.tsx
@@ -15,23 +15,25 @@ interface MintAPIKeyModalProps {
 
 type Phase = 'loading' | 'form' | 'reveal'
 
+// YYYY-MM-DD in local time, offset by `days` from today.
+function dateOffsetStr(days: number): string {
+  const d = new Date()
+  d.setDate(d.getDate() + days)
+  const y = d.getFullYear()
+  const m = String(d.getMonth() + 1).padStart(2, '0')
+  const day = String(d.getDate()).padStart(2, '0')
+  return `${y}-${m}-${day}`
+}
+
 export function MintAPIKeyModal({ workspaceId, onClose, onCreated }: MintAPIKeyModalProps) {
   const [phase, setPhase] = useState<Phase>('loading')
   const [scopes, setScopes] = useState<APIKeyScopeDescriptor[]>([])
   const [loadError, setLoadError] = useState<string | null>(null)
 
-  const EXPIRY_OPTIONS = [
-    { label: '7 days',   days: 7   },
-    { label: '30 days',  days: 30  },
-    { label: '90 days',  days: 90  },
-    { label: '180 days', days: 180 },
-    { label: '365 days', days: 365 },
-  ] as const
-
   // Form state
   const [name, setName] = useState('')
   const [checkedScopes, setCheckedScopes] = useState<Set<string>>(new Set())
-  const [expiryDays, setExpiryDays] = useState<number>(90)
+  const [expiresDate, setExpiresDate] = useState<string>(() => dateOffsetStr(90))
   const [submitting, setSubmitting] = useState(false)
   const [submitError, setSubmitError] = useState<string | null>(null)
 
@@ -69,11 +71,12 @@ export function MintAPIKeyModal({ workspaceId, onClose, onCreated }: MintAPIKeyM
   }
 
   const handleCreate = async () => {
-    if (!name.trim() || checkedScopes.size === 0) return
+    if (!name.trim() || checkedScopes.size === 0 || !expiresDate) return
     setSubmitting(true)
     setSubmitError(null)
     try {
-      const expiresAt = new Date(Date.now() + expiryDays * 24 * 60 * 60 * 1000).toISOString()
+      // Use end-of-day local time so picking "today" doesn't immediately expire.
+      const expiresAt = new Date(`${expiresDate}T23:59:59`).toISOString()
       const result = await mintWorkspaceAPIKey(workspaceId, name.trim(), Array.from(checkedScopes), expiresAt)
       setMinted(result)
       setPhase('reveal')
@@ -91,7 +94,7 @@ export function MintAPIKeyModal({ workspaceId, onClose, onCreated }: MintAPIKeyM
     setTimeout(() => setCopied(false), 2000)
   }
 
-  const canCreate = name.trim().length > 0 && checkedScopes.size > 0 && !submitting
+  const canCreate = name.trim().length > 0 && checkedScopes.size > 0 && !!expiresDate && !submitting
 
   return (
     <div
@@ -189,18 +192,17 @@ export function MintAPIKeyModal({ workspaceId, onClose, onCreated }: MintAPIKeyM
 
             <div>
               <label className="block text-xs font-medium text-[var(--muted-foreground)] mb-1">
-                Expires in
+                Expires on
               </label>
-              <select
-                value={expiryDays}
-                onChange={(e) => setExpiryDays(parseInt(e.target.value, 10))}
+              <input
+                type="date"
+                value={expiresDate}
+                min={dateOffsetStr(0)}
+                max={dateOffsetStr(365)}
+                onChange={(e) => setExpiresDate(e.target.value)}
                 disabled={submitting}
                 className="w-full rounded-md border border-[var(--border)] bg-[var(--background)] px-3 py-2 text-sm text-[var(--foreground)] focus:outline-none focus:ring-1 focus:ring-[var(--primary)] disabled:opacity-50"
-              >
-                {EXPIRY_OPTIONS.map((opt) => (
-                  <option key={opt.days} value={opt.days}>{opt.label}</option>
-                ))}
-              </select>
+              />
             </div>
 
             {submitError && (

--- a/web/src/components/RemoteExecutorsPanel.tsx
+++ b/web/src/components/RemoteExecutorsPanel.tsx
@@ -73,13 +73,13 @@ export default function RemoteExecutorsPanel({ workspaceId }: Props) {
     id: r.exe_id,
     name: r.name,
     description: r.description,
-    is_online: r.is_online,
+    is_online: r.is_online ?? false,
     client_ip: r.client_ip,
     os: r.os,
     codex_version: r.codex_version,
-    connected_at: r.connected_at,
-    disconnected_at: r.disconnected_at,
-    lastSeenFallback: r.last_seen_at,
+    connected_at: r.connected_at ?? undefined,
+    disconnected_at: r.disconnected_at ?? undefined,
+    lastSeenFallback: r.last_seen_at ?? undefined,
   }))
 
   const findRow = (id: string) => rows.find((r) => r.exe_id === id)

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -60,17 +60,8 @@ export type WorkspaceQuotaResponse = components['schemas']['AdminWorkspaceQuotaR
 export type WorkspaceQuotaDefaults = components['schemas']['AdminWorkspaceQuotaDefaults']
 export type WorkspaceQuotaOverrides = components['schemas']['AdminWorkspaceQuotaOverrides']
 
-export interface TelegramConfigureResult {
-  connected: boolean
-  bot_id: string
-  bot_name: string
-}
-
-export interface MatrixConfigureResult {
-  connected: boolean
-  bot_id: string
-  user_id: string
-}
+export type TelegramConfigureResult = components['schemas']['IMTelegramConfigureResponse']
+export type MatrixConfigureResult = components['schemas']['IMMatrixConfigureResponse']
 
 export type Sandbox = components['schemas']['Sandbox']
 export type SandboxCreateRequest = components['schemas']['SandboxCreateRequest']
@@ -366,19 +357,8 @@ export async function resumeSandbox(id: string): Promise<components['schemas']['
 
 // WeChat QR Login API
 
-export interface WeixinQRStartResult {
-  qrcode_url: string
-  message: string
-}
-
-export interface WeixinQRWaitResult {
-  connected: boolean
-  status: 'wait' | 'scaned' | 'confirmed' | 'expired'
-  message: string
-  qrcode_url?: string
-  bot_id?: string
-  user_id?: string
-}
+export type WeixinQRStartResult = components['schemas']['IMWeixinQRStartResponse']
+export type WeixinQRWaitResult = components['schemas']['IMWeixinQRWaitResponse']
 
 export async function weixinQRStart(sandboxId: string): Promise<WeixinQRStartResult> {
   const res = await fetch(`/api/sandboxes/${sandboxId}/im/weixin/qr-start`, { method: 'POST' })
@@ -610,26 +590,8 @@ export async function getSandboxTraces(id: string, limit: number, offset: number
   return res.json()
 }
 
-export interface TokenUsageItem {
-  id: string
-  trace_id: string
-  provider: string
-  model: string
-  message_id?: string
-  input_tokens: number
-  output_tokens: number
-  cache_creation_input_tokens: number
-  cache_read_input_tokens: number
-  streaming: boolean
-  duration: number
-  ttft: number
-  created_at: string
-}
-
-export interface TraceDetailResponse {
-  trace: TraceItem
-  requests: TokenUsageItem[]
-}
+export type TokenUsageItem = components['schemas']['TraceRequest']
+export type TraceDetailResponse = components['schemas']['TraceDetailResponse']
 
 export async function getTraceDetail(sandboxId: string, traceId: string): Promise<TraceDetailResponse> {
   const res = await fetch(`/api/sandboxes/${sandboxId}/traces/${traceId}`)
@@ -847,23 +809,7 @@ export async function revokeCodexToken(id: string): Promise<void> {
 
 // Remote Executor API
 
-export interface RemoteExecutor {
-  exe_id: string
-  name: string
-  description: string
-  is_default: boolean
-  last_seen_at?: string
-  // Live online state from the gateway's in-memory registry. The old
-  // client-side `last_seen_at < 90s` heuristic showed freshly-disconnected
-  // executors as online for 90s; this is the authoritative replacement.
-  is_online: boolean
-  client_ip?: string
-  client_ua?: string
-  codex_version?: string
-  os?: string
-  connected_at?: string
-  disconnected_at?: string
-}
+export type RemoteExecutor = components['schemas']['ExecutorItem']
 
 export async function listCodexBrowsers(workspaceId: string): Promise<CodexBrowser[]> {
   return apiFetch<CodexBrowser[]>({
@@ -872,27 +818,9 @@ export async function listCodexBrowsers(workspaceId: string): Promise<CodexBrows
   })
 }
 
-export interface RegisterExecutorRequest {
-  // Workspace-unique name shown to the LLM (env_id parameter).
-  name: string
-  description?: string
-}
-
-export interface ConnectCommands {
-  agent_identity?: string
-}
-
-export interface RegisterExecutorResponse {
-  exe_id: string
-  // Same string as connect_commands.agent_identity, kept for older
-  // clients that read the single-string field.
-  connect_command?: string
-  // The Agent Identity JWT minted for this executor.
-  agent_identity_jwt?: string
-  // Single-variant Agent-Identity command bundle. Present only when
-  // codexAuth is enabled.
-  connect_commands?: ConnectCommands
-}
+export type RegisterExecutorRequest = components['schemas']['ExecutorRegisterRequest']
+export type ConnectCommands = components['schemas']['ExecutorConnectCommands']
+export type RegisterExecutorResponse = components['schemas']['ExecutorRegisterResponse']
 
 export async function listRemoteExecutors(workspaceId: string): Promise<RemoteExecutor[]> {
   const res = await fetch(`/api/workspaces/${encodeURIComponent(workspaceId)}/executors`)


### PR DESCRIPTION
## Summary
Two UX fixes for the token-mint dialogs (codex tokens + workspace API keys):

1. **Show full command, not bare token** — "Token generated" modal previously showed the raw token *and* a snippet below; users would copy the token alone then have to hand-assemble the `codex --remote` command. Collapsed to one block: the ready-to-paste command with token inlined, plus one copy button.
2. **Date picker instead of preset dropdown** — both mint dialogs used a hardcoded 7/30/90/180/365-day select. Replaced with `<input type="date">`, range `[today, today+365d]` (server's hard cap), default = today+90d. Picked date is converted to local end-of-day before sending as RFC3339, so picking "today" gives ~24h instead of instant expiry.

## Test plan
- [ ] Generate a browser token → modal shows only the full command block; copy button copies the multi-line command (not just the token)
- [ ] Codex token mint dialog → date input shown, max 365d out, accepts any in-range date
- [ ] Workspace API key mint dialog → same date input behavior
- [ ] Pick "today" as expiry → token actually valid for ~remainder of day, not expired immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)