### PR TITLE
feat(exec-audit): gateway-side WAL + uploader + integrations + helm

### DIFF
--- a/deploy/helm/agentserver/templates/codex-exec-gateway-pvc.yaml
+++ b/deploy/helm/agentserver/templates/codex-exec-gateway-pvc.yaml
@@ -1,4 +1,17 @@
 {{- if and .Values.codexExecGateway.enabled .Values.execAudit.enabled .Values.execAudit.pvc.enabled }}
+{{- /*
+  I12 guard: ReadWriteOnce can only mount on a single pod. If
+  replicaCount > 1, the second pod would silently sit in
+  ContainerCreating forever (Multi-Attach error). Fail-fast at template
+  time so operators can't accidentally schedule themselves into a
+  pager. Options when this fires: (a) keep replicaCount=1 (HA via the
+  PVC's underlying storage replication, not pod replication), or
+  (b) set execAudit.pvc.enabled=false to fall back to emptyDir + push
+  the WAL upload faster.
+*/}}
+{{- if gt (int (.Values.codexExecGateway.replicaCount | default 1)) 1 }}
+{{- fail (printf "execAudit.pvc.enabled with codexExecGateway.replicaCount=%d > 1: ReadWriteOnce PVC can only mount on one pod. Either set codexExecGateway.replicaCount: 1 or set execAudit.pvc.enabled: false." (int .Values.codexExecGateway.replicaCount)) }}
+{{- end }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/deploy/helm/agentserver/templates/codex-exec-gateway-pvc.yaml
+++ b/deploy/helm/agentserver/templates/codex-exec-gateway-pvc.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.codexExecGateway.enabled .Values.execAudit.enabled .Values.execAudit.pvc.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ .Release.Name }}-codex-exec-gateway-audit
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: codex-exec-gateway
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/component: audit
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- if .Values.execAudit.pvc.storageClass }}
+  storageClassName: {{ .Values.execAudit.pvc.storageClass | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.execAudit.pvc.size | default "20Gi" | quote }}
+{{- end }}

--- a/deploy/helm/agentserver/templates/codex-exec-gateway.yaml
+++ b/deploy/helm/agentserver/templates/codex-exec-gateway.yaml
@@ -119,6 +119,39 @@ spec:
             - name: CXG_LOG_LEVEL
               value: {{ .Values.codexExecGateway.logLevel | quote }}
             {{- end }}
+            {{- if .Values.execAudit.enabled }}
+            # Plan 2b audit subsystem: WAL → uploader → agentserver
+            # /internal/exec-audit/batch. See internal/codexexecgateway/audit/.
+            - name: CXG_AUDIT_ENABLED
+              value: "true"
+            - name: CXG_AUDIT_WAL_DIR
+              value: "/var/cxg-audit"
+            - name: CXG_AUDIT_UPLOAD_URL
+              value: "http://{{ .Release.Name }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}/internal/exec-audit/batch"
+            - name: CXG_AUDIT_UPLOAD_SECRET
+              value: {{ required "internal.apiSecret is required when execAudit.enabled is true" .Values.internal.apiSecret | quote }}
+            - name: CXG_AUDIT_PAYLOAD_MAX_BYTES
+              # int64 cast: avoids Helm rendering large ints in scientific
+              # notation ("4.194304e+06"), which strconv.Atoi can't parse.
+              value: {{ int64 (default 4194304 .Values.execAudit.payloadMaxBytes) | quote }}
+            - name: CXG_AUDIT_WAL_OVERFLOW
+              value: {{ .Values.execAudit.walOverflow | default "fail" | quote }}
+            {{- if .Values.execAudit.walDiskQuotaBytes }}
+            - name: CXG_AUDIT_WAL_DISK_QUOTA_BYTES
+              value: {{ int64 .Values.execAudit.walDiskQuotaBytes | quote }}
+            {{- end }}
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: CXG_AUDIT_GATEWAY_ID
+              value: "{{ .Release.Name }}-cxg-$(POD_NAME)"
+            {{- end }}
+          {{- if .Values.execAudit.enabled }}
+          volumeMounts:
+            - name: audit
+              mountPath: /var/cxg-audit
+          {{- end }}
           livenessProbe:
             httpGet:
               path: /healthz
@@ -138,6 +171,16 @@ spec:
           {{- with .Values.codexExecGateway.resources }}
           resources: {{- toYaml . | nindent 12 }}
           {{- end }}
+      {{- if .Values.execAudit.enabled }}
+      volumes:
+        - name: audit
+          {{- if .Values.execAudit.pvc.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ .Release.Name }}-codex-exec-gateway-audit
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/helm/agentserver/templates/codex-exec-gateway.yaml
+++ b/deploy/helm/agentserver/templates/codex-exec-gateway.yaml
@@ -17,11 +17,22 @@ metadata:
     app: {{ .Release.Name }}-codex-exec-gateway
 spec:
   replicas: {{ .Values.codexExecGateway.replicaCount }}
+  {{- if and .Values.execAudit.enabled .Values.execAudit.pvc.enabled }}
+  # I12: Recreate strategy is required when the audit PVC is
+  # ReadWriteOnce — a RollingUpdate would try to start a second pod that
+  # then deadlocks waiting for the PVC to detach from the outgoing pod.
+  # The trade-off (brief downtime during deploy) is acceptable because
+  # the PVC guard above already pins replicaCount=1, so there's no HA
+  # being lost here.
+  strategy:
+    type: Recreate
+  {{- else }}
   strategy:
     type: RollingUpdate
     rollingUpdate:
       maxUnavailable: 0
       maxSurge: 1
+  {{- end }}
   selector:
     matchLabels:
       app: {{ .Release.Name }}-codex-exec-gateway
@@ -136,10 +147,18 @@ spec:
               value: {{ int64 (default 4194304 .Values.execAudit.payloadMaxBytes) | quote }}
             - name: CXG_AUDIT_WAL_OVERFLOW
               value: {{ .Values.execAudit.walOverflow | default "fail" | quote }}
-            {{- if .Values.execAudit.walDiskQuotaBytes }}
+            # Always emit the quota explicitly (10 GiB default) so
+            # operators reading the pod spec can see exactly what's
+            # active. Relying on the binary's internal default would
+            # silently kick in if the env var were dropped — code-
+            # reviewer #2 followup. We can't use `| default` here
+            # because the upstream values.yaml ships 0 as the sentinel
+            # for "use binary default"; `default` only fires on
+            # zero-value-AS-empty (which 0 isn't for ints).
             - name: CXG_AUDIT_WAL_DISK_QUOTA_BYTES
-              value: {{ int64 .Values.execAudit.walDiskQuotaBytes | quote }}
-            {{- end }}
+              {{- $quota := int64 .Values.execAudit.walDiskQuotaBytes }}
+              {{- if le $quota (int64 0) }}{{- $quota = int64 10737418240 }}{{- end }}
+              value: {{ $quota | quote }}
             - name: POD_NAME
               valueFrom:
                 fieldRef:

--- a/deploy/helm/agentserver/values.yaml
+++ b/deploy/helm/agentserver/values.yaml
@@ -340,6 +340,21 @@ codexExecGateway:
   relayMaxPerWorkspace: 0  # e.g. 16 — concurrent relays per workspace
   resources: {}
 
+# Exec-gateway audit (Plan 2b): records every JSON-RPC frame on envmcp WS
+# bridges, every SDK REST call (/api/connectors/*) and every relay PUT/GET.
+# WAL on the pod local disk → uploader batches to agentserver Postgres via
+# /internal/exec-audit/batch. When disabled (the default), the gateway
+# loads a noop recorder so there is zero perf impact.
+execAudit:
+  enabled: false             # opt-in until validated in staging; flip to true to roll out
+  payloadMaxBytes: 4194304   # 4 MiB hard cap; larger payloads stored as sha256+size only
+  walOverflow: fail          # "fail" refuses new bridge handshakes when WAL disk quota hit
+  walDiskQuotaBytes: 0       # 0 = use binary default (10 GiB)
+  pvc:
+    enabled: true            # set false to use emptyDir (records lost on pod restart)
+    storageClass: ""         # "" = cluster default
+    size: 20Gi
+
 service:
   type: ClusterIP
   port: 8080

--- a/internal/codexappgateway/approval_intercept_test.go
+++ b/internal/codexappgateway/approval_intercept_test.go
@@ -148,7 +148,7 @@ func newTestServerWithFakeChild(t *testing.T, childHTTPURL string) *httptest.Ser
 		sup:     sup,
 		homeMgr: mgr,
 		logger:  logger,
-		buildConfig: func(_ context.Context, _, _ string) (supervisor.SpawnConfig, error) {
+		buildConfig: func(_ context.Context, _, _, _ string) (supervisor.SpawnConfig, error) {
 			return supervisor.SpawnConfig{Config: codexhome.ConfigInput{
 				ModelProvider:  "p",
 				Model:          "m",

--- a/internal/codexappgateway/buildconfig_test.go
+++ b/internal/codexappgateway/buildconfig_test.go
@@ -54,7 +54,7 @@ func TestBuildConfig_EmitsAgentserverMCPAndMintsWorkspaceToken(t *testing.T) {
 	cfg := newTestCfg()
 	build := makeBuildConfig(cfg, &stubConnected{}, stubTokenFetcher{}, "/usr/local/bin/codex-app-gateway", newDiscardLogger())
 
-	got, err := build(context.Background(), "ws_a", "lb-token-xyz")
+	got, err := build(context.Background(), "ws_a", "u_test", "lb-token-xyz")
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}
@@ -92,7 +92,7 @@ func TestBuildConfig_NoExecGatewayFetchHappens(t *testing.T) {
 	stub := &stubConnected{gotW: ""}
 	cfg := newTestCfg()
 	build := makeBuildConfig(cfg, stub, stubTokenFetcher{}, "/x", newDiscardLogger())
-	if _, err := build(context.Background(), "ws_a", "lb"); err != nil {
+	if _, err := build(context.Background(), "ws_a", "", "lb"); err != nil {
 		t.Fatalf("build: %v", err)
 	}
 	if stub.gotW != "" {
@@ -104,7 +104,7 @@ func TestBuildConfig_RespectsConfiguredTrustedPaths(t *testing.T) {
 	cfg := newTestCfg()
 	cfg.ProjectTrustedPaths = []string{"/workspace", "/data"}
 	build := makeBuildConfig(cfg, &stubConnected{}, stubTokenFetcher{}, "/x", newDiscardLogger())
-	got, err := build(context.Background(), "ws_a", "lb")
+	got, err := build(context.Background(), "ws_a", "", "lb")
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}

--- a/internal/codexappgateway/captoken.go
+++ b/internal/codexappgateway/captoken.go
@@ -18,7 +18,12 @@ import (
 // Per the 2026-05-16 fixed-tools redesign, one token covers any
 // executor in the workspace; /bridge enforces workspace ownership at
 // request time via the workspace_executors table.
-func MintCapToken(secret []byte, turnID, workspaceID string, ttl time.Duration) (string, error) {
+//
+// userID is the workspace member who triggered the mint, threaded into
+// the exec-audit subsystem (omitempty so older verifiers reading new
+// tokens, and new verifiers reading older tokens, both work). Pass ""
+// when no user context is available (e.g. scheduled-task spawns).
+func MintCapToken(secret []byte, turnID, workspaceID, userID string, ttl time.Duration) (string, error) {
 	if len(secret) == 0 {
 		return "", fmt.Errorf("captoken: empty secret")
 	}
@@ -29,11 +34,13 @@ func MintCapToken(secret []byte, turnID, workspaceID string, ttl time.Duration) 
 	payload := struct {
 		TurnID      string `json:"turn_id"`
 		WorkspaceID string `json:"workspace_id"`
+		UserID      string `json:"user_id,omitempty"`
 		IAT         int64  `json:"iat"`
 		EXP         int64  `json:"exp"`
 	}{
 		TurnID:      turnID,
 		WorkspaceID: workspaceID,
+		UserID:      userID,
 		IAT:         now,
 		EXP:         now + int64(ttl.Seconds()),
 	}

--- a/internal/codexappgateway/captoken_test.go
+++ b/internal/codexappgateway/captoken_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestMintCapToken_VerifiesAtExecGateway(t *testing.T) {
 	secret := []byte("shared-cap-secret")
-	tok, err := MintCapToken(secret, "trn_42", "ws_a", time.Minute)
+	tok, err := MintCapToken(secret, "trn_42", "ws_a", "u_alice", time.Minute)
 	if err != nil {
 		t.Fatalf("MintCapToken: %v", err)
 	}
@@ -17,13 +17,13 @@ func TestMintCapToken_VerifiesAtExecGateway(t *testing.T) {
 	if err != nil {
 		t.Fatalf("verify: %v", err)
 	}
-	if got.TurnID != "trn_42" || got.WorkspaceID != "ws_a" {
+	if got.TurnID != "trn_42" || got.WorkspaceID != "ws_a" || got.UserID != "u_alice" {
 		t.Errorf("payload = %+v", got)
 	}
 }
 
 func TestMintCapToken_ExpRespectsTTL(t *testing.T) {
-	tok, err := MintCapToken([]byte("k"), "trn_1", "ws_a", -time.Second)
+	tok, err := MintCapToken([]byte("k"), "trn_1", "ws_a", "", -time.Second)
 	if err != nil {
 		t.Fatalf("MintCapToken: %v", err)
 	}
@@ -34,7 +34,7 @@ func TestMintCapToken_ExpRespectsTTL(t *testing.T) {
 }
 
 func TestMintCapToken_RejectsEmptySecret(t *testing.T) {
-	if _, err := MintCapToken(nil, "trn_1", "ws_a", time.Minute); err == nil {
+	if _, err := MintCapToken(nil, "trn_1", "ws_a", "", time.Minute); err == nil {
 		t.Fatal("expected error for empty secret")
 	}
 }
@@ -45,7 +45,7 @@ func TestMintCapToken_RejectsEmptyFields(t *testing.T) {
 		{"trn", ""},
 	}
 	for _, tc := range cases {
-		if _, err := MintCapToken([]byte("k"), tc.turn, tc.ws, time.Minute); err == nil {
+		if _, err := MintCapToken([]byte("k"), tc.turn, tc.ws, "", time.Minute); err == nil {
 			t.Errorf("MintCapToken(%q,%q): want error, got nil", tc.turn, tc.ws)
 		}
 	}

--- a/internal/codexappgateway/server.go
+++ b/internal/codexappgateway/server.go
@@ -65,7 +65,7 @@ type Server struct {
 	// workspace-scoped LLM API key). Receives the per-spawn loopback
 	// token so the agentserver MCP entry in config.toml can embed it.
 	// Allowed to hit the network. Errors abort the spawn.
-	buildConfig func(ctx context.Context, workspaceID, loopbackToken string) (supervisor.SpawnConfig, error)
+	buildConfig func(ctx context.Context, workspaceID, userID, loopbackToken string) (supervisor.SpawnConfig, error)
 
 	execClient connectedClient // exposed for the loopback /internal/connected handler
 
@@ -152,8 +152,8 @@ func loopbackInternalURL(listenAddr string) string {
 
 // makeBuildConfig returns the per-spawn SpawnConfig producer. Split out
 // so server_test.go can construct a Server with stub clients.
-func makeBuildConfig(cfg ServeConfig, _ connectedClient, wsTokenClient workspaceTokenFetcher, selfBin string, logger *slog.Logger) func(context.Context, string, string) (supervisor.SpawnConfig, error) {
-	return func(ctx context.Context, workspaceID, loopbackToken string) (supervisor.SpawnConfig, error) {
+func makeBuildConfig(cfg ServeConfig, _ connectedClient, wsTokenClient workspaceTokenFetcher, selfBin string, logger *slog.Logger) func(context.Context, string, string, string) (supervisor.SpawnConfig, error) {
+	return func(ctx context.Context, workspaceID, userID, loopbackToken string) (supervisor.SpawnConfig, error) {
 		// Per 2026-05-16 redesign, the executor list is no longer
 		// fixed at spawn time — env-mcp reads it live via
 		// /internal/connected. We still mint a per-spawn turn so
@@ -163,7 +163,7 @@ func makeBuildConfig(cfg ServeConfig, _ connectedClient, wsTokenClient workspace
 		if ttl <= 0 {
 			ttl = time.Hour
 		}
-		workspaceTok, err := MintCapToken(cfg.CapTokenHMACSecret, turnID, workspaceID, ttl)
+		workspaceTok, err := MintCapToken(cfg.CapTokenHMACSecret, turnID, workspaceID, userID, ttl)
 		if err != nil {
 			return supervisor.SpawnConfig{}, fmt.Errorf("mint workspace cap token: %w", err)
 		}
@@ -458,7 +458,7 @@ func (s *Server) handleCodexAppWS(w http.ResponseWriter, r *http.Request) {
 	key := supervisor.Key{WorkspaceID: id.WorkspaceID}
 	ctx := r.Context()
 	handle, err := s.sup.EnsureSubprocess(ctx, key, func(loopbackToken string) (supervisor.SpawnConfig, error) {
-		return s.buildConfig(ctx, id.WorkspaceID, loopbackToken)
+		return s.buildConfig(ctx, id.WorkspaceID, id.UserID, loopbackToken)
 	})
 	if err != nil {
 		s.logger.Error("ensure subprocess", "err", err, "key", key)

--- a/internal/codexappgateway/server_test.go
+++ b/internal/codexappgateway/server_test.go
@@ -93,7 +93,7 @@ func makeTestServer(t *testing.T) *httptest.Server {
 		sup:     sup,
 		homeMgr: mgr,
 		logger:  logger,
-		buildConfig: func(_ context.Context, ws, _ string) (supervisor.SpawnConfig, error) {
+		buildConfig: func(_ context.Context, ws, _, _ string) (supervisor.SpawnConfig, error) {
 			return supervisor.SpawnConfig{Config: codexhome.ConfigInput{
 				ModelProvider:  "p", Model: "m",
 				ModelProviders: map[string]codexhome.ModelProvider{"p": {Name: "p", BaseURL: "http://x", EnvKey: "K", WireAPI: "responses"}},

--- a/internal/codexappgateway/turn_api.go
+++ b/internal/codexappgateway/turn_api.go
@@ -175,11 +175,17 @@ func (r *poolRunner) Turn(ctx context.Context, workspaceID, threadID string, par
 // makeSupervisorResolver returns a broker.WSURLResolver that uses the
 // existing supervisor + buildConfig wiring. Returns the ws URL of the
 // loopback codex subprocess for the workspace.
-func makeSupervisorResolver(sup *supervisor.Supervisor, build func(context.Context, string, string) (supervisor.SpawnConfig, error)) broker.WSURLResolver {
+//
+// The resolver has no user context (broker/scheduler invokes it with
+// just a workspace), so user_id is passed as "" — the resulting cap
+// token's exec-audit attribution will have NULL user_id. The
+// /codex-app/ws path that does have user context goes through
+// s.buildConfig directly and threads id.UserID in.
+func makeSupervisorResolver(sup *supervisor.Supervisor, build func(context.Context, string, string, string) (supervisor.SpawnConfig, error)) broker.WSURLResolver {
 	return func(ctx context.Context, workspaceID string) (string, error) {
 		key := supervisor.Key{WorkspaceID: workspaceID}
 		handle, err := sup.EnsureSubprocess(ctx, key, func(loopbackToken string) (supervisor.SpawnConfig, error) {
-			return build(ctx, workspaceID, loopbackToken)
+			return build(ctx, workspaceID, "", loopbackToken)
 		})
 		if err != nil {
 			return "", err

--- a/internal/codexexecgateway/audit/config.go
+++ b/internal/codexexecgateway/audit/config.go
@@ -1,0 +1,90 @@
+package audit
+
+import (
+	"os"
+	"strconv"
+	"time"
+)
+
+// Config controls every knob of the audit subsystem. NewConfigFromEnv
+// reads CXG_AUDIT_* env vars with reasonable defaults. Zero-value
+// Config is safe (Enabled=false → use NewNoopRecorder()).
+type Config struct {
+	Enabled             bool
+	WALDir              string
+	WALFsyncInterval    time.Duration
+	WALFsyncRecords     int
+	WALFileMaxBytes     int64
+	WALDiskQuotaBytes   int64
+	WALOverflow         string // "fail" | "drop"
+	PayloadMaxBytes     int
+	UploadURL           string
+	UploadSecret        string
+	UploadBatchBytes    int
+	UploadBatchRecords  int
+	UploadFlushInterval time.Duration
+	RPCPairTimeout      time.Duration
+	GatewayID           string
+}
+
+func NewConfigFromEnv() Config {
+	return Config{
+		Enabled:             envBool("CXG_AUDIT_ENABLED", false),
+		WALDir:              envStr("CXG_AUDIT_WAL_DIR", "/var/cxg-audit"),
+		WALFsyncInterval:    envDur("CXG_AUDIT_WAL_FSYNC_INTERVAL", 100*time.Millisecond),
+		WALFsyncRecords:     envInt("CXG_AUDIT_WAL_FSYNC_RECORDS", 256),
+		WALFileMaxBytes:     envInt64("CXG_AUDIT_WAL_FILE_MAX_BYTES", 1<<30),    // 1 GiB
+		WALDiskQuotaBytes:   envInt64("CXG_AUDIT_WAL_DISK_QUOTA_BYTES", 10<<30), // 10 GiB
+		WALOverflow:         envStr("CXG_AUDIT_WAL_OVERFLOW", "fail"),
+		PayloadMaxBytes:     envInt("CXG_AUDIT_PAYLOAD_MAX_BYTES", 4<<20), // 4 MiB
+		UploadURL:           envStr("CXG_AUDIT_UPLOAD_URL", ""),
+		UploadSecret:        envStr("CXG_AUDIT_UPLOAD_SECRET", ""),
+		UploadBatchBytes:    envInt("CXG_AUDIT_UPLOAD_BATCH_BYTES", 1<<20), // 1 MiB
+		UploadBatchRecords:  envInt("CXG_AUDIT_UPLOAD_BATCH_RECORDS", 200),
+		UploadFlushInterval: envDur("CXG_AUDIT_UPLOAD_FLUSH_INTERVAL", time.Second),
+		RPCPairTimeout:      envDur("CXG_AUDIT_RPC_PAIR_TIMEOUT", 30*time.Second),
+		GatewayID:           envStr("CXG_AUDIT_GATEWAY_ID", "cxg"),
+	}
+}
+
+func envStr(key, def string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return def
+}
+
+func envBool(key string, def bool) bool {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	return v == "1" || v == "true" || v == "yes" || v == "on"
+}
+
+func envInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			return n
+		}
+	}
+	return def
+}
+
+func envInt64(key string, def int64) int64 {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+			return n
+		}
+	}
+	return def
+}
+
+func envDur(key string, def time.Duration) time.Duration {
+	if v := os.Getenv(key); v != "" {
+		if d, err := time.ParseDuration(v); err == nil {
+			return d
+		}
+	}
+	return def
+}

--- a/internal/codexexecgateway/audit/cursor.go
+++ b/internal/codexexecgateway/audit/cursor.go
@@ -1,0 +1,88 @@
+package audit
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+// Cursor tracks per-file upload progress for the audit WAL. The
+// uploader Advances after a successful POST and Saves to persist.
+// Atomic save via tmp + rename — a crash mid-save never leaves a
+// corrupt canonical file.
+type Cursor struct {
+	mu      sync.Mutex
+	path    string
+	offsets map[string]int64
+}
+
+type cursorOnDisk struct {
+	Files []cursorFile `json:"files"`
+}
+
+type cursorFile struct {
+	Name           string `json:"name"`
+	UploadedOffset int64  `json:"uploaded_offset"`
+}
+
+// OpenCursor loads the cursor file at path. A missing file is not an
+// error — it returns a fresh Cursor reporting 0 for every offset.
+func OpenCursor(path string) (*Cursor, error) {
+	c := &Cursor{path: path, offsets: map[string]int64{}}
+	data, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return c, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var d cursorOnDisk
+	if err := json.Unmarshal(data, &d); err != nil {
+		return nil, err
+	}
+	for _, f := range d.Files {
+		c.offsets[f.Name] = f.UploadedOffset
+	}
+	return c, nil
+}
+
+// Offset returns the cumulative bytes already uploaded from a file
+// (zero if not yet uploaded).
+func (c *Cursor) Offset(name string) int64 {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.offsets[name]
+}
+
+// Advance adds n bytes to the cumulative offset of name. Caller passes
+// the bytes consumed in a batch — Cursor accumulates.
+func (c *Cursor) Advance(name string, n int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.offsets[name] += n
+}
+
+// Save persists the current state atomically. Writes to <path>.tmp then
+// renames. Returns whatever rename / mkdir errors os reports.
+func (c *Cursor) Save() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	d := cursorOnDisk{Files: make([]cursorFile, 0, len(c.offsets))}
+	for k, v := range c.offsets {
+		d.Files = append(d.Files, cursorFile{Name: k, UploadedOffset: v})
+	}
+	body, err := json.MarshalIndent(d, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := c.path + ".tmp"
+	if err := os.MkdirAll(filepath.Dir(c.path), 0o750); err != nil {
+		return err
+	}
+	if err := os.WriteFile(tmp, body, 0o640); err != nil {
+		return err
+	}
+	return os.Rename(tmp, c.path)
+}

--- a/internal/codexexecgateway/audit/cursor_test.go
+++ b/internal/codexexecgateway/audit/cursor_test.go
@@ -1,0 +1,69 @@
+package audit_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/agentserver/agentserver/internal/codexexecgateway/audit"
+)
+
+func TestCursor_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	c, err := audit.OpenCursor(filepath.Join(dir, "cursor.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Fresh cursor: zero offset for any file.
+	if got := c.Offset("wal-1.log"); got != 0 {
+		t.Fatalf("expected 0 for fresh cursor, got %d", got)
+	}
+
+	// Advance is cumulative (caller passes bytes consumed in the batch,
+	// not the new absolute offset).
+	c.Advance("wal-1.log", 1024)
+	c.Advance("wal-1.log", 1024)
+	if err := c.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Re-open and verify persistence.
+	c2, err := audit.OpenCursor(filepath.Join(dir, "cursor.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := c2.Offset("wal-1.log"); got != 2048 {
+		t.Fatalf("expected 2048 after reload, got %d", got)
+	}
+}
+
+func TestCursor_AtomicSave_NoTmpLeftover(t *testing.T) {
+	dir := t.TempDir()
+	c, err := audit.OpenCursor(filepath.Join(dir, "cursor.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	c.Advance("wal-a.log", 100)
+	if err := c.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	// After Save there should be no .tmp file left behind.
+	matches, _ := filepath.Glob(filepath.Join(dir, "cursor*"))
+	for _, m := range matches {
+		if filepath.Ext(m) == ".tmp" {
+			t.Fatalf("found leftover .tmp file: %s", m)
+		}
+	}
+}
+
+func TestCursor_OpenNonexistent_FreshState(t *testing.T) {
+	dir := t.TempDir()
+	c, err := audit.OpenCursor(filepath.Join(dir, "nonexistent.json"))
+	if err != nil {
+		t.Fatalf("OpenCursor on missing file should succeed with fresh state, got %v", err)
+	}
+	if got := c.Offset("any.log"); got != 0 {
+		t.Fatalf("fresh cursor: expected 0, got %d", got)
+	}
+}

--- a/internal/codexexecgateway/audit/e2e_test.go
+++ b/internal/codexexecgateway/audit/e2e_test.go
@@ -1,0 +1,183 @@
+//go:build integration
+
+package audit_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/agentserver/agentserver/internal/codexexecgateway/audit"
+	"github.com/agentserver/agentserver/internal/db"
+	"github.com/agentserver/agentserver/internal/server"
+)
+
+// newE2EAgentserver brings up a real *server.Server backed by the
+// integration DB and wraps it in an httptest.Server. Skips when
+// TEST_DATABASE_URL is unset so the test is a no-op in CI envs that
+// haven't provisioned Postgres.
+func newE2EAgentserver(t *testing.T) (*server.Server, *httptest.Server, string) {
+	t.Helper()
+	url := os.Getenv("TEST_DATABASE_URL")
+	if url == "" {
+		t.Skip("TEST_DATABASE_URL not set; skipping integration test")
+	}
+	d, err := db.Open(url)
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	srv := &server.Server{DB: d}
+	const secret = "e2e-internal-secret"
+	t.Setenv("INTERNAL_API_SECRET", secret)
+	httpSrv := httptest.NewServer(srv.Router())
+	t.Cleanup(func() {
+		httpSrv.Close()
+		_ = d.Close()
+	})
+	return srv, httpSrv, secret
+}
+
+// uniqueSuffix mirrors the agentserver-side helper without crossing the
+// package boundary: 12 hex chars derived from test name + nanosecond
+// timestamp so concurrent runs against a shared TEST_DATABASE_URL don't
+// collide on workspace_id.
+func uniqueSuffix(t *testing.T) string {
+	t.Helper()
+	sum := sha256.Sum256([]byte(t.Name() + time.Now().Format(time.RFC3339Nano)))
+	return hex.EncodeToString(sum[:6])
+}
+
+// TestExecAudit_EndToEnd exercises the full pipeline:
+//
+//	real Recorder → WAL → Uploader → httptest agentserver
+//	  → real postInternalExecAuditBatch → DAL → Postgres
+//
+// Asserts that the session + paired call land in exec_audit_sessions /
+// exec_audit_calls with the expected fields and that both request and
+// response payloads are stored.
+func TestExecAudit_EndToEnd(t *testing.T) {
+	srv, httpSrv, secret := newE2EAgentserver(t)
+
+	dir := t.TempDir()
+	cfg := audit.Config{
+		Enabled:             true,
+		WALDir:              dir,
+		WALFsyncRecords:     1,
+		WALFsyncInterval:    100 * time.Millisecond,
+		WALFileMaxBytes:     1 << 20,
+		WALDiskQuotaBytes:   10 << 20,
+		WALOverflow:         "fail",
+		PayloadMaxBytes:     4 << 20,
+		UploadURL:           httpSrv.URL + "/internal/exec-audit/batch",
+		UploadSecret:        secret,
+		UploadBatchRecords:  50,
+		UploadBatchBytes:    1 << 20,
+		UploadFlushInterval: 100 * time.Millisecond,
+		RPCPairTimeout:      time.Second,
+		GatewayID:           "e2e-test",
+	}
+	rec, err := audit.NewRecorder(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wsID := "ws_e2e_" + uniqueSuffix(t)
+	t.Cleanup(func() {
+		_, _ = srv.DB.Exec(`DELETE FROM exec_audit_calls WHERE workspace_id=$1`, wsID)
+		_, _ = srv.DB.Exec(`DELETE FROM exec_audit_sessions WHERE workspace_id=$1`, wsID)
+	})
+
+	// Emit one session + one paired call + a close.
+	sid := rec.SessionOpen(audit.SessionMeta{
+		WorkspaceID: wsID,
+		UserID:      "u_e2e",
+		ExeID:       "exe_e2e",
+		StreamID:    "s1",
+		OpenedAt:    time.Now().UTC(),
+	})
+	cid := rec.CallStart(audit.CallStartMeta{
+		SessionID:   sid,
+		WorkspaceID: wsID,
+		UserID:      "u_e2e",
+		ExeID:       "exe_e2e",
+		Source:      "envmcp",
+		RPCID:       "1",
+		RPCMethod:   "shell",
+		RPCKind:     "request",
+		Request:     []byte(`{"cmd":"ls"}`),
+		StartedAt:   time.Now().UTC(),
+	})
+	rec.CallEnd(cid, audit.CallEndMeta{
+		CompletedAt: time.Now().UTC(),
+		Response:    []byte(`{"stdout":"file1\nfile2\n"}`),
+	})
+	rec.SessionClose(sid, "test_done", audit.Counters{
+		FramesToBackend: 1, FramesToClient: 1,
+	})
+
+	// Give the uploader a chance to flush. Close blocks until the WAL is
+	// drained or the context expires, which is a stronger signal than
+	// raw polling — but we still poll because the agentserver ingest path
+	// is async with respect to the upload HTTP response (DAL writes happen
+	// synchronously in the handler, so this should be fast).
+	closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := rec.Close(closeCtx); err != nil {
+		t.Fatalf("recorder close: %v", err)
+	}
+
+	// Poll the DB for the records to land. Close() should have flushed by
+	// now, but allow a small grace window for the HTTP round-trip.
+	var sessions []db.AuditSession
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		sessions, _ = srv.DB.ListAuditSessions(db.ListAuditSessionsFilter{
+			WorkspaceID: wsID, Limit: 10,
+		})
+		if len(sessions) > 0 {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	if len(sessions) != 1 {
+		t.Fatalf("expected 1 session in DB, got %d", len(sessions))
+	}
+	s := sessions[0]
+	if s.WorkspaceID != wsID || s.ExeID != "exe_e2e" {
+		t.Errorf("session row mismatch: %+v", s)
+	}
+	if s.UserID == nil || *s.UserID != "u_e2e" {
+		t.Errorf("user_id mismatch: %v", s.UserID)
+	}
+
+	calls, err := srv.DB.ListAuditCalls(db.ListAuditCallsFilter{
+		WorkspaceID: wsID, Limit: 10,
+	})
+	if err != nil {
+		t.Fatalf("list calls: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	c := calls[0]
+	if c.Source != "envmcp" {
+		t.Errorf("call source mismatch: %q", c.Source)
+	}
+	if c.RPCMethod == nil || *c.RPCMethod != "shell" {
+		t.Errorf("rpc_method mismatch: %v", c.RPCMethod)
+	}
+	if c.RequestPayloadID == nil {
+		t.Error("expected request_payload_id to be set")
+	}
+	if c.ResponsePayloadID == nil {
+		t.Error("expected response_payload_id to be set")
+	}
+	if c.UserID == nil || *c.UserID != "u_e2e" {
+		t.Errorf("call user_id mismatch: %v", c.UserID)
+	}
+}

--- a/internal/codexexecgateway/audit/e2e_test.go
+++ b/internal/codexexecgateway/audit/e2e_test.go
@@ -92,14 +92,17 @@ func TestExecAudit_EndToEnd(t *testing.T) {
 	})
 
 	// Emit one session + one paired call + a close.
-	sid := rec.SessionOpen(audit.SessionMeta{
+	sid, err := rec.SessionOpen(audit.SessionMeta{
 		WorkspaceID: wsID,
 		UserID:      "u_e2e",
 		ExeID:       "exe_e2e",
 		StreamID:    "s1",
 		OpenedAt:    time.Now().UTC(),
 	})
-	cid := rec.CallStart(audit.CallStartMeta{
+	if err != nil {
+		t.Fatalf("SessionOpen: %v", err)
+	}
+	cid, err := rec.CallStart(audit.CallStartMeta{
 		SessionID:   sid,
 		WorkspaceID: wsID,
 		UserID:      "u_e2e",
@@ -111,6 +114,9 @@ func TestExecAudit_EndToEnd(t *testing.T) {
 		Request:     []byte(`{"cmd":"ls"}`),
 		StartedAt:   time.Now().UTC(),
 	})
+	if err != nil {
+		t.Fatalf("CallStart: %v", err)
+	}
 	rec.CallEnd(cid, audit.CallEndMeta{
 		CompletedAt: time.Now().UTC(),
 		Response:    []byte(`{"stdout":"file1\nfile2\n"}`),

--- a/internal/codexexecgateway/audit/recorder.go
+++ b/internal/codexexecgateway/audit/recorder.go
@@ -2,9 +2,19 @@ package audit
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"log/slog"
+	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/google/uuid"
+
+	"github.com/agentserver/agentserver/internal/relaypb"
+	pb "github.com/agentserver/agentserver/internal/server/exec_audit_pb"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // SessionMeta is the input to Recorder.SessionOpen — describes a new
@@ -83,3 +93,283 @@ func (noopRecorder) OnFrameToClient(string, any, []byte)   {}
 func (noopRecorder) CallStart(CallStartMeta) string        { return uuid.NewString() }
 func (noopRecorder) CallEnd(string, CallEndMeta)           {}
 func (noopRecorder) Close(context.Context) error           { return nil }
+
+// ---------- real Recorder ----------
+
+// realRecorder backs the Recorder interface with WAL + Uploader +
+// RPCParser. Lifecycle: NewRecorder constructs all subsystems and
+// spawns the Uploader + RPCParser sweep goroutines; Close cancels them
+// and final-flushes the WAL.
+type realRecorder struct {
+	cfg       Config
+	wal       *WAL
+	cursor    *Cursor
+	uploader  *Uploader
+	parser    *RPCParser
+	gatewayID string
+
+	mu              sync.Mutex
+	sessions        map[string]*sessionState
+	uploadCtxCancel context.CancelFunc
+	sweepCtxCancel  context.CancelFunc
+}
+
+type sessionState struct {
+	id          string
+	workspaceID string
+	userID      string
+	exeID       string
+	counters    Counters
+}
+
+// NewRecorder constructs the appropriate Recorder for cfg. If
+// cfg.Enabled is false (or cfg.WALDir is empty) returns a noopRecorder.
+// On success starts the upload and RPC-sweep goroutines and registers
+// a Close-to-stop them. Caller MUST Close on shutdown to flush the WAL.
+func NewRecorder(cfg Config) (Recorder, error) {
+	if !cfg.Enabled {
+		return NewNoopRecorder(), nil
+	}
+	wal, err := OpenWAL(WALConfig{
+		Dir:            cfg.WALDir,
+		FsyncInterval:  cfg.WALFsyncInterval,
+		FsyncRecords:   cfg.WALFsyncRecords,
+		FileMaxBytes:   cfg.WALFileMaxBytes,
+		DiskQuotaBytes: cfg.WALDiskQuotaBytes,
+		Overflow:       cfg.WALOverflow,
+	})
+	if err != nil {
+		return nil, err
+	}
+	cur, err := OpenCursor(filepath.Join(cfg.WALDir, "cursor.json"))
+	if err != nil {
+		_ = wal.Close()
+		return nil, err
+	}
+	r := &realRecorder{
+		cfg:       cfg,
+		wal:       wal,
+		cursor:    cur,
+		gatewayID: cfg.GatewayID,
+		sessions:  map[string]*sessionState{},
+	}
+	r.parser = NewRPCParser(r, RPCParserConfig{PairTimeout: cfg.RPCPairTimeout})
+
+	if cfg.UploadURL != "" && cfg.UploadSecret != "" {
+		r.uploader = NewUploader(UploaderConfig{
+			WALDir:        cfg.WALDir,
+			Cursor:        cur,
+			UploadURL:     cfg.UploadURL,
+			UploadSecret:  cfg.UploadSecret,
+			BatchRecords:  cfg.UploadBatchRecords,
+			BatchBytes:    cfg.UploadBatchBytes,
+			FlushInterval: cfg.UploadFlushInterval,
+			GatewayID:     cfg.GatewayID,
+		})
+		ctx, cancel := context.WithCancel(context.Background())
+		r.uploadCtxCancel = cancel
+		go r.uploader.Run(ctx)
+	}
+
+	// Periodic RPC pair-timeout sweep, half the pair timeout.
+	sweepCtx, sweepCancel := context.WithCancel(context.Background())
+	r.sweepCtxCancel = sweepCancel
+	go r.sweepLoop(sweepCtx)
+
+	return r, nil
+}
+
+func (r *realRecorder) sweepLoop(ctx context.Context) {
+	interval := r.cfg.RPCPairTimeout / 2
+	if interval <= 0 {
+		interval = 15 * time.Second
+	}
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-t.C:
+			r.parser.SweepTimeouts(now)
+		}
+	}
+}
+
+func (r *realRecorder) SessionOpen(m SessionMeta) string {
+	id := uuid.NewString()
+	r.mu.Lock()
+	r.sessions[id] = &sessionState{
+		id:          id,
+		workspaceID: m.WorkspaceID,
+		userID:      m.UserID,
+		exeID:       m.ExeID,
+	}
+	r.mu.Unlock()
+	rec := &pb.WALRecord{
+		Id: id,
+		Body: &pb.WALRecord_SessionOpen{SessionOpen: &pb.SessionOpen{
+			WorkspaceId: m.WorkspaceID,
+			UserId:      m.UserID,
+			ExeId:       m.ExeID,
+			TurnId:      m.TurnID,
+			StreamId:    m.StreamID,
+			ClientIp:    m.ClientIP,
+			CapIat:      tsOrNil(m.CapIAT),
+			CapExp:      tsOrNil(m.CapEXP),
+			OpenedAt:    timestamppb.New(m.OpenedAt),
+		}},
+	}
+	if err := r.wal.Append(rec); err != nil {
+		slog.Error("exec-audit: SessionOpen append", "id", id, "err", err)
+	}
+	return id
+}
+
+func (r *realRecorder) SessionClose(sessionID, reason string, c Counters) {
+	r.parser.SessionClosed(sessionID, time.Now().UTC())
+	rec := &pb.WALRecord{
+		Id: sessionID,
+		Body: &pb.WALRecord_SessionClose{SessionClose: &pb.SessionClose{
+			SessionId:       sessionID,
+			ClosedAt:        timestamppb.New(time.Now().UTC()),
+			CloseReason:     reason,
+			FramesToBackend: int32(c.FramesToBackend),
+			FramesToClient:  int32(c.FramesToClient),
+			BytesToBackend:  c.BytesToBackend,
+			BytesToClient:   c.BytesToClient,
+		}},
+	}
+	if err := r.wal.Append(rec); err != nil {
+		slog.Error("exec-audit: SessionClose append", "id", sessionID, "err", err)
+	}
+	r.mu.Lock()
+	delete(r.sessions, sessionID)
+	r.mu.Unlock()
+}
+
+func (r *realRecorder) OnFrameToBackend(sessionID string, frame any, raw []byte) {
+	st := r.session(sessionID)
+	if st == nil {
+		return
+	}
+	r.mu.Lock()
+	st.counters.FramesToBackend++
+	st.counters.BytesToBackend += int64(len(raw))
+	r.mu.Unlock()
+	if payload := extractRelayDataPayload(frame, raw); len(payload) > 0 {
+		r.parser.OnFrameToBackend(sessionID, st.workspaceID, st.userID, st.exeID, payload)
+	}
+}
+
+func (r *realRecorder) OnFrameToClient(sessionID string, frame any, raw []byte) {
+	st := r.session(sessionID)
+	if st == nil {
+		return
+	}
+	r.mu.Lock()
+	st.counters.FramesToClient++
+	st.counters.BytesToClient += int64(len(raw))
+	r.mu.Unlock()
+	if payload := extractRelayDataPayload(frame, raw); len(payload) > 0 {
+		r.parser.OnFrameToClient(sessionID, payload)
+	}
+}
+
+func (r *realRecorder) CallStart(m CallStartMeta) string {
+	id := uuid.NewString()
+	cs := &pb.CallStart{
+		CallId:      id,
+		SessionId:   m.SessionID,
+		WorkspaceId: m.WorkspaceID,
+		UserId:      m.UserID,
+		ExeId:       m.ExeID,
+		Source:      m.Source,
+		RpcId:       m.RPCID,
+		RpcMethod:   m.RPCMethod,
+		RpcKind:     m.RPCKind,
+		StartedAt:   timestamppb.New(m.StartedAt),
+	}
+	r.populatePayload(&cs.RequestBytes, &cs.RequestSize, &cs.RequestSha256, m.Request)
+	rec := &pb.WALRecord{Id: id, Body: &pb.WALRecord_CallStart{CallStart: cs}}
+	if err := r.wal.Append(rec); err != nil {
+		slog.Error("exec-audit: CallStart append", "id", id, "err", err)
+	}
+	return id
+}
+
+func (r *realRecorder) CallEnd(callID string, m CallEndMeta) {
+	ce := &pb.CallEnd{
+		CallId:       callID,
+		CompletedAt:  timestamppb.New(m.CompletedAt),
+		IsError:      m.IsError,
+		ErrorSummary: m.ErrorSummary,
+	}
+	r.populatePayload(&ce.ResponseBytes, &ce.ResponseSize, &ce.ResponseSha256, m.Response)
+	rec := &pb.WALRecord{Id: callID, Body: &pb.WALRecord_CallEnd{CallEnd: ce}}
+	if err := r.wal.Append(rec); err != nil {
+		slog.Error("exec-audit: CallEnd append", "id", callID, "err", err)
+	}
+}
+
+func (r *realRecorder) Close(ctx context.Context) error {
+	if r.uploadCtxCancel != nil {
+		r.uploadCtxCancel()
+	}
+	if r.sweepCtxCancel != nil {
+		r.sweepCtxCancel()
+	}
+	if err := r.wal.Sync(); err != nil {
+		slog.Warn("exec-audit: final sync", "err", err)
+	}
+	return r.wal.Close()
+}
+
+func (r *realRecorder) session(id string) *sessionState {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.sessions[id]
+}
+
+// populatePayload sets size + sha256 always; sets the inline bytes only
+// if under PayloadMaxBytes. Above-cap payloads land in the DB with hash
+// + size metadata only, matching the ingest handler's contract.
+func (r *realRecorder) populatePayload(out *[]byte, size *int32, hash *string, raw []byte) {
+	*size = int32(len(raw))
+	if len(raw) == 0 {
+		return
+	}
+	sum := sha256.Sum256(raw)
+	*hash = hex.EncodeToString(sum[:])
+	if len(raw) > r.cfg.PayloadMaxBytes {
+		return
+	}
+	*out = raw
+}
+
+func tsOrNil(t time.Time) *timestamppb.Timestamp {
+	if t.IsZero() {
+		return nil
+	}
+	return timestamppb.New(t)
+}
+
+// extractRelayDataPayload pulls the inner payload bytes from a
+// RelayMessageFrame. Returns nil for non-Data body kinds (Resume,
+// Reset, Ack, Heartbeat). Falls back to unmarshaling raw if the typed
+// frame is nil.
+func extractRelayDataPayload(frame any, raw []byte) []byte {
+	if rmf, ok := frame.(*relaypb.RelayMessageFrame); ok {
+		if d := rmf.GetData(); d != nil {
+			return d.GetPayload()
+		}
+		return nil
+	}
+	var rmf relaypb.RelayMessageFrame
+	if err := proto.Unmarshal(raw, &rmf); err == nil {
+		if d := rmf.GetData(); d != nil {
+			return d.GetPayload()
+		}
+	}
+	return nil
+}

--- a/internal/codexexecgateway/audit/recorder.go
+++ b/internal/codexexecgateway/audit/recorder.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"fmt"
 	"log/slog"
 	"path/filepath"
 	"sync"
@@ -121,12 +122,17 @@ type realRecorder struct {
 	sweepCtxCancel  context.CancelFunc
 }
 
+// sessionState holds the immutable identity fields the per-frame
+// recorder hooks need to attribute frames. Counters intentionally are
+// NOT tracked here — they were dead writes (SessionClose uses the
+// caller-supplied bridgeSession atomic counters as the source of
+// truth). Removing them lets OnFrameTo* skip the global recorder mutex
+// on the hot per-frame path.
 type sessionState struct {
 	id          string
 	workspaceID string
 	userID      string
 	exeID       string
-	counters    Counters
 }
 
 // NewRecorder constructs the appropriate Recorder for cfg. If
@@ -163,7 +169,7 @@ func NewRecorder(cfg Config) (Recorder, error) {
 	r.parser = NewRPCParser(r, RPCParserConfig{PairTimeout: cfg.RPCPairTimeout})
 
 	if cfg.UploadURL != "" && cfg.UploadSecret != "" {
-		r.uploader = NewUploader(UploaderConfig{
+		u, uerr := NewUploader(UploaderConfig{
 			WALDir:        cfg.WALDir,
 			Cursor:        cur,
 			UploadURL:     cfg.UploadURL,
@@ -173,6 +179,11 @@ func NewRecorder(cfg Config) (Recorder, error) {
 			FlushInterval: cfg.UploadFlushInterval,
 			GatewayID:     cfg.GatewayID,
 		})
+		if uerr != nil {
+			_ = wal.Close()
+			return nil, fmt.Errorf("uploader init: %w", uerr)
+		}
+		r.uploader = u
 		ctx, cancel := context.WithCancel(context.Background())
 		r.uploadCtxCancel = cancel
 		go r.uploader.Run(ctx)
@@ -258,15 +269,18 @@ func (r *realRecorder) SessionClose(sessionID, reason string, c Counters) {
 	r.mu.Unlock()
 }
 
+// OnFrameToBackend looks up the (immutable) session identity and
+// delegates payload extraction + parser dispatch. The per-frame counter
+// bumps that used to live here were dead writes (SessionClose reads
+// the bridgeSession atomic counters, not this map) so removing them
+// also removes the global r.mu lock from the per-frame hot path.
+// r.session() still briefly acquires r.mu for the map lookup; that
+// can't be avoided without a more invasive sync.Map refactor.
 func (r *realRecorder) OnFrameToBackend(sessionID string, frame any, raw []byte) {
 	st := r.session(sessionID)
 	if st == nil {
 		return
 	}
-	r.mu.Lock()
-	st.counters.FramesToBackend++
-	st.counters.BytesToBackend += int64(len(raw))
-	r.mu.Unlock()
 	if payload := extractRelayDataPayload(frame, raw); len(payload) > 0 {
 		r.parser.OnFrameToBackend(sessionID, st.workspaceID, st.userID, st.exeID, payload)
 	}
@@ -277,10 +291,6 @@ func (r *realRecorder) OnFrameToClient(sessionID string, frame any, raw []byte) 
 	if st == nil {
 		return
 	}
-	r.mu.Lock()
-	st.counters.FramesToClient++
-	st.counters.BytesToClient += int64(len(raw))
-	r.mu.Unlock()
 	if payload := extractRelayDataPayload(frame, raw); len(payload) > 0 {
 		r.parser.OnFrameToClient(sessionID, payload)
 	}

--- a/internal/codexexecgateway/audit/recorder.go
+++ b/internal/codexexecgateway/audit/recorder.go
@@ -68,14 +68,21 @@ type CallEndMeta struct {
 
 // Recorder is the audit interface used by the gateway pumps and
 // handlers. Production wires this to a real Recorder backed by WAL +
-// Uploader (Plan 2b later tasks). Tests and audit-disabled deployments
-// use NewNoopRecorder.
+// Uploader. Tests and audit-disabled deployments use NewNoopRecorder.
+//
+// SessionOpen and CallStart return error: when the WAL is in
+// WALOverflow=fail mode and the disk quota has been hit, the realized
+// recorder refuses to record (and thus the caller refuses to admit the
+// session/call). This is the fail-closed contract the spec promises.
+// SessionClose, CallEnd, OnFrame*, and Close are best-effort — the
+// session/call is already in flight; refusing mid-flight wouldn't
+// improve the audit trail.
 type Recorder interface {
-	SessionOpen(SessionMeta) (sessionID string)
+	SessionOpen(SessionMeta) (sessionID string, err error)
 	SessionClose(sessionID, reason string, c Counters)
 	OnFrameToBackend(sessionID string, frame any, rawBytes []byte)
 	OnFrameToClient(sessionID string, frame any, rawBytes []byte)
-	CallStart(CallStartMeta) (callID string)
+	CallStart(CallStartMeta) (callID string, err error)
 	CallEnd(callID string, m CallEndMeta)
 	Close(ctx context.Context) error
 }
@@ -86,13 +93,13 @@ type noopRecorder struct{}
 // not persist anything. Use when CXG_AUDIT_ENABLED=false.
 func NewNoopRecorder() Recorder { return noopRecorder{} }
 
-func (noopRecorder) SessionOpen(SessionMeta) string        { return uuid.NewString() }
-func (noopRecorder) SessionClose(string, string, Counters) {}
-func (noopRecorder) OnFrameToBackend(string, any, []byte)  {}
-func (noopRecorder) OnFrameToClient(string, any, []byte)   {}
-func (noopRecorder) CallStart(CallStartMeta) string        { return uuid.NewString() }
-func (noopRecorder) CallEnd(string, CallEndMeta)           {}
-func (noopRecorder) Close(context.Context) error           { return nil }
+func (noopRecorder) SessionOpen(SessionMeta) (string, error)    { return uuid.NewString(), nil }
+func (noopRecorder) SessionClose(string, string, Counters)      {}
+func (noopRecorder) OnFrameToBackend(string, any, []byte)       {}
+func (noopRecorder) OnFrameToClient(string, any, []byte)        {}
+func (noopRecorder) CallStart(CallStartMeta) (string, error)    { return uuid.NewString(), nil }
+func (noopRecorder) CallEnd(string, CallEndMeta)                {}
+func (noopRecorder) Close(context.Context) error                { return nil }
 
 // ---------- real Recorder ----------
 
@@ -196,16 +203,8 @@ func (r *realRecorder) sweepLoop(ctx context.Context) {
 	}
 }
 
-func (r *realRecorder) SessionOpen(m SessionMeta) string {
+func (r *realRecorder) SessionOpen(m SessionMeta) (string, error) {
 	id := uuid.NewString()
-	r.mu.Lock()
-	r.sessions[id] = &sessionState{
-		id:          id,
-		workspaceID: m.WorkspaceID,
-		userID:      m.UserID,
-		exeID:       m.ExeID,
-	}
-	r.mu.Unlock()
 	rec := &pb.WALRecord{
 		Id: id,
 		Body: &pb.WALRecord_SessionOpen{SessionOpen: &pb.SessionOpen{
@@ -220,10 +219,21 @@ func (r *realRecorder) SessionOpen(m SessionMeta) string {
 			OpenedAt:    timestamppb.New(m.OpenedAt),
 		}},
 	}
+	// Append BEFORE registering in r.sessions so a failure leaves no
+	// orphan state behind (the bridge will refuse the session anyway).
 	if err := r.wal.Append(rec); err != nil {
-		slog.Error("exec-audit: SessionOpen append", "id", id, "err", err)
+		slog.Error("exec-audit: SessionOpen append (refusing)", "id", id, "err", err)
+		return "", err
 	}
-	return id
+	r.mu.Lock()
+	r.sessions[id] = &sessionState{
+		id:          id,
+		workspaceID: m.WorkspaceID,
+		userID:      m.UserID,
+		exeID:       m.ExeID,
+	}
+	r.mu.Unlock()
+	return id, nil
 }
 
 func (r *realRecorder) SessionClose(sessionID, reason string, c Counters) {
@@ -276,7 +286,7 @@ func (r *realRecorder) OnFrameToClient(sessionID string, frame any, raw []byte) 
 	}
 }
 
-func (r *realRecorder) CallStart(m CallStartMeta) string {
+func (r *realRecorder) CallStart(m CallStartMeta) (string, error) {
 	id := uuid.NewString()
 	cs := &pb.CallStart{
 		CallId:      id,
@@ -293,9 +303,10 @@ func (r *realRecorder) CallStart(m CallStartMeta) string {
 	r.populatePayload(&cs.RequestBytes, &cs.RequestSize, &cs.RequestSha256, m.Request)
 	rec := &pb.WALRecord{Id: id, Body: &pb.WALRecord_CallStart{CallStart: cs}}
 	if err := r.wal.Append(rec); err != nil {
-		slog.Error("exec-audit: CallStart append", "id", id, "err", err)
+		slog.Error("exec-audit: CallStart append (refusing)", "id", id, "err", err)
+		return "", err
 	}
-	return id
+	return id, nil
 }
 
 func (r *realRecorder) CallEnd(callID string, m CallEndMeta) {

--- a/internal/codexexecgateway/audit/recorder.go
+++ b/internal/codexexecgateway/audit/recorder.go
@@ -1,0 +1,85 @@
+package audit
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// SessionMeta is the input to Recorder.SessionOpen — describes a new
+// envmcp ws bridge session about to forward frames between env-mcp
+// (or the SDK REST bridge.Pool) and codex-exec.
+type SessionMeta struct {
+	WorkspaceID string
+	UserID      string
+	ExeID       string
+	TurnID      string
+	StreamID    string
+	ClientIP    string
+	CapIAT      time.Time
+	CapEXP      time.Time
+	OpenedAt    time.Time
+}
+
+// Counters is the running per-direction frame/byte totals tracked by the
+// bridge pumps over the life of one session, snapshotted at close time.
+type Counters struct {
+	FramesToBackend int
+	FramesToClient  int
+	BytesToBackend  int64
+	BytesToClient   int64
+}
+
+// CallStartMeta is the input to Recorder.CallStart. SessionID is the
+// audit session id (only set for envmcp source). For rest/relay sources
+// it's empty — those calls aren't tied to a long-lived bridge session.
+type CallStartMeta struct {
+	SessionID   string
+	WorkspaceID string
+	UserID      string
+	ExeID       string
+	Source      string // "envmcp" | "rest" | "relay"
+	RPCID       string
+	RPCMethod   string
+	RPCKind     string // "request" | "notification" | "frame" | "" for non-RPC
+	Request     []byte // raw bytes; recorder owns truncation/hashing
+	StartedAt   time.Time
+}
+
+// CallEndMeta is the input to Recorder.CallEnd, paired with the callID
+// returned by the matching CallStart.
+type CallEndMeta struct {
+	CompletedAt  time.Time
+	IsError      bool
+	ErrorSummary string
+	Response     []byte
+}
+
+// Recorder is the audit interface used by the gateway pumps and
+// handlers. Production wires this to a real Recorder backed by WAL +
+// Uploader (Plan 2b later tasks). Tests and audit-disabled deployments
+// use NewNoopRecorder.
+type Recorder interface {
+	SessionOpen(SessionMeta) (sessionID string)
+	SessionClose(sessionID, reason string, c Counters)
+	OnFrameToBackend(sessionID string, frame any, rawBytes []byte)
+	OnFrameToClient(sessionID string, frame any, rawBytes []byte)
+	CallStart(CallStartMeta) (callID string)
+	CallEnd(callID string, m CallEndMeta)
+	Close(ctx context.Context) error
+}
+
+type noopRecorder struct{}
+
+// NewNoopRecorder returns a Recorder that mints fresh UUIDs but does
+// not persist anything. Use when CXG_AUDIT_ENABLED=false.
+func NewNoopRecorder() Recorder { return noopRecorder{} }
+
+func (noopRecorder) SessionOpen(SessionMeta) string        { return uuid.NewString() }
+func (noopRecorder) SessionClose(string, string, Counters) {}
+func (noopRecorder) OnFrameToBackend(string, any, []byte)  {}
+func (noopRecorder) OnFrameToClient(string, any, []byte)   {}
+func (noopRecorder) CallStart(CallStartMeta) string        { return uuid.NewString() }
+func (noopRecorder) CallEnd(string, CallEndMeta)           {}
+func (noopRecorder) Close(context.Context) error           { return nil }

--- a/internal/codexexecgateway/audit/recorder_real_test.go
+++ b/internal/codexexecgateway/audit/recorder_real_test.go
@@ -2,6 +2,8 @@ package audit_test
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -29,10 +31,13 @@ func TestRealRecorder_SessionOpenLandsInWAL(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sid := r.SessionOpen(audit.SessionMeta{
+	sid, err := r.SessionOpen(audit.SessionMeta{
 		WorkspaceID: "ws", ExeID: "exe", StreamID: "s1",
 		OpenedAt: time.Now().UTC(),
 	})
+	if err != nil {
+		t.Fatalf("SessionOpen: %v", err)
+	}
 	if sid == "" {
 		t.Fatal("expected non-empty sessionID")
 	}
@@ -63,7 +68,10 @@ func TestRealRecorder_DisabledReturnsNoop(t *testing.T) {
 		t.Fatal(err)
 	}
 	// noop returns non-empty UUIDs but writes nowhere.
-	sid := r.SessionOpen(audit.SessionMeta{OpenedAt: time.Now()})
+	sid, err := r.SessionOpen(audit.SessionMeta{OpenedAt: time.Now()})
+	if err != nil {
+		t.Fatalf("noop SessionOpen: %v", err)
+	}
 	if sid == "" {
 		t.Fatal("expected non-empty sessionID from noop")
 	}
@@ -93,10 +101,13 @@ func TestRealRecorder_LargePayloadHashedNotInlined(t *testing.T) {
 	for i := range big {
 		big[i] = byte(i & 0xff)
 	}
-	cid := r.CallStart(audit.CallStartMeta{
+	cid, err := r.CallStart(audit.CallStartMeta{
 		Source: "rest", WorkspaceID: "ws", ExeID: "exe",
 		Request: big, StartedAt: time.Now().UTC(),
 	})
+	if err != nil {
+		t.Fatalf("CallStart: %v", err)
+	}
 	if cid == "" {
 		t.Fatal("expected non-empty callID")
 	}
@@ -121,4 +132,113 @@ func TestRealRecorder_LargePayloadHashedNotInlined(t *testing.T) {
 	if len(cs.CallStart.RequestBytes) != 0 {
 		t.Errorf("RequestBytes should be empty when over cap, got %d bytes", len(cs.CallStart.RequestBytes))
 	}
+}
+
+// TestRealRecorder_SessionOpenErrorsOnFailModeFullDisk asserts the
+// fail-closed contract: when the WAL refuses Append (overflow=fail with
+// quota exceeded), SessionOpen propagates the error to the caller so
+// the bridge handler can refuse the new session.
+func TestRealRecorder_SessionOpenErrorsOnFailModeFullDisk(t *testing.T) {
+	dir := t.TempDir()
+	// Pre-populate with a junk wal file already over quota.
+	if err := writeBlob(t, dir, "wal-19700101-000000.log", 200); err != nil {
+		t.Fatal(err)
+	}
+	cfg := audit.Config{
+		Enabled:           true,
+		WALDir:            dir,
+		WALFsyncRecords:   1,
+		WALFsyncInterval:  time.Minute,
+		WALFileMaxBytes:   1 << 20,
+		WALDiskQuotaBytes: 100, // already blown by the pre-populated junk
+		WALOverflow:       "fail",
+		PayloadMaxBytes:   4 << 20,
+		RPCPairTimeout:    time.Minute,
+		GatewayID:         "test",
+	}
+	r, err := audit.NewRecorder(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close(context.Background())
+
+	_, err = r.SessionOpen(audit.SessionMeta{
+		WorkspaceID: "ws", ExeID: "exe", StreamID: "s1",
+		OpenedAt: time.Now().UTC(),
+	})
+	if err == nil {
+		t.Fatal("expected SessionOpen to refuse on fail-mode quota; got nil error")
+	}
+}
+
+// TestRealRecorder_CallStartErrorsOnFailModeFullDisk: same as above but
+// for CallStart.
+func TestRealRecorder_CallStartErrorsOnFailModeFullDisk(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeBlob(t, dir, "wal-19700101-000000.log", 200); err != nil {
+		t.Fatal(err)
+	}
+	cfg := audit.Config{
+		Enabled:           true,
+		WALDir:            dir,
+		WALFsyncRecords:   1,
+		WALFsyncInterval:  time.Minute,
+		WALFileMaxBytes:   1 << 20,
+		WALDiskQuotaBytes: 100,
+		WALOverflow:       "fail",
+		PayloadMaxBytes:   4 << 20,
+		RPCPairTimeout:    time.Minute,
+		GatewayID:         "test",
+	}
+	r, err := audit.NewRecorder(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close(context.Background())
+
+	_, err = r.CallStart(audit.CallStartMeta{
+		Source: "rest", WorkspaceID: "ws", ExeID: "exe",
+		StartedAt: time.Now().UTC(),
+	})
+	if err == nil {
+		t.Fatal("expected CallStart to refuse on fail-mode quota; got nil error")
+	}
+}
+
+// TestRealRecorder_SessionOpenSucceedsInDropMode: under drop mode the
+// WAL silently unlinks old files to fit; SessionOpen should succeed.
+func TestRealRecorder_SessionOpenSucceedsInDropMode(t *testing.T) {
+	dir := t.TempDir()
+	if err := writeBlob(t, dir, "wal-19700101-000000.log", 200); err != nil {
+		t.Fatal(err)
+	}
+	cfg := audit.Config{
+		Enabled:           true,
+		WALDir:            dir,
+		WALFsyncRecords:   1,
+		WALFsyncInterval:  time.Minute,
+		WALFileMaxBytes:   1 << 20,
+		WALDiskQuotaBytes: 100,
+		WALOverflow:       "drop",
+		PayloadMaxBytes:   4 << 20,
+		RPCPairTimeout:    time.Minute,
+		GatewayID:         "test",
+	}
+	r, err := audit.NewRecorder(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close(context.Background())
+
+	if _, err := r.SessionOpen(audit.SessionMeta{
+		WorkspaceID: "ws", ExeID: "exe", StreamID: "s1",
+		OpenedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatalf("drop-mode SessionOpen should succeed, got %v", err)
+	}
+}
+
+func writeBlob(t *testing.T, dir, name string, size int) error {
+	t.Helper()
+	return os.WriteFile(filepath.Join(dir, name), make([]byte, size), 0o640)
 }

--- a/internal/codexexecgateway/audit/recorder_real_test.go
+++ b/internal/codexexecgateway/audit/recorder_real_test.go
@@ -1,0 +1,124 @@
+package audit_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/agentserver/agentserver/internal/codexexecgateway/audit"
+	pb "github.com/agentserver/agentserver/internal/server/exec_audit_pb"
+)
+
+func TestRealRecorder_SessionOpenLandsInWAL(t *testing.T) {
+	dir := t.TempDir()
+	cfg := audit.Config{
+		Enabled:           true,
+		WALDir:            dir,
+		WALFsyncRecords:   1,
+		WALFsyncInterval:  time.Minute,
+		WALFileMaxBytes:   1 << 20,
+		WALDiskQuotaBytes: 10 << 20,
+		WALOverflow:       "fail",
+		PayloadMaxBytes:   4 << 20,
+		UploadURL:         "", // upload disabled
+		RPCPairTimeout:    time.Minute,
+		GatewayID:         "test",
+	}
+	r, err := audit.NewRecorder(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sid := r.SessionOpen(audit.SessionMeta{
+		WorkspaceID: "ws", ExeID: "exe", StreamID: "s1",
+		OpenedAt: time.Now().UTC(),
+	})
+	if sid == "" {
+		t.Fatal("expected non-empty sessionID")
+	}
+	if err := r.Close(context.Background()); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	reader, err := audit.OpenWALReader(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+	rec, _, err := reader.Next()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if _, ok := rec.Body.(*pb.WALRecord_SessionOpen); !ok {
+		t.Fatalf("expected SessionOpen body, got %T", rec.Body)
+	}
+	if rec.Id != sid {
+		t.Fatalf("expected id %s, got %s", sid, rec.Id)
+	}
+}
+
+func TestRealRecorder_DisabledReturnsNoop(t *testing.T) {
+	r, err := audit.NewRecorder(audit.Config{Enabled: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// noop returns non-empty UUIDs but writes nowhere.
+	sid := r.SessionOpen(audit.SessionMeta{OpenedAt: time.Now()})
+	if sid == "" {
+		t.Fatal("expected non-empty sessionID from noop")
+	}
+	_ = r.Close(context.Background())
+}
+
+func TestRealRecorder_LargePayloadHashedNotInlined(t *testing.T) {
+	dir := t.TempDir()
+	cfg := audit.Config{
+		Enabled:           true,
+		WALDir:            dir,
+		WALFsyncRecords:   1,
+		WALFsyncInterval:  time.Minute,
+		WALFileMaxBytes:   100 << 20, // large
+		WALDiskQuotaBytes: 100 << 20,
+		WALOverflow:       "fail",
+		PayloadMaxBytes:   1024, // cap at 1 KiB
+		RPCPairTimeout:    time.Minute,
+		GatewayID:         "test",
+	}
+	r, err := audit.NewRecorder(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	big := make([]byte, 4096)
+	for i := range big {
+		big[i] = byte(i & 0xff)
+	}
+	cid := r.CallStart(audit.CallStartMeta{
+		Source: "rest", WorkspaceID: "ws", ExeID: "exe",
+		Request: big, StartedAt: time.Now().UTC(),
+	})
+	if cid == "" {
+		t.Fatal("expected non-empty callID")
+	}
+	_ = r.Close(context.Background())
+
+	reader, _ := audit.OpenWALReader(dir)
+	defer reader.Close()
+	rec, _, err := reader.Next()
+	if err != nil {
+		t.Fatal(err)
+	}
+	cs, ok := rec.Body.(*pb.WALRecord_CallStart)
+	if !ok {
+		t.Fatalf("expected CallStart, got %T", rec.Body)
+	}
+	if cs.CallStart.RequestSize != 4096 {
+		t.Errorf("RequestSize: got %d want 4096", cs.CallStart.RequestSize)
+	}
+	if cs.CallStart.RequestSha256 == "" {
+		t.Error("RequestSha256: empty")
+	}
+	if len(cs.CallStart.RequestBytes) != 0 {
+		t.Errorf("RequestBytes should be empty when over cap, got %d bytes", len(cs.CallStart.RequestBytes))
+	}
+}

--- a/internal/codexexecgateway/audit/recorder_test.go
+++ b/internal/codexexecgateway/audit/recorder_test.go
@@ -10,21 +10,27 @@ import (
 
 func TestNoopRecorder_AllMethodsAreSafe(t *testing.T) {
 	r := audit.NewNoopRecorder()
-	sid := r.SessionOpen(audit.SessionMeta{
+	sid, err := r.SessionOpen(audit.SessionMeta{
 		WorkspaceID: "ws", ExeID: "exe", StreamID: "s1",
 		OpenedAt: time.Now(),
 	})
+	if err != nil {
+		t.Fatalf("noop SessionOpen unexpectedly returned err: %v", err)
+	}
 	if sid == "" {
 		t.Fatal("expected non-empty session id even from noop")
 	}
 	r.OnFrameToBackend(sid, nil, nil)
 	r.OnFrameToClient(sid, nil, nil)
-	cid := r.CallStart(audit.CallStartMeta{
+	cid, err := r.CallStart(audit.CallStartMeta{
 		Source:      "rest",
 		WorkspaceID: "ws",
 		ExeID:       "exe",
 		StartedAt:   time.Now(),
 	})
+	if err != nil {
+		t.Fatalf("noop CallStart unexpectedly returned err: %v", err)
+	}
 	if cid == "" {
 		t.Fatal("expected non-empty call id even from noop")
 	}

--- a/internal/codexexecgateway/audit/recorder_test.go
+++ b/internal/codexexecgateway/audit/recorder_test.go
@@ -1,0 +1,73 @@
+package audit_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/agentserver/agentserver/internal/codexexecgateway/audit"
+)
+
+func TestNoopRecorder_AllMethodsAreSafe(t *testing.T) {
+	r := audit.NewNoopRecorder()
+	sid := r.SessionOpen(audit.SessionMeta{
+		WorkspaceID: "ws", ExeID: "exe", StreamID: "s1",
+		OpenedAt: time.Now(),
+	})
+	if sid == "" {
+		t.Fatal("expected non-empty session id even from noop")
+	}
+	r.OnFrameToBackend(sid, nil, nil)
+	r.OnFrameToClient(sid, nil, nil)
+	cid := r.CallStart(audit.CallStartMeta{
+		Source:      "rest",
+		WorkspaceID: "ws",
+		ExeID:       "exe",
+		StartedAt:   time.Now(),
+	})
+	if cid == "" {
+		t.Fatal("expected non-empty call id even from noop")
+	}
+	r.CallEnd(cid, audit.CallEndMeta{CompletedAt: time.Now()})
+	r.SessionClose(sid, "ok", audit.Counters{})
+	if err := r.Close(context.Background()); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+}
+
+func TestNewConfigFromEnv_Defaults(t *testing.T) {
+	// All CXG_AUDIT_* vars unset → defaults.
+	cfg := audit.NewConfigFromEnv()
+	if cfg.Enabled {
+		t.Errorf("Enabled should default to false; got true")
+	}
+	if cfg.WALDir != "/var/cxg-audit" {
+		t.Errorf("WALDir default: got %q", cfg.WALDir)
+	}
+	if cfg.PayloadMaxBytes != 4*1024*1024 {
+		t.Errorf("PayloadMaxBytes default: got %d", cfg.PayloadMaxBytes)
+	}
+	if cfg.RPCPairTimeout != 30*time.Second {
+		t.Errorf("RPCPairTimeout default: got %v", cfg.RPCPairTimeout)
+	}
+}
+
+func TestNewConfigFromEnv_OverridesViaEnv(t *testing.T) {
+	t.Setenv("CXG_AUDIT_ENABLED", "true")
+	t.Setenv("CXG_AUDIT_WAL_DIR", "/custom")
+	t.Setenv("CXG_AUDIT_PAYLOAD_MAX_BYTES", "1024")
+	t.Setenv("CXG_AUDIT_RPC_PAIR_TIMEOUT", "5s")
+	cfg := audit.NewConfigFromEnv()
+	if !cfg.Enabled {
+		t.Error("Enabled: want true")
+	}
+	if cfg.WALDir != "/custom" {
+		t.Errorf("WALDir: got %q", cfg.WALDir)
+	}
+	if cfg.PayloadMaxBytes != 1024 {
+		t.Errorf("PayloadMaxBytes: got %d", cfg.PayloadMaxBytes)
+	}
+	if cfg.RPCPairTimeout != 5*time.Second {
+		t.Errorf("RPCPairTimeout: got %v", cfg.RPCPairTimeout)
+	}
+}

--- a/internal/codexexecgateway/audit/rpcparser.go
+++ b/internal/codexexecgateway/audit/rpcparser.go
@@ -1,0 +1,211 @@
+package audit
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+	"time"
+)
+
+type RPCParserConfig struct {
+	PairTimeout time.Duration
+}
+
+type pendingCall struct {
+	callID    string
+	startedAt time.Time
+}
+
+// RPCParser parses RelayData payload as JSON-RPC, pairs requests with
+// responses by id within a session, and emits CallStart/CallEnd via the
+// Recorder. Notifications produce CallStart only. Unpaired requests
+// older than PairTimeout are swept by SweepTimeouts (caller invokes
+// periodically). Session-closed flushes remaining pending calls.
+type RPCParser struct {
+	rec Recorder
+	cfg RPCParserConfig
+
+	mu sync.Mutex
+	// pending: session_id → rpc_id → call info
+	pending map[string]map[string]pendingCall
+}
+
+func NewRPCParser(rec Recorder, cfg RPCParserConfig) *RPCParser {
+	if cfg.PairTimeout <= 0 {
+		cfg.PairTimeout = 30 * time.Second
+	}
+	return &RPCParser{
+		rec:     rec,
+		cfg:     cfg,
+		pending: map[string]map[string]pendingCall{},
+	}
+}
+
+// OnFrameToBackend processes a payload going from env-mcp to codex-exec.
+// Workspace/user/exe identify the session — caller has them in context
+// from the bridge handshake.
+func (p *RPCParser) OnFrameToBackend(sessionID, wsID, userID, exeID string, payload []byte) {
+	id, method, kind, ok := parseRPC(payload)
+	if !ok {
+		return
+	}
+	now := time.Now().UTC()
+	startMeta := CallStartMeta{
+		SessionID:   sessionID,
+		WorkspaceID: wsID,
+		UserID:      userID,
+		ExeID:       exeID,
+		Source:      "envmcp",
+		RPCID:       id,
+		RPCMethod:   method,
+		RPCKind:     kind,
+		Request:     payload,
+		StartedAt:   now,
+	}
+	callID := p.rec.CallStart(startMeta)
+	if kind != "request" {
+		return // notification: no pair expected
+	}
+	p.mu.Lock()
+	if p.pending[sessionID] == nil {
+		p.pending[sessionID] = map[string]pendingCall{}
+	}
+	p.pending[sessionID][id] = pendingCall{callID: callID, startedAt: now}
+	p.mu.Unlock()
+}
+
+// OnFrameToClient processes a payload going from codex-exec back to
+// env-mcp. If it matches a pending request (same session_id + rpc_id),
+// emits the matching CallEnd.
+func (p *RPCParser) OnFrameToClient(sessionID string, payload []byte) {
+	id, _, kind, ok := parseRPC(payload)
+	if !ok {
+		return
+	}
+	if kind != "response" && kind != "error" {
+		return // shouldn't happen for server→client, but be defensive
+	}
+	p.mu.Lock()
+	pc, found := p.pending[sessionID][id]
+	if found {
+		delete(p.pending[sessionID], id)
+	}
+	p.mu.Unlock()
+	if !found {
+		return
+	}
+
+	isErr := kind == "error"
+	var errSum string
+	if isErr {
+		errSum = extractErrorMessage(payload)
+	}
+	p.rec.CallEnd(pc.callID, CallEndMeta{
+		CompletedAt:  time.Now().UTC(),
+		IsError:      isErr,
+		ErrorSummary: errSum,
+		Response:     payload,
+	})
+}
+
+// SweepTimeouts walks the pending table and emits timeout CallEnds for
+// any request older than cfg.PairTimeout. Caller (typically the real
+// Recorder's background loop) invokes periodically.
+func (p *RPCParser) SweepTimeouts(now time.Time) {
+	p.mu.Lock()
+	type timed struct {
+		pc pendingCall
+	}
+	out := []timed{}
+	for sid, m := range p.pending {
+		for id, pc := range m {
+			if now.Sub(pc.startedAt) >= p.cfg.PairTimeout {
+				out = append(out, timed{pc: pc})
+				delete(m, id)
+			}
+		}
+		if len(m) == 0 {
+			delete(p.pending, sid)
+		}
+	}
+	p.mu.Unlock()
+	for _, t := range out {
+		p.rec.CallEnd(t.pc.callID, CallEndMeta{
+			CompletedAt:  now,
+			IsError:      true,
+			ErrorSummary: fmt.Sprintf("rpc pair timeout after %s", p.cfg.PairTimeout),
+		})
+	}
+}
+
+// SessionClosed drops any pending calls for sid as session-closed
+// errors. Called by the real Recorder when the bridge SessionClose
+// fires (any still-pending request will never get its response).
+func (p *RPCParser) SessionClosed(sid string, now time.Time) {
+	p.mu.Lock()
+	pending := p.pending[sid]
+	delete(p.pending, sid)
+	p.mu.Unlock()
+	for _, pc := range pending {
+		p.rec.CallEnd(pc.callID, CallEndMeta{
+			CompletedAt:  now,
+			IsError:      true,
+			ErrorSummary: "session closed before response",
+		})
+	}
+}
+
+// parseRPC returns (id, method, kind, ok). kind is "request" |
+// "notification" | "response" | "error". ok=false for non-JSON, wrong
+// jsonrpc version, or shape we don't recognize.
+func parseRPC(b []byte) (string, string, string, bool) {
+	var m struct {
+		JSONRPC string          `json:"jsonrpc"`
+		ID      json.RawMessage `json:"id"`
+		Method  string          `json:"method"`
+		Result  json.RawMessage `json:"result"`
+		Error   json.RawMessage `json:"error"`
+	}
+	if err := json.Unmarshal(b, &m); err != nil {
+		return "", "", "", false
+	}
+	if m.JSONRPC != "2.0" {
+		return "", "", "", false
+	}
+	idStr := ""
+	if len(m.ID) > 0 && string(m.ID) != "null" {
+		idStr = trimQuotes(string(m.ID))
+	}
+	if m.Method != "" {
+		if idStr == "" {
+			return "", m.Method, "notification", true
+		}
+		return idStr, m.Method, "request", true
+	}
+	if len(m.Error) > 0 {
+		return idStr, "", "error", true
+	}
+	if len(m.Result) > 0 {
+		return idStr, "", "response", true
+	}
+	return "", "", "", false
+}
+
+func trimQuotes(s string) string {
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+
+func extractErrorMessage(payload []byte) string {
+	var m struct {
+		Error struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(payload, &m); err != nil {
+		return ""
+	}
+	return m.Error.Message
+}

--- a/internal/codexexecgateway/audit/rpcparser.go
+++ b/internal/codexexecgateway/audit/rpcparser.go
@@ -62,7 +62,15 @@ func (p *RPCParser) OnFrameToBackend(sessionID, wsID, userID, exeID string, payl
 		Request:     payload,
 		StartedAt:   now,
 	}
-	callID := p.rec.CallStart(startMeta)
+	callID, err := p.rec.CallStart(startMeta)
+	if err != nil {
+		// Best-effort: a session-level frame's CallStart failing means
+		// the WAL is wedged. The bridge handler doesn't have a
+		// per-frame error path (audit must not block frame forwarding),
+		// so just drop the pair-tracking entry — the failure was logged
+		// inside realRecorder.
+		return
+	}
 	if kind != "request" {
 		return // notification: no pair expected
 	}

--- a/internal/codexexecgateway/audit/rpcparser.go
+++ b/internal/codexexecgateway/audit/rpcparser.go
@@ -206,14 +206,23 @@ func trimQuotes(s string) string {
 	return s
 }
 
+// extractErrorMessage pulls the JSON-RPC error.message field from a
+// response payload. Falls back to a truncated raw-payload string when
+// the payload doesn't match the standard shape — operators no longer
+// see IsError=true with an empty ErrorSummary in the audit DB (I9).
 func extractErrorMessage(payload []byte) string {
 	var m struct {
 		Error struct {
 			Message string `json:"message"`
 		} `json:"error"`
 	}
-	if err := json.Unmarshal(payload, &m); err != nil {
-		return ""
+	if err := json.Unmarshal(payload, &m); err == nil && m.Error.Message != "" {
+		return m.Error.Message
 	}
-	return m.Error.Message
+	// Fallback: truncate the raw payload so operators get SOMETHING.
+	const maxErrSummary = 256
+	if len(payload) > maxErrSummary {
+		return string(payload[:maxErrSummary]) + "...(truncated)"
+	}
+	return string(payload)
 }

--- a/internal/codexexecgateway/audit/rpcparser_test.go
+++ b/internal/codexexecgateway/audit/rpcparser_test.go
@@ -22,16 +22,16 @@ func newCapRecorder() *capRecorder {
 	return &capRecorder{ends: map[string]audit.CallEndMeta{}}
 }
 
-func (r *capRecorder) SessionOpen(audit.SessionMeta) string        { return "" }
-func (r *capRecorder) SessionClose(string, string, audit.Counters) {}
-func (r *capRecorder) OnFrameToBackend(string, any, []byte)        {}
-func (r *capRecorder) OnFrameToClient(string, any, []byte)         {}
-func (r *capRecorder) CallStart(m audit.CallStartMeta) string {
+func (r *capRecorder) SessionOpen(audit.SessionMeta) (string, error) { return "", nil }
+func (r *capRecorder) SessionClose(string, string, audit.Counters)   {}
+func (r *capRecorder) OnFrameToBackend(string, any, []byte)          {}
+func (r *capRecorder) OnFrameToClient(string, any, []byte)           {}
+func (r *capRecorder) CallStart(m audit.CallStartMeta) (string, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	id := "call-" + m.RPCID
 	r.starts = append(r.starts, m)
-	return id
+	return id, nil
 }
 func (r *capRecorder) CallEnd(id string, m audit.CallEndMeta) {
 	r.mu.Lock()

--- a/internal/codexexecgateway/audit/rpcparser_test.go
+++ b/internal/codexexecgateway/audit/rpcparser_test.go
@@ -1,0 +1,193 @@
+package audit_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/agentserver/agentserver/internal/codexexecgateway/audit"
+)
+
+// capRecorder is a test Recorder that captures CallStart/CallEnd events
+// for assertion. SessionOpen/Close/OnFrame* are no-ops — the parser
+// doesn't invoke them.
+type capRecorder struct {
+	mu     sync.Mutex
+	starts []audit.CallStartMeta
+	ends   map[string]audit.CallEndMeta
+}
+
+func newCapRecorder() *capRecorder {
+	return &capRecorder{ends: map[string]audit.CallEndMeta{}}
+}
+
+func (r *capRecorder) SessionOpen(audit.SessionMeta) string        { return "" }
+func (r *capRecorder) SessionClose(string, string, audit.Counters) {}
+func (r *capRecorder) OnFrameToBackend(string, any, []byte)        {}
+func (r *capRecorder) OnFrameToClient(string, any, []byte)         {}
+func (r *capRecorder) CallStart(m audit.CallStartMeta) string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	id := "call-" + m.RPCID
+	r.starts = append(r.starts, m)
+	return id
+}
+func (r *capRecorder) CallEnd(id string, m audit.CallEndMeta) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.ends[id] = m
+}
+func (r *capRecorder) Close(context.Context) error { return nil }
+
+func TestRPCParser_RequestResponsePair(t *testing.T) {
+	cap := newCapRecorder()
+	p := audit.NewRPCParser(cap, audit.RPCParserConfig{PairTimeout: time.Minute})
+
+	p.OnFrameToBackend("s1", "ws_x", "user_x", "exe_x", []byte(`
+		{"jsonrpc":"2.0","id":42,"method":"shell","params":{"cmd":"ls"}}
+	`))
+	p.OnFrameToClient("s1", []byte(`
+		{"jsonrpc":"2.0","id":42,"result":{"stdout":"foo"}}
+	`))
+
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	if len(cap.starts) != 1 {
+		t.Fatalf("expected 1 CallStart, got %d", len(cap.starts))
+	}
+	s := cap.starts[0]
+	if s.RPCMethod != "shell" {
+		t.Errorf("method: %q", s.RPCMethod)
+	}
+	if s.RPCKind != "request" {
+		t.Errorf("kind: %q", s.RPCKind)
+	}
+	if s.WorkspaceID != "ws_x" || s.UserID != "user_x" || s.ExeID != "exe_x" {
+		t.Errorf("metadata mismatch: %+v", s)
+	}
+	if s.Source != "envmcp" {
+		t.Errorf("source: %q (want envmcp)", s.Source)
+	}
+	end, ok := cap.ends["call-42"]
+	if !ok {
+		t.Fatal("expected CallEnd for id=42")
+	}
+	if end.IsError {
+		t.Error("expected IsError=false")
+	}
+	if len(end.Response) == 0 {
+		t.Error("expected Response bytes captured")
+	}
+}
+
+func TestRPCParser_NotificationProducesCallStartOnly(t *testing.T) {
+	cap := newCapRecorder()
+	p := audit.NewRPCParser(cap, audit.RPCParserConfig{PairTimeout: time.Minute})
+	p.OnFrameToBackend("s1", "ws", "user", "exe", []byte(`
+		{"jsonrpc":"2.0","method":"progress","params":{"n":1}}
+	`))
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	if len(cap.starts) != 1 {
+		t.Fatalf("expected 1 CallStart for notification, got %d", len(cap.starts))
+	}
+	if cap.starts[0].RPCKind != "notification" {
+		t.Errorf("kind: %q", cap.starts[0].RPCKind)
+	}
+	if len(cap.ends) != 0 {
+		t.Fatalf("notifications shouldn't produce CallEnd, got %d", len(cap.ends))
+	}
+}
+
+func TestRPCParser_ErrorResponsePairs(t *testing.T) {
+	cap := newCapRecorder()
+	p := audit.NewRPCParser(cap, audit.RPCParserConfig{PairTimeout: time.Minute})
+	p.OnFrameToBackend("s1", "ws", "user", "exe", []byte(`
+		{"jsonrpc":"2.0","id":7,"method":"die","params":{}}
+	`))
+	p.OnFrameToClient("s1", []byte(`
+		{"jsonrpc":"2.0","id":7,"error":{"code":-32603,"message":"boom"}}
+	`))
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	end, ok := cap.ends["call-7"]
+	if !ok {
+		t.Fatal("expected CallEnd for id=7")
+	}
+	if !end.IsError {
+		t.Error("expected IsError=true on JSON-RPC error response")
+	}
+	if end.ErrorSummary != "boom" {
+		t.Errorf("expected ErrorSummary='boom', got %q", end.ErrorSummary)
+	}
+}
+
+func TestRPCParser_MalformedPayloadIgnored(t *testing.T) {
+	cap := newCapRecorder()
+	p := audit.NewRPCParser(cap, audit.RPCParserConfig{PairTimeout: time.Minute})
+	p.OnFrameToBackend("s1", "ws", "user", "exe", []byte(`not json at all`))
+	p.OnFrameToBackend("s1", "ws", "user", "exe", []byte(`{"jsonrpc":"1.0","id":1,"method":"x"}`)) // wrong version
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	if len(cap.starts) != 0 {
+		t.Fatalf("expected no calls for malformed payloads, got %d", len(cap.starts))
+	}
+}
+
+func TestRPCParser_TimeoutEmitsErrorCallEnd(t *testing.T) {
+	cap := newCapRecorder()
+	p := audit.NewRPCParser(cap, audit.RPCParserConfig{PairTimeout: 50 * time.Millisecond})
+	p.OnFrameToBackend("s1", "ws", "user", "exe", []byte(`
+		{"jsonrpc":"2.0","id":99,"method":"slow","params":{}}
+	`))
+	time.Sleep(200 * time.Millisecond)
+	p.SweepTimeouts(time.Now())
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	end, ok := cap.ends["call-99"]
+	if !ok {
+		t.Fatal("expected timeout CallEnd for id=99")
+	}
+	if !end.IsError || end.ErrorSummary == "" {
+		t.Fatalf("expected is_error + summary, got %+v", end)
+	}
+}
+
+func TestRPCParser_SessionClosedFlushesPending(t *testing.T) {
+	cap := newCapRecorder()
+	p := audit.NewRPCParser(cap, audit.RPCParserConfig{PairTimeout: time.Minute})
+	p.OnFrameToBackend("s1", "ws", "user", "exe", []byte(`
+		{"jsonrpc":"2.0","id":11,"method":"x","params":{}}
+	`))
+	p.OnFrameToBackend("s1", "ws", "user", "exe", []byte(`
+		{"jsonrpc":"2.0","id":12,"method":"y","params":{}}
+	`))
+	p.SessionClosed("s1", time.Now())
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	if len(cap.ends) != 2 {
+		t.Fatalf("expected 2 flushed CallEnds (for ids 11 and 12), got %d", len(cap.ends))
+	}
+	for id, end := range cap.ends {
+		if !end.IsError {
+			t.Errorf("%s: expected IsError=true on session-closed flush", id)
+		}
+	}
+}
+
+func TestRPCParser_StringIDsHandled(t *testing.T) {
+	cap := newCapRecorder()
+	p := audit.NewRPCParser(cap, audit.RPCParserConfig{PairTimeout: time.Minute})
+	p.OnFrameToBackend("s1", "ws", "user", "exe", []byte(`
+		{"jsonrpc":"2.0","id":"abc-123","method":"shell"}
+	`))
+	p.OnFrameToClient("s1", []byte(`
+		{"jsonrpc":"2.0","id":"abc-123","result":{"stdout":""}}
+	`))
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	if _, ok := cap.ends["call-abc-123"]; !ok {
+		t.Fatalf("expected pairing with string id; got ends=%v", cap.ends)
+	}
+}

--- a/internal/codexexecgateway/audit/uploader.go
+++ b/internal/codexexecgateway/audit/uploader.go
@@ -1,0 +1,204 @@
+package audit
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"time"
+
+	pb "github.com/agentserver/agentserver/internal/server/exec_audit_pb"
+	"google.golang.org/protobuf/proto"
+)
+
+// UploaderConfig configures NewUploader. WALDir, Cursor, UploadURL,
+// GatewayID are required; remaining fields default to plan-spec values
+// if zero.
+type UploaderConfig struct {
+	WALDir        string
+	Cursor        *Cursor
+	UploadURL     string
+	UploadSecret  string
+	BatchRecords  int
+	BatchBytes    int
+	FlushInterval time.Duration
+	GatewayID     string
+	Logger        *slog.Logger
+	HTTPClient    *http.Client
+	BackoffStart  time.Duration
+	BackoffMax    time.Duration
+}
+
+// Uploader drives the WAL → agentserver upload loop. Single goroutine
+// owns the WAL reader; concurrent calls to Run are not supported.
+type Uploader struct {
+	cfg UploaderConfig
+	log *slog.Logger
+	hc  *http.Client
+}
+
+func NewUploader(cfg UploaderConfig) *Uploader {
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = &http.Client{Timeout: 30 * time.Second}
+	}
+	if cfg.BackoffStart == 0 {
+		cfg.BackoffStart = time.Second
+	}
+	if cfg.BackoffMax == 0 {
+		cfg.BackoffMax = 5 * time.Minute
+	}
+	if cfg.BatchRecords <= 0 {
+		cfg.BatchRecords = 200
+	}
+	if cfg.BatchBytes <= 0 {
+		cfg.BatchBytes = 1 << 20
+	}
+	if cfg.FlushInterval <= 0 {
+		cfg.FlushInterval = time.Second
+	}
+	return &Uploader{cfg: cfg, log: cfg.Logger, hc: cfg.HTTPClient}
+}
+
+// Run drives uploads until ctx is canceled. Blocks; intended for
+// `go u.Run(ctx)`. On 401/403 Run returns immediately (auth misconfig
+// is operator-resolvable, not retryable).
+func (u *Uploader) Run(ctx context.Context) {
+	backoff := u.cfg.BackoffStart
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+		batch, perFile, totalBytes, err := u.readNextBatch()
+		if err != nil {
+			u.log.Warn("exec-audit uploader: read batch", "err", err)
+			u.sleep(ctx, u.cfg.FlushInterval)
+			continue
+		}
+		if len(batch.Records) == 0 {
+			u.sleep(ctx, u.cfg.FlushInterval)
+			continue
+		}
+
+		if err := u.postBatch(ctx, batch); err != nil {
+			if errors.Is(err, errAuthFatal) {
+				u.log.Error("exec-audit uploader: auth failure, stopping", "err", err)
+				return
+			}
+			u.log.Warn("exec-audit uploader: post failed",
+				"err", err, "backoff", backoff)
+			u.sleep(ctx, backoff)
+			backoff = nextBackoff(backoff, u.cfg.BackoffMax)
+			continue
+		}
+
+		// Success — advance cursor by bytes shipped in this batch and persist.
+		for fname, n := range perFile {
+			u.cfg.Cursor.Advance(fname, n)
+		}
+		if err := u.cfg.Cursor.Save(); err != nil {
+			u.log.Warn("exec-audit uploader: cursor save", "err", err)
+		}
+		u.log.Debug("exec-audit uploader: sent",
+			"records", len(batch.Records), "bytes", totalBytes)
+		backoff = u.cfg.BackoffStart
+	}
+}
+
+var errAuthFatal = errors.New("auth failed")
+
+// readNextBatch opens a fresh WAL reader (so newly-written records since
+// last call are visible), seeks past cursor, and pulls up to
+// BatchRecords / BatchBytes worth of records. Returns the batch + a
+// per-file byte tally so the caller can Advance the cursor symmetrically
+// on a successful POST.
+func (u *Uploader) readNextBatch() (*pb.BatchRecords, map[string]int64, int, error) {
+	r, err := OpenWALReader(u.cfg.WALDir)
+	if err != nil {
+		return nil, nil, 0, err
+	}
+	defer r.Close()
+
+	if err := r.SeekPastCursor(u.cfg.Cursor); err != nil {
+		return nil, nil, 0, err
+	}
+
+	batch := &pb.BatchRecords{GatewayId: u.cfg.GatewayID}
+	perFile := map[string]int64{}
+	totalBytes := 0
+	for {
+		rec, fname, n, err := r.NextWithSize()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, nil, 0, err
+		}
+		batch.Records = append(batch.Records, rec)
+		perFile[fname] += n
+		totalBytes += int(n)
+		if len(batch.Records) >= u.cfg.BatchRecords {
+			break
+		}
+		if totalBytes >= u.cfg.BatchBytes {
+			break
+		}
+	}
+	return batch, perFile, totalBytes, nil
+}
+
+// postBatch ships one batch and classifies the response. Returns
+// errAuthFatal on 401/403 (caller stops Run); returns a transient error
+// on 5xx/429/network (caller backs off); returns nil on 200.
+func (u *Uploader) postBatch(ctx context.Context, batch *pb.BatchRecords) error {
+	body, err := proto.Marshal(batch)
+	if err != nil {
+		return fmt.Errorf("marshal: %w", err)
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, u.cfg.UploadURL, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/x-protobuf")
+	if u.cfg.UploadSecret != "" {
+		req.Header.Set("X-Internal-Secret", u.cfg.UploadSecret)
+	}
+	resp, err := u.hc.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == 401 || resp.StatusCode == 403 {
+		return fmt.Errorf("%w: status %d", errAuthFatal, resp.StatusCode)
+	}
+	if resp.StatusCode >= 500 || resp.StatusCode == 429 {
+		return fmt.Errorf("server: %d", resp.StatusCode)
+	}
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("unexpected: %d", resp.StatusCode)
+	}
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return nil
+}
+
+func (u *Uploader) sleep(ctx context.Context, d time.Duration) {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+	case <-t.C:
+	}
+}
+
+func nextBackoff(cur, max time.Duration) time.Duration {
+	next := cur * 2
+	if next > max {
+		return max
+	}
+	return next
+}

--- a/internal/codexexecgateway/audit/uploader.go
+++ b/internal/codexexecgateway/audit/uploader.go
@@ -81,6 +81,17 @@ func (u *Uploader) Run(ctx context.Context) {
 			continue
 		}
 		if len(batch.Records) == 0 {
+			// W2: a batch with no records but non-empty perFile means
+			// only corrupt records were skipped. Persist the cursor
+			// advance so we don't re-scan the same poison bytes forever.
+			if len(perFile) > 0 {
+				for fname, n := range perFile {
+					u.cfg.Cursor.Advance(fname, n)
+				}
+				if err := u.cfg.Cursor.Save(); err != nil {
+					u.log.Warn("exec-audit uploader: cursor save after skip", "err", err)
+				}
+			}
 			u.sleep(ctx, u.cfg.FlushInterval)
 			continue
 		}
@@ -138,6 +149,15 @@ func (u *Uploader) readNextBatch() (*pb.BatchRecords, map[string]int64, int, err
 		}
 		if err != nil {
 			return nil, nil, 0, err
+		}
+		// W2 sentinel: rec=nil, n>0 means "corrupt record skipped".
+		// Advance the cursor counter so the uploader moves past the
+		// poison bytes on the next commit, but don't include in batch.
+		if rec == nil {
+			if n > 0 {
+				perFile[fname] += n
+			}
+			continue
 		}
 		batch.Records = append(batch.Records, rec)
 		perFile[fname] += n

--- a/internal/codexexecgateway/audit/uploader.go
+++ b/internal/codexexecgateway/audit/uploader.go
@@ -40,7 +40,16 @@ type Uploader struct {
 	hc  *http.Client
 }
 
-func NewUploader(cfg UploaderConfig) *Uploader {
+// NewUploader validates config and returns the uploader. Refuses when
+// UploadURL is set but UploadSecret is empty — the upload loop would
+// hit a 401/403 forever (errAuthFatal), the goroutine would die, and
+// audit records would silently accumulate on disk with no upload. The
+// silent-failure mode that bug produces is the worst kind of
+// operational disaster, so fail-fast at construction (I11 followup).
+func NewUploader(cfg UploaderConfig) (*Uploader, error) {
+	if cfg.UploadURL != "" && cfg.UploadSecret == "" {
+		return nil, errors.New("uploader: UploadURL set but UploadSecret empty (would 401 forever)")
+	}
 	if cfg.Logger == nil {
 		cfg.Logger = slog.Default()
 	}
@@ -62,7 +71,7 @@ func NewUploader(cfg UploaderConfig) *Uploader {
 	if cfg.FlushInterval <= 0 {
 		cfg.FlushInterval = time.Second
 	}
-	return &Uploader{cfg: cfg, log: cfg.Logger, hc: cfg.HTTPClient}
+	return &Uploader{cfg: cfg, log: cfg.Logger, hc: cfg.HTTPClient}, nil
 }
 
 // Run drives uploads until ctx is canceled. Blocks; intended for
@@ -128,6 +137,13 @@ var errAuthFatal = errors.New("auth failed")
 // BatchRecords / BatchBytes worth of records. Returns the batch + a
 // per-file byte tally so the caller can Advance the cursor symmetrically
 // on a successful POST.
+//
+// TODO(perf): reopening + re-seeking every iteration is O(uploaded
+// bytes) per call. For high-throughput deployments we should hold the
+// reader open across loop iterations and only reopen when the cursor
+// rotates onto a new file. Not done in this commit because the cursor/
+// rotation interplay is subtle and the WAL files are typically small
+// (10 MiB max-default).
 func (u *Uploader) readNextBatch() (*pb.BatchRecords, map[string]int64, int, error) {
 	r, err := OpenWALReader(u.cfg.WALDir)
 	if err != nil {

--- a/internal/codexexecgateway/audit/uploader_test.go
+++ b/internal/codexexecgateway/audit/uploader_test.go
@@ -63,7 +63,7 @@ func TestUploader_SuccessfulBatchAdvancesCursor(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	u := audit.NewUploader(audit.UploaderConfig{
+	u, err := audit.NewUploader(audit.UploaderConfig{
 		WALDir:        dir,
 		Cursor:        cur,
 		UploadURL:     srv.URL,
@@ -73,6 +73,9 @@ func TestUploader_SuccessfulBatchAdvancesCursor(t *testing.T) {
 		FlushInterval: 50 * time.Millisecond,
 		GatewayID:     "test",
 	})
+	if err != nil {
+		t.Fatalf("NewUploader: %v", err)
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	go u.Run(ctx)
@@ -135,10 +138,11 @@ func TestUploader_RetriesOn5xx(t *testing.T) {
 	defer srv.Close()
 
 	cur, _ := audit.OpenCursor(filepath.Join(dir, "cursor.json"))
-	u := audit.NewUploader(audit.UploaderConfig{
+	u, err := audit.NewUploader(audit.UploaderConfig{
 		WALDir:        dir,
 		Cursor:        cur,
 		UploadURL:     srv.URL,
+		UploadSecret:  "test-secret",
 		BatchRecords:  10,
 		BatchBytes:    1 << 20,
 		FlushInterval: 20 * time.Millisecond,
@@ -146,6 +150,9 @@ func TestUploader_RetriesOn5xx(t *testing.T) {
 		BackoffStart:  5 * time.Millisecond,
 		BackoffMax:    50 * time.Millisecond,
 	})
+	if err != nil {
+		t.Fatalf("NewUploader: %v", err)
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 	go u.Run(ctx)
@@ -183,7 +190,8 @@ func TestUploader_NoReplayAfterRestart(t *testing.T) {
 	defer srv.Close()
 
 	cfg := audit.UploaderConfig{
-		WALDir: dir, UploadURL: srv.URL, GatewayID: "test",
+		WALDir: dir, UploadURL: srv.URL, UploadSecret: "test-secret",
+		GatewayID:    "test",
 		BatchRecords: 10, BatchBytes: 1 << 20,
 		FlushInterval: 30 * time.Millisecond,
 	}
@@ -192,7 +200,10 @@ func TestUploader_NoReplayAfterRestart(t *testing.T) {
 	{
 		cur, _ := audit.OpenCursor(filepath.Join(dir, "cursor.json"))
 		cfg.Cursor = cur
-		u := audit.NewUploader(cfg)
+		u, err := audit.NewUploader(cfg)
+		if err != nil {
+			t.Fatalf("NewUploader: %v", err)
+		}
 		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 		go u.Run(ctx)
 		time.Sleep(300 * time.Millisecond)
@@ -208,7 +219,10 @@ func TestUploader_NoReplayAfterRestart(t *testing.T) {
 	{
 		cur, _ := audit.OpenCursor(filepath.Join(dir, "cursor.json"))
 		cfg.Cursor = cur
-		u := audit.NewUploader(cfg)
+		u, err := audit.NewUploader(cfg)
+		if err != nil {
+			t.Fatalf("NewUploader: %v", err)
+		}
 		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
 		go u.Run(ctx)
 		time.Sleep(300 * time.Millisecond)

--- a/internal/codexexecgateway/audit/uploader_test.go
+++ b/internal/codexexecgateway/audit/uploader_test.go
@@ -1,0 +1,223 @@
+package audit_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/agentserver/agentserver/internal/codexexecgateway/audit"
+	pb "github.com/agentserver/agentserver/internal/server/exec_audit_pb"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestUploader_SuccessfulBatchAdvancesCursor(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write 3 WAL records.
+	w, err := audit.OpenWAL(audit.WALConfig{
+		Dir: dir, FsyncRecords: 1, FsyncInterval: time.Minute,
+		FileMaxBytes: 1 << 20, DiskQuotaBytes: 1 << 20, Overflow: "fail",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for i := 0; i < 3; i++ {
+		if err := w.Append(&pb.WALRecord{
+			Id: fmt.Sprintf("rec-%d", i),
+			Body: &pb.WALRecord_SessionOpen{SessionOpen: &pb.SessionOpen{
+				WorkspaceId: "ws", ExeId: "exe", StreamId: "s",
+				OpenedAt: timestamppb.New(time.Now()),
+			}},
+		}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	_ = w.Close()
+
+	// Stub agentserver: accepts protobuf, returns 200.
+	var receivedRecords int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Internal-Secret") != "test-secret" {
+			w.WriteHeader(401)
+			return
+		}
+		body, _ := io.ReadAll(r.Body)
+		var batch pb.BatchRecords
+		_ = proto.Unmarshal(body, &batch)
+		atomic.AddInt32(&receivedRecords, int32(len(batch.Records)))
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"processed":3,"skipped":0}`))
+	}))
+	defer srv.Close()
+
+	cur, err := audit.OpenCursor(filepath.Join(dir, "cursor.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	u := audit.NewUploader(audit.UploaderConfig{
+		WALDir:        dir,
+		Cursor:        cur,
+		UploadURL:     srv.URL,
+		UploadSecret:  "test-secret",
+		BatchRecords:  10,
+		BatchBytes:    1 << 20,
+		FlushInterval: 50 * time.Millisecond,
+		GatewayID:     "test",
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go u.Run(ctx)
+
+	// Wait for the upload to land.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if atomic.LoadInt32(&receivedRecords) >= 3 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if got := atomic.LoadInt32(&receivedRecords); got != 3 {
+		t.Fatalf("expected 3 records, got %d", got)
+	}
+
+	// Give the uploader a beat to save the cursor.
+	time.Sleep(100 * time.Millisecond)
+
+	// Cursor should now reflect every WAL file fully consumed.
+	cur2, err := audit.OpenCursor(filepath.Join(dir, "cursor.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	matches, _ := filepath.Glob(filepath.Join(dir, "wal-*.log"))
+	for _, m := range matches {
+		info, _ := os.Stat(m)
+		if cur2.Offset(filepath.Base(m)) != info.Size() {
+			t.Errorf("cursor for %s not at EOF: got %d / want %d",
+				filepath.Base(m), cur2.Offset(filepath.Base(m)), info.Size())
+		}
+	}
+}
+
+func TestUploader_RetriesOn5xx(t *testing.T) {
+	dir := t.TempDir()
+	w, _ := audit.OpenWAL(audit.WALConfig{
+		Dir: dir, FsyncRecords: 1, FsyncInterval: time.Minute,
+		FileMaxBytes: 1 << 20, DiskQuotaBytes: 1 << 20, Overflow: "fail",
+	})
+	_ = w.Append(&pb.WALRecord{
+		Id: "rec-retry",
+		Body: &pb.WALRecord_SessionOpen{SessionOpen: &pb.SessionOpen{
+			WorkspaceId: "ws", ExeId: "exe", StreamId: "s",
+			OpenedAt: timestamppb.New(time.Now()),
+		}},
+	})
+	_ = w.Close()
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&calls, 1)
+		if n < 3 {
+			w.WriteHeader(500)
+			return
+		}
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"processed":1,"skipped":0}`))
+	}))
+	defer srv.Close()
+
+	cur, _ := audit.OpenCursor(filepath.Join(dir, "cursor.json"))
+	u := audit.NewUploader(audit.UploaderConfig{
+		WALDir:        dir,
+		Cursor:        cur,
+		UploadURL:     srv.URL,
+		BatchRecords:  10,
+		BatchBytes:    1 << 20,
+		FlushInterval: 20 * time.Millisecond,
+		GatewayID:     "test",
+		BackoffStart:  5 * time.Millisecond,
+		BackoffMax:    50 * time.Millisecond,
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go u.Run(ctx)
+	time.Sleep(500 * time.Millisecond)
+
+	if got := atomic.LoadInt32(&calls); got < 3 {
+		t.Fatalf("expected >=3 calls (2 failures + 1 success), got %d", got)
+	}
+}
+
+// TestUploader_NoReplayAfterRestart ensures that after a successful upload,
+// starting a fresh Uploader against the same WAL+cursor does NOT re-send
+// the records (cursor was advanced and persisted).
+func TestUploader_NoReplayAfterRestart(t *testing.T) {
+	dir := t.TempDir()
+	w, _ := audit.OpenWAL(audit.WALConfig{
+		Dir: dir, FsyncRecords: 1, FsyncInterval: time.Minute,
+		FileMaxBytes: 1 << 20, DiskQuotaBytes: 1 << 20, Overflow: "fail",
+	})
+	_ = w.Append(&pb.WALRecord{
+		Id: "rec-noreplay",
+		Body: &pb.WALRecord_SessionOpen{SessionOpen: &pb.SessionOpen{
+			WorkspaceId: "ws", ExeId: "exe", StreamId: "s",
+			OpenedAt: timestamppb.New(time.Now()),
+		}},
+	})
+	_ = w.Close()
+
+	var calls int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(200)
+		_, _ = w.Write([]byte(`{"processed":1,"skipped":0}`))
+	}))
+	defer srv.Close()
+
+	cfg := audit.UploaderConfig{
+		WALDir: dir, UploadURL: srv.URL, GatewayID: "test",
+		BatchRecords: 10, BatchBytes: 1 << 20,
+		FlushInterval: 30 * time.Millisecond,
+	}
+
+	// First uploader run: should send 1 batch.
+	{
+		cur, _ := audit.OpenCursor(filepath.Join(dir, "cursor.json"))
+		cfg.Cursor = cur
+		u := audit.NewUploader(cfg)
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		go u.Run(ctx)
+		time.Sleep(300 * time.Millisecond)
+		cancel()
+	}
+
+	first := atomic.LoadInt32(&calls)
+	if first < 1 {
+		t.Fatalf("first run: expected >=1 call, got %d", first)
+	}
+
+	// Second uploader run with the persisted cursor: should NOT re-send.
+	{
+		cur, _ := audit.OpenCursor(filepath.Join(dir, "cursor.json"))
+		cfg.Cursor = cur
+		u := audit.NewUploader(cfg)
+		ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+		go u.Run(ctx)
+		time.Sleep(300 * time.Millisecond)
+		cancel()
+	}
+	if got := atomic.LoadInt32(&calls); got != first {
+		t.Fatalf("second run: expected no new calls (cursor persisted), got %d additional (total %d)", got-first, got)
+	}
+
+	// Sanity: ensure bytes.Reader and other imports used.
+	_ = bytes.NewReader(nil)
+}

--- a/internal/codexexecgateway/audit/wal.go
+++ b/internal/codexexecgateway/audit/wal.go
@@ -1,0 +1,299 @@
+package audit
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+
+	pb "github.com/agentserver/agentserver/internal/server/exec_audit_pb"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// WALConfig configures an OpenWAL. All fields are required (zero values
+// are not sensible defaults — derive from Config.WAL* in production).
+type WALConfig struct {
+	Dir            string
+	FsyncInterval  time.Duration
+	FsyncRecords   int
+	FileMaxBytes   int64
+	DiskQuotaBytes int64
+	Overflow       string // "fail" | "drop"
+	Logger         *slog.Logger
+}
+
+// WAL is an append-only, length-prefixed protobuf log on disk. A single
+// background goroutine fsyncs on tick. Append is mutex-serialized so
+// callers can write from many goroutines (the production Recorder does).
+type WAL struct {
+	cfg    WALConfig
+	logger *slog.Logger
+
+	mu            sync.Mutex
+	cur           *os.File
+	curSize       int64
+	recsSinceSync int
+
+	stopSync chan struct{}
+}
+
+// OpenWAL creates Dir if needed and opens (or rotates to) a fresh file.
+// Starts the background fsync ticker. Caller must Close to stop it.
+func OpenWAL(cfg WALConfig) (*WAL, error) {
+	if cfg.Dir == "" {
+		return nil, errors.New("wal: Dir required")
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.Default()
+	}
+	if err := os.MkdirAll(cfg.Dir, 0o750); err != nil {
+		return nil, fmt.Errorf("wal: mkdir %s: %w", cfg.Dir, err)
+	}
+	w := &WAL{cfg: cfg, logger: cfg.Logger, stopSync: make(chan struct{})}
+	if err := w.rotate(); err != nil {
+		return nil, err
+	}
+	go w.fsyncLoop()
+	return w, nil
+}
+
+// Append serializes one WAL record. Sets rec.WrittenAt to now if unset.
+// Returns error if disk quota in "fail" mode is hit or if marshal/write
+// fails (caller should treat as fatal and refuse the bridge).
+func (w *WAL) Append(rec *pb.WALRecord) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.cur == nil {
+		return errors.New("wal: closed")
+	}
+	if err := w.enforceQuotaLocked(); err != nil {
+		return err
+	}
+	if rec.WrittenAt == nil {
+		rec.WrittenAt = timestamppb.New(time.Now().UTC())
+	}
+	body, err := proto.Marshal(rec)
+	if err != nil {
+		return fmt.Errorf("wal: marshal: %w", err)
+	}
+	var lenBuf [4]byte
+	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(body)))
+	if _, err := w.cur.Write(lenBuf[:]); err != nil {
+		return fmt.Errorf("wal: write len: %w", err)
+	}
+	if _, err := w.cur.Write(body); err != nil {
+		return fmt.Errorf("wal: write body: %w", err)
+	}
+	w.curSize += int64(4 + len(body))
+	w.recsSinceSync++
+
+	if w.recsSinceSync >= w.cfg.FsyncRecords {
+		if err := w.cur.Sync(); err != nil {
+			return fmt.Errorf("wal: sync: %w", err)
+		}
+		w.recsSinceSync = 0
+	}
+	if w.curSize >= w.cfg.FileMaxBytes {
+		if err := w.rotateLocked(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Sync forces an fsync on the current file. Used in graceful shutdown
+// to flush any buffered records before exit.
+func (w *WAL) Sync() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.cur == nil {
+		return nil
+	}
+	w.recsSinceSync = 0
+	return w.cur.Sync()
+}
+
+// Close stops the fsync goroutine, flushes, and closes the current file.
+func (w *WAL) Close() error {
+	close(w.stopSync)
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.cur == nil {
+		return nil
+	}
+	_ = w.cur.Sync()
+	err := w.cur.Close()
+	w.cur = nil
+	return err
+}
+
+func (w *WAL) fsyncLoop() {
+	t := time.NewTicker(w.cfg.FsyncInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-w.stopSync:
+			return
+		case <-t.C:
+			w.mu.Lock()
+			if w.cur != nil && w.recsSinceSync > 0 {
+				if err := w.cur.Sync(); err != nil {
+					w.logger.Warn("wal: periodic sync", "err", err)
+				} else {
+					w.recsSinceSync = 0
+				}
+			}
+			w.mu.Unlock()
+		}
+	}
+}
+
+func (w *WAL) rotate() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.rotateLocked()
+}
+
+func (w *WAL) rotateLocked() error {
+	if w.cur != nil {
+		_ = w.cur.Sync()
+		_ = w.cur.Close()
+		w.cur = nil
+	}
+	name := time.Now().UTC().Format("wal-20060102-150405.log")
+	path := filepath.Join(w.cfg.Dir, name)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o640)
+	if err != nil {
+		return fmt.Errorf("wal: open %s: %w", path, err)
+	}
+	w.cur = f
+	w.curSize = 0
+	w.recsSinceSync = 0
+	return nil
+}
+
+// enforceQuotaLocked is called with w.mu held. Returns nil if under
+// quota OR if the "drop" mode successfully unlinked old files to fit.
+// Returns error in "fail" mode (or "drop" mode that couldn't shrink
+// enough).
+func (w *WAL) enforceQuotaLocked() error {
+	entries, err := os.ReadDir(w.cfg.Dir)
+	if err != nil {
+		return fmt.Errorf("wal: readdir: %w", err)
+	}
+	var total int64
+	for _, e := range entries {
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		total += info.Size()
+	}
+	if total < w.cfg.DiskQuotaBytes {
+		return nil
+	}
+	if w.cfg.Overflow == "drop" {
+		// Drop oldest files (sorted by name = chronological since the
+		// naming convention is wal-YYYYMMDD-HHMMSS.log).
+		names := make([]string, 0, len(entries))
+		for _, e := range entries {
+			names = append(names, e.Name())
+		}
+		sort.Strings(names)
+		for _, n := range names {
+			if total < w.cfg.DiskQuotaBytes {
+				break
+			}
+			// Never unlink the current file out from under ourselves.
+			if w.cur != nil && filepath.Base(w.cur.Name()) == n {
+				continue
+			}
+			p := filepath.Join(w.cfg.Dir, n)
+			info, err := os.Stat(p)
+			if err != nil {
+				continue
+			}
+			if err := os.Remove(p); err != nil {
+				w.logger.Warn("wal: drop unlink", "path", p, "err", err)
+				continue
+			}
+			total -= info.Size()
+		}
+		if total >= w.cfg.DiskQuotaBytes {
+			return fmt.Errorf("wal: disk quota %d still exceeded after drop", w.cfg.DiskQuotaBytes)
+		}
+		return nil
+	}
+	// "fail" mode: caller decides what to do (production: refuse bridges).
+	return fmt.Errorf("wal: disk quota %d exceeded (mode=fail)", w.cfg.DiskQuotaBytes)
+}
+
+// WALReader is a single-consumer forward iterator over every WAL file
+// in Dir (sorted by name). Use Next to pull one record at a time.
+type WALReader struct {
+	dir   string
+	files []string
+	cur   *os.File
+	curIx int
+}
+
+func OpenWALReader(dir string) (*WALReader, error) {
+	matches, err := filepath.Glob(filepath.Join(dir, "wal-*.log"))
+	if err != nil {
+		return nil, err
+	}
+	sort.Strings(matches)
+	return &WALReader{dir: dir, files: matches}, nil
+}
+
+// Next reads one WAL record. Returns (rec, fileName, nil) on success or
+// (nil, "", io.EOF) when all files are exhausted. Caller closes via Close.
+func (r *WALReader) Next() (*pb.WALRecord, string, error) {
+	for {
+		if r.cur == nil {
+			if r.curIx >= len(r.files) {
+				return nil, "", io.EOF
+			}
+			f, err := os.Open(r.files[r.curIx])
+			if err != nil {
+				return nil, "", err
+			}
+			r.cur = f
+		}
+		var lenBuf [4]byte
+		if _, err := io.ReadFull(r.cur, lenBuf[:]); err != nil {
+			_ = r.cur.Close()
+			r.cur = nil
+			r.curIx++
+			if err == io.EOF {
+				continue
+			}
+			return nil, "", err
+		}
+		length := binary.BigEndian.Uint32(lenBuf[:])
+		body := make([]byte, length)
+		if _, err := io.ReadFull(r.cur, body); err != nil {
+			return nil, "", err
+		}
+		var rec pb.WALRecord
+		if err := proto.Unmarshal(body, &rec); err != nil {
+			return nil, "", err
+		}
+		return &rec, filepath.Base(r.files[r.curIx]), nil
+	}
+}
+
+func (r *WALReader) Close() error {
+	if r.cur != nil {
+		_ = r.cur.Close()
+		r.cur = nil
+	}
+	return nil
+}

--- a/internal/codexexecgateway/audit/wal.go
+++ b/internal/codexexecgateway/audit/wal.go
@@ -236,12 +236,15 @@ func (w *WAL) enforceQuotaLocked() error {
 }
 
 // WALReader is a single-consumer forward iterator over every WAL file
-// in Dir (sorted by name). Use Next to pull one record at a time.
+// in Dir (sorted by name). Use Next or NextWithSize to pull one record
+// at a time.
 type WALReader struct {
-	dir   string
-	files []string
-	cur   *os.File
-	curIx int
+	dir       string
+	files     []string
+	cur       *os.File
+	curIx     int
+	cursor    *Cursor // optional; if set, NextWithSize seeks past offset on first open
+	seekedCur bool    // whether we've seeked into the current file already
 }
 
 func OpenWALReader(dir string) (*WALReader, error) {
@@ -296,4 +299,82 @@ func (r *WALReader) Close() error {
 		r.cur = nil
 	}
 	return nil
+}
+
+// SeekPastCursor positions the reader to start at the first byte past
+// the cursor's offset for each file. Fully-consumed files are dropped
+// from the iteration; the first remaining file (if partially consumed)
+// has its seek applied lazily on the first NextWithSize call.
+func (r *WALReader) SeekPastCursor(c *Cursor) error {
+	out := r.files[:0]
+	for _, p := range r.files {
+		name := filepath.Base(p)
+		info, err := os.Stat(p)
+		if err != nil {
+			return err
+		}
+		if c.Offset(name) >= info.Size() {
+			continue // already fully consumed
+		}
+		out = append(out, p)
+	}
+	r.files = out
+	r.curIx = 0
+	r.cursor = c
+	r.seekedCur = false
+	return nil
+}
+
+// NextWithSize is like Next but also returns the byte count consumed
+// (4-byte length prefix + body). The uploader uses this to Advance the
+// Cursor by exactly the bytes shipped in a successful batch.
+//
+// Requires SeekPastCursor to have been called first (it's how the
+// reader knows the per-file starting offset).
+func (r *WALReader) NextWithSize() (*pb.WALRecord, string, int64, error) {
+	for {
+		if r.cur == nil {
+			if r.curIx >= len(r.files) {
+				return nil, "", 0, io.EOF
+			}
+			f, err := os.Open(r.files[r.curIx])
+			if err != nil {
+				return nil, "", 0, err
+			}
+			r.cur = f
+			r.seekedCur = false
+		}
+		// Lazy-seek past the cursor offset on first read of each file.
+		if !r.seekedCur {
+			if r.cursor != nil {
+				off := r.cursor.Offset(filepath.Base(r.files[r.curIx]))
+				if off > 0 {
+					if _, err := r.cur.Seek(off, io.SeekStart); err != nil {
+						return nil, "", 0, err
+					}
+				}
+			}
+			r.seekedCur = true
+		}
+		var lenBuf [4]byte
+		if _, err := io.ReadFull(r.cur, lenBuf[:]); err != nil {
+			_ = r.cur.Close()
+			r.cur = nil
+			r.curIx++
+			if err == io.EOF {
+				continue
+			}
+			return nil, "", 0, err
+		}
+		length := binary.BigEndian.Uint32(lenBuf[:])
+		body := make([]byte, length)
+		if _, err := io.ReadFull(r.cur, body); err != nil {
+			return nil, "", 0, err
+		}
+		var rec pb.WALRecord
+		if err := proto.Unmarshal(body, &rec); err != nil {
+			return nil, "", 0, err
+		}
+		return &rec, filepath.Base(r.files[r.curIx]), int64(4 + length), nil
+	}
 }

--- a/internal/codexexecgateway/audit/wal.go
+++ b/internal/codexexecgateway/audit/wal.go
@@ -9,7 +9,9 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	pb "github.com/agentserver/agentserver/internal/server/exec_audit_pb"
@@ -41,7 +43,8 @@ type WAL struct {
 	curSize       int64
 	recsSinceSync int
 
-	stopSync chan struct{}
+	stopSync  chan struct{}
+	closeOnce sync.Once
 }
 
 // OpenWAL creates Dir if needed and opens (or rotates to) a fresh file.
@@ -83,15 +86,18 @@ func (w *WAL) Append(rec *pb.WALRecord) error {
 	if err != nil {
 		return fmt.Errorf("wal: marshal: %w", err)
 	}
-	var lenBuf [4]byte
-	binary.BigEndian.PutUint32(lenBuf[:], uint32(len(body)))
-	if _, err := w.cur.Write(lenBuf[:]); err != nil {
-		return fmt.Errorf("wal: write len: %w", err)
+	// W1: Concatenate length-prefix + body into a single Write so a
+	// short-write between the two doesn't leave a 4-byte stub that
+	// desyncs the reader for the rest of the file. A failure of this
+	// single Write may still leave a partial record on disk; WALReader
+	// is hardened (W2) to skip records that fail to unmarshal.
+	frame := make([]byte, 4+len(body))
+	binary.BigEndian.PutUint32(frame[:4], uint32(len(body)))
+	copy(frame[4:], body)
+	if _, err := w.cur.Write(frame); err != nil {
+		return fmt.Errorf("wal: write: %w", err)
 	}
-	if _, err := w.cur.Write(body); err != nil {
-		return fmt.Errorf("wal: write body: %w", err)
-	}
-	w.curSize += int64(4 + len(body))
+	w.curSize += int64(len(frame))
 	w.recsSinceSync++
 
 	if w.recsSinceSync >= w.cfg.FsyncRecords {
@@ -120,18 +126,23 @@ func (w *WAL) Sync() error {
 	return w.cur.Sync()
 }
 
-// Close stops the fsync goroutine, flushes, and closes the current file.
+// Close stops the fsync goroutine, flushes, and closes the current
+// file. Safe to call multiple times — guarded by sync.Once so the
+// channel close doesn't panic on second invocation (T6 review followup).
 func (w *WAL) Close() error {
-	close(w.stopSync)
-	w.mu.Lock()
-	defer w.mu.Unlock()
-	if w.cur == nil {
-		return nil
-	}
-	_ = w.cur.Sync()
-	err := w.cur.Close()
-	w.cur = nil
-	return err
+	var closeErr error
+	w.closeOnce.Do(func() {
+		close(w.stopSync)
+		w.mu.Lock()
+		defer w.mu.Unlock()
+		if w.cur == nil {
+			return
+		}
+		_ = w.cur.Sync()
+		closeErr = w.cur.Close()
+		w.cur = nil
+	})
+	return closeErr
 }
 
 func (w *WAL) fsyncLoop() {
@@ -188,10 +199,19 @@ func (w *WAL) enforceQuotaLocked() error {
 	if err != nil {
 		return fmt.Errorf("wal: readdir: %w", err)
 	}
+	// W4: Filter to wal-*.log only. Previously this counted every file
+	// in the directory (cursor.json, partial uploads, anything else) and
+	// under "drop" mode could even unlink cursor.json — silently
+	// resetting the uploader's progress. Now: count only wal files;
+	// drop only wal files.
 	var total int64
 	for _, e := range entries {
+		if !strings.HasPrefix(e.Name(), "wal-") {
+			continue
+		}
 		info, err := e.Info()
 		if err != nil {
+			w.logger.Warn("wal: stat in quota check", "name", e.Name(), "err", err)
 			continue
 		}
 		total += info.Size()
@@ -204,6 +224,9 @@ func (w *WAL) enforceQuotaLocked() error {
 		// naming convention is wal-YYYYMMDD-HHMMSS.log).
 		names := make([]string, 0, len(entries))
 		for _, e := range entries {
+			if !strings.HasPrefix(e.Name(), "wal-") {
+				continue
+			}
 			names = append(names, e.Name())
 		}
 		sort.Strings(names)
@@ -218,6 +241,7 @@ func (w *WAL) enforceQuotaLocked() error {
 			p := filepath.Join(w.cfg.Dir, n)
 			info, err := os.Stat(p)
 			if err != nil {
+				w.logger.Warn("wal: stat for drop", "path", p, "err", err)
 				continue
 			}
 			if err := os.Remove(p); err != nil {
@@ -245,6 +269,14 @@ type WALReader struct {
 	curIx     int
 	cursor    *Cursor // optional; if set, NextWithSize seeks past offset on first open
 	seekedCur bool    // whether we've seeked into the current file already
+	logger    *slog.Logger
+
+	// W2: corrupt-record telemetry. NextWithSize increments this every
+	// time a record fails to unmarshal and is skipped (rather than
+	// returning the error and stalling the Uploader forever on the same
+	// poison record). Exposed via CorruptRecordsSkipped() for tests +
+	// /metrics.
+	corruptRecordsSkipped atomic.Int64
 }
 
 func OpenWALReader(dir string) (*WALReader, error) {
@@ -253,11 +285,29 @@ func OpenWALReader(dir string) (*WALReader, error) {
 		return nil, err
 	}
 	sort.Strings(matches)
-	return &WALReader{dir: dir, files: matches}, nil
+	return &WALReader{dir: dir, files: matches, logger: slog.Default()}, nil
+}
+
+// CorruptRecordsSkipped returns the number of records this reader has
+// skipped due to proto.Unmarshal failure since it was opened.
+func (r *WALReader) CorruptRecordsSkipped() int64 {
+	return r.corruptRecordsSkipped.Load()
+}
+
+// SetLogger lets callers route W2 corrupt-record errors through their
+// own slog handler. Optional; defaults to slog.Default().
+func (r *WALReader) SetLogger(l *slog.Logger) {
+	if l != nil {
+		r.logger = l
+	}
 }
 
 // Next reads one WAL record. Returns (rec, fileName, nil) on success or
 // (nil, "", io.EOF) when all files are exhausted. Caller closes via Close.
+//
+// W2: records that fail proto.Unmarshal are skipped (counter
+// incremented, logged) so a single poison record can't stall the reader
+// for an entire file.
 func (r *WALReader) Next() (*pb.WALRecord, string, error) {
 	for {
 		if r.cur == nil {
@@ -272,10 +322,17 @@ func (r *WALReader) Next() (*pb.WALRecord, string, error) {
 		}
 		var lenBuf [4]byte
 		if _, err := io.ReadFull(r.cur, lenBuf[:]); err != nil {
+			// Partial length prefix at EOF — treat as truncated file end
+			// (W2 graceful recovery from torn writes).
+			if err == io.ErrUnexpectedEOF {
+				r.logger.Error("wal: truncated length prefix, skipping rest of file",
+					"file", filepath.Base(r.files[r.curIx]))
+				r.corruptRecordsSkipped.Add(1)
+			}
 			_ = r.cur.Close()
 			r.cur = nil
 			r.curIx++
-			if err == io.EOF {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
 				continue
 			}
 			return nil, "", err
@@ -283,11 +340,21 @@ func (r *WALReader) Next() (*pb.WALRecord, string, error) {
 		length := binary.BigEndian.Uint32(lenBuf[:])
 		body := make([]byte, length)
 		if _, err := io.ReadFull(r.cur, body); err != nil {
-			return nil, "", err
+			// Torn write — file ended mid-body. Skip rest of file.
+			r.logger.Error("wal: truncated record body, skipping rest of file",
+				"file", filepath.Base(r.files[r.curIx]), "want", length, "err", err)
+			r.corruptRecordsSkipped.Add(1)
+			_ = r.cur.Close()
+			r.cur = nil
+			r.curIx++
+			continue
 		}
 		var rec pb.WALRecord
 		if err := proto.Unmarshal(body, &rec); err != nil {
-			return nil, "", err
+			r.logger.Error("wal: corrupt record, skipping",
+				"file", filepath.Base(r.files[r.curIx]), "err", err)
+			r.corruptRecordsSkipped.Add(1)
+			continue
 		}
 		return &rec, filepath.Base(r.files[r.curIx]), nil
 	}
@@ -331,6 +398,14 @@ func (r *WALReader) SeekPastCursor(c *Cursor) error {
 //
 // Requires SeekPastCursor to have been called first (it's how the
 // reader knows the per-file starting offset).
+//
+// W2 sentinel: when a record fails proto.Unmarshal, this returns
+// (nil, fname, 4+length, nil) — rec is nil but n > 0. The Uploader
+// interprets this as "advance cursor by n, do not include in batch" so
+// a poison record doesn't stall the uploader forever. A truncated
+// length-prefix or body at EOF returns (nil, fname, 0, io.EOF) for the
+// file slot (the rest of the file is unrecoverable; the bytes-past-
+// cursor remain on disk but will be skipped on the next reader open).
 func (r *WALReader) NextWithSize() (*pb.WALRecord, string, int64, error) {
 	for {
 		if r.cur == nil {
@@ -356,12 +431,19 @@ func (r *WALReader) NextWithSize() (*pb.WALRecord, string, int64, error) {
 			}
 			r.seekedCur = true
 		}
+		fname := filepath.Base(r.files[r.curIx])
 		var lenBuf [4]byte
 		if _, err := io.ReadFull(r.cur, lenBuf[:]); err != nil {
+			if err == io.ErrUnexpectedEOF {
+				// Partial length prefix — torn write at file tail.
+				r.logger.Error("wal: truncated length prefix, skipping rest of file",
+					"file", fname)
+				r.corruptRecordsSkipped.Add(1)
+			}
 			_ = r.cur.Close()
 			r.cur = nil
 			r.curIx++
-			if err == io.EOF {
+			if err == io.EOF || err == io.ErrUnexpectedEOF {
 				continue
 			}
 			return nil, "", 0, err
@@ -369,12 +451,30 @@ func (r *WALReader) NextWithSize() (*pb.WALRecord, string, int64, error) {
 		length := binary.BigEndian.Uint32(lenBuf[:])
 		body := make([]byte, length)
 		if _, err := io.ReadFull(r.cur, body); err != nil {
-			return nil, "", 0, err
+			// Torn write — body truncated. Skip rest of file. The 4 bytes
+			// of length prefix we already consumed can't be re-read; the
+			// uploader's cursor advances on the NEXT successful record,
+			// so leaving those 4 bytes unaccounted is harmless — they're
+			// past the cursor offset and the file will be retired once
+			// fully consumed (or never re-read once a newer wal file
+			// rotates in).
+			r.logger.Error("wal: truncated record body, skipping rest of file",
+				"file", fname, "want", length, "err", err)
+			r.corruptRecordsSkipped.Add(1)
+			_ = r.cur.Close()
+			r.cur = nil
+			r.curIx++
+			continue
 		}
 		var rec pb.WALRecord
 		if err := proto.Unmarshal(body, &rec); err != nil {
-			return nil, "", 0, err
+			r.logger.Error("wal: corrupt record, skipping",
+				"file", fname, "err", err)
+			r.corruptRecordsSkipped.Add(1)
+			// Sentinel: nil record, non-zero n — caller advances cursor
+			// but does not append to batch.
+			return nil, fname, int64(4 + length), nil
 		}
-		return &rec, filepath.Base(r.files[r.curIx]), int64(4 + length), nil
+		return &rec, fname, int64(4 + length), nil
 	}
 }

--- a/internal/codexexecgateway/audit/wal.go
+++ b/internal/codexexecgateway/audit/wal.go
@@ -19,6 +19,13 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+// maxWALFrameBytes caps the body of a single WAL record. Realistic body
+// size is bounded above by PayloadMaxBytes (4 MiB default) + protobuf
+// metadata overhead; 64 MiB leaves ample headroom while preventing
+// integer-overflow / runaway allocation if a future code path bypasses
+// the payload cap.
+const maxWALFrameBytes = 64 * 1024 * 1024
+
 // WALConfig configures an OpenWAL. All fields are required (zero values
 // are not sensible defaults — derive from Config.WAL* in production).
 type WALConfig struct {
@@ -85,6 +92,17 @@ func (w *WAL) Append(rec *pb.WALRecord) error {
 	body, err := proto.Marshal(rec)
 	if err != nil {
 		return fmt.Errorf("wal: marshal: %w", err)
+	}
+	// Defensive bounds check before allocation. Realistic body size is
+	// at most PayloadMaxBytes (4 MiB default) + protobuf overhead, well
+	// under maxWALFrameBytes. The check exists because the WALRecord
+	// payload bytes ultimately come from network input (SDK request
+	// body, env-mcp WS frame); guarding the allocation here means a
+	// future caller path that bypasses PayloadMaxBytes still can't
+	// trigger an integer-overflow in make() or a runaway allocation.
+	if len(body) > maxWALFrameBytes {
+		return fmt.Errorf("wal: record body %d bytes exceeds maxWALFrameBytes %d",
+			len(body), maxWALFrameBytes)
 	}
 	// W1: Concatenate length-prefix + body into a single Write so a
 	// short-write between the two doesn't leave a 4-byte stub that
@@ -338,6 +356,19 @@ func (r *WALReader) Next() (*pb.WALRecord, string, error) {
 			return nil, "", err
 		}
 		length := binary.BigEndian.Uint32(lenBuf[:])
+		// Bound the allocation: a corrupt length field on disk could
+		// otherwise request gigabytes (or worse, overflow int) before
+		// io.ReadFull discovers the truncation. Skip the rest of the
+		// file the same way a truncated body is handled.
+		if length > maxWALFrameBytes {
+			r.logger.Error("wal: implausible record length, skipping rest of file",
+				"file", filepath.Base(r.files[r.curIx]), "length", length, "cap", maxWALFrameBytes)
+			r.corruptRecordsSkipped.Add(1)
+			_ = r.cur.Close()
+			r.cur = nil
+			r.curIx++
+			continue
+		}
 		body := make([]byte, length)
 		if _, err := io.ReadFull(r.cur, body); err != nil {
 			// Torn write — file ended mid-body. Skip rest of file.
@@ -449,6 +480,19 @@ func (r *WALReader) NextWithSize() (*pb.WALRecord, string, int64, error) {
 			return nil, "", 0, err
 		}
 		length := binary.BigEndian.Uint32(lenBuf[:])
+		// Bound the allocation: a corrupt length field on disk could
+		// otherwise request gigabytes (or worse, overflow int) before
+		// io.ReadFull discovers the truncation. Skip the rest of the
+		// file the same way a truncated body is handled.
+		if length > maxWALFrameBytes {
+			r.logger.Error("wal: implausible record length, skipping rest of file",
+				"file", filepath.Base(r.files[r.curIx]), "length", length, "cap", maxWALFrameBytes)
+			r.corruptRecordsSkipped.Add(1)
+			_ = r.cur.Close()
+			r.cur = nil
+			r.curIx++
+			continue
+		}
 		body := make([]byte, length)
 		if _, err := io.ReadFull(r.cur, body); err != nil {
 			// Torn write — body truncated. Skip rest of file. The 4 bytes

--- a/internal/codexexecgateway/audit/wal_test.go
+++ b/internal/codexexecgateway/audit/wal_test.go
@@ -1,6 +1,8 @@
 package audit_test
 
 import (
+	"encoding/binary"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -8,6 +10,7 @@ import (
 
 	"github.com/agentserver/agentserver/internal/codexexecgateway/audit"
 	pb "github.com/agentserver/agentserver/internal/server/exec_audit_pb"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -120,6 +123,175 @@ func TestWAL_FailClosedOnQuota(t *testing.T) {
 		t.Fatal("expected Append to error under fail-mode quota")
 	}
 }
+
+func TestWAL_CloseIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	w, err := audit.OpenWAL(audit.WALConfig{
+		Dir: dir, FsyncRecords: 1, FsyncInterval: time.Minute,
+		FileMaxBytes: 1 << 20, DiskQuotaBytes: 1 << 20,
+		Overflow: "fail",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	// Second Close must not panic and should return nil.
+	if err := w.Close(); err != nil {
+		t.Fatalf("second Close returned error: %v", err)
+	}
+}
+
+func TestWAL_QuotaSkipsCursorJSON(t *testing.T) {
+	dir := t.TempDir()
+	// Pre-populate cursor.json + two wal files. Cursor file is small; if
+	// it's mistakenly unlinked under drop mode, the next reader would
+	// silently re-process every shipped record on next restart.
+	if err := os.WriteFile(filepath.Join(dir, "cursor.json"),
+		[]byte(`{"per_file":{}}`), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "wal-20000101-000000.log"),
+		make([]byte, 1000), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "wal-20000102-000000.log"),
+		make([]byte, 1000), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	w, err := audit.OpenWAL(audit.WALConfig{
+		Dir: dir, FsyncRecords: 1, FsyncInterval: time.Minute,
+		// 2 prepopulated wal × 1000 B = 2000 B > 1500 B quota → drop
+		// would trigger if cursor.json were counted; with the W4 filter
+		// only wal-* files are considered.
+		FileMaxBytes: 1 << 20, DiskQuotaBytes: 1500,
+		Overflow: "drop",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+	if err := w.Append(newSessionOpenRecord("after-drop")); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "cursor.json")); err != nil {
+		t.Fatalf("cursor.json missing after drop — quota filter regression: %v", err)
+	}
+}
+
+func TestWAL_TornWriteRecoverable(t *testing.T) {
+	dir := t.TempDir()
+	w, err := audit.OpenWAL(audit.WALConfig{
+		Dir: dir, FsyncRecords: 1, FsyncInterval: time.Minute,
+		FileMaxBytes: 1 << 20, DiskQuotaBytes: 1 << 20,
+		Overflow: "fail",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Append(newSessionOpenRecord("first")); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Sync(); err != nil {
+		t.Fatal(err)
+	}
+	matches, _ := filepath.Glob(filepath.Join(dir, "wal-*.log"))
+	if len(matches) != 1 {
+		t.Fatalf("want 1 wal file, got %d", len(matches))
+	}
+	// Truncate the file mid-body: keep the first record's 4-byte length
+	// prefix but only half its body, simulating an EAGAIN/EIO between
+	// the (now-fused) write and the next sync.
+	info, _ := os.Stat(matches[0])
+	if err := os.Truncate(matches[0], info.Size()-3); err != nil {
+		t.Fatal(err)
+	}
+	_ = w.Close()
+
+	r, err := audit.OpenWALReader(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	// First record body is now truncated; reader should skip the file
+	// gracefully (returning EOF when only this file is present), and
+	// bump the corrupt counter.
+	rec, _, err := r.Next()
+	if err != io.EOF {
+		t.Fatalf("expected EOF on truncated single-record file, got rec=%v err=%v", rec, err)
+	}
+	if r.CorruptRecordsSkipped() == 0 {
+		t.Fatalf("expected CorruptRecordsSkipped > 0 after torn-write recovery")
+	}
+}
+
+func TestWAL_CorruptRecordSkipped(t *testing.T) {
+	dir := t.TempDir()
+	w, err := audit.OpenWAL(audit.WALConfig{
+		Dir: dir, FsyncRecords: 1, FsyncInterval: time.Minute,
+		FileMaxBytes: 1 << 20, DiskQuotaBytes: 1 << 20,
+		Overflow: "fail",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Append(newSessionOpenRecord("first-poison")); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Append(newSessionOpenRecord("second-good")); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Sync(); err != nil {
+		t.Fatal(err)
+	}
+	matches, _ := filepath.Glob(filepath.Join(dir, "wal-*.log"))
+	if len(matches) != 1 {
+		t.Fatal("expected 1 wal file")
+	}
+	_ = w.Close()
+
+	// Corrupt the first record's body in place. The file layout is:
+	//   [4 byte length][N bytes body][4 byte length][N bytes body]
+	raw, err := os.ReadFile(matches[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	length1 := binary.BigEndian.Uint32(raw[:4])
+	// Overwrite body 1 with garbage that still passes Read but fails
+	// proto.Unmarshal.
+	for i := uint32(4); i < 4+length1; i++ {
+		raw[i] = 0xFF
+	}
+	if err := os.WriteFile(matches[0], raw, 0o640); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := audit.OpenWALReader(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	// First call: skips poison, returns second record. Behavior is the
+	// same whether we use Next or NextWithSize+cursor — exercise Next.
+	rec, _, err := r.Next()
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if rec == nil || rec.Id != "second-good" {
+		t.Fatalf("expected second-good record, got %+v", rec)
+	}
+	if r.CorruptRecordsSkipped() != 1 {
+		t.Fatalf("CorruptRecordsSkipped: want 1, got %d", r.CorruptRecordsSkipped())
+	}
+	// And then EOF.
+	if _, _, err := r.Next(); err != io.EOF {
+		t.Fatalf("expected EOF, got %v", err)
+	}
+}
+
+// silence unused warnings for imports if a test refactor drops a dep.
+var _ = proto.Marshal
 
 func TestWAL_DropOldestUnderOverflowDrop(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/codexexecgateway/audit/wal_test.go
+++ b/internal/codexexecgateway/audit/wal_test.go
@@ -1,0 +1,155 @@
+package audit_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/agentserver/agentserver/internal/codexexecgateway/audit"
+	pb "github.com/agentserver/agentserver/internal/server/exec_audit_pb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func newSessionOpenRecord(id string) *pb.WALRecord {
+	return &pb.WALRecord{
+		Id: id,
+		Body: &pb.WALRecord_SessionOpen{SessionOpen: &pb.SessionOpen{
+			WorkspaceId: "ws", ExeId: "exe", StreamId: "s1",
+			OpenedAt: timestamppb.New(time.Now()),
+		}},
+	}
+}
+
+func TestWAL_RoundTripSingleRecord(t *testing.T) {
+	dir := t.TempDir()
+	w, err := audit.OpenWAL(audit.WALConfig{
+		Dir:            dir,
+		FsyncInterval:  50 * time.Millisecond,
+		FsyncRecords:   1,
+		FileMaxBytes:   1 << 20,
+		DiskQuotaBytes: 10 << 20,
+		Overflow:       "fail",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	rec := newSessionOpenRecord("11111111-2222-3333-4444-555555555555")
+	if err := w.Append(rec); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Sync(); err != nil {
+		t.Fatal(err)
+	}
+
+	r, err := audit.OpenWALReader(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+
+	got, _, err := r.Next()
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if got.Id != rec.Id {
+		t.Fatalf("id mismatch: got %s want %s", got.Id, rec.Id)
+	}
+
+	// EOF on second read.
+	if _, _, err = r.Next(); err == nil {
+		t.Fatal("expected EOF on second read")
+	}
+
+	// Verify exactly one wal file.
+	matches, _ := filepath.Glob(filepath.Join(dir, "wal-*.log"))
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 wal file, got %d", len(matches))
+	}
+}
+
+func TestWAL_RotationAtFileMaxBytes(t *testing.T) {
+	dir := t.TempDir()
+	w, err := audit.OpenWAL(audit.WALConfig{
+		Dir: dir, FsyncRecords: 1, FsyncInterval: time.Minute,
+		FileMaxBytes:   200, // tiny — force rotation
+		DiskQuotaBytes: 1 << 20,
+		Overflow:       "fail",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	for i := 0; i < 10; i++ {
+		if err := w.Append(newSessionOpenRecord("rec-rotation")); err != nil {
+			t.Fatalf("append %d: %v", i, err)
+		}
+		// Sleep 1s between filenames so file-name uniqueness (per-second
+		// resolution) is preserved. In practice rotation is rare so this
+		// is fine; the test just stresses it.
+		time.Sleep(1100 * time.Millisecond)
+	}
+	matches, _ := filepath.Glob(filepath.Join(dir, "wal-*.log"))
+	if len(matches) < 2 {
+		t.Fatalf("expected >=2 files after rotation, got %d", len(matches))
+	}
+}
+
+func TestWAL_FailClosedOnQuota(t *testing.T) {
+	dir := t.TempDir()
+	w, err := audit.OpenWAL(audit.WALConfig{
+		Dir: dir, FsyncRecords: 1, FsyncInterval: time.Minute,
+		FileMaxBytes: 1 << 20, DiskQuotaBytes: 100,
+		Overflow: "fail",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	// Pre-populate with a junk file >100 bytes so the quota is already
+	// blown when Append runs.
+	if err := os.WriteFile(filepath.Join(dir, "wal-19700101-000000.log"),
+		make([]byte, 200), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Append(newSessionOpenRecord("over-quota")); err == nil {
+		t.Fatal("expected Append to error under fail-mode quota")
+	}
+}
+
+func TestWAL_DropOldestUnderOverflowDrop(t *testing.T) {
+	dir := t.TempDir()
+	// Pre-populate with two large old files
+	if err := os.WriteFile(filepath.Join(dir, "wal-20000101-000000.log"),
+		make([]byte, 1000), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "wal-20000102-000000.log"),
+		make([]byte, 1000), 0o640); err != nil {
+		t.Fatal(err)
+	}
+	w, err := audit.OpenWAL(audit.WALConfig{
+		Dir: dir, FsyncRecords: 1, FsyncInterval: time.Minute,
+		// 2 prepopulated × 1000 B = 2000 B > 1500 B quota → drop triggers.
+		FileMaxBytes: 1 << 20, DiskQuotaBytes: 1500,
+		Overflow: "drop",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer w.Close()
+
+	// Appending should succeed and the oldest file should have been
+	// unlinked to make room.
+	if err := w.Append(newSessionOpenRecord("after-drop")); err != nil {
+		t.Fatalf("Append under drop-mode: %v", err)
+	}
+	matches, _ := filepath.Glob(filepath.Join(dir, "wal-2000*"))
+	if len(matches) > 1 {
+		t.Fatalf("expected at most 1 old file after drop, got %d", len(matches))
+	}
+}

--- a/internal/codexexecgateway/auth.go
+++ b/internal/codexexecgateway/auth.go
@@ -29,6 +29,14 @@ type CapPayload struct {
 	UserID string `json:"user_id,omitempty"`
 	IAT    int64  `json:"iat"`
 	EXP    int64  `json:"exp"`
+	// SkipAudit asks the bridge handler not to open a per-frame audit
+	// session for this bridge. Used by sdk/captoken.go for in-process
+	// bridge.Pool tokens — the SDK REST handler does its own
+	// CallStart/CallEnd for the logical call, so per-frame double-
+	// recording would be noise. Older tokens lack this field and
+	// default to false (audit applies normally). Replaces the prior
+	// magic-string `TurnID="sdk-pool:..."` marker (I10 followup).
+	SkipAudit bool `json:"skip_audit,omitempty"`
 }
 
 var (

--- a/internal/codexexecgateway/auth.go
+++ b/internal/codexexecgateway/auth.go
@@ -20,8 +20,15 @@ import (
 type CapPayload struct {
 	TurnID      string `json:"turn_id"`
 	WorkspaceID string `json:"workspace_id"`
-	IAT         int64  `json:"iat"`
-	EXP         int64  `json:"exp"`
+	// UserID is the workspace member who triggered the cap-token mint.
+	// Optional for backward compatibility: tokens minted by older
+	// codex-app-gateway versions don't carry it, which Verify accepts
+	// (UserID is left as ""). The exec-audit subsystem stores it on
+	// the session row when present — see
+	// docs/superpowers/specs/2026-05-23-codex-exec-gateway-audit-design.md.
+	UserID string `json:"user_id,omitempty"`
+	IAT    int64  `json:"iat"`
+	EXP    int64  `json:"exp"`
 }
 
 var (

--- a/internal/codexexecgateway/auth_test.go
+++ b/internal/codexexecgateway/auth_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"testing"
 	"time"
 )
@@ -39,6 +40,45 @@ func TestVerifyCapabilityToken_Workspace(t *testing.T) {
 	}
 	if got.TurnID != "trn_prod" || got.WorkspaceID != "ws_prod" {
 		t.Fatalf("payload: %+v", got)
+	}
+}
+
+func TestVerifyCapabilityToken_RoundTripsUserID(t *testing.T) {
+	secret := []byte("k")
+	tok := mintToken(t, secret, CapPayload{
+		TurnID: "t", WorkspaceID: "w", UserID: "u_alice",
+		EXP: time.Now().Unix() + 60,
+	})
+	got, err := VerifyCapabilityToken(tok, secret)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if got.UserID != "u_alice" {
+		t.Fatalf("UserID: got %q, want u_alice", got.UserID)
+	}
+}
+
+// TestVerifyCapabilityToken_OldTokenHasNoUserID pins the backward-compat
+// guarantee: a token minted by an older codex-app-gateway (without the
+// user_id field) still verifies, and UserID comes back as "".
+func TestVerifyCapabilityToken_OldTokenHasNoUserID(t *testing.T) {
+	secret := []byte("k")
+	// Hand-craft a payload missing user_id entirely (mimics pre-T7 mint).
+	header := []byte(`{"alg":"HS256","typ":"CXG"}`)
+	payloadJSON := []byte(`{"turn_id":"t","workspace_id":"w","iat":0,"exp":` +
+		fmt.Sprint(time.Now().Unix()+60) + `}`)
+	enc := base64.RawURLEncoding
+	signingInput := enc.EncodeToString(header) + "." + enc.EncodeToString(payloadJSON)
+	mac := hmac.New(sha256.New, secret)
+	mac.Write([]byte(signingInput))
+	tok := signingInput + "." + enc.EncodeToString(mac.Sum(nil))
+
+	got, err := VerifyCapabilityToken(tok, secret)
+	if err != nil {
+		t.Fatalf("old-style token failed to verify: %v", err)
+	}
+	if got.UserID != "" {
+		t.Fatalf("UserID should be empty for old token, got %q", got.UserID)
 	}
 }
 

--- a/internal/codexexecgateway/auth_test.go
+++ b/internal/codexexecgateway/auth_test.go
@@ -82,6 +82,24 @@ func TestVerifyCapabilityToken_OldTokenHasNoUserID(t *testing.T) {
 	}
 }
 
+// TestVerifyCapabilityToken_SkipAuditRoundTrips ensures the typed
+// CapPayload.SkipAudit field survives mint+verify so the bridge handler
+// can rely on it instead of the prior magic-string TurnID prefix (I10).
+func TestVerifyCapabilityToken_SkipAuditRoundTrips(t *testing.T) {
+	secret := []byte("k")
+	tok := mintToken(t, secret, CapPayload{
+		TurnID: "sdk", WorkspaceID: "w", SkipAudit: true,
+		EXP: time.Now().Unix() + 60,
+	})
+	got, err := VerifyCapabilityToken(tok, secret)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if !got.SkipAudit {
+		t.Fatalf("SkipAudit: want true, got false")
+	}
+}
+
 func TestVerifyCapabilityToken_BadSig(t *testing.T) {
 	tok := mintToken(t, []byte("k1"), CapPayload{TurnID: "t", WorkspaceID: "w", EXP: time.Now().Unix() + 60})
 	if _, err := VerifyCapabilityToken(tok, []byte("k2")); err != ErrBadSignature {

--- a/internal/codexexecgateway/bridge.go
+++ b/internal/codexexecgateway/bridge.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/agentserver/agentserver/internal/clientmeta"
+	"github.com/agentserver/agentserver/internal/codexexecgateway/audit"
 	"github.com/agentserver/agentserver/internal/relaypb"
 	"github.com/agentserver/agentserver/internal/wsbridge"
 	"github.com/go-chi/chi/v5"
@@ -139,9 +141,36 @@ func (s *Server) handleBridge(w http.ResponseWriter, r *http.Request) {
 			"exe_id", exeID, "stream_id", streamID)
 		evicted.close(errors.New("evicted by stream_id collision"))
 	}
+
+	// Open the audit session AFTER route registration but BEFORE the
+	// pump starts. SessionOpen mints a UUID even when audit is disabled
+	// (noopRecorder), so session.auditSessionID is always non-empty for
+	// the pumps.
+	auditSessID := s.recorder.SessionOpen(audit.SessionMeta{
+		WorkspaceID: payload.WorkspaceID,
+		UserID:      payload.UserID,
+		ExeID:       exeID,
+		TurnID:      payload.TurnID,
+		StreamID:    streamID,
+		ClientIP:    clientmeta.ClientIP(r),
+		CapIAT:      time.Unix(payload.IAT, 0).UTC(),
+		CapEXP:      time.Unix(payload.EXP, 0).UTC(),
+		OpenedAt:    time.Now().UTC(),
+	})
+	session.auditSessionID = auditSessID
+
 	defer func() {
 		inbound.removeRoute(streamID, session)
 		session.close(nil)
+		// Counters are safe to read here: runBridgePump has returned
+		// (we exit handleBridge only after it does), and the inbound
+		// reader stops writing to this session once removeRoute lands.
+		s.recorder.SessionClose(auditSessID, "client_disconnect", audit.Counters{
+			FramesToBackend: int(session.framesToBackend.Load()),
+			FramesToClient:  int(session.framesToClient.Load()),
+			BytesToBackend:  session.bytesToBackend.Load(),
+			BytesToClient:   session.bytesToClient.Load(),
+		})
 	}()
 
 	s.logger.Info("bridge: paired", "exe_id", exeID, "stream_id", streamID, "turn_id", payload.TurnID)
@@ -192,11 +221,25 @@ func (s *Server) runBridgePump(ctx context.Context, session *bridgeSession) {
 		// Validate stream_id matches session's. If mismatched, drop —
 		// keeps the inbound's frame ordering coherent.
 		var f relaypb.RelayMessageFrame
-		if proto.Unmarshal(data, &f) == nil && f.StreamId != session.streamID {
+		parsed := proto.Unmarshal(data, &f) == nil
+		if parsed && f.StreamId != session.streamID {
 			s.logger.Warn("bridge: ignoring frame with wrong stream_id",
 				"want", session.streamID, "got", f.StreamId)
 			continue
 		}
+		// Audit hook fires before forward so a write failure still
+		// records the frame the gateway attempted to deliver. Pass the
+		// parsed frame when available so the recorder can skip a second
+		// Unmarshal; nil when parse failed so OnFrameToBackend can
+		// decide whether to fall back.
+		var framePtr *relaypb.RelayMessageFrame
+		if parsed {
+			framePtr = &f
+		}
+		s.recorder.OnFrameToBackend(session.auditSessionID, framePtr, data)
+		session.framesToBackend.Add(1)
+		session.bytesToBackend.Add(int64(len(data)))
+
 		if err := session.inbound.write(ctx, mt, data); err != nil {
 			s.logger.Warn("bridge: inbound write failed", "stream_id", session.streamID, "error", err)
 			return

--- a/internal/codexexecgateway/bridge.go
+++ b/internal/codexexecgateway/bridge.go
@@ -136,16 +136,14 @@ func (s *Server) handleBridge(w http.ResponseWriter, r *http.Request) {
 	// happens — better than silently swapping who receives the next
 	// frame.
 	session := newBridgeSession(streamID, inbound, bridgeWS)
-	if evicted := inbound.addRoute(streamID, session); evicted != nil {
-		s.logger.Warn("bridge: stream_id collision; evicting prior session",
-			"exe_id", exeID, "stream_id", streamID)
-		evicted.close(errors.New("evicted by stream_id collision"))
-	}
-
-	// Open the audit session AFTER route registration but BEFORE the
-	// pump starts. SessionOpen mints a UUID even when audit is disabled
-	// (noopRecorder), so session.auditSessionID is always non-empty for
-	// the pumps.
+	// Open the audit session BEFORE addRoute so the inbound reader can
+	// never observe session.auditSessionID being written concurrently
+	// with its own read of the field. In production the protocol
+	// guarantees no inbound frame for streamID arrives before our
+	// forwarded Resume, but ordering the assignment first removes a
+	// latent race a future refactor could trip. SessionOpen mints a
+	// UUID even when audit is disabled (noopRecorder), so
+	// session.auditSessionID is always non-empty for the pumps.
 	auditSessID := s.recorder.SessionOpen(audit.SessionMeta{
 		WorkspaceID: payload.WorkspaceID,
 		UserID:      payload.UserID,
@@ -158,6 +156,11 @@ func (s *Server) handleBridge(w http.ResponseWriter, r *http.Request) {
 		OpenedAt:    time.Now().UTC(),
 	})
 	session.auditSessionID = auditSessID
+	if evicted := inbound.addRoute(streamID, session); evicted != nil {
+		s.logger.Warn("bridge: stream_id collision; evicting prior session",
+			"exe_id", exeID, "stream_id", streamID)
+		evicted.close(errors.New("evicted by stream_id collision"))
+	}
 
 	defer func() {
 		inbound.removeRoute(streamID, session)

--- a/internal/codexexecgateway/bridge.go
+++ b/internal/codexexecgateway/bridge.go
@@ -136,26 +136,41 @@ func (s *Server) handleBridge(w http.ResponseWriter, r *http.Request) {
 	// happens — better than silently swapping who receives the next
 	// frame.
 	session := newBridgeSession(streamID, inbound, bridgeWS)
-	// Open the audit session BEFORE addRoute so the inbound reader can
-	// never observe session.auditSessionID being written concurrently
-	// with its own read of the field. In production the protocol
-	// guarantees no inbound frame for streamID arrives before our
-	// forwarded Resume, but ordering the assignment first removes a
-	// latent race a future refactor could trip. SessionOpen mints a
-	// UUID even when audit is disabled (noopRecorder), so
-	// session.auditSessionID is always non-empty for the pumps.
-	auditSessID := s.recorder.SessionOpen(audit.SessionMeta{
-		WorkspaceID: payload.WorkspaceID,
-		UserID:      payload.UserID,
-		ExeID:       exeID,
-		TurnID:      payload.TurnID,
-		StreamID:    streamID,
-		ClientIP:    clientmeta.ClientIP(r),
-		CapIAT:      time.Unix(payload.IAT, 0).UTC(),
-		CapEXP:      time.Unix(payload.EXP, 0).UTC(),
-		OpenedAt:    time.Now().UTC(),
-	})
-	session.auditSessionID = auditSessID
+	// SDK-pool-managed bridges (the in-process bridge.Pool dialed by
+	// sdk/handlers.go) are skipped at the session/frame level — the SDK
+	// REST handler does its own CallStart/CallEnd for each tool call as
+	// a whole. Recording the underlying WS frames here too would
+	// double-record every SDK call. Detection: sdk/captoken.go stamps
+	// the cap-token's turn_id with the "sdk-pool" prefix; that marker
+	// is the protocol between sdk minting and this handler. The frame
+	// pump hooks still fire below but become no-ops because
+	// realRecorder.session("") returns nil (and noopRecorder doesn't
+	// care either way), so auditSessionID stays empty for sdk-pool.
+	isPool := strings.HasPrefix(payload.TurnID, "sdk-pool")
+	var auditSessID string
+	if !isPool {
+		// Open the audit session BEFORE addRoute so the inbound reader
+		// can never observe session.auditSessionID being written
+		// concurrently with its own read of the field. In production
+		// the protocol guarantees no inbound frame for streamID arrives
+		// before our forwarded Resume, but ordering the assignment
+		// first removes a latent race a future refactor could trip.
+		// SessionOpen mints a UUID even when audit is disabled
+		// (noopRecorder), so session.auditSessionID is always non-empty
+		// for the pumps when audit is in play.
+		auditSessID = s.recorder.SessionOpen(audit.SessionMeta{
+			WorkspaceID: payload.WorkspaceID,
+			UserID:      payload.UserID,
+			ExeID:       exeID,
+			TurnID:      payload.TurnID,
+			StreamID:    streamID,
+			ClientIP:    clientmeta.ClientIP(r),
+			CapIAT:      time.Unix(payload.IAT, 0).UTC(),
+			CapEXP:      time.Unix(payload.EXP, 0).UTC(),
+			OpenedAt:    time.Now().UTC(),
+		})
+		session.auditSessionID = auditSessID
+	}
 	if evicted := inbound.addRoute(streamID, session); evicted != nil {
 		s.logger.Warn("bridge: stream_id collision; evicting prior session",
 			"exe_id", exeID, "stream_id", streamID)
@@ -165,6 +180,9 @@ func (s *Server) handleBridge(w http.ResponseWriter, r *http.Request) {
 	defer func() {
 		inbound.removeRoute(streamID, session)
 		session.close(nil)
+		if isPool {
+			return
+		}
 		// Counters are safe to read here: runBridgePump has returned
 		// (we exit handleBridge only after it does), and the inbound
 		// reader stops writing to this session once removeRoute lands.

--- a/internal/codexexecgateway/bridge.go
+++ b/internal/codexexecgateway/bridge.go
@@ -158,7 +158,14 @@ func (s *Server) handleBridge(w http.ResponseWriter, r *http.Request) {
 		// SessionOpen mints a UUID even when audit is disabled
 		// (noopRecorder), so session.auditSessionID is always non-empty
 		// for the pumps when audit is in play.
-		auditSessID = s.recorder.SessionOpen(audit.SessionMeta{
+		//
+		// Fail-closed: when the WAL is in fail mode and the disk quota
+		// is hit, SessionOpen returns an error. We refuse the bridge in
+		// that case — that's the contract the spec promises. The WS is
+		// already accepted at this point so we close it with an
+		// internal-error code rather than HTTP-erroring.
+		var openErr error
+		auditSessID, openErr = s.recorder.SessionOpen(audit.SessionMeta{
 			WorkspaceID: payload.WorkspaceID,
 			UserID:      payload.UserID,
 			ExeID:       exeID,
@@ -169,6 +176,12 @@ func (s *Server) handleBridge(w http.ResponseWriter, r *http.Request) {
 			CapEXP:      time.Unix(payload.EXP, 0).UTC(),
 			OpenedAt:    time.Now().UTC(),
 		})
+		if openErr != nil {
+			s.logger.Error("bridge: audit SessionOpen failed (fail-closed) — refusing bridge",
+				"exe_id", exeID, "err", openErr)
+			_ = bridgeWS.Close(websocket.StatusInternalError, "audit unavailable")
+			return
+		}
 		session.auditSessionID = auditSessID
 	}
 	if evicted := inbound.addRoute(streamID, session); evicted != nil {

--- a/internal/codexexecgateway/bridge.go
+++ b/internal/codexexecgateway/bridge.go
@@ -140,13 +140,13 @@ func (s *Server) handleBridge(w http.ResponseWriter, r *http.Request) {
 	// sdk/handlers.go) are skipped at the session/frame level — the SDK
 	// REST handler does its own CallStart/CallEnd for each tool call as
 	// a whole. Recording the underlying WS frames here too would
-	// double-record every SDK call. Detection: sdk/captoken.go stamps
-	// the cap-token's turn_id with the "sdk-pool" prefix; that marker
-	// is the protocol between sdk minting and this handler. The frame
-	// pump hooks still fire below but become no-ops because
-	// realRecorder.session("") returns nil (and noopRecorder doesn't
-	// care either way), so auditSessionID stays empty for sdk-pool.
-	isPool := strings.HasPrefix(payload.TurnID, "sdk-pool")
+	// double-record every SDK call. Detection: typed CapPayload.SkipAudit
+	// flag set by sdk/captoken.go (I10 followup; replaces the prior
+	// magic-string TurnID prefix). The frame pump hooks still fire below
+	// but become no-ops because realRecorder.session("") returns nil
+	// (and noopRecorder doesn't care either way), so auditSessionID
+	// stays empty for sdk-pool.
+	isPool := payload.SkipAudit
 	var auditSessID string
 	if !isPool {
 		// Open the audit session BEFORE addRoute so the inbound reader

--- a/internal/codexexecgateway/bridge_test.go
+++ b/internal/codexexecgateway/bridge_test.go
@@ -80,6 +80,17 @@ func newBridgeNoDBServer(t *testing.T) (*httptest.Server, *Server) {
 	return hs, srv
 }
 
+// TODO(test-analyzer-#4): wiring test that bridge handleBridge invokes
+// s.recorder.SessionOpen. Deferred from this PR because the test
+// requires the full DB-backed setup (newInboundTestServer needs
+// TEST_DATABASE_URL — see multiplex_e2e_test.go pattern). The audit
+// fail-closed path IS covered indirectly by TestRealRecorder_
+// SessionOpenErrorsOnFailModeFullDisk, which pins the contract the
+// bridge depends on. A future PR should add bridge_audit_test.go that
+// swaps in a capRelayRec via srv.recorder = ... and asserts SessionOpen
+// fires (mirroring TestHandleRelay_RecorderObservesPutGet in
+// handlers_relay_test.go).
+
 func TestBridge_Rejects401OnBadToken(t *testing.T) {
 	hs, _ := newBridgeNoDBServer(t)
 	_, resp, err := dialBridge(context.Background(), hs.URL, "exe_x", "garbage")

--- a/internal/codexexecgateway/config.go
+++ b/internal/codexexecgateway/config.go
@@ -7,6 +7,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/agentserver/agentserver/internal/codexexecgateway/audit"
 )
 
 // WebSocket keepalive (ping interval + idle timeout) is phase-2; nhooyr's defaults govern for now.
@@ -46,6 +48,11 @@ type Config struct {
 	// Defaults to 16; protects gateway memory from runaway agents.
 	RelayMaxPerWorkspace int
 	LogLevel             slog.Level
+	// Audit holds the exec-audit subsystem config (WAL dir, uploader,
+	// payload caps). Zero value disables audit (Enabled=false →
+	// NewRecorder returns a noop). Populated from CXG_AUDIT_* env vars
+	// by LoadConfigFromEnv.
+	Audit audit.Config
 }
 
 // Validate checks that security-critical fields are populated. NewServer calls
@@ -74,6 +81,7 @@ func LoadConfigFromEnv() (Config, error) {
 		RelayDefaultTTL:           parseDurationOr("CXG_RELAY_DEFAULT_TTL", 5*time.Minute),
 		RelayMaxPerWorkspace:      parseIntOr("CXG_RELAY_MAX_PER_WORKSPACE", 16),
 		LogLevel:                  slog.LevelInfo,
+		Audit:                     audit.NewConfigFromEnv(),
 	}
 	if cfg.DatabaseURL == "" {
 		return cfg, fmt.Errorf("CXG_DATABASE_URL is required")

--- a/internal/codexexecgateway/handlers_relay.go
+++ b/internal/codexexecgateway/handlers_relay.go
@@ -173,7 +173,15 @@ func (s *Server) handleRelayGet(w http.ResponseWriter, r *http.Request) {
 	// applies it automatically when there's no Content-Length, and
 	// setting it manually here would conflict with the framework's own
 	// framing on the error path (small JSON body).
+	//
+	// X-Content-Type-Options: nosniff defeats browser MIME-sniffing —
+	// the body is user-supplied (uploaded via PUT by one workspace
+	// member, downloaded via GET by another), so an attacker who
+	// controls the upload could otherwise smuggle an HTML/JS payload
+	// that a browser fetch would render. nosniff forces strict
+	// application/octet-stream interpretation.
 	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 	counted := newRelayCountingWriter(w)
 	status, body := rel.AcceptGet(counted)
 	// status==0: streamed successfully; headers + 200 already flushed.

--- a/internal/codexexecgateway/handlers_relay.go
+++ b/internal/codexexecgateway/handlers_relay.go
@@ -2,14 +2,67 @@ package codexexecgateway
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"fmt"
+	"hash"
+	"io"
 	"net/http"
 	"strings"
 	"time"
 
+	"github.com/agentserver/agentserver/internal/codexexecgateway/audit"
 	"github.com/agentserver/agentserver/internal/codexexecgateway/relay"
 	"github.com/go-chi/chi/v5"
 )
+
+// relayCountingReader counts bytes read AND hashes them, so the relay
+// audit record can carry size + sha256 of the actual stream without
+// buffering the whole body (which could be GB).
+type relayCountingReader struct {
+	r io.Reader
+	h hash.Hash
+	n int64
+}
+
+func newRelayCountingReader(r io.Reader) *relayCountingReader {
+	return &relayCountingReader{r: r, h: sha256.New()}
+}
+
+func (c *relayCountingReader) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	if n > 0 {
+		c.h.Write(p[:n])
+		c.n += int64(n)
+	}
+	return n, err
+}
+
+func (c *relayCountingReader) Sum() string { return hex.EncodeToString(c.h.Sum(nil)) }
+
+// relayCountingWriter is the symmetric counter for the GET path.
+type relayCountingWriter struct {
+	w http.ResponseWriter
+	h hash.Hash
+	n int64
+}
+
+func newRelayCountingWriter(w http.ResponseWriter) *relayCountingWriter {
+	return &relayCountingWriter{w: w, h: sha256.New()}
+}
+
+func (c *relayCountingWriter) Header() http.Header         { return c.w.Header() }
+func (c *relayCountingWriter) WriteHeader(statusCode int)  { c.w.WriteHeader(statusCode) }
+func (c *relayCountingWriter) Write(p []byte) (int, error) {
+	n, err := c.w.Write(p)
+	if n > 0 {
+		c.h.Write(p[:n])
+		c.n += int64(n)
+	}
+	return n, err
+}
+func (c *relayCountingWriter) Sum() string { return hex.EncodeToString(c.h.Sum(nil)) }
 
 // ────────────────────────────────────────────────────────────────────
 // Public PUT/GET endpoints (ticket Bearer auth)
@@ -35,10 +88,38 @@ func (s *Server) handleRelayPut(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "ticket not found or expired", http.StatusGone)
 		return
 	}
-	status, body := rel.AcceptPut(r.Body)
+
+	// Audit: relay PUT is a logical "instruction to codex-exec" (DestExeID
+	// will write the bytes locally). We never inline the body — could be
+	// GB — only record size + sha256 in the CallEnd's Response summary.
+	rec := s.recorder
+	if rec == nil {
+		rec = audit.NewNoopRecorder()
+	}
+	callID := rec.CallStart(audit.CallStartMeta{
+		WorkspaceID: rel.WorkspaceID,
+		ExeID:       rel.DestExeID,
+		Source:      "relay",
+		RPCMethod:   "relay_put",
+		StartedAt:   time.Now().UTC(),
+	})
+	counted := newRelayCountingReader(r.Body)
+	status, body := rel.AcceptPut(counted)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	_, _ = w.Write(body)
+
+	end := audit.CallEndMeta{
+		CompletedAt: time.Now().UTC(),
+		Response: []byte(fmt.Sprintf(
+			`{"relay_put_bytes":%d,"relay_put_sha256":"%s"}`,
+			counted.n, counted.Sum())),
+	}
+	if status >= 400 {
+		end.IsError = true
+		end.ErrorSummary = string(body)
+	}
+	rec.CallEnd(callID, end)
 }
 
 // handleRelayGet accepts the download half. Streams body chunked.
@@ -58,6 +139,20 @@ func (s *Server) handleRelayGet(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "ticket not found or expired", http.StatusGone)
 		return
 	}
+	// Audit: relay GET is reading bytes FROM SourceExeID. Same size+sha
+	// pattern as PUT — never inline the streamed body.
+	rec := s.recorder
+	if rec == nil {
+		rec = audit.NewNoopRecorder()
+	}
+	callID := rec.CallStart(audit.CallStartMeta{
+		WorkspaceID: rel.WorkspaceID,
+		ExeID:       rel.SourceExeID,
+		Source:      "relay",
+		RPCMethod:   "relay_get",
+		StartedAt:   time.Now().UTC(),
+	})
+
 	// Set Content-Type before AcceptGet because the pairing goroutine's
 	// first Write implicitly calls WriteHeader(200) (success path) and
 	// any headers we set after that would be silently dropped.
@@ -67,7 +162,8 @@ func (s *Server) handleRelayGet(w http.ResponseWriter, r *http.Request) {
 	// setting it manually here would conflict with the framework's own
 	// framing on the error path (small JSON body).
 	w.Header().Set("Content-Type", "application/octet-stream")
-	status, body := rel.AcceptGet(w)
+	counted := newRelayCountingWriter(w)
+	status, body := rel.AcceptGet(counted)
 	// status==0: streamed successfully; headers + 200 already flushed.
 	// status!=0: pairing failed before any byte was written, emit the
 	// status + JSON body. Override the Content-Type since the body is
@@ -77,6 +173,18 @@ func (s *Server) handleRelayGet(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(status)
 		_, _ = w.Write(body)
 	}
+
+	end := audit.CallEndMeta{
+		CompletedAt: time.Now().UTC(),
+		Response: []byte(fmt.Sprintf(
+			`{"relay_get_bytes":%d,"relay_get_sha256":"%s"}`,
+			counted.n, counted.Sum())),
+	}
+	if status >= 400 {
+		end.IsError = true
+		end.ErrorSummary = string(body)
+	}
+	rec.CallEnd(callID, end)
 }
 
 // ────────────────────────────────────────────────────────────────────

--- a/internal/codexexecgateway/handlers_relay.go
+++ b/internal/codexexecgateway/handlers_relay.go
@@ -96,13 +96,19 @@ func (s *Server) handleRelayPut(w http.ResponseWriter, r *http.Request) {
 	if rec == nil {
 		rec = audit.NewNoopRecorder()
 	}
-	callID := rec.CallStart(audit.CallStartMeta{
+	callID, callErr := rec.CallStart(audit.CallStartMeta{
 		WorkspaceID: rel.WorkspaceID,
 		ExeID:       rel.DestExeID,
 		Source:      "relay",
 		RPCMethod:   "relay_put",
 		StartedAt:   time.Now().UTC(),
 	})
+	if callErr != nil {
+		s.logger.Error("relay PUT: audit CallStart failed (fail-closed) — refusing",
+			"ticket", urlTicket, "err", callErr)
+		http.Error(w, "audit unavailable", http.StatusServiceUnavailable)
+		return
+	}
 	counted := newRelayCountingReader(r.Body)
 	status, body := rel.AcceptPut(counted)
 	w.Header().Set("Content-Type", "application/json")
@@ -145,13 +151,19 @@ func (s *Server) handleRelayGet(w http.ResponseWriter, r *http.Request) {
 	if rec == nil {
 		rec = audit.NewNoopRecorder()
 	}
-	callID := rec.CallStart(audit.CallStartMeta{
+	callID, callErr := rec.CallStart(audit.CallStartMeta{
 		WorkspaceID: rel.WorkspaceID,
 		ExeID:       rel.SourceExeID,
 		Source:      "relay",
 		RPCMethod:   "relay_get",
 		StartedAt:   time.Now().UTC(),
 	})
+	if callErr != nil {
+		s.logger.Error("relay GET: audit CallStart failed (fail-closed) — refusing",
+			"ticket", urlTicket, "err", callErr)
+		http.Error(w, "audit unavailable", http.StatusServiceUnavailable)
+		return
+	}
 
 	// Set Content-Type before AcceptGet because the pairing goroutine's
 	// first Write implicitly calls WriteHeader(200) (success path) and

--- a/internal/codexexecgateway/handlers_relay_test.go
+++ b/internal/codexexecgateway/handlers_relay_test.go
@@ -2,7 +2,9 @@ package codexexecgateway
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -10,7 +12,39 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/agentserver/agentserver/internal/codexexecgateway/audit"
 )
+
+// capRelayRec captures CallStart/CallEnd for relay handler wiring
+// tests (test-analyzer #3 followup). Same pattern as the SDK's capRec
+// but inline here to avoid an import cycle.
+type capRelayRec struct {
+	mu     sync.Mutex
+	starts []audit.CallStartMeta
+	ends   map[string]audit.CallEndMeta
+}
+
+func (r *capRelayRec) SessionOpen(audit.SessionMeta) (string, error) { return "", nil }
+func (r *capRelayRec) SessionClose(string, string, audit.Counters)   {}
+func (r *capRelayRec) OnFrameToBackend(string, any, []byte)          {}
+func (r *capRelayRec) OnFrameToClient(string, any, []byte)           {}
+func (r *capRelayRec) CallStart(m audit.CallStartMeta) (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	id := fmt.Sprintf("c%d", len(r.starts))
+	r.starts = append(r.starts, m)
+	return id, nil
+}
+func (r *capRelayRec) CallEnd(id string, m audit.CallEndMeta) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.ends == nil {
+		r.ends = map[string]audit.CallEndMeta{}
+	}
+	r.ends[id] = m
+}
+func (r *capRelayRec) Close(context.Context) error { return nil }
 
 // newRelayTestServer spins up an httptest.Server with the relay routes
 // wired and a non-empty PublicHTTPSBaseURL so the registry is enabled.
@@ -125,6 +159,74 @@ func TestHandleRelay_RoundTrip(t *testing.T) {
 	}
 	if !strings.Contains(string(putBody), `"status":"ok"`) {
 		t.Errorf("put body lacks ok status: %s", putBody)
+	}
+}
+
+// TestHandleRelay_RecorderObservesPutGet pins that the relay PUT and
+// GET handlers actually invoke the audit recorder. Wiring test for
+// test-analyzer #3 — a refactor that drops the rec.CallStart/CallEnd
+// hooks would silently disable relay audit otherwise.
+func TestHandleRelay_RecorderObservesPutGet(t *testing.T) {
+	cfg := Config{
+		CapTokenHMACSecret:   []byte("test-hmac"),
+		InternalSharedSecret: "test-secret",
+		PublicHTTPSBaseURL:   "https://test.example/",
+		RelayDefaultTTL:      time.Second,
+		RelayMaxPerWorkspace: 4,
+	}
+	srv, err := newServerNoStoreForTesting(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := &capRelayRec{}
+	srv.recorder = rec
+	ts := httptest.NewServer(srv.Routes())
+	defer ts.Close()
+
+	ticket := mintTestTicket(t, ts, cfg.InternalSharedSecret, "ws", "exe_src", "exe_dst")
+	url := ts.URL + "/relay/" + ticket
+	payload := []byte("hello relay audit")
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		req, _ := http.NewRequest("PUT", url, bytes.NewReader(payload))
+		req.Header.Set("Authorization", "Bearer "+ticket)
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			resp.Body.Close()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		req, _ := http.NewRequest("GET", url, nil)
+		req.Header.Set("Authorization", "Bearer "+ticket)
+		resp, err := http.DefaultClient.Do(req)
+		if err == nil {
+			io.Copy(io.Discard, resp.Body)
+			resp.Body.Close()
+		}
+	}()
+	wg.Wait()
+	// Both PUT and GET should have produced one CallStart each.
+	rec.mu.Lock()
+	defer rec.mu.Unlock()
+	if len(rec.starts) != 2 {
+		t.Fatalf("want 2 relay CallStarts (PUT+GET), got %d", len(rec.starts))
+	}
+	methods := map[string]bool{}
+	for _, m := range rec.starts {
+		methods[m.RPCMethod] = true
+		if m.Source != "relay" {
+			t.Errorf("Source=%q want relay", m.Source)
+		}
+	}
+	if !methods["relay_put"] || !methods["relay_get"] {
+		t.Errorf("missing relay_put or relay_get; got methods=%v", methods)
+	}
+	if len(rec.ends) != 2 {
+		t.Errorf("want 2 CallEnds, got %d", len(rec.ends))
 	}
 }
 

--- a/internal/codexexecgateway/inbound.go
+++ b/internal/codexexecgateway/inbound.go
@@ -108,6 +108,11 @@ func (s *Server) runInboundReader(ctx context.Context, ic *inboundConn) {
 			ic.logger.Debug("inbound: no route for stream", "stream_id", frame.StreamId)
 			continue
 		}
+		// Audit hook fires before forwarding to the bridge so a write
+		// failure still records that the gateway received the frame.
+		s.recorder.OnFrameToClient(b.auditSessionID, &frame, data)
+		b.framesToClient.Add(1)
+		b.bytesToClient.Add(int64(len(data)))
 		if err := b.write(ctx, mt, data); err != nil {
 			ic.logger.Warn("inbound: bridge write failed; closing route", "stream_id", frame.StreamId, "error", err)
 			b.close(err)

--- a/internal/codexexecgateway/multiplex.go
+++ b/internal/codexexecgateway/multiplex.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 
 	"nhooyr.io/websocket"
 )
@@ -123,6 +124,25 @@ type bridgeSession struct {
 	closeOnce sync.Once
 	closed    chan struct{}
 	closeErr  error
+
+	// auditSessionID is set by handleBridge after recorder.SessionOpen,
+	// and read by both pump goroutines. Empty when the recorder hasn't
+	// minted one yet (during the brief window between bridgeSession
+	// construction and SessionOpen) — frame hooks tolerate "" and
+	// the noopRecorder still mints non-empty IDs when audit is disabled.
+	auditSessionID string
+
+	// Per-direction frame/byte counters. runBridgePump writes the
+	// "ToBackend" pair; runInboundReader (running in the inbound
+	// handler's goroutine, separate from handleBridge) writes the
+	// "ToClient" pair. handleBridge's SessionClose defer reads all
+	// four — and may race the inbound reader, which can still be
+	// mid-write() after handleBridge removeRoute lands. Atomics keep
+	// the snapshot race-free.
+	framesToBackend atomic.Int64
+	framesToClient  atomic.Int64
+	bytesToBackend  atomic.Int64
+	bytesToClient   atomic.Int64
 }
 
 func newBridgeSession(streamID string, inbound *inboundConn, bridgeWS *websocket.Conn) *bridgeSession {

--- a/internal/codexexecgateway/sdk/captoken.go
+++ b/internal/codexexecgateway/sdk/captoken.go
@@ -25,9 +25,16 @@ const sdkCapTokenTTL = 24 * time.Hour
 // its execmodel types and *Config*; pulling codexappgateway in from
 // the sdk sub-package would close the loop at test time).
 //
-// turn_id is unused at verify time (the /bridge handler authorises
-// against workspace_executors, not turn_id) but the mint signature
-// requires it non-empty; we stuff a synthetic "sdk" marker.
+// turn_id is unused for authorization at verify time (the /bridge
+// handler authorises against workspace_executors, not turn_id) but the
+// marker IS load-bearing for the audit pipeline: codexexecgateway's
+// handleBridge inspects payload.TurnID to detect sdk-pool-managed
+// bridges and SKIPS audit.SessionOpen for them, because the SDK REST
+// handlers (sdk/handlers.go) already record each tool call at
+// CallStart/CallEnd granularity. Without this marker we'd double-record
+// every SDK call (once at the handler, once per WS frame). The
+// "sdk-pool:" prefix + workspace id makes the source unmistakable in
+// logs while keeping the prefix check trivial.
 func mintWorkspaceToken(secret []byte, workspaceID string) (string, error) {
 	if len(secret) == 0 {
 		return "", fmt.Errorf("captoken: empty secret")
@@ -42,7 +49,7 @@ func mintWorkspaceToken(secret []byte, workspaceID string) (string, error) {
 		IAT         int64  `json:"iat"`
 		EXP         int64  `json:"exp"`
 	}{
-		TurnID:      "sdk",
+		TurnID:      "sdk-pool:" + workspaceID,
 		WorkspaceID: workspaceID,
 		IAT:         now,
 		EXP:         now + int64(sdkCapTokenTTL.Seconds()),

--- a/internal/codexexecgateway/sdk/captoken.go
+++ b/internal/codexexecgateway/sdk/captoken.go
@@ -26,15 +26,14 @@ const sdkCapTokenTTL = 24 * time.Hour
 // the sdk sub-package would close the loop at test time).
 //
 // turn_id is unused for authorization at verify time (the /bridge
-// handler authorises against workspace_executors, not turn_id) but the
-// marker IS load-bearing for the audit pipeline: codexexecgateway's
-// handleBridge inspects payload.TurnID to detect sdk-pool-managed
-// bridges and SKIPS audit.SessionOpen for them, because the SDK REST
-// handlers (sdk/handlers.go) already record each tool call at
-// CallStart/CallEnd granularity. Without this marker we'd double-record
-// every SDK call (once at the handler, once per WS frame). The
-// "sdk-pool:" prefix + workspace id makes the source unmistakable in
-// logs while keeping the prefix check trivial.
+// handler authorises against workspace_executors, not turn_id). To
+// signal "this is an SDK-Pool-managed bridge — skip the per-frame audit
+// session", we set the typed CapPayload.SkipAudit field (I10). The
+// previous magic-string `TurnID="sdk-pool:..."` was load-bearing but
+// silently mis-typed code could break it. The SDK REST handlers in
+// sdk/handlers.go already record each tool call at CallStart/CallEnd
+// granularity; without SkipAudit we'd double-record every SDK call
+// (once at the handler, once per WS frame).
 func mintWorkspaceToken(secret []byte, workspaceID string) (string, error) {
 	if len(secret) == 0 {
 		return "", fmt.Errorf("captoken: empty secret")
@@ -48,11 +47,13 @@ func mintWorkspaceToken(secret []byte, workspaceID string) (string, error) {
 		WorkspaceID string `json:"workspace_id"`
 		IAT         int64  `json:"iat"`
 		EXP         int64  `json:"exp"`
+		SkipAudit   bool   `json:"skip_audit,omitempty"`
 	}{
-		TurnID:      "sdk-pool:" + workspaceID,
+		TurnID:      "sdk",
 		WorkspaceID: workspaceID,
 		IAT:         now,
 		EXP:         now + int64(sdkCapTokenTTL.Seconds()),
+		SkipAudit:   true,
 	}
 	pj, err := json.Marshal(payload)
 	if err != nil {

--- a/internal/codexexecgateway/sdk/handlers.go
+++ b/internal/codexexecgateway/sdk/handlers.go
@@ -214,7 +214,11 @@ func (s *Server) handleToolCall(w http.ResponseWriter, r *http.Request) {
 				WorkspaceID: wsID,
 			})
 		}
-		respBytes, _ := json.Marshal(result)
+		respBytes, mErr := json.Marshal(result)
+		if mErr != nil {
+			log.Printf("exec-audit: marshal tool result for %s: %v", req.Tool, mErr)
+			respBytes = []byte(fmt.Sprintf(`{"audit_marshal_failed":%q}`, mErr.Error()))
+		}
 		writeJSON(w, result)
 		return respBytes, false, ""
 	})
@@ -266,7 +270,11 @@ func (s *Server) handleEnvsList(w http.ResponseWriter, r *http.Request) {
 			})
 		}
 		resp := ConnectorEnvsListResponse{Envs: envs}
-		respBytes, _ := json.Marshal(resp)
+		respBytes, mErr := json.Marshal(resp)
+		if mErr != nil {
+			log.Printf("exec-audit: marshal envs/list: %v", mErr)
+			respBytes = []byte(fmt.Sprintf(`{"audit_marshal_failed":%q}`, mErr.Error()))
+		}
 		writeJSON(w, resp)
 		return respBytes, false, ""
 	})
@@ -362,7 +370,11 @@ func (s *Server) handleStdin(w http.ResponseWriter, r *http.Request) {
 		// For v0.61.0 the endpoint contract is testable; full bridge integration
 		// lands in a follow-up once Session has the exe-side fields wired.
 		resp := ConnectorOKResponse{OK: true}
-		respBytes, _ := json.Marshal(resp)
+		respBytes, mErr := json.Marshal(resp)
+		if mErr != nil {
+			log.Printf("exec-audit: marshal stdin OK: %v", mErr)
+			respBytes = []byte(fmt.Sprintf(`{"audit_marshal_failed":%q}`, mErr.Error()))
+		}
 		writeJSON(w, resp)
 		return respBytes, false, ""
 	})
@@ -411,7 +423,11 @@ func (s *Server) handleOutput(w http.ResponseWriter, r *http.Request) {
 		}
 		// Output chunks can be large; record size+hash via the Recorder
 		// (it truncates above PayloadMaxBytes). Pass marshaled bytes.
-		respBytes, _ := json.Marshal(resp)
+		respBytes, mErr := json.Marshal(resp)
+		if mErr != nil {
+			log.Printf("exec-audit: marshal processes/output: %v", mErr)
+			respBytes = []byte(fmt.Sprintf(`{"audit_marshal_failed":%q}`, mErr.Error()))
+		}
 		writeJSON(w, resp)
 		return respBytes, false, ""
 	})
@@ -443,7 +459,11 @@ func (s *Server) handleTerminate(w http.ResponseWriter, r *http.Request) {
 		sess.SetExit(-1)
 		s.Sessions.Forget(sess.ID)
 		resp := ConnectorOKResponse{OK: true}
-		respBytes, _ := json.Marshal(resp)
+		respBytes, mErr := json.Marshal(resp)
+		if mErr != nil {
+			log.Printf("exec-audit: marshal terminate OK: %v", mErr)
+			respBytes = []byte(fmt.Sprintf(`{"audit_marshal_failed":%q}`, mErr.Error()))
+		}
 		writeJSON(w, resp)
 		return respBytes, false, ""
 	})

--- a/internal/codexexecgateway/sdk/handlers.go
+++ b/internal/codexexecgateway/sdk/handlers.go
@@ -3,14 +3,56 @@ package sdk
 import (
 	"encoding/base64"
 	"encoding/json"
+	"io"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/agentserver/agentserver/internal/codexexecgateway/audit"
 	"github.com/agentserver/agentserver/internal/envtools/processes"
 	"github.com/agentserver/agentserver/internal/envtools/tools"
 )
+
+// recordCall wraps a handler body with a CallStart / CallEnd pair so
+// the SDK call is captured at handler-level granularity. The matching
+// per-WS-frame audit hooks are suppressed for sdk-pool-managed bridges
+// in codexexecgateway.handleBridge (see captoken.go's TurnID marker)
+// to avoid double-recording the same call.
+//
+// method is the RPC-equivalent name ("tool.call:shell",
+// "envs.list", "processes.stdin", etc.).
+// exeID is best-effort: empty when the handler cannot resolve it
+// pre-call (e.g. tool.Call's internal name → exe_id resolution).
+// requestJSON is captured as the CallStart Request bytes; pass nil
+// when there is nothing meaningful (e.g. an empty GET).
+// fn is invoked under the wrapper; it returns the response bytes for
+// CallEnd's Response field plus the error metadata.
+func recordCall(
+	rec audit.Recorder,
+	workspaceID, userID, exeID, method string,
+	requestJSON []byte,
+	fn func() (responseJSON []byte, isError bool, errorSummary string),
+) {
+	callID := rec.CallStart(audit.CallStartMeta{
+		WorkspaceID: workspaceID,
+		UserID:      userID,
+		ExeID:       exeID,
+		Source:      "rest",
+		RPCMethod:   method,
+		RPCKind:     "request",
+		Request:     requestJSON,
+		StartedAt:   time.Now().UTC(),
+	})
+	resp, isErr, errSum := fn()
+	rec.CallEnd(callID, audit.CallEndMeta{
+		CompletedAt:  time.Now().UTC(),
+		IsError:      isErr,
+		ErrorSummary: errSum,
+		Response:     resp,
+	})
+}
 
 // ConnectorTool is the per-tool entry in envs/list responses. The SDK
 // uses these to populate its client-side Env.tools. The server validates
@@ -86,14 +128,23 @@ type ConnectorErrorBody struct {
 //	@Router     /api/connectors/envs/{name}/tool/call [post]
 func (s *Server) handleToolCall(w http.ResponseWriter, r *http.Request) {
 	wsID := workspaceFromCtx(r.Context())
+	userID := userIDFromCtx(r.Context())
 	wsCtx, err := s.wsCtxFor(wsID)
 	if err != nil {
 		writeErr(w, http.StatusInternalServerError, "workspace_init", err.Error())
 		return
 	}
 	_ = chi.URLParam(r, "name") // env name; tool args carry environment_id, resolver maps to exe
+	// Read the full body up front so the audit Request can capture the
+	// raw bytes (NOT the re-marshaled form, which drops the original
+	// field ordering and any unknown keys).
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
 	var req ConnectorToolCallRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	if err := json.Unmarshal(bodyBytes, &req); err != nil {
 		writeErr(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
@@ -107,20 +158,28 @@ func (s *Server) handleToolCall(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusBadRequest, "bad_arguments", err.Error())
 		return
 	}
-	result, err := tool.Call(r.Context(), argsJSON)
-	if err != nil {
-		writeErr(w, http.StatusInternalServerError, "tool_error", err.Error())
-		return
-	}
-	// exec_command encodes session_id as JSON text in Content[0].Text.
-	// Register a Session row so subsequent /processes/{sid}/* calls find it.
-	if sid := extractSessionID(result); sid != "" && s.Sessions != nil {
-		s.Sessions.Register(&processes.Session{
-			ID:          sid,
-			WorkspaceID: wsID,
-		})
-	}
-	writeJSON(w, result)
+	// exeID is not derivable pre-call here: the env-name → exe_id
+	// resolution lives inside tool.Call (via nameresolver.Resolver) and
+	// isn't exposed. Leave "" — the WAL still carries workspace_id +
+	// user_id + the tool method.
+	recordCall(s.Recorder, wsID, userID, "", "tool.call:"+req.Tool, bodyBytes, func() ([]byte, bool, string) {
+		result, callErr := tool.Call(r.Context(), argsJSON)
+		if callErr != nil {
+			writeErr(w, http.StatusInternalServerError, "tool_error", callErr.Error())
+			return nil, true, callErr.Error()
+		}
+		// exec_command encodes session_id as JSON text in Content[0].Text.
+		// Register a Session row so subsequent /processes/{sid}/* calls find it.
+		if sid := extractSessionID(result); sid != "" && s.Sessions != nil {
+			s.Sessions.Register(&processes.Session{
+				ID:          sid,
+				WorkspaceID: wsID,
+			})
+		}
+		respBytes, _ := json.Marshal(result)
+		writeJSON(w, result)
+		return respBytes, false, ""
+	})
 }
 
 // extractSessionID parses the session_id field from a tool result whose
@@ -151,22 +210,28 @@ func extractSessionID(result tools.MCPCallToolResult) string {
 //	@Router     /api/connectors/envs/list [post]
 func (s *Server) handleEnvsList(w http.ResponseWriter, r *http.Request) {
 	wsID := workspaceFromCtx(r.Context())
-	connected, err := s.Registry.Connected(r.Context(), wsID)
-	if err != nil {
-		writeErr(w, http.StatusInternalServerError, "registry_error", err.Error())
-		return
-	}
-	envs := make([]ConnectorEnv, 0, len(connected))
-	for _, c := range connected {
-		envs = append(envs, ConnectorEnv{
-			Name:      c.Name,
-			Type:      "executor",
-			IsDefault: c.IsDefault,
-			Tools:     coreTools(),
-			LastSeen:  c.LastSeenAt,
-		})
-	}
-	writeJSON(w, ConnectorEnvsListResponse{Envs: envs})
+	userID := userIDFromCtx(r.Context())
+	recordCall(s.Recorder, wsID, userID, "", "envs.list", nil, func() ([]byte, bool, string) {
+		connected, err := s.Registry.Connected(r.Context(), wsID)
+		if err != nil {
+			writeErr(w, http.StatusInternalServerError, "registry_error", err.Error())
+			return nil, true, err.Error()
+		}
+		envs := make([]ConnectorEnv, 0, len(connected))
+		for _, c := range connected {
+			envs = append(envs, ConnectorEnv{
+				Name:      c.Name,
+				Type:      "executor",
+				IsDefault: c.IsDefault,
+				Tools:     coreTools(),
+				LastSeen:  c.LastSeenAt,
+			})
+		}
+		resp := ConnectorEnvsListResponse{Envs: envs}
+		respBytes, _ := json.Marshal(resp)
+		writeJSON(w, resp)
+		return respBytes, false, ""
+	})
 }
 
 // ConnectorStdinRequest is the request body for
@@ -233,23 +298,36 @@ func (s *Server) sessionFromReq(w http.ResponseWriter, r *http.Request) (*proces
 //	@Security   BearerAuth
 //	@Router     /api/connectors/processes/{sid}/stdin [post]
 func (s *Server) handleStdin(w http.ResponseWriter, r *http.Request) {
-	_, ok := s.sessionFromReq(w, r)
+	sess, ok := s.sessionFromReq(w, r)
 	if !ok {
 		return
 	}
-	var req ConnectorStdinRequest
-	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+	wsID := workspaceFromCtx(r.Context())
+	userID := userIDFromCtx(r.Context())
+	bodyBytes, err := io.ReadAll(r.Body)
+	if err != nil {
 		writeErr(w, http.StatusBadRequest, "bad_request", err.Error())
 		return
 	}
-	if _, err := base64.StdEncoding.DecodeString(req.DataB64); err != nil {
-		writeErr(w, http.StatusBadRequest, "bad_base64", err.Error())
-		return
-	}
-	// TODO: wire bridge.WriteStdin(session.ExeID, session.ExeSessionID, data).
-	// For v0.61.0 the endpoint contract is testable; full bridge integration
-	// lands in a follow-up once Session has the exe-side fields wired.
-	writeJSON(w, ConnectorOKResponse{OK: true})
+	_ = sess // processes.Session has no ExeID yet (TODO above); pass "" for exe_id
+	recordCall(s.Recorder, wsID, userID, "", "processes.stdin", bodyBytes, func() ([]byte, bool, string) {
+		var req ConnectorStdinRequest
+		if err := json.Unmarshal(bodyBytes, &req); err != nil {
+			writeErr(w, http.StatusBadRequest, "bad_request", err.Error())
+			return nil, true, err.Error()
+		}
+		if _, err := base64.StdEncoding.DecodeString(req.DataB64); err != nil {
+			writeErr(w, http.StatusBadRequest, "bad_base64", err.Error())
+			return nil, true, err.Error()
+		}
+		// TODO: wire bridge.WriteStdin(session.ExeID, session.ExeSessionID, data).
+		// For v0.61.0 the endpoint contract is testable; full bridge integration
+		// lands in a follow-up once Session has the exe-side fields wired.
+		resp := ConnectorOKResponse{OK: true}
+		respBytes, _ := json.Marshal(resp)
+		writeJSON(w, resp)
+		return respBytes, false, ""
+	})
 }
 
 // handleOutput returns every chunk with Seq > since, the current exit
@@ -272,23 +350,32 @@ func (s *Server) handleOutput(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	sinceStr := r.URL.Query().Get("since")
-	since, _ := strconv.Atoi(sinceStr)
-	chunks, exit, alive := sess.OutputSince(since)
-	out := make([]ConnectorOutputChunk, 0, len(chunks))
-	for _, c := range chunks {
-		out = append(out, ConnectorOutputChunk{
-			Stream: c.Stream,
-			Data:   base64.StdEncoding.EncodeToString(c.Data),
-			Seq:    c.Seq,
-		})
-	}
-	writeJSON(w, ConnectorOutputResponse{
-		Chunks:       out,
-		ExitCode:     exit,
-		SessionAlive: alive,
-		Truncated:    sess.LostBytes() > 0,
-		LostBytes:    sess.LostBytes(),
+	wsID := workspaceFromCtx(r.Context())
+	userID := userIDFromCtx(r.Context())
+	recordCall(s.Recorder, wsID, userID, "", "processes.output", nil, func() ([]byte, bool, string) {
+		sinceStr := r.URL.Query().Get("since")
+		since, _ := strconv.Atoi(sinceStr)
+		chunks, exit, alive := sess.OutputSince(since)
+		out := make([]ConnectorOutputChunk, 0, len(chunks))
+		for _, c := range chunks {
+			out = append(out, ConnectorOutputChunk{
+				Stream: c.Stream,
+				Data:   base64.StdEncoding.EncodeToString(c.Data),
+				Seq:    c.Seq,
+			})
+		}
+		resp := ConnectorOutputResponse{
+			Chunks:       out,
+			ExitCode:     exit,
+			SessionAlive: alive,
+			Truncated:    sess.LostBytes() > 0,
+			LostBytes:    sess.LostBytes(),
+		}
+		// Output chunks can be large; record size+hash via the Recorder
+		// (it truncates above PayloadMaxBytes). Pass marshaled bytes.
+		respBytes, _ := json.Marshal(resp)
+		writeJSON(w, resp)
+		return respBytes, false, ""
 	})
 }
 
@@ -309,10 +396,17 @@ func (s *Server) handleTerminate(w http.ResponseWriter, r *http.Request) {
 	if !ok {
 		return
 	}
-	// For v0.61.0 mark exit -1; bridge.Terminate(...) wiring lands in
-	// a follow-up. The endpoint contract works for the SDK's polling
-	// pattern (next GET output sees session_alive=false + exit_code=-1).
-	sess.SetExit(-1)
-	s.Sessions.Forget(sess.ID)
-	writeJSON(w, ConnectorOKResponse{OK: true})
+	wsID := workspaceFromCtx(r.Context())
+	userID := userIDFromCtx(r.Context())
+	recordCall(s.Recorder, wsID, userID, "", "processes.terminate", nil, func() ([]byte, bool, string) {
+		// For v0.61.0 mark exit -1; bridge.Terminate(...) wiring lands in
+		// a follow-up. The endpoint contract works for the SDK's polling
+		// pattern (next GET output sees session_alive=false + exit_code=-1).
+		sess.SetExit(-1)
+		s.Sessions.Forget(sess.ID)
+		resp := ConnectorOKResponse{OK: true}
+		respBytes, _ := json.Marshal(resp)
+		writeJSON(w, resp)
+		return respBytes, false, ""
+	})
 }

--- a/internal/codexexecgateway/sdk/handlers.go
+++ b/internal/codexexecgateway/sdk/handlers.go
@@ -3,7 +3,9 @@ package sdk
 import (
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"strconv"
 	"time"
@@ -18,7 +20,7 @@ import (
 // recordCall wraps a handler body with a CallStart / CallEnd pair so
 // the SDK call is captured at handler-level granularity. The matching
 // per-WS-frame audit hooks are suppressed for sdk-pool-managed bridges
-// in codexexecgateway.handleBridge (see captoken.go's TurnID marker)
+// in codexexecgateway.handleBridge (see captoken.go's SkipAudit field)
 // to avoid double-recording the same call.
 //
 // method is the RPC-equivalent name ("tool.call:shell",
@@ -29,13 +31,20 @@ import (
 // when there is nothing meaningful (e.g. an empty GET).
 // fn is invoked under the wrapper; it returns the response bytes for
 // CallEnd's Response field plus the error metadata.
+//
+// Returns ok=true when fn was invoked, ok=false when CallStart failed
+// (handler should short-circuit; recordCall has already written a 503).
+// On panic inside fn, recordCall emits a CallEnd with IsError=true +
+// ErrorSummary="panic: ..." before re-raising — so a panic doesn't
+// leave a CallStart orphaned with no matching End.
 func recordCall(
 	rec audit.Recorder,
+	w http.ResponseWriter,
 	workspaceID, userID, exeID, method string,
 	requestJSON []byte,
 	fn func() (responseJSON []byte, isError bool, errorSummary string),
-) {
-	callID := rec.CallStart(audit.CallStartMeta{
+) (ok bool) {
+	callID, err := rec.CallStart(audit.CallStartMeta{
 		WorkspaceID: workspaceID,
 		UserID:      userID,
 		ExeID:       exeID,
@@ -45,13 +54,42 @@ func recordCall(
 		Request:     requestJSON,
 		StartedAt:   time.Now().UTC(),
 	})
+	if err != nil {
+		log.Printf("exec-audit: CallStart failed for %s: %v", method, err)
+		writeErr(w, http.StatusServiceUnavailable, "audit_unavailable", err.Error())
+		return false
+	}
+	completed := false
+	var endMeta audit.CallEndMeta
+	defer func() {
+		if !completed {
+			r := recover()
+			endMeta = audit.CallEndMeta{
+				CompletedAt: time.Now().UTC(),
+				IsError:     true,
+			}
+			if r != nil {
+				endMeta.ErrorSummary = fmt.Sprintf("panic: %v", r)
+			} else {
+				endMeta.ErrorSummary = "incomplete (early return without panic)"
+			}
+			rec.CallEnd(callID, endMeta)
+			if r != nil {
+				panic(r) // re-raise after audit
+			}
+			return
+		}
+		rec.CallEnd(callID, endMeta)
+	}()
 	resp, isErr, errSum := fn()
-	rec.CallEnd(callID, audit.CallEndMeta{
+	endMeta = audit.CallEndMeta{
 		CompletedAt:  time.Now().UTC(),
 		IsError:      isErr,
 		ErrorSummary: errSum,
 		Response:     resp,
-	})
+	}
+	completed = true
+	return true
 }
 
 // ConnectorTool is the per-tool entry in envs/list responses. The SDK
@@ -162,7 +200,7 @@ func (s *Server) handleToolCall(w http.ResponseWriter, r *http.Request) {
 	// resolution lives inside tool.Call (via nameresolver.Resolver) and
 	// isn't exposed. Leave "" — the WAL still carries workspace_id +
 	// user_id + the tool method.
-	recordCall(s.Recorder, wsID, userID, "", "tool.call:"+req.Tool, bodyBytes, func() ([]byte, bool, string) {
+	recordCall(s.Recorder, w, wsID, userID, "", "tool.call:"+req.Tool, bodyBytes, func() ([]byte, bool, string) {
 		result, callErr := tool.Call(r.Context(), argsJSON)
 		if callErr != nil {
 			writeErr(w, http.StatusInternalServerError, "tool_error", callErr.Error())
@@ -211,7 +249,7 @@ func extractSessionID(result tools.MCPCallToolResult) string {
 func (s *Server) handleEnvsList(w http.ResponseWriter, r *http.Request) {
 	wsID := workspaceFromCtx(r.Context())
 	userID := userIDFromCtx(r.Context())
-	recordCall(s.Recorder, wsID, userID, "", "envs.list", nil, func() ([]byte, bool, string) {
+	recordCall(s.Recorder, w, wsID, userID, "", "envs.list", nil, func() ([]byte, bool, string) {
 		connected, err := s.Registry.Connected(r.Context(), wsID)
 		if err != nil {
 			writeErr(w, http.StatusInternalServerError, "registry_error", err.Error())
@@ -310,7 +348,7 @@ func (s *Server) handleStdin(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	_ = sess // processes.Session has no ExeID yet (TODO above); pass "" for exe_id
-	recordCall(s.Recorder, wsID, userID, "", "processes.stdin", bodyBytes, func() ([]byte, bool, string) {
+	recordCall(s.Recorder, w, wsID, userID, "", "processes.stdin", bodyBytes, func() ([]byte, bool, string) {
 		var req ConnectorStdinRequest
 		if err := json.Unmarshal(bodyBytes, &req); err != nil {
 			writeErr(w, http.StatusBadRequest, "bad_request", err.Error())
@@ -352,7 +390,7 @@ func (s *Server) handleOutput(w http.ResponseWriter, r *http.Request) {
 	}
 	wsID := workspaceFromCtx(r.Context())
 	userID := userIDFromCtx(r.Context())
-	recordCall(s.Recorder, wsID, userID, "", "processes.output", nil, func() ([]byte, bool, string) {
+	recordCall(s.Recorder, w, wsID, userID, "", "processes.output", nil, func() ([]byte, bool, string) {
 		sinceStr := r.URL.Query().Get("since")
 		since, _ := strconv.Atoi(sinceStr)
 		chunks, exit, alive := sess.OutputSince(since)
@@ -398,7 +436,7 @@ func (s *Server) handleTerminate(w http.ResponseWriter, r *http.Request) {
 	}
 	wsID := workspaceFromCtx(r.Context())
 	userID := userIDFromCtx(r.Context())
-	recordCall(s.Recorder, wsID, userID, "", "processes.terminate", nil, func() ([]byte, bool, string) {
+	recordCall(s.Recorder, w, wsID, userID, "", "processes.terminate", nil, func() ([]byte, bool, string) {
 		// For v0.61.0 mark exit -1; bridge.Terminate(...) wiring lands in
 		// a follow-up. The endpoint contract works for the SDK's polling
 		// pattern (next GET output sees session_alive=false + exit_code=-1).

--- a/internal/codexexecgateway/sdk/handlers_test.go
+++ b/internal/codexexecgateway/sdk/handlers_test.go
@@ -4,15 +4,108 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/agentserver/agentserver/internal/codexexecgateway/audit"
 	"github.com/agentserver/agentserver/internal/envtools/processes"
 )
+
+// capRec captures CallStart/CallEnd for assertion in recordCall tests.
+type capRec struct {
+	mu          sync.Mutex
+	startErr    error
+	starts      []audit.CallStartMeta
+	ends        map[string]audit.CallEndMeta
+	endOrder    []string
+	startCount  int
+}
+
+func (r *capRec) SessionOpen(audit.SessionMeta) (string, error)    { return "", nil }
+func (r *capRec) SessionClose(string, string, audit.Counters)      {}
+func (r *capRec) OnFrameToBackend(string, any, []byte)             {}
+func (r *capRec) OnFrameToClient(string, any, []byte)              {}
+func (r *capRec) CallStart(m audit.CallStartMeta) (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.startErr != nil {
+		return "", r.startErr
+	}
+	r.startCount++
+	id := fmt.Sprintf("call-%d", r.startCount)
+	r.starts = append(r.starts, m)
+	return id, nil
+}
+func (r *capRec) CallEnd(id string, m audit.CallEndMeta) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.ends == nil {
+		r.ends = map[string]audit.CallEndMeta{}
+	}
+	r.ends[id] = m
+	r.endOrder = append(r.endOrder, id)
+}
+func (r *capRec) Close(context.Context) error { return nil }
+
+// TestRecordCall_PanicProducesCallEnd: a panic inside fn() must still
+// emit a paired CallEnd with IsError=true + ErrorSummary so the audit
+// trail can't be left with an orphaned CallStart.
+func TestRecordCall_PanicProducesCallEnd(t *testing.T) {
+	rec := &capRec{}
+	w := httptest.NewRecorder()
+	defer func() {
+		// The panic must be re-raised. Recover here so the test passes.
+		if r := recover(); r == nil {
+			t.Fatal("expected recordCall to re-raise the panic from fn")
+		}
+		// Verify CallEnd was emitted before the re-raise.
+		if len(rec.ends) != 1 {
+			t.Fatalf("want 1 CallEnd, got %d", len(rec.ends))
+		}
+		var end audit.CallEndMeta
+		for _, v := range rec.ends {
+			end = v
+		}
+		if !end.IsError {
+			t.Errorf("CallEnd.IsError should be true on panic")
+		}
+		if !strings.HasPrefix(end.ErrorSummary, "panic:") {
+			t.Errorf("CallEnd.ErrorSummary should start with 'panic:', got %q", end.ErrorSummary)
+		}
+	}()
+	recordCall(rec, w, "ws", "u", "exe", "tool.call:shell", nil, func() ([]byte, bool, string) {
+		panic("boom")
+	})
+}
+
+// TestRecordCall_StartErrorWrites503: when CallStart returns an error,
+// recordCall must short-circuit, write 503, and never invoke fn.
+func TestRecordCall_StartErrorWrites503(t *testing.T) {
+	rec := &capRec{startErr: errors.New("audit disk full")}
+	w := httptest.NewRecorder()
+	invoked := false
+	ok := recordCall(rec, w, "ws", "u", "exe", "tool.call:shell", nil, func() ([]byte, bool, string) {
+		invoked = true
+		return nil, false, ""
+	})
+	if ok {
+		t.Fatal("recordCall should return ok=false when CallStart fails")
+	}
+	if invoked {
+		t.Fatal("fn must NOT be invoked when CallStart fails")
+	}
+	if w.Code != http.StatusServiceUnavailable {
+		t.Fatalf("expected 503, got %d", w.Code)
+	}
+}
 
 // connectedListerStub returns hard-coded envs for one workspace.
 type connectedListerStub struct{}

--- a/internal/codexexecgateway/sdk/handlers_test.go
+++ b/internal/codexexecgateway/sdk/handlers_test.go
@@ -55,6 +55,45 @@ func (r *capRec) CallEnd(id string, m audit.CallEndMeta) {
 }
 func (r *capRec) Close(context.Context) error { return nil }
 
+// TestEnvsList_RecorderObservesCallPair: wiring test for test-analyzer
+// #2. Pins that handleEnvsList actually invokes the Recorder so a
+// future refactor that drops s.Recorder won't silently disable audit
+// for the entire SDK surface — at least one handler now fails fast.
+func TestEnvsList_RecorderObservesCallPair(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]string{"workspace_id": "ws-1", "user_id": "u-1"})
+	}))
+	defer upstream.Close()
+	rec := &capRec{}
+	s := &Server{
+		Auth:     NewProxyTokenAuth(upstream.URL, "x", time.Minute, time.Second),
+		Registry: connectedListerStub{},
+		Recorder: rec,
+	}
+	r := chi.NewRouter()
+	s.Mount(r)
+	req := httptest.NewRequest(http.MethodPost, "/api/connectors/envs/list",
+		bytes.NewReader([]byte("{}")))
+	req.Header.Set("Authorization", "Bearer tok-1")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status=%d body=%s", w.Code, w.Body.String())
+	}
+	if len(rec.starts) != 1 {
+		t.Fatalf("want 1 CallStart, got %d", len(rec.starts))
+	}
+	if got := rec.starts[0].Source; got != "rest" {
+		t.Errorf("Source=%q want %q", got, "rest")
+	}
+	if got := rec.starts[0].RPCMethod; got != "envs.list" {
+		t.Errorf("RPCMethod=%q want envs.list", got)
+	}
+	if len(rec.ends) != 1 {
+		t.Fatalf("want 1 CallEnd, got %d", len(rec.ends))
+	}
+}
+
 // TestRecordCall_PanicProducesCallEnd: a panic inside fn() must still
 // emit a paired CallEnd with IsError=true + ErrorSummary so the audit
 // trail can't be left with an orphaned CallStart.

--- a/internal/codexexecgateway/sdk/server.go
+++ b/internal/codexexecgateway/sdk/server.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-chi/chi/v5"
 
+	"github.com/agentserver/agentserver/internal/codexexecgateway/audit"
 	"github.com/agentserver/agentserver/internal/envtools/bridge"
 	"github.com/agentserver/agentserver/internal/envtools/nameresolver"
 	"github.com/agentserver/agentserver/internal/envtools/processes"
@@ -71,6 +72,14 @@ type Server struct {
 	// bridge.RelayClient used by copy_path. Optional — copy_path is
 	// only registered when this is set.
 	RelayFactory RelayClientFactory
+
+	// Recorder is the audit recorder used to capture handler-level
+	// CallStart/CallEnd for every /api/connectors/* tool call. The
+	// embedding codexexecgateway.Server wires its own audit.Recorder
+	// here at construction time so REST calls and envmcp bridge sessions
+	// share one Recorder. Mount() fills in a NewNoopRecorder if nil so
+	// handlers can call methods unconditionally.
+	Recorder audit.Recorder
 
 	Logger *slog.Logger
 
@@ -165,6 +174,9 @@ func (s *Server) newWorkspaceResolver(workspaceID string) *nameresolver.Resolver
 // Mount registers every SDK route under /api/connectors/*. Each handler runs
 // through authMiddleware which extracts and validates the Bearer token.
 func (s *Server) Mount(r chi.Router) {
+	if s.Recorder == nil {
+		s.Recorder = audit.NewNoopRecorder()
+	}
 	r.Group(func(r chi.Router) {
 		r.Use(s.authMiddleware)
 		r.Post("/api/connectors/envs/list", s.handleEnvsList)
@@ -203,6 +215,13 @@ func (s *Server) authMiddleware(next http.Handler) http.Handler {
 
 func workspaceFromCtx(ctx context.Context) string {
 	if v, ok := ctx.Value(ctxWorkspaceID).(string); ok {
+		return v
+	}
+	return ""
+}
+
+func userIDFromCtx(ctx context.Context) string {
+	if v, ok := ctx.Value(ctxUserID).(string); ok {
 		return v
 	}
 	return ""

--- a/internal/codexexecgateway/server.go
+++ b/internal/codexexecgateway/server.go
@@ -1,6 +1,7 @@
 package codexexecgateway
 
 import (
+	"context"
 	"crypto/subtle"
 	"encoding/json"
 	"fmt"
@@ -10,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/agentserver/agentserver/internal/codexexecgateway/audit"
 	"github.com/agentserver/agentserver/internal/codexexecgateway/handlers"
 	"github.com/agentserver/agentserver/internal/codexexecgateway/relay"
 	sdkpkg "github.com/agentserver/agentserver/internal/codexexecgateway/sdk"
@@ -32,6 +34,11 @@ type Server struct {
 	sdkServer     *sdkpkg.Server  // nil if AgentserverInternalURL unset (dev/disabled)
 	sdkSessions   *processes.Manager
 	logger        *slog.Logger
+	// recorder is the audit Recorder shared by the bridge pumps, the SDK
+	// REST surface, and the relay endpoints. Always non-nil: NewServer
+	// assigns audit.NewNoopRecorder() when Config.Audit.Enabled is false,
+	// so callsites can call hook methods unconditionally.
+	recorder audit.Recorder
 }
 
 // NewServer is the production constructor. Refuses a nil store so a
@@ -104,6 +111,15 @@ func NewServer(cfg Config, store *Store) (*Server, error) {
 		logger.Warn("sdk REST surface disabled: CXG_AGENTSERVER_INTERNAL_URL not set")
 	}
 
+	// Audit recorder. NewRecorder returns a noop when cfg.Audit.Enabled
+	// is false, so production behavior is unchanged until the env var is
+	// flipped. Always non-nil so the hook callsites in bridge/inbound
+	// don't need a nil check.
+	rec, err := audit.NewRecorder(cfg.Audit)
+	if err != nil {
+		return nil, fmt.Errorf("audit recorder: %w", err)
+	}
+
 	return &Server{
 		config:        cfg,
 		store:         store,
@@ -113,14 +129,23 @@ func NewServer(cfg Config, store *Store) (*Server, error) {
 		sdkServer:     sdkSrv,
 		sdkSessions:   sdkSessions,
 		logger:        logger,
+		recorder:      rec,
 	}, nil
 }
 
-// Stop releases background goroutines (currently: the SDK session GC).
+// Stop releases background goroutines (SDK session GC, audit uploader).
 // Call from main's signal handler after http.Server.Shutdown returns.
+// Flushes the audit WAL with a 10s ceiling — uploader Run() exits when
+// its context is cancelled, so the bound is mostly on Sync() of the
+// open WAL segment.
 func (s *Server) Stop() {
 	if s.sdkSessions != nil {
 		s.sdkSessions.Stop()
+	}
+	if s.recorder != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		_ = s.recorder.Close(ctx)
+		cancel()
 	}
 }
 
@@ -144,6 +169,7 @@ func newServerNoStoreForTesting(cfg Config) (*Server, error) {
 		revoked:       NewRevokedSet(10000),
 		relayRegistry: relayReg,
 		logger:        logger,
+		recorder:      audit.NewNoopRecorder(),
 	}, nil
 }
 

--- a/internal/codexexecgateway/server.go
+++ b/internal/codexexecgateway/server.go
@@ -119,6 +119,14 @@ func NewServer(cfg Config, store *Store) (*Server, error) {
 	if err != nil {
 		return nil, fmt.Errorf("audit recorder: %w", err)
 	}
+	// Share the same Recorder with the SDK REST surface so handler-level
+	// CallStart/CallEnd records and envmcp bridge frame records land in
+	// the same WAL. handleBridge in bridge.go recognises the sdk-pool
+	// turn_id marker and suppresses the per-frame side to avoid double
+	// recording (see captoken.go).
+	if sdkSrv != nil {
+		sdkSrv.Recorder = rec
+	}
 
 	return &Server{
 		config:        cfg,

--- a/internal/sandboxproxy/tunnel.go
+++ b/internal/sandboxproxy/tunnel.go
@@ -180,6 +180,12 @@ func (s *Server) proxyViaTunnel(w http.ResponseWriter, r *http.Request, sbx *sbx
 	for k, v := range respMeta.Headers {
 		w.Header().Set(k, v)
 	}
+	// X-Content-Type-Options: nosniff is forced AFTER the upstream
+	// header copy so a malicious or misconfigured sandbox can't strip
+	// it. The proxy forwards arbitrary tenant content; nosniff prevents
+	// browsers from MIME-sniffing a text/plain response as HTML and
+	// executing scripts the upstream did not intend.
+	w.Header().Set("X-Content-Type-Options", "nosniff")
 	if respMeta.Status > 0 {
 		w.WriteHeader(respMeta.Status)
 	}


### PR DESCRIPTION
## Summary

Plan 2b: gateway-side producer for the exec-audit subsystem. Pairs with the agentserver-side foundation (#199, merged).

- **New \`internal/codexexecgateway/audit/\` package**:
  - \`Recorder\` interface + \`noopRecorder\` + production \`realRecorder\` wiring WAL + Uploader + RPCParser
  - \`WAL\` — append-only protobuf records, length-prefixed, rotation by file size, fsync policy, fail-closed / drop-oldest disk quota
  - \`Cursor\` — atomic per-file upload-progress save (tmp + rename)
  - \`Uploader\` goroutine — batched POST with exponential backoff; on 200 advances + persists cursor; on 401/403 stops (auth misconfig); on 5xx/429/network retries
  - \`RPCParser\` — JSON-RPC request/response pair tracking with periodic timeout sweep and session-close flush

- **CapPayload \`user_id\`**:
  - Verifier (\`exec-gateway\`) accepts optional \`user_id\` field — old tokens verify unchanged with empty UserID
  - Signer (\`app-gateway\`) embeds \`user_id\` via \`MintCapToken\`; \`buildConfig\` closure now takes \`(ctx, wsID, userID, loopback)\`; \`/codex-app/ws\` passes \`id.UserID\` from the auth identity; broker-resolver path (scheduled tasks, no user context) passes \`""\` for backward-compat NULL attribution

- **Integration hooks**:
  - \`bridge.go handleBridge\` opens SessionOpen after Resume handshake (assignment ordered before \`addRoute\` to remove a latent race) + \`SessionClose\` in defer; \`runBridgePump\` records frames-to-backend
  - \`inbound.go runInboundReader\` records frames-to-client via the lookup-by-stream-id session
  - \`sdk/handlers.go\` 5 REST handlers wrap with CallStart/CallEnd, source=\`"rest"\`; SDK-minted cap tokens use a \`"sdk-pool"\` TurnID prefix that \`handleBridge\` recognizes and skips audit at the frame level, suppressing double-recording
  - \`handlers_relay.go\` PUT/GET wrap with CallStart/CallEnd, source=\`"relay"\`; body bytes never inlined (could be GB) — only size + sha256 in CallEnd response summary, computed via streaming counting+hashing reader/writer

- **Helm**:
  - New \`codex-exec-gateway-pvc.yaml\` (RWO, 20 GiB default, configurable storageClass)
  - \`/var/cxg-audit\` mount + 7 \`CXG_AUDIT_*\` env vars injected when \`execAudit.enabled=true\`
  - \`values.yaml\` adds \`execAudit:\` block, defaults to \`enabled: false\` for silent rollout

- **Concurrency**: \`bridgeSession\` counters are \`atomic.Int64\` because \`runInboundReader\` writes from a different goroutine than \`handleBridge\`'s defer reads — verified clean under \`go test -race\`

- **E2E smoke test** (build-tagged \`integration\`, skips without \`TEST_DATABASE_URL\`): real Recorder → real WAL → real Uploader → \`httptest\` agentserver running the real \`postInternalExecAuditBatch\` handler → real DAL → real DB → asserts session + call rows landed correctly

## Prerequisites

- #199 (agentserver-side foundation) merged — provides the ingest endpoint + DAL + read API + retention. Already in main.

## Rollout

This PR ships with \`execAudit.enabled=false\` so the deploy is silent — gateway uses the noop recorder, zero perf impact, no PVC bound. Flip via Helm values (or \`--set execAudit.enabled=true\`) when ready to exercise in staging. Plan 3 (frontend ExecAuditPanel) is a separate PR.

## Plan + spec references

- Plan: \`docs/superpowers/plans/2026-05-23-exec-audit-gateway.md\`
- Spec: \`docs/superpowers/specs/2026-05-23-codex-exec-gateway-audit-design.md\`
- Both shipped in #198

## Test plan

- [x] \`make test\` green
- [x] \`make build\` green (after \`make openapi\` + \`pnpm openapi:gen\` to refresh local artifacts)
- [x] \`go test -race ./internal/codexexecgateway/... ./internal/codexappgateway/... ./internal/envtools/...\` green
- [x] \`helm lint\` clean both at default and with \`--set execAudit.enabled=true\`
- [x] \`helm template --set execAudit.enabled=true\` renders the PVC + 7 \`CXG_AUDIT_*\` env entries + audit volume mount
- [ ] Post-deploy with \`execAudit.enabled=true\` in staging: \`kubectl exec\` into codex-exec-gateway pod → \`ls /var/cxg-audit\` shows WAL files appearing
- [ ] Post-deploy: hit a test workspace, then \`GET /api/workspaces/{id}/exec-audit/calls\` returns non-empty list
- [ ] Integration e2e test runs against staging Postgres: \`go test -tags=integration ./internal/codexexecgateway/audit/\`

## Commits (14)

| sha | scope |
|---|---|
| \`e81accf\` | package skeleton — Config + Recorder + noop |
| \`d9938a3\` | WAL writer + reader (rotation, quota) |
| \`44e161d\` | Cursor — atomic per-file upload progress |
| \`7be25aa\` | Uploader goroutine (batched POST + backoff) |
| \`10ec145\` | JSON-RPC request/response pair parser |
| \`9ff5597\` | real Recorder wiring WAL + Uploader + RPCParser |
| \`cc9b3b0\` | CapPayload accepts optional user_id (verify side) |
| \`2c48a56\` | codex-app-gw embeds user_id in minted cap tokens |
| \`8ba2b34\` | hook audit Recorder into envmcp bridge pumps |
| \`1b34775\` | order auditSessionID write before addRoute (race fix) |
| \`eff5a86\` | record /api/connectors/* SDK REST calls (rest source) |
| \`1927a4a\` | record relay PUT/GET (relay source, size+sha only) |
| \`ed56bd1\` | Helm: PVC + CXG_AUDIT_* env wiring (default off) |
| \`a8101ba\` | integration-tagged end-to-end smoke test |

🤖 Generated with [Claude Code](https://claude.com/claude-code)