### PR TITLE
fix(imbridge): seed BridgeBinding.RoutingMode from DB on channel create

### DIFF
--- a/internal/db/im_channels.go
+++ b/internal/db/im_channels.go
@@ -22,18 +22,21 @@ type IMChannel struct {
 
 // CreateIMChannel inserts or updates a workspace IM channel record.
 // On conflict (same workspace+provider+bot), updates bound_at.
-// Returns the channel ID.
-func (db *DB) CreateIMChannel(workspaceID, provider, botID, userID string) (string, error) {
-	var id string
-	err := db.QueryRow(
+// Returns the channel ID and its routing_mode (column default 'codex' on
+// insert; existing value on conflict). Callers must seed BridgeBinding
+// with this routing_mode so the in-memory channelRouting map matches
+// the DB — otherwise forwardMessage falls through to the nanoclaw path
+// for any new channel created via configure handlers.
+func (db *DB) CreateIMChannel(workspaceID, provider, botID, userID string) (id, routingMode string, err error) {
+	err = db.QueryRow(
 		`INSERT INTO workspace_im_channels (workspace_id, provider, bot_id, user_id)
 		VALUES ($1, $2, $3, $4)
 		ON CONFLICT (workspace_id, provider, bot_id)
 		DO UPDATE SET bound_at = NOW()
-		RETURNING id`,
+		RETURNING id, routing_mode`,
 		workspaceID, provider, botID, userID,
-	).Scan(&id)
-	return id, err
+	).Scan(&id, &routingMode)
+	return id, routingMode, err
 }
 
 // SaveIMChannelCredentials stores bot credentials for a workspace IM channel.

--- a/internal/imbridgesvc/handlers.go
+++ b/internal/imbridgesvc/handlers.go
@@ -482,7 +482,7 @@ func (s *Server) saveWeixinCredentials(ctx context.Context, sandboxID string, re
 		if baseURL == "" {
 			baseURL = wp.DefaultBaseURL()
 		}
-		channelID, err := s.db.CreateIMChannel(sbx.WorkspaceID, "weixin", accountID, result.UserID)
+		channelID, routingMode, err := s.db.CreateIMChannel(sbx.WorkspaceID, "weixin", accountID, result.UserID)
 		if err != nil {
 			return fmt.Errorf("create IM channel: %w", err)
 		}
@@ -503,6 +503,7 @@ func (s *Server) saveWeixinCredentials(ctx context.Context, sandboxID string, re
 			ChannelID:   channelID,
 			Cursor:      "",
 			WorkspaceID: sbx.WorkspaceID,
+			RoutingMode: routingMode,
 		})
 		return nil
 	}
@@ -590,7 +591,7 @@ func (s *Server) handleIMTelegramConfigure(w http.ResponseWriter, r *http.Reques
 		tgBaseURL = d.DefaultBaseURL()
 	}
 
-	channelID, err := s.db.CreateIMChannel(sbx.WorkspaceID, "telegram", botID, "")
+	channelID, routingMode, err := s.db.CreateIMChannel(sbx.WorkspaceID, "telegram", botID, "")
 	if err != nil {
 		log.Printf("telegram configure: create channel: %v", err)
 		http.Error(w, "failed to save channel", http.StatusInternalServerError)
@@ -618,6 +619,7 @@ func (s *Server) handleIMTelegramConfigure(w http.ResponseWriter, r *http.Reques
 		ChannelID:   channelID,
 		Cursor:      "",
 		WorkspaceID: sbx.WorkspaceID,
+		RoutingMode: routingMode,
 	})
 
 	w.Header().Set("Content-Type", "application/json")
@@ -707,7 +709,7 @@ func (s *Server) handleIMMatrixConfigure(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	channelID, err := s.db.CreateIMChannel(sbx.WorkspaceID, "matrix", botID, "")
+	channelID, routingMode, err := s.db.CreateIMChannel(sbx.WorkspaceID, "matrix", botID, "")
 	if err != nil {
 		log.Printf("matrix configure: create channel: %v", err)
 		http.Error(w, "failed to save channel", http.StatusInternalServerError)
@@ -745,6 +747,7 @@ func (s *Server) handleIMMatrixConfigure(w http.ResponseWriter, r *http.Request)
 		ChannelID:   channelID,
 		Cursor:      "",
 		WorkspaceID: sbx.WorkspaceID,
+		RoutingMode: routingMode,
 	})
 
 	w.Header().Set("Content-Type", "application/json")
@@ -1049,7 +1052,7 @@ func (s *Server) handleWorkspaceWeixinQRWait(w http.ResponseWriter, r *http.Requ
 			baseURL = wp.DefaultBaseURL()
 		}
 
-		channelID, err := s.db.CreateIMChannel(wsID, "weixin", accountID, result.UserID)
+		channelID, routingMode, err := s.db.CreateIMChannel(wsID, "weixin", accountID, result.UserID)
 		if err != nil {
 			http.Error(w, "failed to save channel", http.StatusInternalServerError)
 			return
@@ -1065,6 +1068,7 @@ func (s *Server) handleWorkspaceWeixinQRWait(w http.ResponseWriter, r *http.Requ
 			Credentials: imbridge.Credentials{ChannelID: channelID, BotID: accountID, BotToken: result.Token, BaseURL: baseURL},
 			ChannelID:   channelID,
 			WorkspaceID: wsID,
+			RoutingMode: routingMode,
 		})
 
 		w.Header().Set("Content-Type", "application/json")
@@ -1168,7 +1172,7 @@ func (s *Server) handleWorkspaceTelegramConfigure(w http.ResponseWriter, r *http
 		baseURL = d.DefaultBaseURL()
 	}
 
-	channelID, err := s.db.CreateIMChannel(wsID, "telegram", botID, "")
+	channelID, routingMode, err := s.db.CreateIMChannel(wsID, "telegram", botID, "")
 	if err != nil {
 		http.Error(w, "failed to save channel", http.StatusInternalServerError)
 		return
@@ -1183,6 +1187,7 @@ func (s *Server) handleWorkspaceTelegramConfigure(w http.ResponseWriter, r *http
 		Credentials: imbridge.Credentials{ChannelID: channelID, BotID: botID, BotToken: req.BotToken, BaseURL: baseURL},
 		ChannelID:   channelID,
 		WorkspaceID: wsID,
+		RoutingMode: routingMode,
 	})
 
 	w.Header().Set("Content-Type", "application/json")
@@ -1225,7 +1230,7 @@ func (s *Server) handleWorkspaceMatrixConfigure(w http.ResponseWriter, r *http.R
 		return
 	}
 
-	channelID, err := s.db.CreateIMChannel(wsID, "matrix", botID, "")
+	channelID, routingMode, err := s.db.CreateIMChannel(wsID, "matrix", botID, "")
 	if err != nil {
 		http.Error(w, "failed to save channel", http.StatusInternalServerError)
 		return
@@ -1250,6 +1255,7 @@ func (s *Server) handleWorkspaceMatrixConfigure(w http.ResponseWriter, r *http.R
 		Credentials: imbridge.Credentials{ChannelID: channelID, BotID: botID, BotToken: req.AccessToken, BaseURL: req.HomeserverURL},
 		ChannelID:   channelID,
 		WorkspaceID: wsID,
+		RoutingMode: routingMode,
 	})
 
 	w.Header().Set("Content-Type", "application/json")


### PR DESCRIPTION
## Summary

- 6 configure handlers in `imbridgesvc/handlers.go` (weixin/telegram/matrix × sandbox/workspace levels) called `StartPoller` without populating `BridgeBinding.RoutingMode`, leaving it as `""`.
- `StartPoller` seeds the in-memory `channelRouting` map with that empty value (`bridge.go:133`). `forwardMessage`'s switch then falls through to `forwardToNanoClaw` for any channel created via those handlers — even though the DB column `workspace_im_channels.routing_mode` defaults to `'codex'`.
- Symptom: a newly-configured Telegram bot (production hit: `mryao_openclaw_bot`, channel `8782ff89-...`) silently runs the nanoclaw path, fails `GetSandboxForChannel` on every poll, and logs `imbridge: forward failed ... no running sandbox bound to channel ... (will retry next poll)` forever. The bot never replies.
- `RestorePollers` was unaffected because it already reads `routing_mode` from DB into the binding (`lifecycle.go:36`), so a pod restart "fixes" the routing for existing channels — masking the bug until a new channel is configured at runtime.

## Fix

- `CreateIMChannel` now does `INSERT ... RETURNING id, routing_mode`, so callers get the actual DB value (default `'codex'` on insert; existing value on `ON CONFLICT`) without an extra round-trip.
- All 6 `StartPoller` call sites now capture and pass `RoutingMode: routingMode` in the `BridgeBinding`.
- Keeps the DB column as the single source of truth — no hard-coded `"codex"` in Go.

## Operational note

This fix only takes effect for channels created **after** the new imbridge image rolls out. Pre-existing channels with a desynced in-memory `channelRouting` map will be fixed on the next imbridge pod restart (RestorePollers re-seeds from DB).

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/imbridge/... ./internal/imbridgesvc/... ./internal/db/...` — pass
- [ ] After merge + chart bump + image roll: configure a fresh Telegram bot on a workspace, confirm `forwardToCodex` is hit (no `no running sandbox bound to channel` errors in imbridge logs).
- [ ] Restart `agentserver-imbridge` pod now to recover the existing `mryao_openclaw_bot` channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)