### PR TITLE
chore(chart): bump 0.64.18 → 0.64.19 to ship #193

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.18
-appVersion: "0.64.18"
+version: 0.64.19
+appVersion: "0.64.19"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
Bumps chart and appVersion 0.64.18 → 0.64.19 to ship:

- #193 feat(scheduled-tasks): user-scheduled tasks via codex + IM broadcast