### PR TITLE
chore(chart): bump 0.64.21 → 0.64.22 to ship #205

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.21
-appVersion: "0.64.21"
+version: 0.64.22
+appVersion: "0.64.22"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
Ships #205 (frontend ExecAuditPanel). Backend-side audit (#199 + #200) already in 0.64.21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)