### PR TITLE
chore(cxg): install bubblewrap in codex-app-gateway image

### DIFF
--- a/Dockerfile.codex-app-gateway
+++ b/Dockerfile.codex-app-gateway
@@ -29,8 +29,14 @@ RUN set -eux; \
     rm -rf /tmp/codex.tgz /tmp/codex-${arch_tag}
 
 FROM debian:trixie-slim
+# bubblewrap (bwrap) is codex's default Linux sandbox helper. The exec
+# path today goes through env-mcp into the workspace pod, so the codex
+# subprocess in this container doesn't call bwrap in the steady state.
+# Install it anyway so (a) codex's startup sandbox probe finds it
+# instead of warning, and (b) any fallback that ends up using codex's
+# built-in local-shell tool can actually sandbox the command.
 RUN apt-get update \
- && apt-get install -y --no-install-recommends ca-certificates \
+ && apt-get install -y --no-install-recommends ca-certificates bubblewrap \
  && rm -rf /var/lib/apt/lists/*
 COPY --from=codex /usr/local/bin/codex /usr/local/bin/codex
 COPY --from=build /out/codex-app-gateway /usr/local/bin/codex-app-gateway

--- a/web/src/components/Home/Home.tsx
+++ b/web/src/components/Home/Home.tsx
@@ -1,4 +1,5 @@
 import { HomeCompare } from './HomeCompare'
+import { HomeFinalCTA } from './HomeFinalCTA'
 import { HomeHero } from './HomeHero'
 import { HomeNav } from './HomeNav'
 import { HomeHero } from './HomeHero'

--- a/web/src/components/Home/Home.tsx
+++ b/web/src/components/Home/Home.tsx
@@ -1,6 +1,3 @@
-import { HomeCompare } from './HomeCompare'
-import { HomeFinalCTA } from './HomeFinalCTA'
-import { HomeHero } from './HomeHero'
 import { HomeNav } from './HomeNav'
 import { HomeHero } from './HomeHero'
 import { HomeQuote } from './HomeQuote'

--- a/web/src/components/Home/Home.tsx
+++ b/web/src/components/Home/Home.tsx
@@ -1,3 +1,4 @@
+import { HomeHero } from './HomeHero'
 import { HomeNav } from './HomeNav'
 import { HomeHero } from './HomeHero'
 import { HomeQuote } from './HomeQuote'

--- a/web/src/components/Home/Home.tsx
+++ b/web/src/components/Home/Home.tsx
@@ -1,3 +1,4 @@
+import { HomeCompare } from './HomeCompare'
 import { HomeHero } from './HomeHero'
 import { HomeNav } from './HomeNav'
 import { HomeHero } from './HomeHero'


### PR DESCRIPTION
## Summary

Add `bubblewrap` to the runtime stage of `Dockerfile.codex-app-gateway`.

## Why

`codex sandbox linux` defaults to bubblewrap (landlock is the alias). The codex subprocess spawned by CXG (`codex app-server`) doesn't currently invoke bwrap in steady state — all exec calls route through env-mcp into the workspace pod, never touching codex's built-in local-shell tool. But:

1. Codex's startup sandbox probe expects the binary present; missing it shows up as a noisy warning at every spawn.
2. If anything ever falls back to codex's local-shell tool (future change, or a code path I haven't found), the sandboxed exec will fail closed without bwrap installed.

~50 KB on disk, zero behavior change to the current routing.

Confirmed locally: `codex sandbox --help` shows `linux  Run a command under the Linux sandbox (bubblewrap by default) [aliases: landlock]`.

## Test plan

- [x] Diff reviewed; package name is the Debian package providing the `bwrap` binary, present in trixie.
- [ ] Image builds via CI.
- [ ] After deploy: `kubectl exec` into a new CXG pod and `which bwrap` returns `/usr/bin/bwrap`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
