### PR TITLE
fix(web): center homepage footer + drop dead nav.online key

### DIFF
--- a/web/src/components/Home/HomeFooter.tsx
+++ b/web/src/components/Home/HomeFooter.tsx
@@ -5,36 +5,38 @@ export function HomeFooter() {
   const t = useT(homeStrings)
   return (
     <footer className="border-t border-[var(--border)] py-10 mt-10">
-      <div className="grid md:grid-cols-3 gap-8 text-sm">
-        <div>
-          <p className="font-mono font-semibold mb-3">{t('footer.col1.title')}</p>
-          <ul className="space-y-1 text-[var(--muted-foreground)]">
-            <li><a className="hover:text-[var(--foreground)]" href="https://agentserver.dev" target="_blank" rel="noopener noreferrer">agentserver.dev</a></li>
-            <li><a className="hover:text-[var(--foreground)]" href="https://github.com/agentserver/agentserver" target="_blank" rel="noopener noreferrer">GitHub</a></li>
-            <li><a className="hover:text-[var(--foreground)]" href="https://github.com/agentserver/agentserver#readme" target="_blank" rel="noopener noreferrer">Docs</a></li>
-            <li><a className="hover:text-[var(--foreground)]" href="https://github.com/agentserver/agentserver/releases" target="_blank" rel="noopener noreferrer">Changelog</a></li>
-          </ul>
+      <div className="mx-auto max-w-6xl px-6">
+        <div className="grid md:grid-cols-3 gap-8 text-sm">
+          <div>
+            <p className="font-mono font-semibold mb-3">{t('footer.col1.title')}</p>
+            <ul className="space-y-1 text-[var(--muted-foreground)]">
+              <li><a className="hover:text-[var(--foreground)]" href="https://agentserver.dev" target="_blank" rel="noopener noreferrer">agentserver.dev</a></li>
+              <li><a className="hover:text-[var(--foreground)]" href="https://github.com/agentserver/agentserver" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+              <li><a className="hover:text-[var(--foreground)]" href="https://github.com/agentserver/agentserver#readme" target="_blank" rel="noopener noreferrer">Docs</a></li>
+              <li><a className="hover:text-[var(--foreground)]" href="https://github.com/agentserver/agentserver/releases" target="_blank" rel="noopener noreferrer">Changelog</a></li>
+            </ul>
+          </div>
+          <div>
+            <p className="font-mono font-semibold mb-3">{t('footer.col2.title')}</p>
+            <ul className="space-y-1 text-[var(--muted-foreground)]">
+              <li><span>{t('footer.col2.weixin')}</span></li>
+              <li><span>{t('footer.col2.telegram')}</span></li>
+              <li><a className="hover:text-[var(--foreground)]" href="https://github.com/agentserver/agentserver/issues" target="_blank" rel="noopener noreferrer">{t('footer.col2.issues')}</a></li>
+            </ul>
+          </div>
+          <div>
+            <p className="font-mono font-semibold mb-3">{t('footer.col3.title')}</p>
+            <ul className="space-y-1 text-[var(--muted-foreground)]">
+              <li><a className="hover:text-[var(--foreground)]" href="https://github.com/agentserver/agentserver/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">{t('footer.col3.license')}</a></li>
+              <li><span>{t('footer.col3.privacy')}</span></li>
+              <li><span>{t('footer.col3.contact')}</span></li>
+            </ul>
+          </div>
         </div>
-        <div>
-          <p className="font-mono font-semibold mb-3">{t('footer.col2.title')}</p>
-          <ul className="space-y-1 text-[var(--muted-foreground)]">
-            <li><span>{t('footer.col2.weixin')}</span></li>
-            <li><span>{t('footer.col2.telegram')}</span></li>
-            <li><a className="hover:text-[var(--foreground)]" href="https://github.com/agentserver/agentserver/issues" target="_blank" rel="noopener noreferrer">{t('footer.col2.issues')}</a></li>
-          </ul>
-        </div>
-        <div>
-          <p className="font-mono font-semibold mb-3">{t('footer.col3.title')}</p>
-          <ul className="space-y-1 text-[var(--muted-foreground)]">
-            <li><a className="hover:text-[var(--foreground)]" href="https://github.com/agentserver/agentserver/blob/main/LICENSE" target="_blank" rel="noopener noreferrer">{t('footer.col3.license')}</a></li>
-            <li><span>{t('footer.col3.privacy')}</span></li>
-            <li><span>{t('footer.col3.contact')}</span></li>
-          </ul>
-        </div>
+        <p className="mt-8 text-center font-mono text-[10px] text-[var(--muted-foreground)]">
+          v{__APP_VERSION__} · {__BUILD_COMMIT__} · built {__BUILD_DATE__}
+        </p>
       </div>
-      <p className="mt-8 text-center font-mono text-[10px] text-[var(--muted-foreground)]">
-        v{__APP_VERSION__} · {__BUILD_COMMIT__} · built {__BUILD_DATE__}
-      </p>
     </footer>
   )
 }

--- a/web/src/components/Home/strings.ts
+++ b/web/src/components/Home/strings.ts
@@ -9,7 +9,6 @@ export const homeStrings: Dicts = {
     'nav.compare': '对比',
     'nav.signin': '登录 →',
     'nav.lang.toggle': 'EN',
-    'nav.online': '在线',
 
     // hero
     'hero.h1': '你的个人算力网。',
@@ -91,7 +90,6 @@ export const homeStrings: Dicts = {
     'nav.compare': 'Compare',
     'nav.signin': 'Sign in →',
     'nav.lang.toggle': '中',
-    'nav.online': 'online',
 
     // hero
     'hero.h1': 'Your Personal Computility.',


### PR DESCRIPTION
## Summary

Two small fixes for the unauthenticated homepage that shipped via #183:

- **`HomeFooter`** was missing `mx-auto max-w-6xl px-6` on its inner wrapper, so the 3-column grid and build stamp bled edge-to-edge on wide viewports while `HomeNav` and `main` were centered at 1152px.
- **`strings.ts`** `nav.online` key was defined in both locales but never consumed via `t()`. Dropped to prevent silent drift.

## Test plan

- [ ] On a ≥1440px viewport, footer columns are centered at the same max-width as the rest of the page (not full-bleed)
- [ ] `pnpm tsc -b && pnpm build` still green
- [ ] No new lint errors (baseline unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)