### PR TITLE
fix(web): make Hero animations unconditional CSS

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.16
-appVersion: "0.64.16"
+version: 0.64.17
+appVersion: "0.64.17"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/web/src/components/Home/HomeHero.tsx
+++ b/web/src/components/Home/HomeHero.tsx
@@ -1,29 +1,15 @@
-import { useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { useT } from '../../lib/i18n'
 import { homeStrings } from './strings'
 
 export function HomeHero() {
   const t = useT(homeStrings)
-  // Hero is always above the fold on page load, so no IntersectionObserver —
-  // just kick off the animation after mount. Reduced-motion users get the
-  // final state immediately on the very first render via the lazy initializer
-  // below (no flash of empty content).
-  const [started, setStarted] = useState(() => {
-    if (typeof window === 'undefined') return true
-    return window.matchMedia('(prefers-reduced-motion: reduce)').matches
-  })
-
-  useEffect(() => {
-    if (started) return
-    // Defer one frame so the initial opacity:0 paint registers before we
-    // flip data-started, otherwise some browsers skip the animation.
-    const raf = requestAnimationFrame(() => setStarted(true))
-    return () => cancelAnimationFrame(raf)
-  }, [started])
-
+  // Animation is pure CSS, auto-starts at page load. No JS gating — the hero
+  // is always above the fold, and the prior IntersectionObserver / state-flip
+  // approach silently failed in some production builds (data-started never
+  // flipped, every .ln / .bubble stayed opacity:0 → invisible).
   return (
-    <section className="pt-12 pb-20" data-started={started ? 'true' : 'false'}>
+    <section className="pt-12 pb-20">
       <div className="grid lg:grid-cols-[1.1fr_0.9fr] gap-10 items-start">
         {/* Left: heading + CTAs */}
         <div>
@@ -88,15 +74,14 @@ export function HomeHero() {
       </div>
 
       <style>{`
-        .hero-demo .ln,
+        .hero-demo .ln {
+          opacity: 0;
+          transform: translateY(4px);
+          animation: heroFadeIn 280ms ease-out forwards;
+        }
         .hero-demo .bubble {
           opacity: 0;
           transform: translateY(4px);
-        }
-        .hero-demo[data-started="true"] .ln {
-          animation: heroFadeIn 280ms ease-out forwards;
-        }
-        .hero-demo[data-started="true"] .bubble {
           animation: heroBubble 220ms ease-out forwards;
         }
         @keyframes heroFadeIn {
@@ -108,9 +93,9 @@ export function HomeHero() {
         @media (prefers-reduced-motion: reduce) {
           .hero-demo .ln,
           .hero-demo .bubble {
-            opacity: 1 !important;
-            transform: none !important;
-            animation: none !important;
+            opacity: 1;
+            transform: none;
+            animation: none;
           }
         }
       `}</style>


### PR DESCRIPTION
## Summary

Live deployment after #189 still showed all three Hero panes with **bodies completely empty** — `.ln` and `.bubble` elements stuck at `opacity:0` forever because `data-started` never flipped to `true`. The `useState` + `useEffect` + `requestAnimationFrame` mount trigger silently fails in some production path I can't reproduce locally without a browser on this Arch box.

Removing it. The hero is always above the fold, so JS gating was never necessary — the animation can just auto-start at page load using pure CSS.

**Before:** `opacity:0` base rule, animation rule only when `[data-started="true"]`. JS flips the data attr after mount.

**After:** `opacity:0` AND `animation: ... forwards` both on the base rule. Animation auto-starts at first paint, `fill-mode: forwards` locks the final state. Each element keeps its inline `animation-delay` for choreography. `prefers-reduced-motion` short-circuits to opacity:1.

Net effect: no `useState`, no `useEffect`, no `IntersectionObserver`, no `requestAnimationFrame`. One CSS rule per element class, fewer failure modes.

## Test plan

- [ ] Visit `https://agent.cs.ac.cn/` after deploy → within ~1s, both terminal panes start filling; within ~3.4s the WeChat pane is fully populated with all 4 bubbles + plot.png thumbnail
- [ ] DevTools → emulate `prefers-reduced-motion: reduce` → refresh → all panes render fully populated on first paint, no fade
- [ ] `pnpm tsc -b && pnpm build` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)