### PR TITLE
docs(readme): align README with homepage copy fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ It is the answer to a question Addy Osmani frames as the path from L1 (no AI) to
 
 | Tool | Local agents | Cloud sandboxes | Cross-device peering | Chat-app channel |
 |------|:---:|:---:|:---:|:---:|
-| OpenClaw / Claude Code Remote | one at a time | — | — | — |
+| OpenClaw / Claude Code Remote | one at a time | — | — | ✅ |
 | Claude Code on the web | — | ✅ | — | — |
 | Claude Code Agent Teams | — | ✅ (subagents) | — | — |
 | **agentserver** | **✅ many** | **✅** | **✅** | **✅ (WeChat / Telegram / Matrix)** |
@@ -51,6 +51,7 @@ It is the answer to a question Addy Osmani frames as the path from L1 (no AI) to
 - **"Old-school" coding still welcome** — A built-in Jupyter notebook lets users who prefer hand-written code talk to the same workspace, the same files, and the same credentials the agents use.
 - **Multi-user collaboration** — Invite friends or teammates into your Personal Compute Network; role-based access (owner / maintainer / developer / guest) decides who can do what.
 - **Credential & LLM proxy** — Connectors never see real provider keys; per-workspace RPD quotas and usage tracking are enforced server-side.
+- **Audit log** — Every codex session's input and output is persisted to an audit log (gateway-side WAL + server-side ingestion + retention) for post-hoc review and compliance.
 - **SSO ready** — GitHub OAuth and generic OIDC (Keycloak, Authentik, …).
 
 ## Using the hosted instance (7 steps)
@@ -93,9 +94,9 @@ The device shows up as **Online** alongside everything else in your workspace:
   <img src="assets/step-3-device-connected.png" alt="Nine connectors online across cities" width="780">
 </p>
 
-### 4. Pick a "command machine" (Browser)
+### 4. (Optional) Pick a "command machine" (Browser)
 
-A *Browser* is a codex client you actually type into — usually your daily-driver laptop. Generate a Browser token from the **Browsers** tab and the printed `codex --remote …` command turns that machine into a command center that can dispatch work to any Connector:
+A *Browser* is a codex client you actually type into — usually your daily-driver laptop. Generate a Browser token from the **Browsers** tab and the printed `codex --remote …` command turns that machine into a command center that can dispatch work to any Connector. **If you plan to drive everything from WeChat / Telegram / Matrix, skip ahead to step 6**:
 
 <p align="center">
   <img src="assets/step-4-command-machine.png" alt="Browsers tab — Token generated dialog with codex --remote command" width="780">

--- a/README.zh.md
+++ b/README.zh.md
@@ -37,7 +37,7 @@
 
 | 工具 | 本地多智能体 | 云端沙箱 | 跨设备组网 | 聊天软件通道 |
 |------|:---:|:---:|:---:|:---:|
-| OpenClaw / Claude Code Remote | 单实例 | — | — | — |
+| OpenClaw / Claude Code Remote | 单实例 | — | — | ✅ |
 | Claude Code on the web | — | ✅ | — | — |
 | Claude Code Agent Teams | — | ✅（子智能体） | — | — |
 | **agentserver** | **✅ 多实例** | **✅** | **✅** | **✅（微信 / Telegram / Matrix）** |
@@ -51,6 +51,7 @@
 - **同时欢迎"古法编程"** —— 内置 Jupyter notebook，让偏好亲自写代码的用户也能接入同一个工作区，使用智能体所用的文件系统与凭证。
 - **多人协作** —— 邀请朋友或同事一起进入你的个人算力网；基于角色的访问控制（owner / maintainer / developer / guest）决定谁能做什么。
 - **凭证 & LLM 代理** —— Connector 永远不接触真实的厂商密钥；每工作区的 RPD 配额与用量统计在服务端强制执行。
+- **操作审计** —— codex 会话的输入输出统一落盘为审计日志（gateway 端 WAL + 服务端入库 + 保留策略），便于事后回查与合规审计。
 - **支持 SSO** —— GitHub OAuth 及通用 OIDC（Keycloak、Authentik 等）。
 
 ## 托管实例使用指南（共 7 步）
@@ -93,9 +94,9 @@ npm i -g @openai/codex
   <img src="assets/step-3-device-connected.png" alt="九台 Connector 在线，分布多地" width="780">
 </p>
 
-### 4. 选定"指挥机"（Browser）
+### 4.（可选）选定"指挥机"（Browser）
 
-*Browser* 是你实际去敲命令的 codex 客户端 —— 通常是你的主力笔记本。在 **Browsers** 页生成一个 Browser token，按提示运行 `codex --remote …`，这台机器就变成了一个指挥中心，可以把任务下发到任意 Connector：
+*Browser* 是你实际去敲命令的 codex 客户端 —— 通常是你的主力笔记本。在 **Browsers** 页生成一个 Browser token，按提示运行 `codex --remote …`，这台机器就变成了一个指挥中心，可以把任务下发到任意 Connector。**如果你只打算通过微信 / Telegram / Matrix 指挥，可以直接跳到第 6 步**：
 
 <p align="center">
   <img src="assets/step-4-command-machine.png" alt="Browsers 页 —— Token generated 对话框带有 codex --remote 命令" width="780">


### PR DESCRIPTION
## Summary

Mirrors the three applicable homepage copy fixes from #201 into the README files (both EN and zh):

- **Compare table** — `OpenClaw / Claude Code Remote` chat column `—` → `✅`. OpenClaw does have IM channel support; agentserver remains the only row with all four columns checked.
- **Features list** — add `操作审计 / Audit log` between the credential-proxy entry and SSO, reflecting the WAL + ingester + retention pipeline that landed in #199 / #200.
- **Step 4** — `选一台'指挥机'` / `Pick a "command machine"` marked `(可选)` / `(Optional)` with a one-line note that IM-only users can skip ahead to step 6.

Two homepage fixes intentionally not propagated:
- Hero file-compare animation — README has no equivalent animated section
- Tunnel pillar rename — README features list has no "tunnel" entry

## Test plan

- [ ] `README.md` line 40 + `README.zh.md` line 40: chat column shows ✅ for OpenClaw row
- [ ] Both READMEs have an "Audit log" / "操作审计" bullet between credential proxy and SSO entries
- [ ] Step 4 headings show `(Optional)` / `(可选)` and body has the "skip to step 6" note

🤖 Generated with [Claude Code](https://claude.com/claude-code)