### PR TITLE
feat(exec-audit): skip protocol noise (initialize, initialized, process/read)

### DIFF
--- a/internal/codexexecgateway/audit/rpcparser.go
+++ b/internal/codexexecgateway/audit/rpcparser.go
@@ -16,12 +16,27 @@ func NewRPCParser(rec Recorder) *RPCParser {
 	return &RPCParser{rec: rec}
 }
 
+// skippedMethods are bridge frames that aren't meaningful tool calls
+// and would just create noise in the audit timeline:
+//   - initialize / initialized: MCP handshake at session start
+//   - process/read: shell/exec_command output polling — one logical
+//     shell command produces dozens of these. The matching process/start
+//     IS recorded, which is the actual "user issued shell" event.
+var skippedMethods = map[string]bool{
+	"initialize":   true,
+	"initialized":  true,
+	"process/read": true,
+}
+
 // OnFrameToBackend processes a payload going from env-mcp to codex-exec.
 // Workspace/user/exe identify the session — caller has them in context
 // from the bridge handshake.
 func (p *RPCParser) OnFrameToBackend(sessionID, wsID, userID, exeID string, payload []byte) {
 	id, method, kind, ok := parseRPC(payload)
 	if !ok {
+		return
+	}
+	if skippedMethods[method] {
 		return
 	}
 	p.rec.CallStart(CallStartMeta{

--- a/internal/codexexecgateway/audit/rpcparser_test.go
+++ b/internal/codexexecgateway/audit/rpcparser_test.go
@@ -90,6 +90,27 @@ func TestRPCParser_MalformedPayloadIgnored(t *testing.T) {
 	}
 }
 
+func TestRPCParser_ProtocolNoiseSkipped(t *testing.T) {
+	cap := newCapRecorder()
+	p := audit.NewRPCParser(cap)
+	// MCP handshake — should be skipped
+	p.OnFrameToBackend("s1", "ws", "user", "exe", []byte(`{"jsonrpc":"2.0","id":0,"method":"initialize"}`))
+	p.OnFrameToBackend("s1", "ws", "user", "exe", []byte(`{"jsonrpc":"2.0","method":"initialized"}`))
+	// shell output poll — should be skipped
+	p.OnFrameToBackend("s1", "ws", "user", "exe", []byte(`{"jsonrpc":"2.0","id":5,"method":"process/read","params":{"process_id":"p1"}}`))
+	// real tool call — should be recorded
+	p.OnFrameToBackend("s1", "ws", "user", "exe", []byte(`{"jsonrpc":"2.0","id":6,"method":"process/start","params":{"cmd":"ls"}}`))
+
+	cap.mu.Lock()
+	defer cap.mu.Unlock()
+	if len(cap.starts) != 1 {
+		t.Fatalf("expected only process/start recorded, got %d starts: %+v", len(cap.starts), cap.starts)
+	}
+	if cap.starts[0].RPCMethod != "process/start" {
+		t.Errorf("recorded wrong method: %q", cap.starts[0].RPCMethod)
+	}
+}
+
 func TestRPCParser_StringIDsHandled(t *testing.T) {
 	cap := newCapRecorder()
 	p := audit.NewRPCParser(cap)


### PR DESCRIPTION
## Summary

Skip three bridge methods that aren't meaningful tool calls and just bloat the audit timeline:

| Method | Why skip |
|---|---|
| `initialize` | MCP handshake at session start |
| `initialized` | MCP handshake notification |
| `process/read` | shell/exec_command output polling — one logical shell command produces dozens of these |

The matching `process/start` is still recorded, which is the actual "user issued shell" event.

## Implementation

Small skip-set in `RPCParser.OnFrameToBackend` — one line to extend if more noise surfaces.

## Test plan

- [x] `go test ./internal/codexexecgateway/audit/...`
- [x] New test pins the filter and verifies `process/start` still passes through

🤖 Generated with [Claude Code](https://claude.com/claude-code)