### PR TITLE
chore(chart): bump 0.64.23 → 0.64.24 to ship #210

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.23
-appVersion: "0.64.23"
+version: 0.64.24
+appVersion: "0.64.24"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
## Summary
- Bump chart `version`/`appVersion` 0.64.23 → 0.64.24.

## Shipping
- #210 feat(exec-audit): skip protocol noise — initialize, initialized, process/read