### PR TITLE
chore(chart): bump 0.64.15 → 0.64.16 to ship #184 + #183 + #185 + #186

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.15
-appVersion: "0.64.15"
+version: 0.64.16
+appVersion: "0.64.16"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
Bumps chart and appVersion 0.64.15 → 0.64.16 to ship:

- #184 fix(broker): reap conns by ws activity, not caller-side Get/Touch
- #183 fix(web): token mint dialog UX (full command + date picker)
- #185 chore(cxg): install bubblewrap in codex-app-gateway image
- #186 fix(web): center HomeFooter content + remove dead nav.online key