### PR TITLE
feat(web): ExecAuditPanel — Calls/Sessions tabs with detail + download

### DIFF
--- a/web/src/components/ExecAuditCallDetail.tsx
+++ b/web/src/components/ExecAuditCallDetail.tsx
@@ -1,0 +1,154 @@
+import { useEffect, useState } from 'react'
+import { AlertCircle, Download } from 'lucide-react'
+import { downloadAuditCallPayload, getAuditCall, type AuditCallDetail } from '../lib/api'
+
+interface Props {
+  workspaceId: string
+  callId: string
+}
+
+export default function ExecAuditCallDetail({ workspaceId, callId }: Props) {
+  const [call, setCall] = useState<AuditCallDetail | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    getAuditCall(workspaceId, callId)
+      .then((c) => {
+        if (!cancelled) setCall(c)
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [workspaceId, callId])
+
+  if (error) return <div className="text-red-600 text-sm">{error}</div>
+  if (!call) return <div className="text-zinc-500 text-sm">Loading…</div>
+
+  return (
+    <div className="grid grid-cols-2 gap-4">
+      <Section label="Metadata">
+        <KV k="ID" v={call.id} mono />
+        {call.session_id && <KV k="Session" v={call.session_id} mono />}
+        {call.rpc_id && <KV k="RPC ID" v={call.rpc_id} mono />}
+        {call.rpc_kind && <KV k="Kind" v={call.rpc_kind} />}
+        <KV k="Started" v={call.started_at ?? '—'} mono />
+        <KV k="Completed" v={call.completed_at ?? '—'} mono />
+        {call.error_summary && (
+          <div className="flex items-start gap-1 text-red-600 text-sm">
+            <AlertCircle size={14} className="mt-0.5" />
+            <span>{call.error_summary}</span>
+          </div>
+        )}
+      </Section>
+      <Section label="Sizes">
+        <KV k="Request" v={fmtSize(call.request_size ?? 0)} />
+        {call.request_sha256 && <KV k="Req SHA256" v={call.request_sha256.slice(0, 16) + '…'} mono />}
+        <KV k="Response" v={fmtSize(call.response_size ?? 0)} />
+        {call.response_sha256 && <KV k="Resp SHA256" v={call.response_sha256.slice(0, 16) + '…'} mono />}
+      </Section>
+      <Section label="Request preview" cols={2}>
+        <Preview
+          body={call.request_preview}
+          fullSize={call.request_size ?? 0}
+          onDownload={() => downloadAndSave(workspaceId, callId, 'request', setError)}
+        />
+      </Section>
+      <Section label="Response preview" cols={2}>
+        <Preview
+          body={call.response_preview}
+          fullSize={call.response_size ?? 0}
+          onDownload={() => downloadAndSave(workspaceId, callId, 'response', setError)}
+        />
+      </Section>
+    </div>
+  )
+}
+
+function Section({
+  label,
+  cols,
+  children,
+}: {
+  label: string
+  cols?: 1 | 2
+  children: React.ReactNode
+}) {
+  return (
+    <div className={cols === 2 ? 'col-span-2' : ''}>
+      <div className="text-xs uppercase text-zinc-500 mb-1">{label}</div>
+      <div className="flex flex-col gap-1">{children}</div>
+    </div>
+  )
+}
+
+function KV({ k, v, mono }: { k: string; v: string; mono?: boolean }) {
+  return (
+    <div className="flex gap-2 text-sm">
+      <span className="text-zinc-500 min-w-[80px]">{k}</span>
+      <span className={mono ? 'font-mono text-xs break-all' : ''}>{v}</span>
+    </div>
+  )
+}
+
+function Preview({
+  body,
+  fullSize,
+  onDownload,
+}: {
+  body: string | undefined
+  fullSize: number
+  onDownload: () => void
+}) {
+  const previewLen = body?.length ?? 0
+  const truncated = previewLen < fullSize
+  return (
+    <div>
+      <pre className="bg-zinc-100 dark:bg-zinc-950 rounded p-2 max-h-64 overflow-auto text-xs whitespace-pre-wrap break-all">
+        {body ?? '(no body)'}
+      </pre>
+      <div className="flex items-center gap-3 mt-1 text-xs text-zinc-500">
+        {truncated && fullSize > 0 && (
+          <span>truncated ({fmtSize(previewLen)} of {fmtSize(fullSize)})</span>
+        )}
+        <button
+          onClick={onDownload}
+          disabled={fullSize === 0}
+          className="ml-auto flex items-center gap-1 text-zinc-700 dark:text-zinc-300 hover:text-zinc-900 disabled:opacity-30"
+        >
+          <Download size={12} /> Download full
+        </button>
+      </div>
+    </div>
+  )
+}
+
+async function downloadAndSave(
+  workspaceId: string,
+  callId: string,
+  side: 'request' | 'response',
+  setError: (s: string) => void,
+) {
+  try {
+    const { blob, filename } = await downloadAuditCallPayload(workspaceId, callId, side)
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = filename
+    document.body.appendChild(a)
+    a.click()
+    document.body.removeChild(a)
+    URL.revokeObjectURL(url)
+  } catch (e: unknown) {
+    setError(e instanceof Error ? e.message : String(e))
+  }
+}
+
+function fmtSize(n: number): string {
+  if (n < 1024) return `${n} B`
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KiB`
+  return `${(n / 1024 / 1024).toFixed(2)} MiB`
+}

--- a/web/src/components/ExecAuditPanel.tsx
+++ b/web/src/components/ExecAuditPanel.tsx
@@ -1,0 +1,64 @@
+import { useState } from 'react'
+import { Activity, MessageSquare } from 'lucide-react'
+import clsx from 'clsx'
+
+type Tab = 'calls' | 'sessions'
+
+interface Props {
+  workspaceId: string
+}
+
+export default function ExecAuditPanel({ workspaceId }: Props) {
+  const [tab, setTab] = useState<Tab>('calls')
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex items-center gap-2 border-b border-zinc-200 dark:border-zinc-800 px-4 py-3">
+        <TabButton active={tab === 'calls'} onClick={() => setTab('calls')} icon={<MessageSquare size={16} />}>
+          Calls
+        </TabButton>
+        <TabButton active={tab === 'sessions'} onClick={() => setTab('sessions')} icon={<Activity size={16} />}>
+          Sessions
+        </TabButton>
+      </div>
+      <div className="flex-1 overflow-auto p-4">
+        {tab === 'calls' && <CallsTabPlaceholder workspaceId={workspaceId} />}
+        {tab === 'sessions' && <SessionsTabPlaceholder workspaceId={workspaceId} />}
+      </div>
+    </div>
+  )
+}
+
+function TabButton({
+  active,
+  onClick,
+  icon,
+  children,
+}: {
+  active: boolean
+  onClick: () => void
+  icon: React.ReactNode
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={clsx(
+        'flex items-center gap-1.5 px-3 py-1.5 rounded text-sm',
+        active
+          ? 'bg-zinc-200 dark:bg-zinc-800 text-zinc-900 dark:text-zinc-100'
+          : 'text-zinc-600 dark:text-zinc-400 hover:bg-zinc-100 dark:hover:bg-zinc-900',
+      )}
+    >
+      {icon}
+      {children}
+    </button>
+  )
+}
+
+// Placeholders — replaced by real CallsTab (T3) + SessionsTab (T5).
+function CallsTabPlaceholder({ workspaceId }: { workspaceId: string }) {
+  return <div className="text-zinc-500 text-sm">Calls tab (workspace {workspaceId})</div>
+}
+function SessionsTabPlaceholder({ workspaceId }: { workspaceId: string }) {
+  return <div className="text-zinc-500 text-sm">Sessions tab (workspace {workspaceId})</div>
+}

--- a/web/src/components/ExecAuditPanel.tsx
+++ b/web/src/components/ExecAuditPanel.tsx
@@ -3,10 +3,14 @@ import { Activity, AlertCircle, CheckCircle2, ChevronDown, ChevronRight, Message
 import clsx from 'clsx'
 import {
   listAuditCalls,
+  listAuditSessions,
   type AuditCallSummary,
+  type AuditSessionSummary,
   type ListAuditCallsFilters,
+  type ListAuditSessionsFilters,
 } from '../lib/api'
 import ExecAuditCallDetail from './ExecAuditCallDetail'
+import ExecAuditSessionDetail from './ExecAuditSessionDetail'
 
 type Tab = 'calls' | 'sessions'
 
@@ -28,7 +32,7 @@ export default function ExecAuditPanel({ workspaceId }: Props) {
       </div>
       <div className="flex-1 overflow-auto p-4">
         {tab === 'calls' && <CallsTab workspaceId={workspaceId} />}
-        {tab === 'sessions' && <SessionsTabPlaceholder workspaceId={workspaceId} />}
+        {tab === 'sessions' && <SessionsTab workspaceId={workspaceId} />}
       </div>
     </div>
   )
@@ -258,7 +262,166 @@ function CallsFilterBar({
   )
 }
 
-// Sessions placeholder remains for T5.
-function SessionsTabPlaceholder({ workspaceId }: { workspaceId: string }) {
-  return <div className="text-zinc-500 text-sm">Sessions tab (workspace {workspaceId})</div>
+// ----- Sessions tab -----
+
+function SessionsTab({ workspaceId }: { workspaceId: string }) {
+  const [filters, setFilters] = useState<ListAuditSessionsFilters>({ limit: 100 })
+  const [sessions, setSessions] = useState<AuditSessionSummary[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [expanded, setExpanded] = useState<string | null>(null)
+
+  const refresh = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      setSessions(await listAuditSessions(workspaceId, filters))
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void refresh()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspaceId, JSON.stringify(filters)])
+
+  return (
+    <div>
+      <SessionsFilterBar filters={filters} onChange={setFilters} loading={loading} onRefresh={refresh} />
+      {error && (
+        <div className="mt-3 p-3 rounded bg-red-50 dark:bg-red-950 text-red-700 dark:text-red-300 text-sm">
+          {error}
+        </div>
+      )}
+      <div className="mt-3 rounded border border-zinc-200 dark:border-zinc-800 overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-zinc-50 dark:bg-zinc-900 text-zinc-500 text-xs uppercase">
+            <tr>
+              <th className="text-left px-3 py-2 w-8"></th>
+              <th className="text-left px-3 py-2">Opened</th>
+              <th className="text-left px-3 py-2">Exe</th>
+              <th className="text-left px-3 py-2">User</th>
+              <th className="text-left px-3 py-2">Stream</th>
+              <th className="text-right px-3 py-2">Frames ↔</th>
+              <th className="text-right px-3 py-2">Bytes ↔</th>
+            </tr>
+          </thead>
+          <tbody>
+            {sessions.length === 0 && !loading && (
+              <tr><td colSpan={7} className="px-3 py-8 text-center text-zinc-500">No sessions.</td></tr>
+            )}
+            {sessions.map((s) => (
+              <SessionRow
+                key={s.id}
+                session={s}
+                workspaceId={workspaceId}
+                expanded={expanded === s.id}
+                onToggle={() => setExpanded(expanded === s.id ? null : s.id)}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+
+function SessionRow({
+  session,
+  workspaceId,
+  expanded,
+  onToggle,
+}: {
+  session: AuditSessionSummary
+  workspaceId: string
+  expanded: boolean
+  onToggle: () => void
+}) {
+  const fb = session.frames_to_backend ?? 0
+  const fc = session.frames_to_client ?? 0
+  const bb = session.bytes_to_backend ?? 0
+  const bc = session.bytes_to_client ?? 0
+  return (
+    <>
+      <tr
+        onClick={onToggle}
+        className="border-t border-zinc-200 dark:border-zinc-800 hover:bg-zinc-50 dark:hover:bg-zinc-900 cursor-pointer"
+      >
+        <td className="px-3 py-2 text-zinc-400">
+          {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+        </td>
+        <td className="px-3 py-2 font-mono text-xs">{session.opened_at?.slice(11, 19) ?? '—'}</td>
+        <td className="px-3 py-2 font-mono text-xs">{short(session.exe_id)}</td>
+        <td className="px-3 py-2 font-mono text-xs">{session.user_id ? short(session.user_id) : <span className="text-zinc-400">—</span>}</td>
+        <td className="px-3 py-2 font-mono text-xs">{short(session.stream_id)}</td>
+        <td className="px-3 py-2 text-right font-mono text-xs">{fb}/{fc}</td>
+        <td className="px-3 py-2 text-right font-mono text-xs">{fmtSizeShort(bb)}/{fmtSizeShort(bc)}</td>
+      </tr>
+      {expanded && (
+        <tr className="bg-zinc-50 dark:bg-zinc-900">
+          <td colSpan={7} className="px-3 py-3">
+            <ExecAuditSessionDetail workspaceId={workspaceId} sessionId={session.id} />
+          </td>
+        </tr>
+      )}
+    </>
+  )
+}
+
+function SessionsFilterBar({
+  filters,
+  onChange,
+  loading,
+  onRefresh,
+}: {
+  filters: ListAuditSessionsFilters
+  onChange: (f: ListAuditSessionsFilters) => void
+  loading: boolean
+  onRefresh: () => void
+}) {
+  return (
+    <div className="flex flex-wrap items-end gap-2">
+      <label className="flex flex-col text-xs">
+        <span className="text-zinc-500 mb-0.5">Exe ID</span>
+        <input
+          className="rounded border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-2 py-1 text-sm"
+          value={filters.exe_id ?? ''}
+          onChange={(e) => onChange({ ...filters, exe_id: e.target.value || undefined })}
+        />
+      </label>
+      <label className="flex flex-col text-xs">
+        <span className="text-zinc-500 mb-0.5">User ID</span>
+        <input
+          className="rounded border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-2 py-1 text-sm"
+          value={filters.user_id ?? ''}
+          onChange={(e) => onChange({ ...filters, user_id: e.target.value || undefined })}
+        />
+      </label>
+      <label className="flex flex-col text-xs">
+        <span className="text-zinc-500 mb-0.5">Turn ID</span>
+        <input
+          className="rounded border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-2 py-1 text-sm"
+          value={filters.turn_id ?? ''}
+          onChange={(e) => onChange({ ...filters, turn_id: e.target.value || undefined })}
+        />
+      </label>
+      <button
+        onClick={onRefresh}
+        disabled={loading}
+        className="ml-auto rounded bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 px-3 py-1.5 text-sm disabled:opacity-50"
+      >
+        {loading ? 'Loading…' : 'Refresh'}
+      </button>
+    </div>
+  )
+}
+
+// Compact size formatter for the dense table cell.
+function fmtSizeShort(n: number): string {
+  if (n < 1024) return `${n}B`
+  if (n < 1024 * 1024) return `${Math.round(n / 1024)}K`
+  return `${(n / 1024 / 1024).toFixed(1)}M`
 }

--- a/web/src/components/ExecAuditPanel.tsx
+++ b/web/src/components/ExecAuditPanel.tsx
@@ -6,6 +6,7 @@ import {
   type AuditCallSummary,
   type ListAuditCallsFilters,
 } from '../lib/api'
+import ExecAuditCallDetail from './ExecAuditCallDetail'
 
 type Tab = 'calls' | 'sessions'
 
@@ -168,18 +169,12 @@ function CallRow({
       {expanded && (
         <tr className="bg-zinc-50 dark:bg-zinc-900">
           <td colSpan={8} className="px-3 py-3">
-            <ExecAuditCallDetailStub workspaceId={workspaceId} callId={call.id} />
+            <ExecAuditCallDetail workspaceId={workspaceId} callId={call.id} />
           </td>
         </tr>
       )}
     </>
   )
-}
-
-// Stub for the call-detail inline expansion. Replaced by the real
-// ExecAuditCallDetail component in T4.
-function ExecAuditCallDetailStub({ workspaceId, callId }: { workspaceId: string; callId: string }) {
-  return <div className="text-zinc-500 text-sm">Detail for {callId} in {workspaceId} (T4 wires the real component).</div>
 }
 
 function SourceBadge({ source }: { source: string }) {

--- a/web/src/components/ExecAuditPanel.tsx
+++ b/web/src/components/ExecAuditPanel.tsx
@@ -1,6 +1,11 @@
-import { useState } from 'react'
-import { Activity, MessageSquare } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { Activity, AlertCircle, CheckCircle2, ChevronDown, ChevronRight, MessageSquare } from 'lucide-react'
 import clsx from 'clsx'
+import {
+  listAuditCalls,
+  type AuditCallSummary,
+  type ListAuditCallsFilters,
+} from '../lib/api'
 
 type Tab = 'calls' | 'sessions'
 
@@ -21,7 +26,7 @@ export default function ExecAuditPanel({ workspaceId }: Props) {
         </TabButton>
       </div>
       <div className="flex-1 overflow-auto p-4">
-        {tab === 'calls' && <CallsTabPlaceholder workspaceId={workspaceId} />}
+        {tab === 'calls' && <CallsTab workspaceId={workspaceId} />}
         {tab === 'sessions' && <SessionsTabPlaceholder workspaceId={workspaceId} />}
       </div>
     </div>
@@ -55,10 +60,210 @@ function TabButton({
   )
 }
 
-// Placeholders — replaced by real CallsTab (T3) + SessionsTab (T5).
-function CallsTabPlaceholder({ workspaceId }: { workspaceId: string }) {
-  return <div className="text-zinc-500 text-sm">Calls tab (workspace {workspaceId})</div>
+// ----- Calls tab -----
+
+function CallsTab({ workspaceId }: { workspaceId: string }) {
+  const [filters, setFilters] = useState<ListAuditCallsFilters>({ limit: 100 })
+  const [calls, setCalls] = useState<AuditCallSummary[]>([])
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [expanded, setExpanded] = useState<string | null>(null)
+
+  const refresh = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      setCalls(await listAuditCalls(workspaceId, filters))
+    } catch (e: unknown) {
+      setError(e instanceof Error ? e.message : String(e))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // Re-fetch when workspace or filters change. JSON-stringify so the
+  // filter object can be a fresh value each render without infinite
+  // loops; React's structural compare doesn't apply to object refs.
+  useEffect(() => {
+    void refresh()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspaceId, JSON.stringify(filters)])
+
+  return (
+    <div>
+      <CallsFilterBar filters={filters} onChange={setFilters} loading={loading} onRefresh={refresh} />
+      {error && (
+        <div className="mt-3 p-3 rounded bg-red-50 dark:bg-red-950 text-red-700 dark:text-red-300 text-sm">
+          {error}
+        </div>
+      )}
+      <div className="mt-3 rounded border border-zinc-200 dark:border-zinc-800 overflow-hidden">
+        <table className="w-full text-sm">
+          <thead className="bg-zinc-50 dark:bg-zinc-900 text-zinc-500 text-xs uppercase">
+            <tr>
+              <th className="text-left px-3 py-2 w-8"></th>
+              <th className="text-left px-3 py-2">Time</th>
+              <th className="text-left px-3 py-2">Source</th>
+              <th className="text-left px-3 py-2">User</th>
+              <th className="text-left px-3 py-2">Exe</th>
+              <th className="text-left px-3 py-2">Method</th>
+              <th className="text-left px-3 py-2">Status</th>
+              <th className="text-right px-3 py-2">Dur</th>
+            </tr>
+          </thead>
+          <tbody>
+            {calls.length === 0 && !loading && (
+              <tr><td colSpan={8} className="px-3 py-8 text-center text-zinc-500">No calls.</td></tr>
+            )}
+            {calls.map((c) => (
+              <CallRow
+                key={c.id}
+                call={c}
+                workspaceId={workspaceId}
+                expanded={expanded === c.id}
+                onToggle={() => setExpanded(expanded === c.id ? null : c.id)}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
 }
+
+function CallRow({
+  call,
+  workspaceId,
+  expanded,
+  onToggle,
+}: {
+  call: AuditCallSummary
+  workspaceId: string
+  expanded: boolean
+  onToggle: () => void
+}) {
+  return (
+    <>
+      <tr
+        onClick={onToggle}
+        className="border-t border-zinc-200 dark:border-zinc-800 hover:bg-zinc-50 dark:hover:bg-zinc-900 cursor-pointer"
+      >
+        <td className="px-3 py-2 text-zinc-400">
+          {expanded ? <ChevronDown size={14} /> : <ChevronRight size={14} />}
+        </td>
+        <td className="px-3 py-2 font-mono text-xs">{call.started_at?.slice(11, 19) ?? '—'}</td>
+        <td className="px-3 py-2"><SourceBadge source={call.source} /></td>
+        <td className="px-3 py-2 font-mono text-xs">{call.user_id ? short(call.user_id) : <span className="text-zinc-400">—</span>}</td>
+        <td className="px-3 py-2 font-mono text-xs">{short(call.exe_id)}</td>
+        <td className="px-3 py-2">{call.rpc_method ?? <span className="text-zinc-400">—</span>}</td>
+        <td className="px-3 py-2">
+          {call.is_error
+            ? <span className="flex items-center gap-1 text-red-600"><AlertCircle size={14} />error</span>
+            : <span className="flex items-center gap-1 text-emerald-600"><CheckCircle2 size={14} />ok</span>}
+        </td>
+        <td className="px-3 py-2 text-right font-mono text-xs">
+          {call.duration_ms != null ? `${call.duration_ms}ms` : '—'}
+        </td>
+      </tr>
+      {expanded && (
+        <tr className="bg-zinc-50 dark:bg-zinc-900">
+          <td colSpan={8} className="px-3 py-3">
+            <ExecAuditCallDetailStub workspaceId={workspaceId} callId={call.id} />
+          </td>
+        </tr>
+      )}
+    </>
+  )
+}
+
+// Stub for the call-detail inline expansion. Replaced by the real
+// ExecAuditCallDetail component in T4.
+function ExecAuditCallDetailStub({ workspaceId, callId }: { workspaceId: string; callId: string }) {
+  return <div className="text-zinc-500 text-sm">Detail for {callId} in {workspaceId} (T4 wires the real component).</div>
+}
+
+function SourceBadge({ source }: { source: string }) {
+  const color =
+    source === 'envmcp'
+      ? 'bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-300'
+      : source === 'rest'
+        ? 'bg-purple-100 text-purple-700 dark:bg-purple-950 dark:text-purple-300'
+        : 'bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300'
+  return <span className={clsx('px-1.5 py-0.5 rounded text-xs font-medium', color)}>{source}</span>
+}
+
+function short(s: string): string {
+  if (!s) return ''
+  if (s.length <= 12) return s
+  return s.slice(0, 6) + '…' + s.slice(-4)
+}
+
+function CallsFilterBar({
+  filters,
+  onChange,
+  loading,
+  onRefresh,
+}: {
+  filters: ListAuditCallsFilters
+  onChange: (f: ListAuditCallsFilters) => void
+  loading: boolean
+  onRefresh: () => void
+}) {
+  return (
+    <div className="flex flex-wrap items-end gap-2">
+      <label className="flex flex-col text-xs">
+        <span className="text-zinc-500 mb-0.5">Source</span>
+        <select
+          className="rounded border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-2 py-1 text-sm"
+          value={filters.source ?? ''}
+          onChange={(e) =>
+            onChange({ ...filters, source: (e.target.value || undefined) as ListAuditCallsFilters['source'] })
+          }
+        >
+          <option value="">all</option>
+          <option value="envmcp">envmcp</option>
+          <option value="rest">rest</option>
+          <option value="relay">relay</option>
+        </select>
+      </label>
+      <label className="flex flex-col text-xs">
+        <span className="text-zinc-500 mb-0.5">Method</span>
+        <input
+          className="rounded border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-2 py-1 text-sm"
+          value={filters.method ?? ''}
+          onChange={(e) => onChange({ ...filters, method: e.target.value || undefined })}
+          placeholder="e.g. shell"
+        />
+      </label>
+      <label className="flex flex-col text-xs">
+        <span className="text-zinc-500 mb-0.5">Exe ID</span>
+        <input
+          className="rounded border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-900 px-2 py-1 text-sm"
+          value={filters.exe_id ?? ''}
+          onChange={(e) => onChange({ ...filters, exe_id: e.target.value || undefined })}
+        />
+      </label>
+      <label className="flex flex-col text-xs">
+        <span className="text-zinc-500 mb-0.5">Errors only</span>
+        <input
+          type="checkbox"
+          checked={filters.is_error === true}
+          onChange={(e) => onChange({ ...filters, is_error: e.target.checked ? true : undefined })}
+          className="mt-1.5"
+        />
+      </label>
+      <button
+        onClick={onRefresh}
+        disabled={loading}
+        className="ml-auto rounded bg-zinc-900 dark:bg-zinc-100 text-white dark:text-zinc-900 px-3 py-1.5 text-sm disabled:opacity-50"
+      >
+        {loading ? 'Loading…' : 'Refresh'}
+      </button>
+    </div>
+  )
+}
+
+// Sessions placeholder remains for T5.
 function SessionsTabPlaceholder({ workspaceId }: { workspaceId: string }) {
   return <div className="text-zinc-500 text-sm">Sessions tab (workspace {workspaceId})</div>
 }

--- a/web/src/components/ExecAuditSessionDetail.tsx
+++ b/web/src/components/ExecAuditSessionDetail.tsx
@@ -1,0 +1,114 @@
+import { useEffect, useState } from 'react'
+import { AlertCircle, CheckCircle2 } from 'lucide-react'
+import { getAuditSession, type AuditSessionDetail } from '../lib/api'
+
+interface Props {
+  workspaceId: string
+  sessionId: string
+}
+
+export default function ExecAuditSessionDetail({ workspaceId, sessionId }: Props) {
+  const [detail, setDetail] = useState<AuditSessionDetail | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    getAuditSession(workspaceId, sessionId)
+      .then((d) => {
+        if (!cancelled) setDetail(d)
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) setError(e instanceof Error ? e.message : String(e))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [workspaceId, sessionId])
+
+  if (error) return <div className="text-red-600 text-sm">{error}</div>
+  if (!detail) return <div className="text-zinc-500 text-sm">Loading…</div>
+
+  const s = detail.session
+  const calls = detail.first_calls ?? []
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="grid grid-cols-2 gap-4">
+        <Section label="Metadata">
+          <KV k="ID" v={s.id} mono />
+          {s.user_id && <KV k="User" v={s.user_id} mono />}
+          <KV k="Exe" v={s.exe_id} mono />
+          {s.turn_id && <KV k="Turn" v={s.turn_id} mono />}
+          <KV k="Stream" v={s.stream_id} mono />
+          {s.client_ip && <KV k="Client IP" v={s.client_ip} mono />}
+          <KV k="Opened" v={s.opened_at ?? '—'} mono />
+          <KV k="Closed" v={s.closed_at || '— (open)'} mono />
+          {s.close_reason && <KV k="Close reason" v={s.close_reason} />}
+        </Section>
+        <Section label="Frames / bytes">
+          <KV k="Frames →" v={String(s.frames_to_backend ?? 0)} />
+          <KV k="Frames ←" v={String(s.frames_to_client ?? 0)} />
+          <KV k="Bytes →" v={fmtSize(s.bytes_to_backend ?? 0)} />
+          <KV k="Bytes ←" v={fmtSize(s.bytes_to_client ?? 0)} />
+        </Section>
+      </div>
+
+      <div>
+        <div className="text-xs uppercase text-zinc-500 mb-1">First {calls.length} calls</div>
+        <div className="rounded border border-zinc-200 dark:border-zinc-800 overflow-hidden">
+          <table className="w-full text-xs">
+            <thead className="bg-zinc-50 dark:bg-zinc-900 text-zinc-500 uppercase">
+              <tr>
+                <th className="text-left px-2 py-1">Time</th>
+                <th className="text-left px-2 py-1">Method</th>
+                <th className="text-left px-2 py-1">Status</th>
+                <th className="text-right px-2 py-1">Dur</th>
+              </tr>
+            </thead>
+            <tbody>
+              {calls.length === 0 && (
+                <tr><td colSpan={4} className="px-2 py-3 text-center text-zinc-500">No calls recorded.</td></tr>
+              )}
+              {calls.map((c) => (
+                <tr key={c.id} className="border-t border-zinc-200 dark:border-zinc-800">
+                  <td className="px-2 py-1 font-mono">{c.started_at?.slice(11, 19) ?? '—'}</td>
+                  <td className="px-2 py-1">{c.rpc_method ?? <span className="text-zinc-400">—</span>}</td>
+                  <td className="px-2 py-1">
+                    {c.is_error
+                      ? <span className="flex items-center gap-1 text-red-600"><AlertCircle size={12} />error</span>
+                      : <span className="flex items-center gap-1 text-emerald-600"><CheckCircle2 size={12} />ok</span>}
+                  </td>
+                  <td className="px-2 py-1 text-right font-mono">{c.duration_ms != null ? `${c.duration_ms}ms` : '—'}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Section({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <div className="text-xs uppercase text-zinc-500 mb-1">{label}</div>
+      <div className="flex flex-col gap-1">{children}</div>
+    </div>
+  )
+}
+
+function KV({ k, v, mono }: { k: string; v: string; mono?: boolean }) {
+  return (
+    <div className="flex gap-2 text-sm">
+      <span className="text-zinc-500 min-w-[100px]">{k}</span>
+      <span className={mono ? 'font-mono text-xs break-all' : ''}>{v}</span>
+    </div>
+  )
+}
+
+function fmtSize(n: number): string {
+  if (n < 1024) return `${n} B`
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KiB`
+  return `${(n / 1024 / 1024).toFixed(2)} MiB`
+}

--- a/web/src/components/ManageWorkspaces.tsx
+++ b/web/src/components/ManageWorkspaces.tsx
@@ -15,7 +15,7 @@ export function ManageWorkspaces({ workspaces, selectedWorkspaceId, onSelectWork
   const tabParam = searchParams.get('tab')
   const validTabs = new Set<string>([
     'overview', 'browsers', 'connectors', 'sandbox',
-    'llm', 'im', 'traces', 'credentials', 'members', 'api-keys', 'settings',
+    'llm', 'im', 'traces', 'exec-audit', 'credentials', 'members', 'api-keys', 'settings',
   ])
   const initialTab = (tabParam && validTabs.has(tabParam)) ? tabParam as Tab : undefined
 

--- a/web/src/components/WorkspaceDetail.tsx
+++ b/web/src/components/WorkspaceDetail.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import {
+  Activity,
   Clock,
   Users,
   LayoutDashboard,
@@ -63,6 +64,7 @@ import { WeixinLoginModal } from './WeixinLoginModal'
 import { TelegramConfigModal } from './TelegramConfigModal'
 import { MatrixConfigModal } from './MatrixConfigModal'
 import CodexTokensPanel from './CodexTokensPanel'
+import ExecAuditPanel from './ExecAuditPanel'
 import RemoteExecutorsPanel from './RemoteExecutorsPanel'
 import { SandboxList } from './SandboxList'
 
@@ -74,6 +76,7 @@ export type Tab =
   | 'llm'
   | 'im'
   | 'traces'
+  | 'exec-audit'
   | 'credentials'
   | 'members'
   | 'api-keys'
@@ -104,6 +107,7 @@ const TAB_TO_SLUG: Record<Tab, string> = {
   llm: 'llm',
   im: 'im',
   traces: 'traces',
+  'exec-audit': 'exec-audit',
   credentials: 'credentials',
   members: 'members',
   'api-keys': 'api-keys',
@@ -193,6 +197,7 @@ export function WorkspaceDetail({ workspace, onRename, initialTab, sandboxOverri
     { key: 'llm', label: 'LLM', icon: <Brain size={16} /> },
     { key: 'im', label: 'IM', icon: <Bot size={16} /> },
     { key: 'traces', label: 'Traces', icon: <MessageSquare size={16} />, badge: tracesTotal > 0 ? tracesTotal : undefined },
+    { key: 'exec-audit', label: 'Exec Audit', icon: <Activity size={16} /> },
     { key: 'credentials', label: 'Credentials', icon: <Key size={16} /> },
     { key: 'members', label: 'Members', icon: <Users size={16} />, badge: members.length > 0 ? members.length : undefined },
     // Always visible — gate-by-role was causing this entry to pop in after
@@ -275,6 +280,9 @@ export function WorkspaceDetail({ workspace, onRename, initialTab, sandboxOverri
               fetchDetail={fetchDetail}
               showSandboxId
             />
+          )}
+          {tab === 'exec-audit' && (
+            <ExecAuditPanel workspaceId={workspace.id} />
           )}
           {tab === 'credentials' && (
             <CredentialsTab workspaceId={workspace.id} />

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -46,6 +46,14 @@ export type ExecutorItem = components['schemas']['ExecutorItem']
 export type ExecutorRegisterResponse = components['schemas']['ExecutorRegisterResponse']
 export type AgentInteractionItem = components['schemas']['AgentInteractionItem']
 
+// Exec-Audit — generated from OpenAPI spec (PR #199)
+export type AuditSessionSummary = components['schemas']['AuditSessionSummary']
+export type AuditCallSummary = components['schemas']['AuditCallSummary']
+export type AuditCallDetail = components['schemas']['AuditCallDetail']
+export type AuditSessionDetail = components['schemas']['AuditSessionDetail']
+export type ListAuditSessionsResponse = components['schemas']['ListAuditSessionsResponse']
+export type ListAuditCallsResponse = components['schemas']['ListAuditCallsResponse']
+
 // Admin — generated types from OpenAPI spec
 export type AdminUser = components['schemas']['AdminUserItem']
 export type AdminWorkspaceOwner = components['schemas']['AdminOwnerInfo']
@@ -890,3 +898,92 @@ export async function revokeWorkspaceAPIKey(workspaceId: string, keyId: string):
   }
 }
 
+// === Exec-Audit (Plan 2/3) ===
+
+export interface ListAuditSessionsFilters {
+  exe_id?: string
+  user_id?: string
+  turn_id?: string
+  since?: string // RFC3339
+  until?: string // RFC3339
+  limit?: number
+}
+
+export async function listAuditSessions(
+  workspaceId: string,
+  filters: ListAuditSessionsFilters = {},
+): Promise<AuditSessionSummary[]> {
+  const qs = new URLSearchParams()
+  for (const [k, v] of Object.entries(filters)) {
+    if (v !== undefined && v !== null && v !== '') qs.set(k, String(v))
+  }
+  const q = qs.toString()
+  const path = `/api/workspaces/${encodeURIComponent(workspaceId)}/exec-audit/sessions${q ? `?${q}` : ''}`
+  const data = await apiFetch<ListAuditSessionsResponse>({ method: 'GET', path })
+  return data.sessions ?? []
+}
+
+export async function getAuditSession(
+  workspaceId: string,
+  sessionId: string,
+): Promise<AuditSessionDetail> {
+  const path = `/api/workspaces/${encodeURIComponent(workspaceId)}/exec-audit/sessions/${encodeURIComponent(sessionId)}`
+  return apiFetch<AuditSessionDetail>({ method: 'GET', path })
+}
+
+export interface ListAuditCallsFilters {
+  exe_id?: string
+  user_id?: string
+  source?: 'envmcp' | 'rest' | 'relay'
+  method?: string
+  is_error?: boolean
+  since?: string
+  until?: string
+  limit?: number
+}
+
+export async function listAuditCalls(
+  workspaceId: string,
+  filters: ListAuditCallsFilters = {},
+): Promise<AuditCallSummary[]> {
+  const qs = new URLSearchParams()
+  for (const [k, v] of Object.entries(filters)) {
+    if (v !== undefined && v !== null && v !== '') qs.set(k, String(v))
+  }
+  const q = qs.toString()
+  const path = `/api/workspaces/${encodeURIComponent(workspaceId)}/exec-audit/calls${q ? `?${q}` : ''}`
+  const data = await apiFetch<ListAuditCallsResponse>({ method: 'GET', path })
+  return data.calls ?? []
+}
+
+export async function getAuditCall(
+  workspaceId: string,
+  callId: string,
+): Promise<AuditCallDetail> {
+  const path = `/api/workspaces/${encodeURIComponent(workspaceId)}/exec-audit/calls/${encodeURIComponent(callId)}`
+  return apiFetch<AuditCallDetail>({ method: 'GET', path })
+}
+
+/**
+ * Returns the raw decompressed payload bytes plus a download filename.
+ * The /payload endpoint returns 404 (not 200 with empty body) when the
+ * payload was over the 4 MiB hard cap — caller should surface this as
+ * "payload not stored" rather than a generic download failure.
+ */
+export async function downloadAuditCallPayload(
+  workspaceId: string,
+  callId: string,
+  side: 'request' | 'response',
+): Promise<{ blob: Blob; filename: string }> {
+  const path = `/api/workspaces/${encodeURIComponent(workspaceId)}/exec-audit/calls/${encodeURIComponent(callId)}/payload?side=${side}`
+  const resp = await fetch(path, { credentials: 'include' })
+  if (resp.status === 404) {
+    throw new Error('payload not stored (size exceeded cap)')
+  }
+  if (!resp.ok) {
+    throw new Error(`download failed: HTTP ${resp.status}`)
+  }
+  const blob = await resp.blob()
+  const filename = `${callId}.${side}.bin`
+  return { blob, filename }
+}


### PR DESCRIPTION
## Summary

Plan 3 — frontend ExecAuditPanel. Pairs with #199 (agentserver-side API) and #200 (gateway-side producer), both already in main.

- **New `ExecAuditPanel.tsx`** mounted as 'exec-audit' sidebar tab on WorkspaceDetail (between Traces and Credentials, Activity icon)
- **Two tabs**: Calls (default) + Sessions
- **Per-tab filter bar**:
  - Calls: source (envmcp/rest/relay) / method / exe_id / errors-only
  - Sessions: exe_id / user_id / turn_id
- **Expandable inline detail rows**:
  - `ExecAuditCallDetail.tsx`: 2-col metadata + sizes, full-width request/response preview boxes (first 8 KiB), Download Full per side
  - `ExecAuditSessionDetail.tsx`: 2-col metadata + frames/bytes counters, sub-table of first 20 calls
- **API client** in `lib/api.ts`: `listAuditSessions` / `getAuditSession` / `listAuditCalls` / `getAuditCall` / `downloadAuditCallPayload`
- **Download helper** handles the 404-on-oversize case with a typed Error so the UI shows "payload not stored" rather than a generic failure
- **SourceBadge** color-codes envmcp/rest/relay for quick visual triage

## Plan + spec references

- Plan: \`docs/superpowers/plans/2026-05-23-exec-audit-frontend.md\`
- Spec: \`docs/superpowers/specs/2026-05-23-codex-exec-gateway-audit-design.md\`
- Both shipped in #198

## Test plan

- [x] \`pnpm build\` green (1777 modules, 477 kB bundle)
- [x] \`pnpm lint\` — 0 new errors in audit files (14 pre-existing in unrelated files)
- [ ] Post-deploy: navigate to a workspace, click "Exec Audit" sidebar
- [ ] Post-deploy (with \`execAudit.enabled=true\` set on agentserver Helm): see live calls + sessions appearing as the workspace runs codex
- [ ] Manual: click row → detail expands; click Download Full → file saves; trigger an oversize call → Download shows "payload not stored"

## Commits (6)

| sha | scope |
|---|---|
| \`85cb152\` | api.ts fetchers + type re-exports |
| \`c303944\` | ExecAuditPanel skeleton (tabs) |
| \`d47f923\` | Calls tab — filter + table + expand (stub detail) |
| \`d31fa2f\` | ExecAuditCallDetail — preview + download (replaces stub) |
| \`79f64c6\` | Sessions tab + ExecAuditSessionDetail |
| \`7a2d16c\` | wire panel into WorkspaceDetail + ManageWorkspaces |

🤖 Generated with [Claude Code](https://claude.com/claude-code)