### PR TITLE
fix(scheduled-tasks): qualify CTE column in lease query (prod 500 → no tasks fire)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,9 +57,47 @@ jobs:
       - name: API reference drift check
         run: make api-docs-check
 
+  db-integration:
+    # Runs internal/db tests that require a real PostgreSQL (gated by
+    # TEST_DATABASE_URL; otherwise t.Skip in newTestDB). Scoped narrowly
+    # to scheduled-tasks for now — broader db tests have pre-existing
+    # FK-setup rot and need a separate cleanup pass before they can
+    # all run in CI.
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Install libolm
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends libolm-dev
+
+      - name: Scheduled tasks integration tests
+        env:
+          TEST_DATABASE_URL: postgres://test:test@localhost:5432/test?sslmode=disable
+        run: go test ./internal/db/ -run '^TestScheduledTask' -count=1 -timeout 2m -v
+
   build-server:
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [test, db-integration]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/internal/db/scheduled_tasks.go
+++ b/internal/db/scheduled_tasks.go
@@ -154,7 +154,7 @@ func (db *DB) ListScheduledTasksByWorkspace(wsID, statusFilter string) ([]Schedu
 func (db *DB) LeaseDueScheduledTasks(limit, leaseSeconds int, owner string) ([]ScheduledTask, error) {
 	rows, err := db.Query(
 		`WITH due AS (
-		   SELECT id FROM scheduled_tasks
+		   SELECT id AS due_id FROM scheduled_tasks
 		    WHERE status = 'pending'
 		      AND process_after <= NOW()
 		      AND (lease_until IS NULL OR lease_until < NOW())
@@ -168,7 +168,7 @@ func (db *DB) LeaseDueScheduledTasks(limit, leaseSeconds int, owner string) ([]S
 		        tries       = tries + 1,
 		        updated_at  = NOW()
 		   FROM due
-		  WHERE t.id = due.id
+		  WHERE t.id = due.due_id
 		  RETURNING `+scheduledTaskCols,
 		limit, leaseSeconds, owner,
 	)


### PR DESCRIPTION
## Summary
- **Bug**: every call to `POST /api/internal/scheduled-tasks/lease` returns 500 in prod with `pq: column reference "id" is ambiguous at position 17:15 (42702)`. No scheduled task can ever be claimed → no IM broadcast → users never get reminded.
- **Root cause**: `LeaseDueScheduledTasks` (`internal/db/scheduled_tasks.go:154`) uses an UPDATE…FROM…RETURNING with a CTE named `due` that exposes an `id` column. The `RETURNING` clause uses unqualified column names from `scheduledTaskCols`, which is ambiguous now that both `scheduled_tasks t` and `due` are in scope. Postgres rejects it.
- **Fix**: alias the CTE column to `due_id`. `RETURNING` then resolves uniquely to `scheduled_tasks.id`.
- **Why CI missed it**: existing integration test `TestScheduledTask_LeaseSkipLocked_Concurrent` reproduces the bug instantly, but `TEST_DATABASE_URL` is unset in CI so `newTestDB` silently `t.Skip`s it. This PR adds a narrow `db-integration` job with a PG service that runs scheduled-tasks integration tests on every PR.

## Affected
- Introduced in #193 (`feat(scheduled-tasks): user-scheduled tasks via codex + IM broadcast`)
- Shipped in chart 0.64.19 / 0.64.20

## Scope notes
- CI job runs `go test ./internal/db -run '^TestScheduledTask'` only. Broader `./internal/db` tests have pre-existing FK-setup rot (`TestAgentSessionTUIFields`, `TestAttachResponder`, etc. fail because their setup doesn't create the workspace they FK to). De-rotting them is a separate cleanup.
- `build-server` now depends on `db-integration` so a regression here blocks image push. Other build-* jobs (llmproxy, opencode, etc.) are unaffected by this codepath and kept on `[test]` only.
- No chart bump in this PR — follow-up `chore(chart): bump 0.64.20 → 0.64.21` once this merges, per the project release flow.

## Test plan
- [x] Reproduced RED locally against fresh PG 15: `TestScheduledTask_LeaseSkipLocked_Concurrent` fails with the exact 42702 prod error
- [x] Applied fix, GREEN: all 3 `TestScheduledTask_*` tests pass
- [x] Confirmed remaining `./internal/db` and `./internal/server` failures are pre-existing on `main` (same failures exist without this patch)
- [ ] CI green on this PR
- [ ] After merge + chart bump + pulumi: confirm `pq: column reference "id" is ambiguous` no longer appears in agentserver logs, and the stuck task `sch_3e72e9f2-ebd4-4812-9700-0ef05ebf85e0` (and any other overdue ones) get leased and broadcast on the next 15s tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)