### PR TITLE
chore(chart): bump 0.64.20 → 0.64.21 to ship #198 #199 #200 #201 #202 #203

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.20
-appVersion: "0.64.20"
+version: 0.64.21
+appVersion: "0.64.21"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
## Summary
- Bump chart `version`/`appVersion` 0.64.20 → 0.64.21 so the helm release picks up commits merged since v0.64.20.

## Shipping
- #198 chore: remove legacy operations/oplog subsystem
- #199 feat(exec-audit): agentserver-side foundation (tables, ingester, read API, retention)
- #200 feat(exec-audit): gateway-side WAL + uploader + integrations + helm
- #201 chore: switch license to Apache-2.0 + refresh homepage copy
- #202 fix(scheduled-tasks): qualify CTE column in lease query to avoid ambiguous id
- #203 docs(readme): align README with homepage copy fixes