### PR TITLE
chore(chart): bump 0.64.17 → 0.64.18 to ship #191

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.17
-appVersion: "0.64.17"
+version: 0.64.18
+appVersion: "0.64.18"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
Bumps chart and appVersion 0.64.17 → 0.64.18 to ship:

- #191 fix(web): make Hero animations unconditional CSS