### PR TITLE
fix: logout actually logs out + tighten Hero animation timing

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -91,6 +91,12 @@ func (a *Auth) ValidateToken(token string) (string, bool) {
 	return userID, true
 }
 
+// InvalidateToken removes the token row so the same cookie value cannot
+// re-authenticate even if the browser fails to clear the cookie.
+func (a *Auth) InvalidateToken(token string) error {
+	return a.db.DeleteToken(token)
+}
+
 // Middleware authenticates web requests via session cookie. The TUI / agent
 // CLI does NOT use this — it goes through BearerMiddleware on /api/agents/*.
 func (a *Auth) Middleware(next http.Handler) http.Handler {

--- a/internal/db/tokens.go
+++ b/internal/db/tokens.go
@@ -32,6 +32,14 @@ func (db *DB) ValidateToken(token string) (string, error) {
 	return userID, nil
 }
 
+func (db *DB) DeleteToken(token string) error {
+	_, err := db.Exec("DELETE FROM auth_tokens WHERE token = $1", token)
+	if err != nil {
+		return fmt.Errorf("delete token: %w", err)
+	}
+	return nil
+}
+
 func (db *DB) DeleteExpiredTokens() error {
 	_, err := db.Exec("DELETE FROM auth_tokens WHERE expires_at < NOW()")
 	if err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -734,6 +734,15 @@ func (s *Server) handleAuthCheck(w http.ResponseWriter, r *http.Request) {
 //	@Success  200  {object}  AuthStatusResponse
 //	@Router   /api/auth/logout [post]
 func (s *Server) handleLogout(w http.ResponseWriter, r *http.Request) {
+	// Invalidate the token in the database first, so even if the browser
+	// fails to clear the cookie (Domain attribute drift across deploys,
+	// extension interference, etc.) the same cookie value will no longer
+	// authenticate on the next request.
+	if c, err := r.Cookie("agentserver-token"); err == nil && c.Value != "" {
+		if err := s.Auth.InvalidateToken(c.Value); err != nil {
+			log.Printf("logout: invalidate token: %v", err)
+		}
+	}
 	// Cookie Domain must match the issuance side (auth.SetTokenCookie)
 	// or the browser won't actually clear the cross-subdomain cookie.
 	http.SetCookie(w, &http.Cookie{

--- a/web/src/components/Home/HomeHero.tsx
+++ b/web/src/components/Home/HomeHero.tsx
@@ -1,37 +1,29 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useT } from '../../lib/i18n'
 import { homeStrings } from './strings'
 
 export function HomeHero() {
   const t = useT(homeStrings)
-  const ref = useRef<HTMLDivElement | null>(null)
-  const [started, setStarted] = useState(false)
+  // Hero is always above the fold on page load, so no IntersectionObserver —
+  // just kick off the animation after mount. Reduced-motion users get the
+  // final state immediately on the very first render via the lazy initializer
+  // below (no flash of empty content).
+  const [started, setStarted] = useState(() => {
+    if (typeof window === 'undefined') return true
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  })
 
   useEffect(() => {
     if (started) return
-    const reduce = window.matchMedia('(prefers-reduced-motion: reduce)').matches
-    if (reduce) {
-      setStarted(true) // eslint-disable-line react-hooks/set-state-in-effect
-      return
-    }
-    const node = ref.current
-    if (!node) return
-    const obs = new IntersectionObserver((entries) => {
-      for (const e of entries) {
-        if (e.isIntersecting) {
-          setStarted(true)
-          obs.disconnect()
-          break
-        }
-      }
-    }, { threshold: 0.25 })
-    obs.observe(node)
-    return () => obs.disconnect()
+    // Defer one frame so the initial opacity:0 paint registers before we
+    // flip data-started, otherwise some browsers skip the animation.
+    const raf = requestAnimationFrame(() => setStarted(true))
+    return () => cancelAnimationFrame(raf)
   }, [started])
 
   return (
-    <section ref={ref} className="pt-12 pb-20" data-started={started ? 'true' : 'false'}>
+    <section className="pt-12 pb-20" data-started={started ? 'true' : 'false'}>
       <div className="grid lg:grid-cols-[1.1fr_0.9fr] gap-10 items-start">
         {/* Left: heading + CTAs */}
         <div>
@@ -73,19 +65,19 @@ export function HomeHero() {
             <Term
               title={t('hero.term.macbook')}
               lines={[
-                { delay: 400,  text: '$ codex relay "把 experiment_0521.csv', kind: 'cmd' },
-                { delay: 700,  text: '   在沙箱里画成图发我"',                kind: 'cmd' },
-                { delay: 1100, text: '▸ found experiment_0521.csv (124MB)',  kind: 'dim' },
-                { delay: 1500, text: '▸ relaying to cloud-sandbox-7…',       kind: 'dim' },
+                { delay: 200,  text: '$ codex relay "把 experiment_0521.csv', kind: 'cmd' },
+                { delay: 400,  text: '   在沙箱里画成图发我"',                kind: 'cmd' },
+                { delay: 600,  text: '▸ found experiment_0521.csv (124MB)',  kind: 'dim' },
+                { delay: 800,  text: '▸ relaying to cloud-sandbox-7…',       kind: 'dim' },
               ]}
             />
             <Term
               title={t('hero.term.sandbox')}
               lines={[
-                { delay: 3000, text: '▸ pandas: 5 conditions × 12 trials',  kind: 'dim' },
-                { delay: 3400, text: '▸ matplotlib: boxplot + error bars',  kind: 'dim' },
-                { delay: 4400, text: '✓ saved plot.png (412KB)',            kind: 'ok'  },
-                { delay: 4900, text: '▸ uploading via imbridge…',           kind: 'dim' },
+                { delay: 1200, text: '▸ pandas: 5 conditions × 12 trials',  kind: 'dim' },
+                { delay: 1400, text: '▸ matplotlib: boxplot + error bars',  kind: 'dim' },
+                { delay: 1800, text: '✓ saved plot.png (412KB)',            kind: 'ok'  },
+                { delay: 2000, text: '▸ uploading via imbridge…',           kind: 'dim' },
               ]}
             />
           </div>
@@ -158,10 +150,10 @@ function Term({ title, lines }: { title: string; lines: TermLine[] }) {
 function ChatPane({ t }: { t: (k: string) => string }) {
   type Bubble = { delay: number; who: 'me' | 'bot'; text: string; thumb?: boolean }
   const bubbles: Bubble[] = [
-    { delay: 5500, who: 'me',  text: t('hero.chat.user') },
-    { delay: 6000, who: 'bot', text: t('hero.chat.bot1') },
-    { delay: 7000, who: 'bot', text: t('hero.chat.bot2') },
-    { delay: 8500, who: 'bot', text: t('hero.chat.bot3'), thumb: true },
+    { delay: 600,  who: 'me',  text: t('hero.chat.user') },
+    { delay: 1000, who: 'bot', text: t('hero.chat.bot1') },
+    { delay: 2200, who: 'bot', text: t('hero.chat.bot2') },
+    { delay: 3200, who: 'bot', text: t('hero.chat.bot3'), thumb: true },
   ]
   return (
     <div className="rounded-md border border-[var(--home-term-border)] bg-[#ededed] dark:bg-[#1a1a1a] overflow-hidden">


### PR DESCRIPTION
## Summary

Two reported bugs after #186 went live:

**1. \"Log out, refresh, and I'm logged back in.\"**

`handleLogout` was only sending `Set-Cookie` with `MaxAge=-1`. The corresponding `auth_tokens` row stayed valid until its full TTL, so any case where the browser failed to actually drop the cookie (Domain attribute drift across deploys, extension interference, subdomain quirks) let the stale cookie sail right back through `Auth.Middleware` on the next request.

Fix: read the cookie value before clearing it, `DELETE FROM auth_tokens WHERE token = $1`, then send the Set-Cookie. Even if the browser does keep the cookie, the same value can no longer authenticate. New `db.DeleteToken` + `auth.InvalidateToken` helpers; DB failure is logged but non-fatal so the cookie-clear half always runs.

**2. \"The WeChat pane on the homepage doesn't show up.\"**

Chat bubbles were spec'd at `animation-delay: 5500ms..8500ms` — a visitor staring at the page for ~5 seconds saw an empty WeChat pane and assumed it was broken. Also the `IntersectionObserver` gating animation start was dead complexity (the hero is always above the fold on load) and an extra failure mode.

Fix: compress the timeline — terminals finish by ~2.2s, chat bubbles start at 600ms and finish by 3.4s. Replace the IO with a `requestAnimationFrame`-deferred state flip after mount. Reduced-motion users get the final state on the very first paint via a lazy `useState` initializer (no flash of empty content).

## Test plan

- [ ] Log in, click \"Log out\", refresh the page → land on `/` (homepage), NOT auto-logged-back-in
- [ ] Open `/` cold — within 1 second the terminal panes start filling; within ~3.5 seconds the WeChat pane is fully populated with all 4 bubbles + plot.png thumbnail
- [ ] DevTools → emulate `prefers-reduced-motion: reduce` → refresh → all panes render fully populated on first paint, no fade
- [ ] `go test ./internal/auth/... ./internal/server/...` green
- [ ] `pnpm tsc -b && pnpm build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)