### PR TITLE
fix(broker): reap conns by ws activity, not caller-side Get/Touch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ notebook/smoke-workspace/
 # Generated from docs/api/openapi.yaml via `pnpm openapi:gen` —
 # never commit; CI and local dev regenerate on demand.
 web/src/lib/api-generated/
+
+# Brainstorming companion scratch dir (HTML mockups served to local browser).
+.superpowers/

--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.14
-appVersion: "0.64.14"
+version: 0.64.15
+appVersion: "0.64.15"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/docs/superpowers/plans/2026-05-22-unauth-home.md
+++ b/docs/superpowers/plans/2026-05-22-unauth-home.md
@@ -1,0 +1,1495 @@
+# Unauthenticated Homepage Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the bare login card on `agent.cs.ac.cn` (when unauthenticated) with a full marketing homepage at `/` that explains agentserver's value (Personal Computility, multi-device orchestration, WeChat channel) and routes visitors to `/login`.
+
+**Architecture:** A single React component tree under `web/src/components/Home/`, composed by `<Home />`, mounted by `App.tsx` only when `authed === false`. Dark terminal aesthetic, page-scoped CSS variables under `[data-theme="home"]`. A minimal i18n primitive in `web/src/lib/i18n.ts` handles `zh`/`en` via `navigator.language` + localStorage override. No new npm dependencies; CSS-only hero animation with `IntersectionObserver` trigger and `prefers-reduced-motion` fallback.
+
+**Tech Stack:** React 19, react-router-dom 7, TypeScript 5.9, Tailwind v4, Vite 7. No test runner is present in `web/` today — verification gates are `pnpm tsc -b` (typecheck), `pnpm lint`, and manual browser smoke via `pnpm dev` + Playwright snapshot. Do not introduce vitest as part of this plan.
+
+**Spec:** `docs/superpowers/specs/2026-05-22-unauth-home-design.md` — every decision in that file is locked.
+
+---
+
+## File Structure
+
+**New files (10):**
+
+| Path | Responsibility |
+|---|---|
+| `web/src/lib/i18n.ts` | `detectLocale()`, `setLocale()`, `useT()` — the only i18n primitives used in this plan |
+| `web/src/components/Home/Home.tsx` | Top-level shell. Sets `data-theme="home"`. Composes the eight sections in spec order |
+| `web/src/components/Home/HomeNav.tsx` | Sticky top bar: logo, jump links, language toggle, Sign in button |
+| `web/src/components/Home/HomeHero.tsx` | The three-pane hero (two terminals + one WeChat) with one-shot CSS animation |
+| `web/src/components/Home/HomeQuote.tsx` | The Addy Osmani conductor → orchestrator quote section |
+| `web/src/components/Home/HomePillars.tsx` | Three pillar cards + secondary pill strip |
+| `web/src/components/Home/HomeCompare.tsx` | Differentiator table (real `<table>`, ASCII frame in dark theme) |
+| `web/src/components/Home/HomeOnboarding.tsx` | Seven-step `<ol>` timeline |
+| `web/src/components/Home/HomeFinalCTA.tsx` | Full-width Sign in / Self-host band |
+| `web/src/components/Home/HomeFooter.tsx` | Three-column footer + version strip |
+| `web/src/components/Home/strings.ts` | Full i18n dictionary (~80 keys), namespaced per section |
+
+**Modified files (4):**
+
+| Path | Change |
+|---|---|
+| `web/src/App.tsx` | Replace the `if (!authed) return <Login />` branch with nested routes: `/` → `<Home />`, `/login` → `<Login />`, `/oauth2/*` preserved, everything else redirects to `/`. |
+| `web/src/components/Login.tsx` | Replace inline `<h1>agentserver</h1>` with a `<Link to="/">← agentserver</Link>` back-link. |
+| `web/src/index.css` | Add `--home-accent`, `--home-accent-fg`, `--home-grid`, `--home-term-bg`, `--home-term-border` scoped to `[data-theme="home"]`. |
+| `web/vite.config.ts` | Add `define: { __APP_VERSION__, __BUILD_COMMIT__, __BUILD_DATE__ }` so the footer can stamp build info. |
+
+**Files NOT touched:** any non-`Home/` component, any backend Go code, `web/embed.go`, any OIDC / OAuth / workspace logic.
+
+---
+
+## Pre-flight (do once before Task 1)
+
+- [ ] Run `pnpm install` in `web/` if `node_modules` is stale
+- [ ] Confirm the dev server starts: `cd web && pnpm dev` → reachable at `http://localhost:5173`
+- [ ] Confirm baseline passes: `cd web && pnpm tsc -b && pnpm lint` → both exit 0
+- [ ] Kill the dev server (we'll restart it in Task 14)
+
+---
+
+### Task 1: Vite build-time constants + CSS tokens
+
+**Files:**
+- Modify: `web/vite.config.ts`
+- Modify: `web/src/index.css`
+- Create or modify: `web/src/vite-env.d.ts`
+
+- [ ] **Step 1: Replace `web/vite.config.ts` with a version that injects `__APP_VERSION__`, `__BUILD_COMMIT__`, `__BUILD_DATE__`**
+
+Use `execFileSync` (no shell, no injection surface) — not `exec` or `execSync`:
+
+```ts
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+
+function safeGit(args: string[], fallback: string): string {
+  try {
+    return execFileSync('git', args, { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim() || fallback
+  } catch {
+    return fallback
+  }
+}
+
+const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf-8'))
+const appVersion: string = pkg.version || '0.0.0'
+const buildCommit: string = safeGit(['rev-parse', '--short', 'HEAD'], 'dev')
+const buildDate: string = new Date().toISOString().slice(0, 10)
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  define: {
+    __APP_VERSION__: JSON.stringify(appVersion),
+    __BUILD_COMMIT__: JSON.stringify(buildCommit),
+    __BUILD_DATE__: JSON.stringify(buildDate),
+  },
+  server: {
+    proxy: {
+      '/api': 'http://localhost:8080',
+    },
+  },
+})
+```
+
+- [ ] **Step 2: Declare the build-time globals as TypeScript ambient types**
+
+If `web/src/vite-env.d.ts` exists, append the three `declare const` lines. Otherwise create it with this content:
+
+```ts
+/// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string
+declare const __BUILD_COMMIT__: string
+declare const __BUILD_DATE__: string
+```
+
+- [ ] **Step 3: Append the `[data-theme="home"]` CSS variables to `web/src/index.css`**
+
+Add the following block immediately after the existing `.dark { ... }` rule:
+
+```css
+[data-theme="home"] {
+  --home-accent: #18181b;
+  --home-accent-fg: #fafafa;
+  --home-grid: rgba(0, 0, 0, 0.06);
+  --home-term-bg: #f4f4f5;
+  --home-term-border: #d4d4d8;
+  --home-term-fg: #18181b;
+  --home-term-dim: #71717a;
+}
+
+.dark[data-theme="home"],
+[data-theme="home"].dark,
+[data-theme="home"] .dark,
+.dark [data-theme="home"] {
+  --home-accent: #7fff7f;
+  --home-accent-fg: #000000;
+  --home-grid: rgba(127, 255, 127, 0.04);
+  --home-term-bg: #000000;
+  --home-term-border: #2a2a2a;
+  --home-term-fg: #e6e6e6;
+  --home-term-dim: #888888;
+}
+```
+
+- [ ] **Step 4: Typecheck and lint**
+
+```bash
+cd web && pnpm tsc -b && pnpm lint
+```
+
+Expected: both exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/vite.config.ts web/src/vite-env.d.ts web/src/index.css
+git commit -m "feat(web): add home theme CSS vars and build-time constants"
+```
+
+---
+
+### Task 2: i18n primitive
+
+**Files:**
+- Create: `web/src/lib/i18n.ts`
+
+- [ ] **Step 1: Create `web/src/lib/i18n.ts` with locale detection, setter, and the `useT()` hook factory**
+
+```ts
+import { useMemo } from 'react'
+
+export type Locale = 'zh' | 'en'
+
+const STORAGE_KEY = 'locale'
+
+export type Dict = Record<string, string>
+export type Dicts = Record<Locale, Dict>
+
+export function detectLocale(): Locale {
+  if (typeof window === 'undefined') return 'en'
+  const stored = window.localStorage.getItem(STORAGE_KEY)
+  if (stored === 'zh' || stored === 'en') return stored
+  const nav = window.navigator.language || ''
+  return nav.toLowerCase().startsWith('zh') ? 'zh' : 'en'
+}
+
+export function setLocale(l: Locale): void {
+  window.localStorage.setItem(STORAGE_KEY, l)
+  window.location.reload()
+}
+
+// Returns a stable `t(key)` function for the active locale.
+// Falls back to the en value if the key is missing in the active locale,
+// then to the key itself.
+export function useT(dicts: Dicts) {
+  const locale = detectLocale()
+  return useMemo(() => {
+    const primary = dicts[locale]
+    const fallback = dicts.en
+    return (key: string): string => primary[key] ?? fallback[key] ?? key
+  }, [locale, dicts])
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd web && pnpm tsc -b
+```
+
+Expected: exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/src/lib/i18n.ts
+git commit -m "feat(web): add minimal i18n primitive (detectLocale/setLocale/useT)"
+```
+
+---
+
+### Task 3: Full i18n dictionary
+
+**Files:**
+- Create: `web/src/components/Home/strings.ts`
+
+This task front-loads all copy so later component tasks reference keys, not literal strings.
+
+- [ ] **Step 1: Create the dictionary with every key the homepage needs**
+
+```ts
+import type { Dicts } from '../../lib/i18n'
+
+export const homeStrings: Dicts = {
+  zh: {
+    // nav
+    'nav.brand': 'agentserver',
+    'nav.why': '卖点',
+    'nav.how': '上手',
+    'nav.compare': '对比',
+    'nav.signin': '登录 →',
+    'nav.lang.toggle': 'EN',
+    'nav.online': '在线',
+
+    // hero
+    'hero.h1': '你的个人算力网。',
+    'hero.sub': 'agentserver 把笔记本、云沙箱、家里的服务器编成一个工作区——从浏览器、命令行，或微信，一并指挥。',
+    'hero.cta.primary': '▸ 登录',
+    'hero.cta.secondary': '在 GitHub 上查看',
+    'hero.term.macbook': 'office-macbook · codex',
+    'hero.term.sandbox': 'cloud-sandbox-7 · codex',
+    'hero.chat.title': '我自己',
+    'hero.chat.user': '把上周的实验数据画成图给我',
+    'hero.chat.bot1': '📂 已从 office-macbook 取到 experiment_0521.csv',
+    'hero.chat.bot2': '🔨 在沙箱里分析 + 画图中…',
+    'hero.chat.bot3': '✓ 完成',
+    'hero.chip.online': '在线',
+
+    // quote
+    'quote.body': '"Once you juggle 10+ agents across machines, you stop being a conductor and become an orchestrator."',
+    'quote.attrib': '— Addy Osmani · Director, Google Gemini & Cloud AI',
+    'quote.caption': 'agentserver = 那个 orchestrator。',
+
+    // pillars
+    'pillars.heading': '为什么用 agentserver',
+    'pillars.pocket.title': '装在口袋里的指挥台',
+    'pillars.pocket.body': '微信里一句中文，落到任意设备执行，结果推回同一个聊天框。Telegram 同样支持。',
+    'pillars.workspace.title': '一个工作区，所有设备',
+    'pillars.workspace.body': '云沙箱、本地机器、IM-bound 代理——全在同一份注册表里，并排出现在 Web UI 上。',
+    'pillars.tunnel.title': '无公网 IP，照常入网',
+    'pillars.tunnel.body': '本地的 codex / Claude Code / opencode 通过 WebSocket 拨号入网，呈现为一个沙箱。',
+    'pillars.also': '+ 暂停 / 恢复沙箱 · Jupyter 笔记本 · 多人协作 · 凭证代理 · SSO（GitHub / OIDC）· 自托管',
+
+    // compare
+    'compare.heading': '和已有的工具相比',
+    'compare.col.tool': '产品',
+    'compare.col.local': '本地代理',
+    'compare.col.cloud': '云沙箱',
+    'compare.col.peer': '跨设备组网',
+    'compare.col.chat': 'IM 通道',
+    'compare.caption': '唯一同时勾上四列的产品。',
+
+    // onboarding
+    'onb.heading': '7 步，把你的设备连上来',
+    'onb.s1.title': '注册',
+    'onb.s1.body': '邮箱 / GitHub / SSO 任选',
+    'onb.s2.title': '链接模型账号',
+    'onb.s2.body': '自带 ChatGPT / Anthropic 凭证，或选平台托管账号',
+    'onb.s3.title': '入网设备',
+    'onb.s3.body': 'brew install codex → 粘贴注册码',
+    'onb.s4.title': '选一台"指挥机"',
+    'onb.s4.body': '通常是你的主力笔电',
+    'onb.s5.title': '(可选) 开 Jupyter',
+    'onb.s5.body': '想手写代码？ctx 已预注入 kernel',
+    'onb.s6.title': '绑定微信',
+    'onb.s6.body': '扫码即可，从此聊天框 = 终端',
+    'onb.s7.title': '邀请协作者',
+    'onb.s7.body': '角色：owner / maintainer / developer / guest',
+    'onb.docs': '完整文档 →',
+
+    // final cta
+    'cta.heading': '把你的设备，编进同一张算力网。',
+    'cta.primary': '▸ 登录',
+    'cta.secondary': '在自己的域名上自托管',
+
+    // footer
+    'footer.col1.title': 'agentserver',
+    'footer.col2.title': '社区',
+    'footer.col2.weixin': '微信群',
+    'footer.col2.telegram': 'Telegram',
+    'footer.col2.issues': 'Issue 跟踪',
+    'footer.col3.title': '法律',
+    'footer.col3.license': 'Apache-2.0',
+    'footer.col3.privacy': '隐私',
+    'footer.col3.contact': '联系',
+  },
+  en: {
+    // nav
+    'nav.brand': 'agentserver',
+    'nav.why': 'Why',
+    'nav.how': 'How',
+    'nav.compare': 'Compare',
+    'nav.signin': 'Sign in →',
+    'nav.lang.toggle': '中',
+    'nav.online': 'online',
+
+    // hero
+    'hero.h1': 'Your Personal Computility.',
+    'hero.sub': 'agentserver weaves laptops, cloud sandboxes, and home servers into one workspace — commanded from your browser, your CLI, or your WeChat chat.',
+    'hero.cta.primary': '▸ Sign in',
+    'hero.cta.secondary': 'View on GitHub',
+    'hero.term.macbook': 'office-macbook · codex',
+    'hero.term.sandbox': 'cloud-sandbox-7 · codex',
+    'hero.chat.title': 'me',
+    'hero.chat.user': 'Plot last week’s experiment data and send it to me',
+    'hero.chat.bot1': '📂 pulled experiment_0521.csv from office-macbook',
+    'hero.chat.bot2': '🔨 analyzing + plotting in sandbox…',
+    'hero.chat.bot3': '✓ done',
+    'hero.chip.online': 'online',
+
+    // quote
+    'quote.body': '"Once you juggle 10+ agents across machines, you stop being a conductor and become an orchestrator."',
+    'quote.attrib': '— Addy Osmani · Director, Google Gemini & Cloud AI',
+    'quote.caption': 'agentserver is that orchestrator.',
+
+    // pillars
+    'pillars.heading': 'Why agentserver',
+    'pillars.pocket.title': 'Pocket-sized command line',
+    'pillars.pocket.body': 'One sentence in WeChat lands on the right device. The result comes back to the same chat. Telegram supported too.',
+    'pillars.workspace.title': 'One workspace, every device',
+    'pillars.workspace.body': 'Cloud sandboxes, local machines, IM-bound agents — all in one registry, side by side in the Web UI.',
+    'pillars.tunnel.title': 'No public IP. Still in the network.',
+    'pillars.tunnel.body': 'Your local codex / Claude Code / opencode dials home over WebSocket and shows up as a sandbox.',
+    'pillars.also': '+ Pausable sandboxes · Jupyter notebook · Multi-user · Credential proxy · SSO (GitHub / OIDC) · Self-host',
+
+    // compare
+    'compare.heading': 'How it differs',
+    'compare.col.tool': 'Tool',
+    'compare.col.local': 'local',
+    'compare.col.cloud': 'cloud',
+    'compare.col.peer': 'peer',
+    'compare.col.chat': 'chat',
+    'compare.caption': 'The only one with all four checked.',
+
+    // onboarding
+    'onb.heading': '7 steps to wire it all up',
+    'onb.s1.title': 'Register',
+    'onb.s1.body': 'Email / GitHub / SSO — your pick',
+    'onb.s2.title': 'Link a model account',
+    'onb.s2.body': 'Bring your own ChatGPT / Anthropic credential, or use a managed one',
+    'onb.s3.title': 'Enroll devices',
+    'onb.s3.body': 'brew install codex → paste the registration code',
+    'onb.s4.title': 'Pick a "command machine"',
+    'onb.s4.body': 'Usually your daily-driver laptop',
+    'onb.s5.title': '(Optional) open Jupyter',
+    'onb.s5.body': 'Prefer hand-written code? ctx is pre-injected in every kernel',
+    'onb.s6.title': 'Bind WeChat',
+    'onb.s6.body': 'Scan the QR. From now on, the chat window is your terminal',
+    'onb.s7.title': 'Invite collaborators',
+    'onb.s7.body': 'Roles: owner / maintainer / developer / guest',
+    'onb.docs': 'Full docs →',
+
+    // final cta
+    'cta.heading': 'Weave your devices into one Computility.',
+    'cta.primary': '▸ Sign in',
+    'cta.secondary': 'Self-host on your own domain',
+
+    // footer
+    'footer.col1.title': 'agentserver',
+    'footer.col2.title': 'Community',
+    'footer.col2.weixin': 'WeChat group',
+    'footer.col2.telegram': 'Telegram',
+    'footer.col2.issues': 'Issue tracker',
+    'footer.col3.title': 'Legal',
+    'footer.col3.license': 'Apache-2.0',
+    'footer.col3.privacy': 'Privacy',
+    'footer.col3.contact': 'Contact',
+  },
+}
+```
+
+- [ ] **Step 2: Typecheck**
+
+```bash
+cd web && pnpm tsc -b
+```
+
+Expected: exit 0.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/src/components/Home/strings.ts
+git commit -m "feat(web): add home page i18n dictionary"
+```
+
+---
+
+### Task 4: App.tsx routing — `/` → `<Home />` stub, keep `/login` working
+
+This wires the new route before any UI is built, so we can verify nothing existing breaks.
+
+**Files:**
+- Modify: `web/src/App.tsx`
+- Create: `web/src/components/Home/Home.tsx` (as a stub for now)
+
+- [ ] **Step 1: Create a minimal `<Home />` stub**
+
+Create `web/src/components/Home/Home.tsx`:
+
+```tsx
+export function Home() {
+  return (
+    <div data-theme="home" className="min-h-screen bg-[var(--background)] text-[var(--foreground)] p-8">
+      <p className="font-mono text-sm">▸ agentserver · home stub</p>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: In `web/src/App.tsx`, add the import**
+
+Find the existing line:
+
+```tsx
+import { Login } from './components/Login'
+```
+
+Add directly below:
+
+```tsx
+import { Home } from './components/Home/Home'
+```
+
+- [ ] **Step 3: Replace the unauthenticated branch with nested routes**
+
+Locate the block starting `if (!authed) {` (around line 305 in current `App.tsx`). Replace the entire `if (!authed) { ... }` block (from `if (!authed) {` through its closing `}` and the `return ( ... )` it contains) with:
+
+```tsx
+if (!authed) {
+  if (location.pathname === '/oauth2/consent') {
+    const params = new URLSearchParams(location.search)
+    const challenge = params.get('consent_challenge')
+    if (challenge) {
+      sessionStorage.setItem(PENDING_CONSENT_CHALLENGE_KEY, challenge)
+    }
+  }
+  if (location.pathname === '/oauth2/device') {
+    sessionStorage.setItem(PENDING_DEVICE_PARAMS_KEY, location.search)
+  }
+
+  const onLoginSuccess = () => {
+    const params = new URLSearchParams(location.search)
+    const next = params.get('next')
+    if (next) {
+      window.location.href = next
+      return
+    }
+    setAuthed(true)
+    listWorkspaces().then((ws) => {
+      setWorkspaces(ws)
+      if (ws.length > 0) setSelectedWorkspaceId(ws[0].id)
+    }).catch(() => {})
+    getMe().then(setUser).catch(() => {})
+  }
+
+  return (
+    <Routes>
+      <Route path="/" element={<Home />} />
+      <Route path="/login" element={<Login onSuccess={onLoginSuccess} />} />
+      <Route path="*" element={<Navigate to="/" replace />} />
+    </Routes>
+  )
+}
+```
+
+Notes for the implementer:
+- `Routes`, `Route`, `Navigate` are already imported at the top of the file.
+- `PENDING_CONSENT_CHALLENGE_KEY`, `PENDING_DEVICE_PARAMS_KEY`, `listWorkspaces`, `getMe`, `setAuthed`, `setWorkspaces`, `setSelectedWorkspaceId`, `setUser` are all already in scope.
+- The `/oauth2/login` short-circuit earlier in the function (around line 278) is **untouched** — `OAuthLoginRoute` still handles that path before the auth gate.
+- The `/oauth2/consent` and `/oauth2/device` handling is preserved: stash the params, then render `<Routes>`. The user will land on `/` (or whatever wildcard match redirects to `/`); when they click Sign in and complete login, the `?next=` flow resumes from sessionStorage as before.
+
+- [ ] **Step 4: Typecheck and lint**
+
+```bash
+cd web && pnpm tsc -b && pnpm lint
+```
+
+Expected: both exit 0.
+
+- [ ] **Step 5: Manual smoke test in dev**
+
+```bash
+cd web && pnpm dev
+```
+
+In a browser at `http://localhost:5173`:
+- `/` shows `▸ agentserver · home stub` on a white background (light theme) — PASS
+- `/login` shows the existing login card unchanged — PASS
+- `/anything-else` redirects to `/` — PASS
+
+Stop the dev server.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add web/src/App.tsx web/src/components/Home/Home.tsx
+git commit -m "feat(web): route unauth / to Home stub, preserve /login"
+```
+
+---
+
+### Task 5: Login.tsx back-link
+
+**Files:**
+- Modify: `web/src/components/Login.tsx`
+
+- [ ] **Step 1: Add the `Link` import at the top of `Login.tsx`**
+
+Find the existing import line:
+
+```tsx
+import { useState, useEffect, type FormEvent } from 'react'
+```
+
+Add directly below:
+
+```tsx
+import { Link } from 'react-router-dom'
+```
+
+- [ ] **Step 2: Replace the inline title with a back-link**
+
+Find:
+
+```tsx
+<h1 className="mb-6 text-center text-xl font-semibold text-[var(--card-foreground)]">
+  agentserver
+</h1>
+```
+
+Replace with:
+
+```tsx
+<h1 className="mb-6 text-center text-xl font-semibold text-[var(--card-foreground)]">
+  <Link to="/" className="hover:text-[var(--muted-foreground)] transition-colors">
+    ← agentserver
+  </Link>
+</h1>
+```
+
+- [ ] **Step 3: Typecheck, lint, smoke**
+
+```bash
+cd web && pnpm tsc -b && pnpm lint
+```
+
+Then `pnpm dev`, visit `/login`, click `← agentserver`, verify it lands on `/`. Stop dev.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/components/Login.tsx
+git commit -m "feat(web): add back-link from /login to / on login page"
+```
+
+---
+
+### Task 6: HomeNav
+
+**Files:**
+- Create: `web/src/components/Home/HomeNav.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+import { Link } from 'react-router-dom'
+import { detectLocale, setLocale, useT } from '../../lib/i18n'
+import { homeStrings } from './strings'
+
+export function HomeNav() {
+  const t = useT(homeStrings)
+  const locale = detectLocale()
+  const next = locale === 'zh' ? 'en' : 'zh'
+
+  return (
+    <nav className="sticky top-0 z-50 backdrop-blur-md bg-[var(--background)]/85 border-b border-[var(--border)]">
+      <div className="mx-auto max-w-6xl px-6 h-14 flex items-center justify-between">
+        <Link to="/" className="flex items-center gap-2 font-mono text-sm">
+          <span aria-hidden="true" className="inline-block h-2 w-2 rounded-full bg-[var(--home-accent)] animate-pulse motion-reduce:animate-none" />
+          <span>▸ {t('nav.brand')}</span>
+        </Link>
+
+        <div className="hidden md:flex items-center gap-6 font-mono text-xs text-[var(--muted-foreground)]">
+          <a href="#why" className="hover:text-[var(--foreground)]">{t('nav.why')}</a>
+          <a href="#how" className="hover:text-[var(--foreground)]">{t('nav.how')}</a>
+          <a href="#compare" className="hover:text-[var(--foreground)]">{t('nav.compare')}</a>
+        </div>
+
+        <div className="flex items-center gap-4">
+          <button
+            type="button"
+            onClick={() => setLocale(next)}
+            className="font-mono text-xs text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+            aria-label={`Switch language to ${next === 'zh' ? '中文' : 'English'}`}
+          >
+            {t('nav.lang.toggle')}
+          </button>
+          <Link
+            to="/login"
+            className="font-mono text-xs px-3 py-1.5 rounded-md bg-[var(--home-accent)] text-[var(--home-accent-fg)] hover:opacity-90"
+          >
+            {t('nav.signin')}
+          </Link>
+        </div>
+      </div>
+    </nav>
+  )
+}
+```
+
+- [ ] **Step 2: Mount it in `Home.tsx`**
+
+Replace the entire body of `web/src/components/Home/Home.tsx` with:
+
+```tsx
+import { HomeNav } from './HomeNav'
+
+export function Home() {
+  return (
+    <div data-theme="home" className="min-h-screen bg-[var(--background)] text-[var(--foreground)]">
+      <HomeNav />
+      <main className="mx-auto max-w-6xl px-6 py-12">
+        <p className="font-mono text-sm text-[var(--muted-foreground)]">sections coming…</p>
+      </main>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: Typecheck, lint, smoke**
+
+```bash
+cd web && pnpm tsc -b && pnpm lint
+```
+
+Then `pnpm dev`, visit `/`:
+- Nav bar visible at top with brand, jump links (hidden on mobile width), language button, Sign in button
+- Click `EN` (or `中`) → page reloads, language flips
+- Click `Sign in →` → lands on `/login`
+- Click `← agentserver` on `/login` → back to `/`
+
+Stop dev.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/components/Home/HomeNav.tsx web/src/components/Home/Home.tsx
+git commit -m "feat(web): add HomeNav with language toggle and sign-in link"
+```
+
+---
+
+### Task 7: HomeHero (the centerpiece)
+
+**Files:**
+- Create: `web/src/components/Home/HomeHero.tsx`
+
+This is the largest single task. The hero comprises markup for three panes, a CSS animation timeline, an IntersectionObserver that starts the animation once, and a `prefers-reduced-motion` fallback.
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+import { useEffect, useRef, useState } from 'react'
+import { Link } from 'react-router-dom'
+import { useT } from '../../lib/i18n'
+import { homeStrings } from './strings'
+
+export function HomeHero() {
+  const t = useT(homeStrings)
+  const ref = useRef<HTMLDivElement | null>(null)
+  const [started, setStarted] = useState(false)
+
+  useEffect(() => {
+    if (started) return
+    const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    if (reduce) {
+      setStarted(true)
+      return
+    }
+    const node = ref.current
+    if (!node) return
+    const obs = new IntersectionObserver((entries) => {
+      for (const e of entries) {
+        if (e.isIntersecting) {
+          setStarted(true)
+          obs.disconnect()
+          break
+        }
+      }
+    }, { threshold: 0.25 })
+    obs.observe(node)
+    return () => obs.disconnect()
+  }, [started])
+
+  return (
+    <section ref={ref} className="pt-12 pb-20" data-started={started ? 'true' : 'false'}>
+      <div className="grid lg:grid-cols-[1.1fr_0.9fr] gap-10 items-start">
+        {/* Left: heading + CTAs */}
+        <div>
+          <h1 className="text-5xl lg:text-6xl font-semibold tracking-tight leading-[1.1]">
+            {t('hero.h1')}
+          </h1>
+          <p className="mt-6 text-base lg:text-lg text-[var(--muted-foreground)] leading-relaxed max-w-xl">
+            {t('hero.sub')}
+          </p>
+          <div className="mt-8 flex flex-wrap items-center gap-3">
+            <Link
+              to="/login"
+              className="font-mono text-sm px-4 py-2 rounded-md bg-[var(--home-accent)] text-[var(--home-accent-fg)] hover:opacity-90"
+            >
+              {t('hero.cta.primary')}
+            </Link>
+            <a
+              href="https://github.com/agentserver/agentserver"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-mono text-sm px-4 py-2 rounded-md border border-[var(--border)] hover:bg-[var(--accent)]"
+            >
+              {t('hero.cta.secondary')}
+            </a>
+            <span className="font-mono text-[10px] px-2 py-1 rounded border border-[var(--home-accent)]/40 text-[var(--home-accent)]">
+              v{__APP_VERSION__} · {t('hero.chip.online')}
+            </span>
+          </div>
+        </div>
+
+        {/* Right: three-pane animated demo */}
+        <div
+          role="img"
+          aria-label={t('hero.sub')}
+          className="hero-demo grid grid-cols-[1fr_1fr] gap-3"
+        >
+          {/* Two terminal panes stacked in the left column */}
+          <div className="flex flex-col gap-3">
+            <Term
+              title={t('hero.term.macbook')}
+              lines={[
+                { delay: 400,  text: '$ codex relay "把 experiment_0521.csv', kind: 'cmd' },
+                { delay: 700,  text: '   在沙箱里画成图发我"',                kind: 'cmd' },
+                { delay: 1100, text: '▸ found experiment_0521.csv (124MB)',  kind: 'dim' },
+                { delay: 1500, text: '▸ relaying to cloud-sandbox-7…',       kind: 'dim' },
+              ]}
+            />
+            <Term
+              title={t('hero.term.sandbox')}
+              lines={[
+                { delay: 3000, text: '▸ pandas: 5 conditions × 12 trials',  kind: 'dim' },
+                { delay: 3400, text: '▸ matplotlib: boxplot + error bars',  kind: 'dim' },
+                { delay: 4400, text: '✓ saved plot.png (412KB)',            kind: 'ok'  },
+                { delay: 4900, text: '▸ uploading via imbridge…',           kind: 'dim' },
+              ]}
+            />
+          </div>
+
+          {/* WeChat pane */}
+          <ChatPane t={t} />
+        </div>
+      </div>
+
+      <style>{`
+        .hero-demo .ln,
+        .hero-demo .bubble {
+          opacity: 0;
+          transform: translateY(4px);
+        }
+        .hero-demo[data-started="true"] .ln {
+          animation: heroFadeIn 280ms ease-out forwards;
+        }
+        .hero-demo[data-started="true"] .bubble {
+          animation: heroBubble 220ms ease-out forwards;
+        }
+        @keyframes heroFadeIn {
+          to { opacity: 1; transform: translateY(0); }
+        }
+        @keyframes heroBubble {
+          to { opacity: 1; transform: translateY(0); }
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .hero-demo .ln,
+          .hero-demo .bubble {
+            opacity: 1 !important;
+            transform: none !important;
+            animation: none !important;
+          }
+        }
+      `}</style>
+    </section>
+  )
+}
+
+type TermLine = { delay: number; text: string; kind: 'cmd' | 'dim' | 'ok' }
+
+function Term({ title, lines }: { title: string; lines: TermLine[] }) {
+  return (
+    <div className="rounded-md border border-[var(--home-term-border)] bg-[var(--home-term-bg)] font-mono text-[11px] overflow-hidden">
+      <div className="px-3 py-1.5 border-b border-[var(--home-term-border)] text-[var(--home-term-dim)]">
+        {title}
+      </div>
+      <div className="px-3 py-2 space-y-1">
+        {lines.map((ln, i) => (
+          <div
+            key={i}
+            className="ln"
+            style={{ animationDelay: `${ln.delay}ms` }}
+          >
+            <span className={
+              ln.kind === 'ok'  ? 'text-[var(--home-accent)]' :
+              ln.kind === 'dim' ? 'text-[var(--home-term-dim)]' :
+                                  'text-[var(--home-term-fg)]'
+            }>
+              {ln.text}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function ChatPane({ t }: { t: (k: string) => string }) {
+  type Bubble = { delay: number; who: 'me' | 'bot'; text: string; thumb?: boolean }
+  const bubbles: Bubble[] = [
+    { delay: 5500, who: 'me',  text: t('hero.chat.user') },
+    { delay: 6000, who: 'bot', text: t('hero.chat.bot1') },
+    { delay: 7000, who: 'bot', text: t('hero.chat.bot2') },
+    { delay: 8500, who: 'bot', text: t('hero.chat.bot3'), thumb: true },
+  ]
+  return (
+    <div className="rounded-md border border-[var(--home-term-border)] bg-[#ededed] dark:bg-[#1a1a1a] overflow-hidden">
+      <div className="px-3 py-1.5 border-b border-[var(--home-term-border)] text-xs font-medium text-[var(--home-term-fg)]">
+        {t('hero.chat.title')}
+      </div>
+      <div role="log" aria-live="polite" className="px-3 py-3 space-y-2 min-h-[260px]">
+        {bubbles.map((b, i) => (
+          <div
+            key={i}
+            className={`bubble flex ${b.who === 'me' ? 'justify-end' : 'justify-start'}`}
+            style={{ animationDelay: `${b.delay}ms` }}
+          >
+            <div className={
+              'max-w-[80%] rounded-md px-3 py-1.5 text-xs leading-relaxed ' +
+              (b.who === 'me'
+                ? 'bg-[#95ec69] text-black'
+                : 'bg-white text-black dark:bg-[#2a2a2a] dark:text-white')
+            }>
+              {b.text}
+              {b.thumb && (
+                <div className="mt-1.5 h-12 w-full rounded bg-gradient-to-br from-[var(--home-accent)]/30 to-[var(--home-accent)]/10 border border-[var(--home-accent)]/40 flex items-center justify-center text-[10px] text-[var(--home-term-dim)]">
+                  plot.png · 412KB
+                </div>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Mount it in `Home.tsx`**
+
+Replace the `<main>` body with:
+
+```tsx
+<main className="mx-auto max-w-6xl px-6">
+  <HomeHero />
+</main>
+```
+
+And add the import: `import { HomeHero } from './HomeHero'`.
+
+- [ ] **Step 3: Typecheck, lint, smoke**
+
+```bash
+cd web && pnpm tsc -b && pnpm lint
+```
+
+`pnpm dev`, visit `/`:
+- Hero displays H1, sub, CTAs on the left, three panes on the right
+- Animation runs once on load (~9s total)
+- Refresh the page → animation runs again
+- Open DevTools → Rendering → "Emulate CSS prefers-reduced-motion: reduce" → refresh → all panes appear fully populated immediately
+
+Stop dev.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/components/Home/HomeHero.tsx web/src/components/Home/Home.tsx
+git commit -m "feat(web): add HomeHero with one-shot three-pane animation"
+```
+
+---
+
+### Task 8: HomeQuote
+
+**Files:**
+- Create: `web/src/components/Home/HomeQuote.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+import { useT } from '../../lib/i18n'
+import { homeStrings } from './strings'
+
+export function HomeQuote() {
+  const t = useT(homeStrings)
+  // Split the quote so 'conductor' and 'orchestrator' can be highlighted.
+  const accent = (text: string) => (
+    <span className="text-[var(--home-accent)] font-medium">{text}</span>
+  )
+  return (
+    <section className="py-16 border-l-2 border-[var(--home-accent)] pl-6">
+      <blockquote className="text-lg lg:text-xl text-[var(--foreground)] leading-relaxed max-w-3xl">
+        "Once you juggle 10+ agents across machines, you stop being a {accent('conductor')} and become an {accent('orchestrator')}."
+      </blockquote>
+      <p className="mt-3 text-sm text-[var(--muted-foreground)] font-mono">
+        {t('quote.attrib')}
+      </p>
+      <p className="mt-2 text-sm text-[var(--muted-foreground)]">
+        {t('quote.caption')}
+      </p>
+    </section>
+  )
+}
+```
+
+Note: the quote body is identical in zh and en (it's a real English quote), so it is hardcoded here rather than going through `t('quote.body')`. The dictionary key `quote.body` exists for completeness but is not used by this component.
+
+- [ ] **Step 2: Mount in `Home.tsx`**
+
+Append `<HomeQuote />` after `<HomeHero />` and add the import.
+
+- [ ] **Step 3: Typecheck, lint, smoke**
+
+```bash
+cd web && pnpm tsc -b && pnpm lint
+```
+
+`pnpm dev`, visit `/`, verify the quote appears below the hero with left accent bar, two highlighted words. Stop dev.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/components/Home/HomeQuote.tsx web/src/components/Home/Home.tsx
+git commit -m "feat(web): add HomeQuote section"
+```
+
+---
+
+### Task 9: HomePillars
+
+**Files:**
+- Create: `web/src/components/Home/HomePillars.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+import { useT } from '../../lib/i18n'
+import { homeStrings } from './strings'
+
+type Pillar = {
+  emoji: string
+  titleKey: string
+  bodyKey: string
+}
+
+const pillars: Pillar[] = [
+  { emoji: '📱', titleKey: 'pillars.pocket.title',    bodyKey: 'pillars.pocket.body' },
+  { emoji: '🌐', titleKey: 'pillars.workspace.title', bodyKey: 'pillars.workspace.body' },
+  { emoji: '🔌', titleKey: 'pillars.tunnel.title',    bodyKey: 'pillars.tunnel.body' },
+]
+
+export function HomePillars() {
+  const t = useT(homeStrings)
+  return (
+    <section id="why" className="py-20">
+      <h2 className="font-mono text-xs tracking-[0.2em] text-[var(--muted-foreground)] uppercase mb-8">
+        {t('pillars.heading')}
+      </h2>
+      <div className="grid md:grid-cols-3 gap-4">
+        {pillars.map((p) => (
+          <article
+            key={p.titleKey}
+            className="rounded-lg border border-[var(--border)] p-6 bg-[var(--card)]"
+          >
+            <div className="text-3xl mb-3" aria-hidden="true">{p.emoji}</div>
+            <h3 className="text-lg font-semibold mb-2">{t(p.titleKey)}</h3>
+            <p className="text-sm text-[var(--muted-foreground)] leading-relaxed">{t(p.bodyKey)}</p>
+          </article>
+        ))}
+      </div>
+      <p className="mt-6 font-mono text-xs text-[var(--muted-foreground)] leading-relaxed">
+        {t('pillars.also')}
+      </p>
+    </section>
+  )
+}
+```
+
+- [ ] **Step 2: Mount in `Home.tsx`**
+
+Add `<HomePillars />` after `<HomeQuote />`, import accordingly.
+
+- [ ] **Step 3: Typecheck, lint, smoke**
+
+```bash
+cd web && pnpm tsc -b && pnpm lint
+```
+
+`pnpm dev`, verify three cards render side-by-side at desktop width, stack at mobile, secondary chip strip appears below. Stop dev.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/components/Home/HomePillars.tsx web/src/components/Home/Home.tsx
+git commit -m "feat(web): add HomePillars (3 cards + secondary pill strip)"
+```
+
+---
+
+### Task 10: HomeCompare
+
+**Files:**
+- Create: `web/src/components/Home/HomeCompare.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+import { useT } from '../../lib/i18n'
+import { homeStrings } from './strings'
+
+type Row = { tool: string; local: string; cloud: string; peer: string; chat: string; us?: boolean }
+
+const rows: Row[] = [
+  { tool: 'OpenClaw / Claude Code Remote', local: '1',      cloud: '—',      peer: '—', chat: '—' },
+  { tool: 'Claude Code on the web',        local: '—',      cloud: '✓',      peer: '—', chat: '—' },
+  { tool: 'CC Agent Teams',                local: '—',      cloud: '✓(sub)', peer: '—', chat: '—' },
+  { tool: 'agentserver',                   local: '✓ many', cloud: '✓',      peer: '✓', chat: '✓', us: true },
+]
+
+export function HomeCompare() {
+  const t = useT(homeStrings)
+  return (
+    <section id="compare" className="py-20">
+      <h2 className="font-mono text-xs tracking-[0.2em] text-[var(--muted-foreground)] uppercase mb-8">
+        {t('compare.heading')}
+      </h2>
+      <div className="overflow-x-auto">
+        <table className="w-full font-mono text-xs border border-[var(--home-term-border)]">
+          <caption className="sr-only">{t('compare.heading')}</caption>
+          <thead>
+            <tr className="bg-[var(--card)] text-[var(--home-accent)]">
+              <th scope="col" className="text-left p-3 font-medium">{t('compare.col.tool')}</th>
+              <th scope="col" className="text-center p-3 font-medium">{t('compare.col.local')}</th>
+              <th scope="col" className="text-center p-3 font-medium">{t('compare.col.cloud')}</th>
+              <th scope="col" className="text-center p-3 font-medium">{t('compare.col.peer')}</th>
+              <th scope="col" className="text-center p-3 font-medium">{t('compare.col.chat')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr
+                key={r.tool}
+                className={r.us
+                  ? 'bg-[var(--home-grid)] border-l-2 border-[var(--home-accent)]'
+                  : 'border-t border-[var(--home-term-border)]'
+                }
+              >
+                <th scope="row" className={`text-left p-3 font-normal ${r.us ? 'text-[var(--home-accent)] font-medium' : ''}`}>
+                  {r.us ? `▸ ${r.tool}` : r.tool}
+                </th>
+                <td className="text-center p-3">{r.local}</td>
+                <td className="text-center p-3">{r.cloud}</td>
+                <td className="text-center p-3">{r.peer}</td>
+                <td className="text-center p-3">{r.chat}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+      <p className="mt-4 text-sm text-[var(--muted-foreground)]">{t('compare.caption')}</p>
+    </section>
+  )
+}
+```
+
+- [ ] **Step 2: Mount in `Home.tsx`**
+
+Add `<HomeCompare />` after `<HomePillars />`, import accordingly.
+
+- [ ] **Step 3: Typecheck, lint, smoke**
+
+```bash
+cd web && pnpm tsc -b && pnpm lint
+```
+
+`pnpm dev`, verify table renders, agentserver row visually distinguished with left border + accent color, mobile width gets horizontal scroll. Stop dev.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/components/Home/HomeCompare.tsx web/src/components/Home/Home.tsx
+git commit -m "feat(web): add HomeCompare differentiator table"
+```
+
+---
+
+### Task 11: HomeOnboarding
+
+**Files:**
+- Create: `web/src/components/Home/HomeOnboarding.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+import { useT } from '../../lib/i18n'
+import { homeStrings } from './strings'
+
+const steps = [
+  { n: 1, titleKey: 'onb.s1.title', bodyKey: 'onb.s1.body' },
+  { n: 2, titleKey: 'onb.s2.title', bodyKey: 'onb.s2.body' },
+  { n: 3, titleKey: 'onb.s3.title', bodyKey: 'onb.s3.body' },
+  { n: 4, titleKey: 'onb.s4.title', bodyKey: 'onb.s4.body' },
+  { n: 5, titleKey: 'onb.s5.title', bodyKey: 'onb.s5.body' },
+  { n: 6, titleKey: 'onb.s6.title', bodyKey: 'onb.s6.body', emphasized: true },
+  { n: 7, titleKey: 'onb.s7.title', bodyKey: 'onb.s7.body' },
+]
+
+export function HomeOnboarding() {
+  const t = useT(homeStrings)
+  return (
+    <section id="how" className="py-20">
+      <h2 className="font-mono text-xs tracking-[0.2em] text-[var(--muted-foreground)] uppercase mb-8">
+        {t('onb.heading')}
+      </h2>
+      <ol className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {steps.map((s) => (
+          <li
+            key={s.n}
+            className={
+              'rounded-lg border p-5 ' +
+              (s.emphasized
+                ? 'border-[var(--home-accent)] bg-[var(--home-grid)]'
+                : 'border-[var(--border)] bg-[var(--card)]')
+            }
+          >
+            <div className={
+              'inline-flex items-center justify-center h-7 w-7 rounded-full font-mono text-xs mb-3 ' +
+              (s.emphasized
+                ? 'bg-[var(--home-accent)] text-[var(--home-accent-fg)]'
+                : 'bg-[var(--secondary)] text-[var(--secondary-foreground)]')
+            }>
+              {s.n}
+            </div>
+            <h3 className={`text-sm font-semibold mb-1 ${s.emphasized ? 'text-[var(--home-accent)]' : ''}`}>
+              {t(s.titleKey)}
+            </h3>
+            <p className="text-xs text-[var(--muted-foreground)] leading-relaxed">{t(s.bodyKey)}</p>
+          </li>
+        ))}
+      </ol>
+      <a
+        href="https://github.com/agentserver/agentserver#readme"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-block mt-6 font-mono text-xs text-[var(--home-accent)] hover:underline"
+      >
+        {t('onb.docs')}
+      </a>
+    </section>
+  )
+}
+```
+
+- [ ] **Step 2: Mount in `Home.tsx`**
+
+Add `<HomeOnboarding />` after `<HomeCompare />`, import accordingly.
+
+- [ ] **Step 3: Typecheck, lint, smoke**
+
+```bash
+cd web && pnpm tsc -b && pnpm lint
+```
+
+`pnpm dev`, verify 7 numbered cards render in a 4-column grid at desktop (with last row having 3 cards), step 6 visually emphasized, vertical stack at mobile. Stop dev.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/components/Home/HomeOnboarding.tsx web/src/components/Home/Home.tsx
+git commit -m "feat(web): add HomeOnboarding 7-step timeline"
+```
+
+---
+
+### Task 12: HomeFinalCTA
+
+**Files:**
+- Create: `web/src/components/Home/HomeFinalCTA.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+import { Link } from 'react-router-dom'
+import { useT } from '../../lib/i18n'
+import { homeStrings } from './strings'
+
+export function HomeFinalCTA() {
+  const t = useT(homeStrings)
+  return (
+    <section className="my-20 py-16 border-y-2 border-[var(--home-accent)]">
+      <div className="text-center">
+        <h2 className="text-3xl lg:text-4xl font-semibold tracking-tight max-w-2xl mx-auto">
+          {t('cta.heading')}
+        </h2>
+        <div className="mt-8 flex flex-wrap items-center justify-center gap-3">
+          <Link
+            to="/login"
+            className="font-mono text-sm px-5 py-2.5 rounded-md bg-[var(--home-accent)] text-[var(--home-accent-fg)] hover:opacity-90"
+          >
+            {t('cta.primary')}
+          </Link>
+          <a
+            href="https://github.com/agentserver/agentserver#self-hosting"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-mono text-sm px-5 py-2.5 rounded-md border border-[var(--border)] hover:bg-[var(--accent)]"
+          >
+            {t('cta.secondary')}
+          </a>
+        </div>
+      </div>
+    </section>
+  )
+}
+```
+
+- [ ] **Step 2: Mount in `Home.tsx`**
+
+Add `<HomeFinalCTA />` after `<HomeOnboarding />`, import accordingly.
+
+- [ ] **Step 3: Typecheck, lint, smoke**
+
+```bash
+cd web && pnpm tsc -b && pnpm lint
+```
+
+`pnpm dev`, verify centered heading with two buttons, accent-colored top + bottom border. Stop dev.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/components/Home/HomeFinalCTA.tsx web/src/components/Home/Home.tsx
+git commit -m "feat(web): add HomeFinalCTA section"
+```
+
+---
+
+### Task 13: HomeFooter + build stamp
+
+**Files:**
+- Create: `web/src/components/Home/HomeFooter.tsx`
+
+- [ ] **Step 1: Create the component**
+
+```tsx
+import { useT } from '../../lib/i18n'
+import { homeStrings } from './strings'
+
+export function HomeFooter() {
+  const t = useT(homeStrings)
+  return (
+    <footer className="border-t border-[var(--border)] py-10 mt-10">
+      <div className="grid md:grid-cols-3 gap-8 text-sm">
+        <div>
+          <p className="font-mono font-semibold mb-3">{t('footer.col1.title')}</p>
+          <ul className="space-y-1 text-[var(--muted-foreground)]">
+            <li><a className="hover:text-[var(--foreground)]" href="https://agentserver.dev" target="_blank" rel="noopener noreferrer">agentserver.dev</a></li>
+            <li><a className="hover:text-[var(--foreground)]" href="https://github.com/agentserver/agentserver" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+            <li><a className="hover:text-[var(--foreground)]" href="https://github.com/agentserver/agentserver#readme" target="_blank" rel="noopener noreferrer">Docs</a></li>
+            <li><a className="hover:text-[var(--foreground)]" href="https://github.com/agentserver/agentserver/releases" target="_blank" rel="noopener noreferrer">Changelog</a></li>
+          </ul>
+        </div>
+        <div>
+          <p className="font-mono font-semibold mb-3">{t('footer.col2.title')}</p>
+          <ul className="space-y-1 text-[var(--muted-foreground)]">
+            <li><span>{t('footer.col2.weixin')}</span></li>
+            <li><span>{t('footer.col2.telegram')}</span></li>
+            <li><a className="hover:text-[var(--foreground)]" href="https://github.com/agentserver/agentserver/issues" target="_blank" rel="noopener noreferrer">{t('footer.col2.issues')}</a></li>
+          </ul>
+        </div>
+        <div>
+          <p className="font-mono font-semibold mb-3">{t('footer.col3.title')}</p>
+          <ul className="space-y-1 text-[var(--muted-foreground)]">
+            <li><a className="hover:text-[var(--foreground)]" href="https://github.com/agentserver/agentserver/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">{t('footer.col3.license')}</a></li>
+            <li><span>{t('footer.col3.privacy')}</span></li>
+            <li><span>{t('footer.col3.contact')}</span></li>
+          </ul>
+        </div>
+      </div>
+      <p className="mt-8 text-center font-mono text-[10px] text-[var(--muted-foreground)]">
+        v{__APP_VERSION__} · {__BUILD_COMMIT__} · built {__BUILD_DATE__}
+      </p>
+    </footer>
+  )
+}
+```
+
+Note: the spec lists a WeChat group QR-on-hover (Open Question #3). It is intentionally **omitted** here — text only — because no asset is in the repo. If/when an asset arrives, swap `<span>{t('footer.col2.weixin')}</span>` for a hover-popover component.
+
+- [ ] **Step 2: Mount in `Home.tsx`**
+
+Add `<HomeFooter />` after `<HomeFinalCTA />`. Final `Home.tsx`:
+
+```tsx
+import { HomeNav } from './HomeNav'
+import { HomeHero } from './HomeHero'
+import { HomeQuote } from './HomeQuote'
+import { HomePillars } from './HomePillars'
+import { HomeCompare } from './HomeCompare'
+import { HomeOnboarding } from './HomeOnboarding'
+import { HomeFinalCTA } from './HomeFinalCTA'
+import { HomeFooter } from './HomeFooter'
+
+export function Home() {
+  return (
+    <div data-theme="home" className="min-h-screen bg-[var(--background)] text-[var(--foreground)]">
+      <HomeNav />
+      <main className="mx-auto max-w-6xl px-6">
+        <HomeHero />
+        <HomeQuote />
+        <HomePillars />
+        <HomeCompare />
+        <HomeOnboarding />
+        <HomeFinalCTA />
+      </main>
+      <HomeFooter />
+    </div>
+  )
+}
+```
+
+- [ ] **Step 3: Typecheck, lint, build**
+
+```bash
+cd web && pnpm tsc -b && pnpm lint && pnpm build
+```
+
+All three should exit 0. `pnpm build` is the first time we exercise the full Vite build with `__BUILD_*__` defines — verify the footer text in `web/dist/assets/*.js` contains the actual version/commit/date, not the literal `__APP_VERSION__`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/components/Home/HomeFooter.tsx web/src/components/Home/Home.tsx
+git commit -m "feat(web): add HomeFooter with build stamp"
+```
+
+---
+
+### Task 14: End-to-end visual verification + responsive sweep
+
+This is the final manual gate. No code is written; the engineer verifies the assembled page across breakpoints, themes, and the reduced-motion fallback.
+
+- [ ] **Step 1: Start dev server**
+
+```bash
+cd web && pnpm dev
+```
+
+- [ ] **Step 2: Desktop sweep (1280×800)**
+
+In the browser, visit `http://localhost:5173/`:
+- All sections render in order: nav, hero, quote, pillars, compare, onboarding, final CTA, footer
+- Hero animation completes once, stops with all panes populated
+- Refresh once — animation runs again
+- Click each nav jump link (`Why`, `How`, `Compare`) — page scrolls to the right section
+- Click `Sign in →` (in nav) → `/login`
+- Click `← agentserver` on `/login` → back to `/`
+- Click language toggle in nav — page reloads, content flips zh ↔ en
+- Switch system to dark mode (or apply `class="dark"` to `<html>` via DevTools) — verify terminal panes go black with green accent, light-mode terminal goes light with neutral accent
+
+- [ ] **Step 3: Tablet sweep (~900×1200)**
+
+Resize the viewport. Verify:
+- Hero panes stack vertically (still all three visible)
+- Pillars become 2 columns or single column
+- Compare table can be scrolled horizontally without overflowing the page
+
+- [ ] **Step 4: Mobile sweep (~390×844)**
+
+Verify:
+- Nav center jump-links are hidden (only logo, language toggle, Sign in)
+- All three hero panes stack
+- Pillars become a single column
+- Compare table scrolls horizontally
+- Onboarding cards stack to a single column
+
+- [ ] **Step 5: Reduced-motion fallback**
+
+In DevTools → Rendering → "Emulate CSS prefers-reduced-motion: reduce". Refresh `/`. Verify:
+- Hero panes render fully populated immediately (no fade-in)
+- Pulsing dot in nav is steady (not pulsing)
+- No animation jitter anywhere on the page
+
+- [ ] **Step 6: Authenticated user does not regress**
+
+Log in via `/login` (use any existing test account). Verify:
+- Lands on the workspace UI as before (no Home page intercept)
+- Sign out, return to `/` — Home page renders again
+
+- [ ] **Step 7: Production build smoke**
+
+```bash
+cd web && pnpm build && pnpm preview
+```
+
+Visit the preview URL (typically `http://localhost:4173/`). Verify the same desktop sweep works against the production bundle.
+
+- [ ] **Step 8: If everything passes, no commit required.** If anything regressed during the sweep, file the fix as a follow-up task in this plan and address before considering the work merged.
+
+---
+
+## Self-Review (already performed by plan author)
+
+**Spec coverage check** — every locked decision in `2026-05-22-unauth-home-design.md` traced to a task:
+
+| Spec section | Task |
+|---|---|
+| Routing (`/` → Home, `/login` preserved, `/oauth2/*` preserved, wildcard → `/`) | Task 4 |
+| `Login.tsx` back-link | Task 5 |
+| CSS tokens scoped to `[data-theme="home"]` | Task 1 |
+| Build-time `__APP_VERSION__` / `__BUILD_COMMIT__` / `__BUILD_DATE__` | Task 1 (defines) + Tasks 7, 13 (consumers) |
+| i18n primitive (`detectLocale` / `setLocale` / `useT`) | Task 2 |
+| Full dictionary (~80 keys) | Task 3 |
+| HomeNav (sticky, jump links, language toggle, Sign in) | Task 6 |
+| HomeHero (three-pane, one-shot animation, IntersectionObserver, reduced-motion) | Task 7 |
+| HomeQuote (with two highlighted words + zh caption) | Task 8 |
+| HomePillars (3 cards + pill strip) | Task 9 |
+| HomeCompare (real `<table>`, highlighted row) | Task 10 |
+| HomeOnboarding (7 steps, step 6 emphasized) | Task 11 |
+| HomeFinalCTA (full-width band, 2 buttons) | Task 12 |
+| HomeFooter (3 cols + version strip) | Task 13 |
+| Responsive across 3 breakpoints | Task 14 |
+| Reduced-motion fallback | Task 14 |
+| AA contrast / `<table>` / focus rings | Tasks 6–13 (markup), Task 14 (verify) |
+
+**Open Questions from spec (intentionally deferred):**
+- README rename — out of scope (separate PR).
+- Live "devices connected" counter — not implemented; the hero chip just shows "online".
+- WeChat group QR — text-only in footer (noted inline in Task 13).
+
+**Placeholder scan:** none — every code step shows the exact code, every verification step shows the exact command and expected outcome.
+
+**Type consistency:** `useT(dicts)` signature is defined in Task 2 and consumed identically in Tasks 6–13. `Locale = 'zh' | 'en'` is the only locale type. The build-time globals `__APP_VERSION__` / `__BUILD_COMMIT__` / `__BUILD_DATE__` are declared once in Task 1's `vite-env.d.ts` and referenced consistently in Tasks 7 and 13.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-05-22-unauth-home.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — Execute tasks in this session using `executing-plans`, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-05-22-unauth-home-design.md
+++ b/docs/superpowers/specs/2026-05-22-unauth-home-design.md
@@ -1,0 +1,314 @@
+# Unauthenticated Homepage Design
+
+**Date:** 2026-05-22
+**Status:** Draft
+**Scope:** `web/src` (frontend only; no backend or routing changes outside React Router)
+
+## Problem
+
+`agent.cs.ac.cn` currently shows unauthenticated visitors only a small centered login card (`web/src/components/Login.tsx`). A first-time visitor cannot tell what the product does, why they would want it, or how it differs from adjacent tools (OpenClaw, Claude Code on the web, Claude Code Agent Teams). The README has a clear pitch — _"Your Personal Computility — command devices anywhere, from your WeChat chat window"_ — but the web surface does not reflect it.
+
+The goal is a single-page marketing homepage at `/` that turns drive-by visitors into registered users while preserving the existing `/login` route untouched.
+
+## Solution
+
+Add a `/` route rendering `<Home />` for unauthenticated visitors. The page is one continuous scrolling story — hero → quote → 3 pillars → comparison table → 7-step onboarding → final CTA → footer — in a dark terminal aesthetic that extends the README's voice into the web. The hero uses a three-pane animation — two stacked terminal panes on the left, a WeChat conversation on the right — showing **three devices collaborating to compute a result and deliver it back via WeChat** — a workflow that genuinely requires `agentserver`'s orchestration layer and that single-device tools (e.g., OpenClaw) cannot do.
+
+`/login` keeps its current React component and behavior; the only change is a small "← agentserver" back link.
+
+## Locked decisions (resolved during brainstorming)
+
+| Topic | Decision | Rationale |
+|---|---|---|
+| Brand tagline | `Your Personal Computility.` / `你的个人算力网。` | New coinage: `compute` + `utility` — frames product as infrastructure. Replaces "Personal Compute Network" in this page (README rename is a separate task). |
+| Visual tone | Geek / terminal (dark, monospace, terminal motif) — see brainstorm `tone.html` | Continues README voice; aligned with developer audience; avoids "self-promotional SaaS" aesthetic that suits a `cs.ac.cn` domain poorly. |
+| Layout | "Story arc" — linear long-scroll narrative (`layout.html` option α) | Concept (`Personal Computility`) is new and needs explaining; dense-console layout (β) would bury the comparison table; try-it-now layout (γ) compresses the depth `cs.ac.cn` visitors tolerate. |
+| Hero scenario | **V5 — multi-device data pipeline → WeChat delivery** | OpenClaw can do single-device remote dispatch (V4) and long-running tasks with notification (V2); only `agentserver` can route a workflow across heterogeneous devices and deliver the result through an IM channel. |
+| Roadmap section | **Cut** | Roadmap is "what we are building" (self-focused); homepage is "what you get" (visitor-focused). Belongs in docs or post-login dashboard. |
+| Language | Auto-detect (`navigator.language`) with manual toggle | Zero-friction default for `cs.ac.cn`'s mostly Chinese audience; explicit escape hatch for international visitors. |
+| Login UX | Keep separate `/login` route; top-nav and hero CTA both link to it | Minimum coupling; preserves existing `Login.tsx` untouched. Modal would complicate OIDC redirect handoff. |
+
+## Routing
+
+```
+/         → <Home />        (unauthenticated only; authenticated users redirect to their workspace)
+/login    → <Login />       (unchanged; only the inline title becomes a "← agentserver" link back to /)
+/*        → redirect to /   (unauthenticated; the existing OIDC/Workspace routes apply when authed)
+```
+
+`App.tsx`'s `authed === false` branch currently renders `<Login />` directly. Change it to render React Router's nested routes so the `/login` URL still works for direct links (e.g., OIDC callbacks and the codex-auth verify flow already use `?next=...`).
+
+## File changes
+
+**New:**
+
+```
+web/src/components/Home/
+├── Home.tsx              # top-level shell; composes the sections
+├── HomeNav.tsx           # sticky top bar: logo, jump-links, language toggle, Sign in
+├── HomeHero.tsx          # dual-pane (terminal + WeChat) with one-shot animation
+├── HomePillars.tsx       # three pillar cards + secondary feature pill strip
+├── HomeCompare.tsx       # ASCII-styled differentiator table
+├── HomeOnboarding.tsx    # 7-step horizontal timeline (vertical on mobile)
+├── HomeFinalCTA.tsx      # full-width band with Sign in + Self-host CTAs
+├── HomeFooter.tsx        # three-column footer + build version stamp
+└── strings.ts            # i18n dictionary, namespaced per section
+```
+
+**Modified:**
+
+- `web/src/App.tsx` — wire `/` to `<Home />` when `authed === false`; redirect `/` to workspace when `authed === true`.
+- `web/src/components/Login.tsx` — replace inline `<h1>agentserver</h1>` with a small `← agentserver` link to `/`.
+- `web/src/lib/i18n.ts` — **new** (despite being "modified" — the file is added here, not under `Home/`, so it is reusable later).
+- `web/src/index.css` — add `--home-accent`, `--home-accent-fg`, `--home-grid`, `--home-term-bg`, `--home-term-border` CSS variables, scoped under `[data-theme="home"]` so they do not affect other pages.
+
+**No new npm dependencies.** Tailwind v4 + CSS variables + hand-rolled `@keyframes` cover everything.
+
+## Visual system
+
+### Color tokens (additive)
+
+```css
+:root[data-theme="home"] {
+  --home-accent:        #18181b;
+  --home-accent-fg:     #fafafa;
+  --home-grid:          rgba(0, 0, 0, 0.06);
+  --home-term-bg:       #f4f4f5;
+  --home-term-border:   #d4d4d8;
+}
+.dark[data-theme="home"], [data-theme="home"].dark {
+  --home-accent:        #7fff7f;
+  --home-accent-fg:     #000;
+  --home-grid:          rgba(127, 255, 127, 0.04);
+  --home-term-bg:       #000;
+  --home-term-border:   #2a2a2a;
+}
+```
+
+Contrast check: `#7fff7f` on `#0a0a0a` = 14.8:1 (AAA). `#18181b` on `#ffffff` = 17.6:1 (AAA).
+
+### Typography
+
+- **Body** — existing `system-ui, -apple-system, sans-serif`.
+- **Brand / terminal panes / pillar labels** — `ui-monospace, 'SF Mono', Menlo, monospace`.
+- **H1** — `font-weight: 600; letter-spacing: -0.02em; font-size: clamp(2rem, 5vw, 3.5rem);`
+- **Code / terminal output** — mono; **WeChat bubbles** — sans. The mono/sans split is what visually separates "machine side" from "human side" in the hero.
+- No webfonts. Emoji are unicode (`📱 🌐 🔌`), not SVG sprite.
+
+### Section separators
+
+Dark theme: `─ ─ ─ ✦ ─ ─ ─` (centered, `--muted-foreground`). Light theme: a single `--border` rule.
+
+## Page sections
+
+### 0 · TopNav (sticky)
+
+- **Left**: `▸ agentserver` in mono, with a pulsing green dot.
+- **Center**: `Why · How · Compare`  (anchor jumps).
+- **Right**: `中 / EN` toggle, then `Sign in →` button.
+- Scrolls with the page until reaching the viewport top, then sticks.
+
+### 1 · Hero (V5 dual-pane)
+
+**H1 zh:** `你的个人算力网。`
+**H1 en:** `Your Personal Computility.`
+
+**Subtitle zh:** `agentserver 把笔记本、云沙箱、家里的服务器编成一个工作区——从浏览器、命令行，或微信，一并指挥。`
+**Subtitle en:** `agentserver weaves laptops, cloud sandboxes, and home servers into one workspace — commanded from your browser, your CLI, or your WeChat chat.`
+
+**CTAs:** primary `▸ Sign in` → `/login`; secondary `View on GitHub` → repo URL.
+
+**Visual — two stacked terminal panes + one WeChat pane, choreographed:**
+
+```
+┌─ office-macbook · codex ─────────────┐   ┌─ 我自己 ─────────────────┐
+$ codex relay "把 experiment_0521         我:  把上周的实验数据
+   .csv 在沙箱里画成图发我"                      画成图给我
+▸ found experiment_0521.csv (124MB)
+▸ relaying to cloud-sandbox-7…             AS: 📂 已从 office-macbook
+                                                取到 experiment_0521.csv
+┌─ cloud-sandbox-7 · codex ────────────┐
+▸ pandas: 5 conditions × 12 trials         AS: 🔨 在沙箱里分析 +
+▸ matplotlib: boxplot + error bars             画图中…
+✓ saved plot.png (412KB)
+▸ uploading via imbridge…                  AS: ✓ 完成
+                                                [plot.png 缩略图]
+```
+
+Animation timeline (one-shot, no loop):
+
+| t | Event |
+|---|---|
+| 0.0s | Both panes mounted, dimmed. |
+| 0.2s | `office-macbook` header appears. |
+| 0.4 – 2.8s | Macbook lines reveal one at a time (200–300ms each). |
+| 3.0 – 5.5s | `cloud-sandbox-7` block reveals same way. |
+| 5.5s | WeChat: user bubble fades + slides in (200ms). |
+| 6.0s | Bot bubble "📂 已取到..." |
+| 7.0s | Bot bubble "🔨 分析中..." |
+| 8.5s | Bot bubble "✓ 完成" + `plot.png` thumbnail. |
+| 8.5s onwards | Animation **stops**. Final state stays on screen. No fade-out, no loop. |
+
+Implementation:
+
+- Pure CSS `@keyframes` with `animation-delay` chains; `animation-fill-mode: forwards` to lock the final state.
+- One `IntersectionObserver` to start the animation only when hero enters the viewport (cheap to start; do nothing if it never enters).
+- `@media (prefers-reduced-motion: reduce)` — skip animation, render final state immediately on mount.
+- A small `v0.64.14 · online` chip bottom-right of the hero card. Version comes from a `__APP_VERSION__` injected via Vite `define`.
+
+### 2 · Quote
+
+```
+│ "Once you juggle 10+ agents across machines, you stop being a
+│  conductor and become an orchestrator."
+│
+│  — Addy Osmani · Director, Google Gemini & Cloud AI
+```
+
+Left vertical bar in `--home-accent`. The two emphasized words (`conductor`, `orchestrator`) are accent-colored. Below, a one-line caption: `agentserver = 那个 orchestrator。` / `agentserver is that orchestrator.`
+
+### 3 · Three Pillars
+
+Three side-by-side cards, each: emoji + heading + 2-line body + a micro-mockup.
+
+| Emoji | zh heading | en heading | Body (zh) | Micro-mockup |
+|---|---|---|---|---|
+| 📱 | 装在口袋里的指挥台 | Pocket-sized command line | 微信里一句中文，落到任意设备执行，结果推回同一个聊天框。Telegram 同样支持。 | A 3-bubble mini-chat |
+| 🌐 | 一个工作区，所有设备 | One workspace, every device | 云沙箱、本地机器、IM-bound 代理——全在同一份注册表里，并排出现在 Web UI 上。 | A 4-item device list |
+| 🔌 | 无公网 IP，照常入网 | No public IP. Still in the network. | 本地的 codex / Claude Code / opencode 通过 WebSocket 拨号入网，呈现为一个沙箱。 | A 2-node topology diagram |
+
+Below the three cards, a single pill strip — small chips, low contrast — covering the secondary features that did not earn a full pillar:
+
+`+ 暂停 / 恢复沙箱 · Jupyter 笔记本 · 多人协作 · 凭证代理 · SSO（GitHub / OIDC）· 自托管`
+
+### 4 · Differentiator Table
+
+**Heading zh:** `和已有的工具相比` **en:** `How it differs`
+
+A real `<table>` (`<th scope="col">` / `<th scope="row">`) styled to look like ASCII art in the dark theme. Visual:
+
+```
+                   ┌─ local ──┬─ cloud ──┬─ peer ─┬─ chat ─┐
+  OpenClaw / CCR   │    1     │    —     │   —    │   —    │
+  Claude Code web  │    —     │    ✓     │   —    │   —    │
+  CC Agent Teams   │    —     │  ✓(sub)  │   —    │   —    │
+▸ agentserver      │ ✓ many   │    ✓     │   ✓    │   ✓    │ ◀
+                   └──────────┴──────────┴────────┴────────┘
+```
+
+Highlighted row uses `background: var(--home-grid)` + `border-left: 2px solid var(--home-accent)`. Caption below: `唯一同时勾上四列的产品。` / `The only one with all four checked.`
+
+Light theme: same table without the ASCII frame — plain rules between cells.
+
+### 5 · 7-Step Onboarding
+
+**Heading zh:** `7 步，把你的设备连上来` **en:** `7 steps to wire it all up`
+
+Horizontal timeline (numbered circles connected by a line). Auto-flips vertical on `<640px`.
+
+| # | zh title | One-line description |
+|---|---|---|
+| 1 | 注册 | 邮箱 / GitHub / SSO 任选 |
+| 2 | 链接模型账号 | 自带 ChatGPT/Anthropic 凭证，或选平台托管账号 |
+| 3 | 入网设备 | `brew install codex` → 粘贴注册码 |
+| 4 | 选一台"指挥机" | 通常是你的主力笔电 |
+| 5 | (可选) 开 Jupyter | 想手写代码？`ctx` 已预注入 kernel |
+| **6** | **绑定微信** | 扫码即可，从此聊天框 = 终端 |
+| 7 | 邀请协作者 | 角色：owner / maintainer / developer / guest |
+
+Step 6 is bolded (matches the hero's WeChat punchline). Footer link: `完整文档 →` / `Full docs →`.
+
+### 6 · Final CTA
+
+Full-width band, `border-top` + `border-bottom` in `--home-accent`. Single line in H2 size:
+
+- **zh:** `把你的设备，编进同一张算力网。`
+- **en:** `Weave your devices into one Computility.`
+
+Two buttons below: `▸ Sign in` (primary, goes to `/login`) + `Self-host on your own domain` (ghost, deep-links to README self-host section).
+
+### 7 · Footer
+
+Three columns + a bottom version strip:
+
+- **agentserver** — agentserver.dev · GitHub · Docs · Changelog
+- **社区 / Community** — WeChat 群 (hover: QR) · Telegram · Issues
+- **法律 / Legal** — Apache-2.0 · 隐私 · 联系
+
+Bottom rule: `v0.64.14 · <commit-short-hash> · built 2026-05-22`. Version + hash + date are Vite `define` injections; no runtime.
+
+## i18n
+
+Minimal, page-scoped:
+
+```ts
+// web/src/lib/i18n.ts
+export type Locale = 'zh' | 'en'
+
+const dicts: Record<Locale, Record<string, string>> = {
+  zh: { /* ... */ },
+  en: { /* ... */ },
+}
+
+export function detectLocale(): Locale {
+  const stored = localStorage.getItem('locale')
+  if (stored === 'zh' || stored === 'en') return stored
+  return navigator.language.toLowerCase().startsWith('zh') ? 'zh' : 'en'
+}
+
+export function setLocale(l: Locale) {
+  localStorage.setItem('locale', l)
+  location.reload()
+}
+
+export function useT() {
+  const locale = detectLocale()
+  return (key: string): string => dicts[locale][key] ?? key
+}
+```
+
+Dictionary content lives in `web/src/components/Home/strings.ts`, keys namespaced per section (`hero.h1`, `hero.subtitle`, `pillars.pocket.title`, …). Roughly 80 keys total.
+
+Language switch = write `localStorage.locale` + `location.reload()`. No React context, no `react-i18next`, no Suspense. If a second page later needs i18n, the same `t()` is already reusable from `lib/`.
+
+## Responsive
+
+| Breakpoint | Hero | Pillars | Compare table |
+|---|---|---|---|
+| ≥1024px | Two columns: stacked terminals on left, WeChat on right | 3 columns | Full table, horizontal |
+| 640–1023px | All three panes stack vertically | 2 + 1 or single column | Horizontal scroll |
+| <640px | All stacked + only the first 4 hero lines + one bot bubble | 1 column | Card list (one product per row) |
+
+On mobile the hero animation is shortened to ~5s and the loop policy is the same (one-shot).
+
+## Accessibility
+
+- Hero terminal: wrap each pane in `<div role="img" aria-label="agentserver 在三台设备间协同的演示" />` so screen readers do not narrate ASCII line by line.
+- Hero WeChat pane: `role="log" aria-live="polite"` — bubble appearances are announced as they arrive (or all at once if `prefers-reduced-motion`).
+- Compare: real `<table>` with `<caption>` (visually hidden), `<th scope>`.
+- Onboarding: real `<ol>`.
+- All CTAs are `<a href>` or `<button>`; focus ring uses `outline: 2px solid var(--ring); outline-offset: 2px`.
+- Reduced motion: skip animation, render final state, drop pulsing dot in nav.
+- Color contrast AA minimum on every text/background pair (`#7fff7f`/`#0a0a0a` = 14.8:1, body text already 4.5:1+ in existing tokens).
+
+## Performance
+
+- LCP element = hero H1 (plain text) — target < 1.5s.
+- First-paint JS bundle increment < 8 KB gzip (no new deps; tree-shake unused).
+- No third-party requests on this page: no analytics, no Google Fonts, no CDN icons.
+- Hero animation is CSS-only; no JS frame ticking.
+- Images: none above the fold. The pillars' micro-mockups are pure CSS / inline SVG.
+
+## Open questions (non-blocking)
+
+1. **README rename.** This spec assumes `Personal Compute Network → Personal Computility` and `个人计算网络 → 个人算力网` are also applied to the README and other surfaces. Out of scope here; flagged for a separate PR if not already in flight.
+2. **"this many devices connected right now" live counter.** Mentioned in section 1 as nice-to-have if a `/api/public/stats` endpoint exists. If it does not exist today, ship without it; do not block on adding a backend endpoint.
+3. **WeChat group QR in footer.** Image asset needs to be provided; if absent at implementation time, drop the hover tooltip and keep `WeChat 群` as plain text linking to a docs anchor.
+
+## Non-goals
+
+- No changes to backend, auth, OIDC, or workspace logic.
+- No redesign of `Login.tsx` itself beyond the back-link.
+- No redesign of post-login UI.
+- No new third-party dependencies.
+- No persisted analytics / telemetry on this page.

--- a/internal/codexappgateway/broker/conn.go
+++ b/internal/codexappgateway/broker/conn.go
@@ -23,6 +23,15 @@ type Conn struct {
 	writeMu sync.Mutex
 	nextID  atomic.Int64
 
+	// lastActiveAt is the unix-nano timestamp of the most recent successful
+	// ws read or write. The pool reaper reads this directly to decide
+	// staleness — frames flowing in either direction (turn items, heartbeats,
+	// approval round-trips) keep the conn alive even when no outer Get()
+	// call has touched it. Previously the pool inferred idleness from
+	// caller-side Get/Touch timestamps, which killed long-running turns
+	// because Turn() didn't refresh that signal mid-flight.
+	lastActiveAt atomic.Int64
+
 	mu              sync.Mutex
 	pendingResp     map[int64]chan rpcResponse   // request id → 1-buffered chan
 	pendingTurns    map[string]chan turnPayload  // turn id → 1-buffered chan
@@ -116,6 +125,7 @@ func (c *Conn) readLoop() {
 			c.closeErr.CompareAndSwap(nil, &errHolder{err})
 			return
 		}
+		c.lastActiveAt.Store(time.Now().UnixNano())
 		c.dispatchFrame(data)
 	}
 }
@@ -581,5 +591,9 @@ func (c *Conn) writeJSON(ctx context.Context, v any) error {
 	}
 	c.writeMu.Lock()
 	defer c.writeMu.Unlock()
-	return c.ws.Write(ctx, websocket.MessageText, b)
+	if err := c.ws.Write(ctx, websocket.MessageText, b); err != nil {
+		return err
+	}
+	c.lastActiveAt.Store(time.Now().UnixNano())
+	return nil
 }

--- a/internal/codexappgateway/broker/pool.go
+++ b/internal/codexappgateway/broker/pool.go
@@ -66,6 +66,13 @@ func (p *Pool) Get(ctx context.Context, workspaceID string) (*Conn, error) {
 	defer e.mu.Unlock()
 
 	if e.conn != nil && !e.connClosed() {
+		// Bump activity on Get so a conn that's been idle ≥ idleTTL but not
+		// yet swept by the reaper isn't reaped in the microsecond window
+		// between Get returning and the caller's first frame. The first
+		// frame would bump it anyway, but the window is enough for the
+		// reaper tick to land in between and surface the exact bug this
+		// file fixes.
+		e.conn.lastActiveAt.Store(time.Now().UnixNano())
 		return e.conn, nil
 	}
 	// (Re)dial.

--- a/internal/codexappgateway/broker/pool.go
+++ b/internal/codexappgateway/broker/pool.go
@@ -13,8 +13,14 @@ import (
 // reuse the codex subprocess; tests inject a fixed URL.
 type WSURLResolver func(ctx context.Context, workspaceID string) (wsURL string, err error)
 
-// Pool caches one *Conn per workspace id. Connections idle for longer
-// than idleTTL are reaped and closed. Safe for concurrent use.
+// Pool caches one *Conn per workspace id. Connections whose ws has been
+// silent (no frames in either direction) for longer than idleTTL are
+// reaped and closed. Safe for concurrent use.
+//
+// Idleness is measured from Conn.lastActiveAt, which the conn itself
+// updates on every successful ws read/write. This means a long-running
+// Turn that keeps streaming item/completed frames stays alive past
+// idleTTL — the reaper only kills conns that are actually silent.
 type Pool struct {
 	resolver WSURLResolver
 	idleTTL  time.Duration
@@ -26,9 +32,8 @@ type Pool struct {
 }
 
 type poolEntry struct {
-	mu         sync.Mutex // single-flight Dial per workspace
-	conn       *Conn
-	lastUsedAt time.Time
+	mu   sync.Mutex // single-flight Dial per workspace
+	conn *Conn
 }
 
 // NewPool starts a background reaper goroutine. Caller must Close().
@@ -61,7 +66,6 @@ func (p *Pool) Get(ctx context.Context, workspaceID string) (*Conn, error) {
 	defer e.mu.Unlock()
 
 	if e.conn != nil && !e.connClosed() {
-		e.lastUsedAt = time.Now()
 		return e.conn, nil
 	}
 	// (Re)dial.
@@ -74,7 +78,6 @@ func (p *Pool) Get(ctx context.Context, workspaceID string) (*Conn, error) {
 		return nil, fmt.Errorf("dial: %w", err)
 	}
 	e.conn = conn
-	e.lastUsedAt = time.Now()
 	return conn, nil
 }
 
@@ -89,23 +92,6 @@ func (e *poolEntry) connClosed() bool {
 		}
 	}
 	return false
-}
-
-// Touch bumps lastUsedAt for workspaceID, extending the idle-reap
-// deadline. Call after long-running operations (Turn, StartThread) so the
-// 5-minute reaper does not kill a connection that is still in use.
-func (p *Pool) Touch(workspaceID string) {
-	p.mu.Lock()
-	e, ok := p.entries[workspaceID]
-	p.mu.Unlock()
-	if !ok {
-		return
-	}
-	e.mu.Lock()
-	if e.conn != nil {
-		e.lastUsedAt = time.Now()
-	}
-	e.mu.Unlock()
 }
 
 // Close stops the reaper and closes all live connections.
@@ -145,7 +131,7 @@ func (p *Pool) reaper() {
 }
 
 func (p *Pool) reapOnce() {
-	cutoff := time.Now().Add(-p.idleTTL)
+	cutoffNanos := time.Now().Add(-p.idleTTL).UnixNano()
 	p.mu.Lock()
 	keys := make([]string, 0, len(p.entries))
 	for k := range p.entries {
@@ -160,7 +146,7 @@ func (p *Pool) reapOnce() {
 			continue
 		}
 		e.mu.Lock()
-		stale := e.conn != nil && e.lastUsedAt.Before(cutoff)
+		stale := e.conn != nil && e.conn.lastActiveAt.Load() < cutoffNanos
 		if stale {
 			e.conn.Close()
 			e.conn = nil

--- a/internal/codexappgateway/broker/pool_activity_test.go
+++ b/internal/codexappgateway/broker/pool_activity_test.go
@@ -1,0 +1,108 @@
+package broker
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"nhooyr.io/websocket"
+)
+
+// TestPoolDoesNotReapConnWithActiveTraffic exercises the reap-mid-turn bug:
+// a Turn that takes longer than idleTTL but receives item/completed frames
+// throughout must keep its conn alive. The reaper's idleness signal is
+// "no ws activity for idleTTL", not "no Get() call for idleTTL" — frames
+// flowing in either direction prove the conn is in use even if no outer
+// Get/Touch was made.
+func TestPoolDoesNotReapConnWithActiveTraffic(t *testing.T) {
+	const (
+		idleTTL    = 150 * time.Millisecond
+		turnLength = 450 * time.Millisecond // 3x idleTTL — guarantees reap if conn looks idle
+		itemEvery  = 30 * time.Millisecond
+	)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := websocket.Accept(w, r, &websocket.AcceptOptions{InsecureSkipVerify: true})
+		if err != nil {
+			return
+		}
+		defer c.Close(websocket.StatusNormalClosure, "")
+		ctx := r.Context()
+		// handshake
+		init := readFrame(t, ctx, c)
+		writeJSON(t, ctx, c, map[string]any{"jsonrpc": "2.0", "id": init["id"], "result": map[string]any{}})
+		readFrame(t, ctx, c) // initialized
+
+		for {
+			f, err := readNoFatal(ctx, c)
+			if err != nil {
+				return
+			}
+			switch f["method"] {
+			case "thread/resume":
+				writeJSON(t, ctx, c, map[string]any{"jsonrpc": "2.0", "id": f["id"], "result": map[string]any{}})
+			case "turn/start":
+				const turnID = "trn-long"
+				// Ack turn/start.
+				writeJSON(t, ctx, c, map[string]any{"jsonrpc": "2.0", "id": f["id"], "result": map[string]any{"turn": map[string]any{"id": turnID}}})
+				// Drip items across `turnLength`. Each frame counts as ws
+				// activity and must reset the reaper deadline.
+				deadline := time.Now().Add(turnLength)
+				tick := time.NewTicker(itemEvery)
+				for time.Now().Before(deadline) {
+					select {
+					case <-ctx.Done():
+						tick.Stop()
+						return
+					case <-tick.C:
+					}
+					writeJSON(t, ctx, c, map[string]any{
+						"jsonrpc": "2.0",
+						"method":  "item/completed",
+						"params": map[string]any{
+							"threadId": "thr-x",
+							"turnId":   turnID,
+							"item":     map[string]any{"type": "agentMessage", "text": "tick"},
+						},
+					})
+				}
+				tick.Stop()
+				// Finish.
+				writeJSON(t, ctx, c, map[string]any{
+					"jsonrpc": "2.0",
+					"method":  "turn/completed",
+					"params": map[string]any{
+						"threadId": "thr-x",
+						"turn": map[string]any{
+							"id":        turnID,
+							"status":    "completed",
+							"items":     []any{},
+							"itemsView": "full",
+							"error":     nil,
+						},
+					},
+				})
+			}
+		}
+	}))
+	defer srv.Close()
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+
+	resolver := func(_ context.Context, _ string) (string, error) { return wsURL, nil }
+	p := NewPool(resolver, idleTTL)
+	defer p.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	conn, err := p.Get(ctx, "ws-A")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if _, err := conn.Turn(ctx, "thr-x", json.RawMessage(`{"input":[]}`), 5*time.Second); err != nil {
+		t.Fatalf("Turn errored — reaper killed conn mid-flight: %v", err)
+	}
+}

--- a/internal/codexappgateway/broker/pool_get_bump_test.go
+++ b/internal/codexappgateway/broker/pool_get_bump_test.go
@@ -1,0 +1,46 @@
+package broker
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// TestPoolGetReuseRefreshesActivity guards the narrow race that would
+// otherwise re-introduce the wsDisconnect bug for callers who Get an
+// almost-stale conn just before a reaper tick. After Get returns a reused
+// conn, lastActiveAt must reflect "now" — otherwise the reaper running
+// microseconds later could close the conn before the caller's first frame.
+func TestPoolGetReuseRefreshesActivity(t *testing.T) {
+	urlFn, _, stop := countingCodexServer(t)
+	defer stop()
+
+	resolver := func(_ context.Context, _ string) (string, error) { return urlFn(""), nil }
+	// Big idleTTL so the background reaper can't interfere with the test.
+	p := NewPool(resolver, time.Hour)
+	defer p.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	conn, err := p.Get(ctx, "ws-A")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	// Simulate a conn that has been idle for an hour: directly backdate its
+	// activity timestamp. The next Get must refresh it.
+	conn.lastActiveAt.Store(time.Now().Add(-time.Hour).UnixNano())
+	threshold := time.Now().UnixNano()
+
+	got, err := p.Get(ctx, "ws-A")
+	if err != nil {
+		t.Fatalf("second Get: %v", err)
+	}
+	if got != conn {
+		t.Fatalf("Get returned different conn — pool didn't reuse")
+	}
+	if v := conn.lastActiveAt.Load(); v < threshold {
+		t.Errorf("Get reuse left stale lastActiveAt=%d (want >= %d)", v, threshold)
+	}
+}

--- a/internal/codexappgateway/turn_api.go
+++ b/internal/codexappgateway/turn_api.go
@@ -161,9 +161,6 @@ func (r *poolRunner) StartThread(ctx context.Context, workspaceID string) (strin
 	if err != nil {
 		return "", err
 	}
-	// Issue 3: bump lastUsedAt after the call so the reaper does not kill a
-	// connection that was active throughout a long StartThread round-trip.
-	defer r.pool.Touch(workspaceID)
 	return conn.StartThread(ctx)
 }
 
@@ -172,10 +169,6 @@ func (r *poolRunner) Turn(ctx context.Context, workspaceID, threadID string, par
 	if err != nil {
 		return nil, err
 	}
-	// Issue 3: bump lastUsedAt after Turn so a 4-minute Turn does not miss
-	// the 5-minute reap deadline (lastUsedAt was only set on Get, not on
-	// completion of the long-running operation).
-	defer r.pool.Touch(workspaceID)
 	return conn.Turn(ctx, threadID, params, timeout)
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -13,6 +13,7 @@ import {
   type Sandbox,
 } from './lib/api'
 import { Login } from './components/Login'
+import { Home } from './components/Home/Home'
 import { OAuthConsent } from './components/OAuthConsent'
 import { OAuthDevice } from './components/OAuthDevice'
 import { OAuthLogin, PENDING_LOGIN_CHALLENGE_KEY } from './components/OAuthLogin'
@@ -303,8 +304,6 @@ export default function App() {
   }
 
   if (!authed) {
-    // If landing on protected OAuth pages without auth, save params
-    // so they survive OIDC redirects.
     if (location.pathname === '/oauth2/consent') {
       const params = new URLSearchParams(location.search)
       const challenge = params.get('consent_challenge')
@@ -315,29 +314,28 @@ export default function App() {
     if (location.pathname === '/oauth2/device') {
       sessionStorage.setItem(PENDING_DEVICE_PARAMS_KEY, location.search)
     }
+
+    const onLoginSuccess = () => {
+      const params = new URLSearchParams(location.search)
+      const next = params.get('next')
+      if (next) {
+        window.location.href = next
+        return
+      }
+      setAuthed(true)
+      listWorkspaces().then((ws) => {
+        setWorkspaces(ws)
+        if (ws.length > 0) setSelectedWorkspaceId(ws[0].id)
+      }).catch(() => {})
+      getMe().then(setUser).catch(() => {})
+    }
+
     return (
-      <Login
-        onSuccess={() => {
-          // ?next= is set by codex-auth's PKCE / device-flow redirect
-          // when the user must log in to complete a codex login. After
-          // login succeeds, bounce back to the codex-auth URL so the
-          // PKCE handler can mint a code with the now-valid session.
-          // Use window.location.href (not setAuthed) because next is
-          // typically a different subdomain that SPA routing can't reach.
-          const params = new URLSearchParams(location.search)
-          const next = params.get('next')
-          if (next) {
-            window.location.href = next
-            return
-          }
-          setAuthed(true)
-          listWorkspaces().then((ws) => {
-            setWorkspaces(ws)
-            if (ws.length > 0) setSelectedWorkspaceId(ws[0].id)
-          }).catch(() => {})
-          getMe().then(setUser).catch(() => {})
-        }}
-      />
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/login" element={<Login onSuccess={onLoginSuccess} />} />
+        <Route path="*" element={<Navigate to="/" replace />} />
+      </Routes>
     )
   }
 

--- a/web/src/components/Home/Home.tsx
+++ b/web/src/components/Home/Home.tsx
@@ -1,7 +1,12 @@
+import { HomeNav } from './HomeNav'
+
 export function Home() {
   return (
-    <div data-theme="home" className="min-h-screen bg-[var(--background)] text-[var(--foreground)] p-8">
-      <p className="font-mono text-sm">▸ agentserver · home stub</p>
+    <div data-theme="home" className="min-h-screen bg-[var(--background)] text-[var(--foreground)]">
+      <HomeNav />
+      <main className="mx-auto max-w-6xl px-6 py-12">
+        <p className="font-mono text-sm text-[var(--muted-foreground)]">sections coming…</p>
+      </main>
     </div>
   )
 }

--- a/web/src/components/Home/Home.tsx
+++ b/web/src/components/Home/Home.tsx
@@ -1,0 +1,7 @@
+export function Home() {
+  return (
+    <div data-theme="home" className="min-h-screen bg-[var(--background)] text-[var(--foreground)] p-8">
+      <p className="font-mono text-sm">▸ agentserver · home stub</p>
+    </div>
+  )
+}

--- a/web/src/components/Home/HomeNav.tsx
+++ b/web/src/components/Home/HomeNav.tsx
@@ -1,0 +1,43 @@
+import { Link } from 'react-router-dom'
+import { detectLocale, setLocale, useT } from '../../lib/i18n'
+import { homeStrings } from './strings'
+
+export function HomeNav() {
+  const t = useT(homeStrings)
+  const locale = detectLocale()
+  const next = locale === 'zh' ? 'en' : 'zh'
+
+  return (
+    <nav className="sticky top-0 z-50 backdrop-blur-md bg-[var(--background)]/85 border-b border-[var(--border)]">
+      <div className="mx-auto max-w-6xl px-6 h-14 flex items-center justify-between">
+        <Link to="/" className="flex items-center gap-2 font-mono text-sm">
+          <span aria-hidden="true" className="inline-block h-2 w-2 rounded-full bg-[var(--home-accent)] animate-pulse motion-reduce:animate-none" />
+          <span>▸ {t('nav.brand')}</span>
+        </Link>
+
+        <div className="hidden md:flex items-center gap-6 font-mono text-xs text-[var(--muted-foreground)]">
+          <a href="#why" className="hover:text-[var(--foreground)]">{t('nav.why')}</a>
+          <a href="#how" className="hover:text-[var(--foreground)]">{t('nav.how')}</a>
+          <a href="#compare" className="hover:text-[var(--foreground)]">{t('nav.compare')}</a>
+        </div>
+
+        <div className="flex items-center gap-4">
+          <button
+            type="button"
+            onClick={() => setLocale(next)}
+            className="font-mono text-xs text-[var(--muted-foreground)] hover:text-[var(--foreground)]"
+            aria-label={`Switch language to ${next === 'zh' ? '中文' : 'English'}`}
+          >
+            {t('nav.lang.toggle')}
+          </button>
+          <Link
+            to="/login"
+            className="font-mono text-xs px-3 py-1.5 rounded-md bg-[var(--home-accent)] text-[var(--home-accent-fg)] hover:opacity-90"
+          >
+            {t('nav.signin')}
+          </Link>
+        </div>
+      </div>
+    </nav>
+  )
+}

--- a/web/src/components/Home/strings.ts
+++ b/web/src/components/Home/strings.ts
@@ -101,7 +101,7 @@ export const homeStrings: Dicts = {
     'hero.term.macbook': 'office-macbook · codex',
     'hero.term.sandbox': 'cloud-sandbox-7 · codex',
     'hero.chat.title': 'me',
-    'hero.chat.user': "Plot last week's experiment data and send it to me",
+    'hero.chat.user': 'Plot last week’s experiment data and send it to me',
     'hero.chat.bot1': '📂 pulled experiment_0521.csv from office-macbook',
     'hero.chat.bot2': '🔨 analyzing + plotting in sandbox…',
     'hero.chat.bot3': '✓ done',

--- a/web/src/components/Home/strings.ts
+++ b/web/src/components/Home/strings.ts
@@ -1,0 +1,168 @@
+import type { Dicts } from '../../lib/i18n'
+
+export const homeStrings: Dicts = {
+  zh: {
+    // nav
+    'nav.brand': 'agentserver',
+    'nav.why': '卖点',
+    'nav.how': '上手',
+    'nav.compare': '对比',
+    'nav.signin': '登录 →',
+    'nav.lang.toggle': 'EN',
+    'nav.online': '在线',
+
+    // hero
+    'hero.h1': '你的个人算力网。',
+    'hero.sub': 'agentserver 把笔记本、云沙箱、家里的服务器编成一个工作区——从浏览器、命令行，或微信，一并指挥。',
+    'hero.cta.primary': '▸ 登录',
+    'hero.cta.secondary': '在 GitHub 上查看',
+    'hero.term.macbook': 'office-macbook · codex',
+    'hero.term.sandbox': 'cloud-sandbox-7 · codex',
+    'hero.chat.title': '我自己',
+    'hero.chat.user': '把上周的实验数据画成图给我',
+    'hero.chat.bot1': '📂 已从 office-macbook 取到 experiment_0521.csv',
+    'hero.chat.bot2': '🔨 在沙箱里分析 + 画图中…',
+    'hero.chat.bot3': '✓ 完成',
+    'hero.chip.online': '在线',
+
+    // quote
+    'quote.body': '"Once you juggle 10+ agents across machines, you stop being a conductor and become an orchestrator."',
+    'quote.attrib': '— Addy Osmani · Director, Google Gemini & Cloud AI',
+    'quote.caption': 'agentserver = 那个 orchestrator。',
+
+    // pillars
+    'pillars.heading': '为什么用 agentserver',
+    'pillars.pocket.title': '装在口袋里的指挥台',
+    'pillars.pocket.body': '微信里一句中文，落到任意设备执行，结果推回同一个聊天框。Telegram 同样支持。',
+    'pillars.workspace.title': '一个工作区，所有设备',
+    'pillars.workspace.body': '云沙箱、本地机器、IM-bound 代理——全在同一份注册表里，并排出现在 Web UI 上。',
+    'pillars.tunnel.title': '无公网 IP，照常入网',
+    'pillars.tunnel.body': '本地的 codex / Claude Code / opencode 通过 WebSocket 拨号入网，呈现为一个沙箱。',
+    'pillars.also': '+ 暂停 / 恢复沙箱 · Jupyter 笔记本 · 多人协作 · 凭证代理 · SSO（GitHub / OIDC）· 自托管',
+
+    // compare
+    'compare.heading': '和已有的工具相比',
+    'compare.col.tool': '产品',
+    'compare.col.local': '本地代理',
+    'compare.col.cloud': '云沙箱',
+    'compare.col.peer': '跨设备组网',
+    'compare.col.chat': 'IM 通道',
+    'compare.caption': '唯一同时勾上四列的产品。',
+
+    // onboarding
+    'onb.heading': '7 步，把你的设备连上来',
+    'onb.s1.title': '注册',
+    'onb.s1.body': '邮箱 / GitHub / SSO 任选',
+    'onb.s2.title': '链接模型账号',
+    'onb.s2.body': '自带 ChatGPT / Anthropic 凭证，或选平台托管账号',
+    'onb.s3.title': '入网设备',
+    'onb.s3.body': 'brew install codex → 粘贴注册码',
+    'onb.s4.title': '选一台"指挥机"',
+    'onb.s4.body': '通常是你的主力笔电',
+    'onb.s5.title': '(可选) 开 Jupyter',
+    'onb.s5.body': '想手写代码？ctx 已预注入 kernel',
+    'onb.s6.title': '绑定微信',
+    'onb.s6.body': '扫码即可，从此聊天框 = 终端',
+    'onb.s7.title': '邀请协作者',
+    'onb.s7.body': '角色：owner / maintainer / developer / guest',
+    'onb.docs': '完整文档 →',
+
+    // final cta
+    'cta.heading': '把你的设备，编进同一张算力网。',
+    'cta.primary': '▸ 登录',
+    'cta.secondary': '在自己的域名上自托管',
+
+    // footer
+    'footer.col1.title': 'agentserver',
+    'footer.col2.title': '社区',
+    'footer.col2.weixin': '微信群',
+    'footer.col2.telegram': 'Telegram',
+    'footer.col2.issues': 'Issue 跟踪',
+    'footer.col3.title': '法律',
+    'footer.col3.license': 'Apache-2.0',
+    'footer.col3.privacy': '隐私',
+    'footer.col3.contact': '联系',
+  },
+  en: {
+    // nav
+    'nav.brand': 'agentserver',
+    'nav.why': 'Why',
+    'nav.how': 'How',
+    'nav.compare': 'Compare',
+    'nav.signin': 'Sign in →',
+    'nav.lang.toggle': '中',
+    'nav.online': 'online',
+
+    // hero
+    'hero.h1': 'Your Personal Computility.',
+    'hero.sub': 'agentserver weaves laptops, cloud sandboxes, and home servers into one workspace — commanded from your browser, your CLI, or your WeChat chat.',
+    'hero.cta.primary': '▸ Sign in',
+    'hero.cta.secondary': 'View on GitHub',
+    'hero.term.macbook': 'office-macbook · codex',
+    'hero.term.sandbox': 'cloud-sandbox-7 · codex',
+    'hero.chat.title': 'me',
+    'hero.chat.user': "Plot last week's experiment data and send it to me",
+    'hero.chat.bot1': '📂 pulled experiment_0521.csv from office-macbook',
+    'hero.chat.bot2': '🔨 analyzing + plotting in sandbox…',
+    'hero.chat.bot3': '✓ done',
+    'hero.chip.online': 'online',
+
+    // quote
+    'quote.body': '"Once you juggle 10+ agents across machines, you stop being a conductor and become an orchestrator."',
+    'quote.attrib': '— Addy Osmani · Director, Google Gemini & Cloud AI',
+    'quote.caption': 'agentserver is that orchestrator.',
+
+    // pillars
+    'pillars.heading': 'Why agentserver',
+    'pillars.pocket.title': 'Pocket-sized command line',
+    'pillars.pocket.body': 'One sentence in WeChat lands on the right device. The result comes back to the same chat. Telegram supported too.',
+    'pillars.workspace.title': 'One workspace, every device',
+    'pillars.workspace.body': 'Cloud sandboxes, local machines, IM-bound agents — all in one registry, side by side in the Web UI.',
+    'pillars.tunnel.title': 'No public IP. Still in the network.',
+    'pillars.tunnel.body': 'Your local codex / Claude Code / opencode dials home over WebSocket and shows up as a sandbox.',
+    'pillars.also': '+ Pausable sandboxes · Jupyter notebook · Multi-user · Credential proxy · SSO (GitHub / OIDC) · Self-host',
+
+    // compare
+    'compare.heading': 'How it differs',
+    'compare.col.tool': 'Tool',
+    'compare.col.local': 'local',
+    'compare.col.cloud': 'cloud',
+    'compare.col.peer': 'peer',
+    'compare.col.chat': 'chat',
+    'compare.caption': 'The only one with all four checked.',
+
+    // onboarding
+    'onb.heading': '7 steps to wire it all up',
+    'onb.s1.title': 'Register',
+    'onb.s1.body': 'Email / GitHub / SSO — your pick',
+    'onb.s2.title': 'Link a model account',
+    'onb.s2.body': 'Bring your own ChatGPT / Anthropic credential, or use a managed one',
+    'onb.s3.title': 'Enroll devices',
+    'onb.s3.body': 'brew install codex → paste the registration code',
+    'onb.s4.title': 'Pick a "command machine"',
+    'onb.s4.body': 'Usually your daily-driver laptop',
+    'onb.s5.title': '(Optional) open Jupyter',
+    'onb.s5.body': 'Prefer hand-written code? ctx is pre-injected in every kernel',
+    'onb.s6.title': 'Bind WeChat',
+    'onb.s6.body': 'Scan the QR. From now on, the chat window is your terminal',
+    'onb.s7.title': 'Invite collaborators',
+    'onb.s7.body': 'Roles: owner / maintainer / developer / guest',
+    'onb.docs': 'Full docs →',
+
+    // final cta
+    'cta.heading': 'Weave your devices into one Computility.',
+    'cta.primary': '▸ Sign in',
+    'cta.secondary': 'Self-host on your own domain',
+
+    // footer
+    'footer.col1.title': 'agentserver',
+    'footer.col2.title': 'Community',
+    'footer.col2.weixin': 'WeChat group',
+    'footer.col2.telegram': 'Telegram',
+    'footer.col2.issues': 'Issue tracker',
+    'footer.col3.title': 'Legal',
+    'footer.col3.license': 'Apache-2.0',
+    'footer.col3.privacy': 'Privacy',
+    'footer.col3.contact': 'Contact',
+  },
+}

--- a/web/src/components/Login.tsx
+++ b/web/src/components/Login.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, type FormEvent } from 'react'
+import { Link } from 'react-router-dom'
 import { login, register, getOIDCProviders } from '../lib/api'
 
 interface LoginProps {
@@ -65,7 +66,9 @@ export function Login({ onSuccess }: LoginProps) {
     <div className="flex min-h-screen flex-col items-center justify-center">
       <div className="w-full max-w-sm rounded-lg border border-[var(--border)] bg-[var(--card)] p-6 shadow-lg">
         <h1 className="mb-6 text-center text-xl font-semibold text-[var(--card-foreground)]">
-          agentserver
+          <Link to="/" className="hover:text-[var(--muted-foreground)] transition-colors">
+            ← agentserver
+          </Link>
         </h1>
         {!providersLoaded && (
           <div className="flex justify-center py-4">

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -37,6 +37,29 @@
   --radius: 0.5rem;
 }
 
+[data-theme="home"] {
+  --home-accent: #18181b;
+  --home-accent-fg: #fafafa;
+  --home-grid: rgba(0, 0, 0, 0.06);
+  --home-term-bg: #f4f4f5;
+  --home-term-border: #d4d4d8;
+  --home-term-fg: #18181b;
+  --home-term-dim: #71717a;
+}
+
+.dark[data-theme="home"],
+[data-theme="home"].dark,
+[data-theme="home"] .dark,
+.dark [data-theme="home"] {
+  --home-accent: #7fff7f;
+  --home-accent-fg: #000000;
+  --home-grid: rgba(127, 255, 127, 0.04);
+  --home-term-bg: #000000;
+  --home-term-border: #2a2a2a;
+  --home-term-fg: #e6e6e6;
+  --home-term-dim: #888888;
+}
+
 * {
   border-color: var(--border);
 }

--- a/web/src/lib/i18n.ts
+++ b/web/src/lib/i18n.ts
@@ -1,0 +1,33 @@
+import { useMemo } from 'react'
+
+export type Locale = 'zh' | 'en'
+
+const STORAGE_KEY = 'locale'
+
+export type Dict = Record<string, string>
+export type Dicts = Record<Locale, Dict>
+
+export function detectLocale(): Locale {
+  if (typeof window === 'undefined') return 'en'
+  const stored = window.localStorage.getItem(STORAGE_KEY)
+  if (stored === 'zh' || stored === 'en') return stored
+  const nav = window.navigator.language || ''
+  return nav.toLowerCase().startsWith('zh') ? 'zh' : 'en'
+}
+
+export function setLocale(l: Locale): void {
+  window.localStorage.setItem(STORAGE_KEY, l)
+  window.location.reload()
+}
+
+// Returns a stable `t(key)` function for the active locale.
+// Falls back to the en value if the key is missing in the active locale,
+// then to the key itself.
+export function useT(dicts: Dicts) {
+  const locale = detectLocale()
+  return useMemo(() => {
+    const primary = dicts[locale]
+    const fallback = dicts.en
+    return (key: string): string => primary[key] ?? fallback[key] ?? key
+  }, [locale, dicts])
+}

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="vite/client" />
+
+declare const __APP_VERSION__: string
+declare const __BUILD_COMMIT__: string
+declare const __BUILD_DATE__: string

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,9 +1,29 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+
+function safeGit(args: string[], fallback: string): string {
+  try {
+    return execFileSync('git', args, { stdio: ['ignore', 'pipe', 'ignore'] }).toString().trim() || fallback
+  } catch {
+    return fallback
+  }
+}
+
+const pkg = JSON.parse(readFileSync(new URL('./package.json', import.meta.url), 'utf-8'))
+const appVersion: string = pkg.version || '0.0.0'
+const buildCommit: string = safeGit(['rev-parse', '--short', 'HEAD'], 'dev')
+const buildDate: string = new Date().toISOString().slice(0, 10)
 
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  define: {
+    __APP_VERSION__: JSON.stringify(appVersion),
+    __BUILD_COMMIT__: JSON.stringify(buildCommit),
+    __BUILD_DATE__: JSON.stringify(buildDate),
+  },
   server: {
     proxy: {
       '/api': 'http://localhost:8080',


### PR DESCRIPTION
## Summary

- Move the broker pool's idleness signal onto the ws conn itself (`Conn.lastActiveAt`), updated on every successful read/write.
- Reaper now decides staleness by reading `conn.lastActiveAt` — any in-flight traffic (turn items, heartbeats, approvals) keeps the conn alive past `idleTTL` automatically.
- `Pool.Get` reuse refreshes `lastActiveAt` so a caller that takes an almost-stale conn isn't racing the next reaper tick.
- Removes the now-dead `Pool.Touch` / `lastUsedAt` and the two `defer r.pool.Touch(workspaceID)` calls in `turn_api.go`. (The unrelated `s.sup.Touch` in `server.go` is a different Touch on the supervisor type and is intentionally untouched.)

## Why

22:05 prod incident: a WeChat user got `⚠️ Codex 处理失败，请稍后重试` mid-conversation. Loki shows the turn ran ~6 min while codex was actively producing items (`broker.Turn: still waiting` heartbeats with items climbing 47→60). At ~6 min agentserver logged:

```
codex_im: transport=wsDisconnect msg=failed to get reader: context canceled
```

Root cause: `idleTTL = 5min`, but `lastUsedAt` was only set on `Pool.Get()` (turn start) and on a `defer Pool.Touch` after Turn returns. A Turn longer than 5 min has stale `lastUsedAt` from the Get; the reaper closes the conn, the readLoop's `ctx` (parented to a `c.closed` watcher) gets cancelled, nhooyr's `Read` returns `"failed to get reader: context canceled"`, pending Turn surfaces wsDisconnect → user-facing "处理失败".

The author's existing comment in `turn_api.go` even acknowledged the bound: *"so a 4-minute Turn does not miss the 5-minute reap deadline"* — the 5–6 min window had no protection.

Fixing this at the caller (Touch during long ops) is the wrong layer — it pushes the conn's real activity state onto every call site. Track it on the conn instead.

## Test plan

- [x] `TestPoolDoesNotReapConnWithActiveTraffic`: a 3×idleTTL turn that drips items every 30ms must complete. Without the fix it fails with the exact production error string; with it, passes. Red→Green→Revert→Red→Restore→Green cycle verified.
- [x] `TestPoolGetReuseRefreshesActivity`: guards the narrow Get-then-reap race introduced by removing caller-side `lastUsedAt`. Same red-green cycle verified.
- [x] `go test ./...` — all packages pass.
- [x] `go test -race ./internal/codexappgateway/...` — clean (atomic.Int64 hot-path safety).
- [x] `go vet ./...` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
