### PR TITLE
chore(chart): bump 0.64.19 → 0.64.20 to ship #195 + #196

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.19
-appVersion: "0.64.19"
+version: 0.64.20
+appVersion: "0.64.20"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
## Summary
- bump Helm chart version + appVersion from 0.64.19 → 0.64.20
- ships #195 (connectors rename) and #196 (per-host cookie Domain)

## Test plan
- [x] CI build green
- [ ] after merge: push `v0.64.20` tag so `docker/metadata-action` emits versioned image tags
- [ ] /root/k8s/stacks/agentserver.ts bumped + `pulumi up`

🤖 Generated with [Claude Code](https://claude.com/claude-code)