### PR TITLE
chore(chart): bump 0.64.22 → 0.64.23 to ship #207

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.22
-appVersion: "0.64.22"
+version: 0.64.23
+appVersion: "0.64.23"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
## Summary
- Bump chart `version`/`appVersion` 0.64.22 → 0.64.23 so the helm release picks up commits merged since v0.64.22.

## Shipping
- #207 refactor(exec-audit): request-only — drop CallEnd pairing entirely