### PR TITLE
Home/README: 'One session, any device' pillar + compare column

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,16 @@ It is the answer to a question Addy Osmani frames as the path from L1 (no AI) to
 
 ### How it differs from what already exists
 
-| Tool | Local agents | Cloud sandboxes | Cross-device peering | Chat-app channel |
-|------|:---:|:---:|:---:|:---:|
-| OpenClaw / Claude Code Remote | one at a time | — | — | ✅ |
-| Claude Code on the web | — | ✅ | — | — |
-| Claude Code Agent Teams | — | ✅ (subagents) | — | — |
-| **agentserver** | **✅ many** | **✅** | **✅** | **✅ (WeChat / Telegram / Matrix)** |
+| Tool | Local agents | Cloud sandboxes | Cross-device peering | Cross-client session | Chat-app channel |
+|------|:---:|:---:|:---:|:---:|:---:|
+| OpenClaw / Claude Code Remote | one at a time | — | — | — | ✅ |
+| Claude Code on the web | — | ✅ | — | — | — |
+| Claude Code Agent Teams | — | ✅ (subagents) | — | — | — |
+| **agentserver** | **✅ many** | **✅** | **✅** | **✅ (CLI / Web / IM / Jupyter)** | **✅ (WeChat / Telegram / Matrix)** |
 
 ## Why agentserver?
 
+- **One session, any device** — Your codex session lives on the server, not on the laptop it started from. Pause a half-finished refactor at the office, then continue the same conversation from WeChat on the subway home. What changes between devices is the front-end, not the agent.
 - **Command from your pocket** — Drive your agents from a WeChat / Weixin, Telegram, or Matrix chat. No terminal required when you are away from the desk.
 - **One workspace, every device** — Cloud sandboxes, local laptops/desktops, and IM-bound agents all register into the *same* workspace and show up side-by-side in the Web UI.
 - **Codex-native** — Built around the [OpenAI codex](https://developers.openai.com/codex/cli) CLI: devices enroll with `codex exec-server --remote`, you drive them from `codex --remote`. No custom client to install on each machine.

--- a/README.zh.md
+++ b/README.zh.md
@@ -35,15 +35,16 @@
 
 ### 它和现有工具有何不同
 
-| 工具 | 本地多智能体 | 云端沙箱 | 跨设备组网 | 聊天软件通道 |
-|------|:---:|:---:|:---:|:---:|
-| OpenClaw / Claude Code Remote | 单实例 | — | — | ✅ |
-| Claude Code on the web | — | ✅ | — | — |
-| Claude Code Agent Teams | — | ✅（子智能体） | — | — |
-| **agentserver** | **✅ 多实例** | **✅** | **✅** | **✅（微信 / Telegram / Matrix）** |
+| 工具 | 本地多智能体 | 云端沙箱 | 跨设备组网 | 会话跨终端 | 聊天软件通道 |
+|------|:---:|:---:|:---:|:---:|:---:|
+| OpenClaw / Claude Code Remote | 单实例 | — | — | — | ✅ |
+| Claude Code on the web | — | ✅ | — | — | — |
+| Claude Code Agent Teams | — | ✅（子智能体） | — | — | — |
+| **agentserver** | **✅ 多实例** | **✅** | **✅** | **✅（CLI / Web / IM / Jupyter）** | **✅（微信 / Telegram / Matrix）** |
 
 ## 为什么选择 agentserver？
 
+- **同一段会话，任意设备** —— codex 会话本身跑在服务端。早上在公司笔电上让 agent 改了一半的任务，地铁里用微信续上同一段对话继续推进；换设备的不是命令，而是 agent 的前端。
 - **口袋里就能指挥算力** —— 通过微信 / Weixin、Telegram 或 Matrix 聊天驱动你的智能体，离开桌面时也不必再打开终端。
 - **一个工作区，统管所有设备** —— 云端沙箱、本地笔记本/台式机、IM 接入的智能体共享同一个工作区，全部并排出现在 Web UI 中。
 - **原生面向 Codex** —— 围绕 [OpenAI codex](https://developers.openai.com/codex/cli) CLI 构建：设备用 `codex exec-server --remote` 接入，指挥机用 `codex --remote` 指挥；不需要在每台机器上额外装客户端。

--- a/web/src/components/Home/HomeCompare.tsx
+++ b/web/src/components/Home/HomeCompare.tsx
@@ -1,13 +1,13 @@
 import { useT } from '../../lib/i18n'
 import { homeStrings } from './strings'
 
-type Row = { tool: string; local: string; cloud: string; peer: string; chat: string; us?: boolean }
+type Row = { tool: string; local: string; cloud: string; peer: string; session: string; chat: string; us?: boolean }
 
 const rows: Row[] = [
-  { tool: 'OpenClaw / Claude Code Remote', local: '1',      cloud: '—',      peer: '—', chat: '✓' },
-  { tool: 'Claude Code on the web',        local: '—',      cloud: '✓',      peer: '—', chat: '—' },
-  { tool: 'CC Agent Teams',                local: '—',      cloud: '✓(sub)', peer: '—', chat: '—' },
-  { tool: 'agentserver',                   local: '✓ many', cloud: '✓',      peer: '✓', chat: '✓', us: true },
+  { tool: 'OpenClaw / Claude Code Remote', local: '1',      cloud: '—',      peer: '—', session: '—',         chat: '✓' },
+  { tool: 'Claude Code on the web',        local: '—',      cloud: '✓',      peer: '—', session: '—',         chat: '—' },
+  { tool: 'CC Agent Teams',                local: '—',      cloud: '✓(sub)', peer: '—', session: '—',         chat: '—' },
+  { tool: 'agentserver',                   local: '✓ many', cloud: '✓',      peer: '✓', session: '✓ any front-end', chat: '✓', us: true },
 ]
 
 export function HomeCompare() {
@@ -26,6 +26,7 @@ export function HomeCompare() {
               <th scope="col" className="text-center p-3 font-medium">{t('compare.col.local')}</th>
               <th scope="col" className="text-center p-3 font-medium">{t('compare.col.cloud')}</th>
               <th scope="col" className="text-center p-3 font-medium">{t('compare.col.peer')}</th>
+              <th scope="col" className="text-center p-3 font-medium">{t('compare.col.session')}</th>
               <th scope="col" className="text-center p-3 font-medium">{t('compare.col.chat')}</th>
             </tr>
           </thead>
@@ -44,6 +45,7 @@ export function HomeCompare() {
                 <td className="text-center p-3">{r.local}</td>
                 <td className="text-center p-3">{r.cloud}</td>
                 <td className="text-center p-3">{r.peer}</td>
+                <td className="text-center p-3">{r.session}</td>
                 <td className="text-center p-3">{r.chat}</td>
               </tr>
             ))}

--- a/web/src/components/Home/HomeHero.tsx
+++ b/web/src/components/Home/HomeHero.tsx
@@ -51,19 +51,19 @@ export function HomeHero() {
             <Term
               title={t('hero.term.macbook')}
               lines={[
-                { delay: 200,  text: '$ codex relay "在所有设备上找 thesis.pdf', kind: 'cmd' },
-                { delay: 400,  text: '   比一下哪份最新"',                       kind: 'cmd' },
-                { delay: 600,  text: '▸ 本机: ~/Documents/thesis.pdf',          kind: 'dim' },
-                { delay: 800,  text: '✓ 2.1MB · 05-22 14:30',                   kind: 'ok'  },
+                { delay: 200,  text: '$ codex "重构 loss 让它支持',     kind: 'cmd' },
+                { delay: 400,  text: '   weighted sampling"',           kind: 'cmd' },
+                { delay: 600,  text: '▸ edit graph.py:42-78',           kind: 'dim' },
+                { delay: 800,  text: '⏸  session#a3f · 离开公司',       kind: 'ok'  },
               ]}
             />
             <Term
               title={t('hero.term.sandbox')}
               lines={[
-                { delay: 1200, text: '▸ 收到广播查找请求',              kind: 'dim' },
-                { delay: 1400, text: '▸ 本机: ~/work/thesis.pdf',       kind: 'dim' },
-                { delay: 1800, text: '✓ 2.4MB · 05-24 10:42',           kind: 'ok'  },
-                { delay: 2000, text: '▸ 已上报到 office-macbook',       kind: 'dim' },
+                { delay: 1200, text: '▸ codex-app-gateway · paused',    kind: 'dim' },
+                { delay: 1400, text: '▸ awaiting reattach …',           kind: 'dim' },
+                { delay: 1800, text: '▸ 18:42 attach: weixin/me',       kind: 'dim' },
+                { delay: 2000, text: '✓ resumed by WeChat',             kind: 'ok'  },
               ]}
             />
           </div>
@@ -161,7 +161,7 @@ function ChatPane({ t }: { t: (k: string) => string }) {
               {b.text}
               {b.thumb && (
                 <div className="mt-1.5 h-12 w-full rounded bg-gradient-to-br from-[var(--home-accent)]/30 to-[var(--home-accent)]/10 border border-[var(--home-accent)]/40 flex items-center justify-center text-[10px] text-[var(--home-term-dim)]">
-                  thesis.pdf · cloud-sandbox-7 · 05-24
+                  session#a3f · feature/weighted-loss · 17/17 ✓
                 </div>
               )}
             </div>

--- a/web/src/components/Home/HomePillars.tsx
+++ b/web/src/components/Home/HomePillars.tsx
@@ -8,6 +8,7 @@ type Pillar = {
 }
 
 const pillars: Pillar[] = [
+  { emoji: '🧵', titleKey: 'pillars.session.title',   bodyKey: 'pillars.session.body' },
   { emoji: '📱', titleKey: 'pillars.pocket.title',    bodyKey: 'pillars.pocket.body' },
   { emoji: '🌐', titleKey: 'pillars.workspace.title', bodyKey: 'pillars.workspace.body' },
   { emoji: '🔌', titleKey: 'pillars.tunnel.title',    bodyKey: 'pillars.tunnel.body' },
@@ -20,7 +21,7 @@ export function HomePillars() {
       <h2 className="font-mono text-xs tracking-[0.2em] text-[var(--muted-foreground)] uppercase mb-8">
         {t('pillars.heading')}
       </h2>
-      <div className="grid md:grid-cols-3 gap-4">
+      <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-4">
         {pillars.map((p) => (
           <article
             key={p.titleKey}

--- a/web/src/components/Home/strings.ts
+++ b/web/src/components/Home/strings.ts
@@ -15,13 +15,13 @@ export const homeStrings: Dicts = {
     'hero.sub': 'agentserver 把笔记本、云沙箱、家里的服务器编成一个工作区——从浏览器、命令行，或微信，一并指挥。',
     'hero.cta.primary': '▸ 登录',
     'hero.cta.secondary': '在 GitHub 上查看',
-    'hero.term.macbook': 'office-macbook · codex',
-    'hero.term.sandbox': 'cloud-sandbox-7 · codex',
-    'hero.chat.title': '我自己',
-    'hero.chat.user': '帮我看看 thesis.pdf 在哪些设备上，哪份最新？',
-    'hero.chat.bot1': '📂 office-macbook · home-server · cloud-sandbox-7 都有',
-    'hero.chat.bot2': '🔨 比对修改时间…',
-    'hero.chat.bot3': '✓ 最新版在 cloud-sandbox-7（今天 10:42）',
+    'hero.term.macbook': 'office-macbook · codex · 10:14',
+    'hero.term.sandbox': 'session#a3f · paused 12:30',
+    'hero.chat.title': '我自己 · 微信 18:42',
+    'hero.chat.user': '上午让你改的 loss 函数跑通了吗？',
+    'hero.chat.bot1': '📎 续上会话 session#a3f（office-macbook · 6h 前）',
+    'hero.chat.bot2': '🔨 跑 pytest tests/test_loss.py …',
+    'hero.chat.bot3': '✓ 17/17 通过 · diff 已推到 feature/weighted-loss',
     'hero.chip.online': '在线',
 
     // quote
@@ -31,6 +31,8 @@ export const homeStrings: Dicts = {
 
     // pillars
     'pillars.heading': '为什么用 agentserver',
+    'pillars.session.title': '同一段会话，任意设备',
+    'pillars.session.body': 'codex 会话本身跑在服务端。早上在笔电上没改完的任务，地铁里用微信续上同一段对话继续推进——换的不是命令的目的地，是 agent 的前端。',
     'pillars.pocket.title': '装在口袋里的指挥台',
     'pillars.pocket.body': '微信里一句中文，落到任意设备执行，结果推回同一个聊天框。Telegram 同样支持。',
     'pillars.workspace.title': '一个工作区，所有设备',
@@ -45,8 +47,9 @@ export const homeStrings: Dicts = {
     'compare.col.local': '本地代理',
     'compare.col.cloud': '云沙箱',
     'compare.col.peer': '跨设备组网',
+    'compare.col.session': '会话跨终端',
     'compare.col.chat': 'IM 通道',
-    'compare.caption': '唯一同时勾上四列的产品。',
+    'compare.caption': '唯一同时勾上五列的产品。',
 
     // onboarding
     'onb.heading': '7 步，把你的设备连上来',
@@ -96,13 +99,13 @@ export const homeStrings: Dicts = {
     'hero.sub': 'agentserver weaves laptops, cloud sandboxes, and home servers into one workspace — commanded from your browser, your CLI, or your WeChat chat.',
     'hero.cta.primary': '▸ Sign in',
     'hero.cta.secondary': 'View on GitHub',
-    'hero.term.macbook': 'office-macbook · codex',
-    'hero.term.sandbox': 'cloud-sandbox-7 · codex',
-    'hero.chat.title': 'me',
-    'hero.chat.user': 'Find thesis.pdf on my devices — which copy is newest?',
-    'hero.chat.bot1': '📂 office-macbook · home-server · cloud-sandbox-7 all have it',
-    'hero.chat.bot2': '🔨 comparing mtimes…',
-    'hero.chat.bot3': '✓ newest is on cloud-sandbox-7 (today 10:42)',
+    'hero.term.macbook': 'office-macbook · codex · 10:14',
+    'hero.term.sandbox': 'session#a3f · paused 12:30',
+    'hero.chat.title': 'me · WeChat 18:42',
+    'hero.chat.user': 'Did the loss-fn refactor we started this morning land?',
+    'hero.chat.bot1': '📎 resumed session#a3f (office-macbook · 6h ago)',
+    'hero.chat.bot2': '🔨 running pytest tests/test_loss.py …',
+    'hero.chat.bot3': '✓ 17/17 passed · pushed to feature/weighted-loss',
     'hero.chip.online': 'online',
 
     // quote
@@ -112,6 +115,8 @@ export const homeStrings: Dicts = {
 
     // pillars
     'pillars.heading': 'Why agentserver',
+    'pillars.session.title': 'One session, any device',
+    'pillars.session.body': 'codex sessions live on the server, not the laptop they started from. Pause a half-finished refactor at the office; pick up the same conversation from WeChat on the subway home. The front-end moves; the agent does not.',
     'pillars.pocket.title': 'Pocket-sized command line',
     'pillars.pocket.body': 'One sentence in WeChat lands on the right device. The result comes back to the same chat. Telegram supported too.',
     'pillars.workspace.title': 'One workspace, every device',
@@ -126,8 +131,9 @@ export const homeStrings: Dicts = {
     'compare.col.local': 'local',
     'compare.col.cloud': 'cloud',
     'compare.col.peer': 'peer',
+    'compare.col.session': 'session',
     'compare.col.chat': 'chat',
-    'compare.caption': 'The only one with all four checked.',
+    'compare.caption': 'The only one with all five checked.',
 
     // onboarding
     'onb.heading': '7 steps to wire it all up',

--- a/web/src/components/WorkspaceDetail.tsx
+++ b/web/src/components/WorkspaceDetail.tsx
@@ -20,6 +20,12 @@ import {
   Globe,
   Server,
   Brain,
+  ArrowRight,
+  CheckCircle2,
+  ChevronDown,
+  ChevronUp,
+  Rocket,
+  ExternalLink,
 } from 'lucide-react'
 import {
   listMembers,
@@ -44,6 +50,8 @@ import {
   setDefaultCredentialBinding,
   pollDeviceCodeComplete,
   listSandboxes,
+  listCodexTokens,
+  listRemoteExecutors,
   type CredentialBinding,
   type DeviceCodeResponse,
   type Workspace,
@@ -57,6 +65,8 @@ import {
   type IMChannel,
   type Sandbox,
 } from '../lib/api'
+import { useT } from '../lib/i18n'
+import { homeStrings } from './Home/strings'
 import { ConfirmModal } from './Modals'
 import { WorkspaceAPIKeysTab } from './WorkspaceAPIKeysTab'
 import { TracesTab, TRACES_PER_PAGE } from './SandboxDetail'
@@ -245,7 +255,9 @@ export function WorkspaceDetail({ workspace, onRename, initialTab, sandboxOverri
               sbxQuota={sbxQuota}
               defaults={defaults}
               llmQuota={llmQuota}
+              memberCount={members.length}
               onRename={onRename}
+              onNavigate={selectTab}
             />
           )}
           {tab === 'browsers' && (
@@ -306,12 +318,14 @@ export function WorkspaceDetail({ workspace, onRename, initialTab, sandboxOverri
   )
 }
 
-function OverviewTab({ workspace, sbxQuota, defaults, llmQuota, onRename }: {
+function OverviewTab({ workspace, sbxQuota, defaults, llmQuota, memberCount, onRename, onNavigate }: {
   workspace: Workspace
   sbxQuota: { current: number; max: number } | null
   defaults: WorkspaceSandboxDefaults | null
   llmQuota: WorkspaceLLMQuota | null
+  memberCount: number
   onRename?: (id: string, name: string) => void
+  onNavigate: (tab: Tab) => void
 }) {
   const effectiveMaxRpd = llmQuota?.workspace_quota?.max_rpd ?? llmQuota?.default_max_rpd ?? null
   const [editing, setEditing] = useState(false)
@@ -349,6 +363,13 @@ function OverviewTab({ workspace, sbxQuota, defaults, llmQuota, onRename }: {
         )}
       </div>
 
+      {/* Getting Started — first-time user guide (README steps 2–7) */}
+      <GettingStartedCard
+        workspaceId={workspace.id}
+        memberCount={memberCount}
+        onNavigate={onNavigate}
+      />
+
       {/* Info cards */}
       <div className="grid grid-cols-2 gap-4 sm:grid-cols-3">
         <InfoCard icon={<Clock size={14} />} label="Created" value={new Date(workspace.created_at).toLocaleString()} />
@@ -381,6 +402,184 @@ function OverviewTab({ workspace, sbxQuota, defaults, llmQuota, onRename }: {
             <StatCell label="Max Sandboxes" value={defaults.max_sandboxes === 0 ? '∞' : String(defaults.max_sandboxes)} />
           </div>
         </div>
+      )}
+    </div>
+  )
+}
+
+type OnboardingStep = {
+  n: number
+  titleKey: string
+  bodyKey: string
+  tab: Tab
+  cta: string
+  done: boolean
+  optional?: boolean
+}
+
+function GettingStartedCard({ workspaceId, memberCount, onNavigate }: {
+  workspaceId: string
+  memberCount: number
+  onNavigate: (tab: Tab) => void
+}) {
+  const t = useT(homeStrings)
+  const dismissKey = `agentserver:onboarding-dismissed:${workspaceId}`
+  const collapseKey = `agentserver:onboarding-collapsed:${workspaceId}`
+
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    if (typeof window === 'undefined') return false
+    return window.localStorage.getItem(dismissKey) === '1'
+  })
+  // null until user has expressed a preference; falls back to "auto" (collapse when required-done)
+  const [userCollapsed, setUserCollapsed] = useState<boolean | null>(() => {
+    if (typeof window === 'undefined') return null
+    const v = window.localStorage.getItem(collapseKey)
+    return v === '1' ? true : v === '0' ? false : null
+  })
+
+  const [loaded, setLoaded] = useState(false)
+  const [llmConfigured, setLlmConfigured] = useState(false)
+  const [hasConnectors, setHasConnectors] = useState(false)
+  const [hasBrowsers, setHasBrowsers] = useState(false)
+  const [hasSandboxes, setHasSandboxes] = useState(false)
+  const [hasIM, setHasIM] = useState(false)
+
+  useEffect(() => {
+    if (dismissed) return
+    let cancelled = false
+    Promise.all([
+      getWorkspaceLLMConfig(workspaceId).catch(() => null),
+      getModelserverStatus(workspaceId).catch(() => null),
+      listRemoteExecutors(workspaceId).catch(() => []),
+      listCodexTokens(workspaceId).catch(() => []),
+      listSandboxes(workspaceId).catch(() => []),
+      listWorkspaceIMChannels(workspaceId).catch(() => ({ channels: [] } as any)),
+    ]).then(([llm, ms, connectors, browsers, sandboxes, im]) => {
+      if (cancelled) return
+      setLlmConfigured(!!(llm?.configured || ms?.connected))
+      setHasConnectors((connectors?.length ?? 0) > 0)
+      setHasBrowsers((browsers?.length ?? 0) > 0)
+      setHasSandboxes((sandboxes?.length ?? 0) > 0)
+      setHasIM(((im?.channels?.length) ?? 0) > 0)
+      setLoaded(true)
+    })
+    return () => { cancelled = true }
+  }, [workspaceId, dismissed])
+
+  const dismiss = () => {
+    window.localStorage.setItem(dismissKey, '1')
+    setDismissed(true)
+  }
+  const setCollapsed = (v: boolean) => {
+    window.localStorage.setItem(collapseKey, v ? '1' : '0')
+    setUserCollapsed(v)
+  }
+
+  if (dismissed) return null
+  if (!loaded) return null
+
+  const steps: OnboardingStep[] = [
+    { n: 2, titleKey: 'onb.s2.title', bodyKey: 'onb.s2.body', tab: 'llm', cta: 'Go to LLM', done: llmConfigured },
+    { n: 3, titleKey: 'onb.s3.title', bodyKey: 'onb.s3.body', tab: 'connectors', cta: 'Go to Connectors', done: hasConnectors },
+    { n: 4, titleKey: 'onb.s4.title', bodyKey: 'onb.s4.body', tab: 'browsers', cta: 'Go to Browsers', done: hasBrowsers, optional: true },
+    { n: 5, titleKey: 'onb.s5.title', bodyKey: 'onb.s5.body', tab: 'sandbox', cta: 'Go to Sandboxes', done: hasSandboxes, optional: true },
+    { n: 6, titleKey: 'onb.s6.title', bodyKey: 'onb.s6.body', tab: 'im', cta: 'Go to IM', done: hasIM },
+    { n: 7, titleKey: 'onb.s7.title', bodyKey: 'onb.s7.body', tab: 'members', cta: 'Go to Members', done: memberCount > 1 },
+  ]
+
+  const doneCount = steps.filter((s) => s.done).length
+  const requiredDone = steps.filter((s) => !s.optional).every((s) => s.done)
+  const collapsed = userCollapsed !== null ? userCollapsed : requiredDone
+
+  return (
+    <div className="rounded-lg border border-[var(--border)] bg-[var(--card)] overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center gap-3 px-5 py-3 border-b border-[var(--border)]">
+        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-[var(--secondary)] text-[var(--foreground)]">
+          {requiredDone ? <CheckCircle2 size={15} className="text-emerald-400" /> : <Rocket size={14} />}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-medium text-[var(--foreground)]">
+            {requiredDone ? 'Setup complete' : 'Getting started'}
+          </div>
+          <div className="text-xs text-[var(--muted-foreground)] truncate">
+            {requiredDone
+              ? `${doneCount} of ${steps.length} steps done · your workspace is ready`
+              : `${doneCount} of ${steps.length} steps done · finish setup to command compute from anywhere`}
+          </div>
+        </div>
+        <button
+          onClick={() => setCollapsed(!collapsed)}
+          className="rounded p-1 text-[var(--muted-foreground)] hover:bg-[var(--secondary)] hover:text-[var(--foreground)] transition-colors"
+          title={collapsed ? 'Expand' : 'Collapse'}
+        >
+          {collapsed ? <ChevronDown size={15} /> : <ChevronUp size={15} />}
+        </button>
+        <button
+          onClick={dismiss}
+          className="rounded p-1 text-[var(--muted-foreground)] hover:bg-[var(--secondary)] hover:text-[var(--foreground)] transition-colors"
+          title="Dismiss"
+        >
+          <X size={15} />
+        </button>
+      </div>
+
+      {/* Steps */}
+      {!collapsed && (
+        <>
+          <ol className="divide-y divide-[var(--border)]">
+            {steps.map((s) => (
+              <li
+                key={s.n}
+                className="flex items-start gap-3 px-5 py-3 hover:bg-[var(--secondary)]/30 transition-colors"
+              >
+                <div className="mt-0.5 shrink-0">
+                  {s.done ? (
+                    <CheckCircle2 size={18} className="text-emerald-400" />
+                  ) : (
+                    <div className="flex h-[18px] w-[18px] items-center justify-center rounded-full border border-[var(--border)] bg-[var(--background)]">
+                      <span className="font-mono text-[10px] text-[var(--muted-foreground)]">{s.n}</span>
+                    </div>
+                  )}
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2">
+                    <span className={`text-sm font-medium ${s.done ? 'text-[var(--muted-foreground)] line-through' : 'text-[var(--foreground)]'}`}>
+                      {t(s.titleKey)}
+                    </span>
+                    {s.optional && (
+                      <span className="rounded-full border border-[var(--border)] bg-[var(--background)] px-1.5 py-0 text-[9px] uppercase tracking-wide text-[var(--muted-foreground)]">
+                        Optional
+                      </span>
+                    )}
+                  </div>
+                  <div className="text-xs text-[var(--muted-foreground)] leading-relaxed">
+                    {t(s.bodyKey)}
+                  </div>
+                </div>
+                <button
+                  onClick={() => onNavigate(s.tab)}
+                  className="shrink-0 inline-flex items-center gap-1 rounded-md border border-[var(--border)] bg-[var(--background)] px-2.5 py-1 text-xs font-medium text-[var(--foreground)] hover:bg-[var(--secondary)] transition-colors"
+                  title={s.cta}
+                >
+                  {s.done ? 'Open' : 'Go'}
+                  <ArrowRight size={12} />
+                </button>
+              </li>
+            ))}
+          </ol>
+          <div className="border-t border-[var(--border)] px-5 py-2 flex justify-end">
+            <a
+              href="https://github.com/agentserver/agentserver#readme"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-xs text-[var(--muted-foreground)] hover:text-[var(--foreground)] transition-colors"
+            >
+              Full docs
+              <ExternalLink size={11} />
+            </a>
+          </div>
+        </>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary

- Adds **One session, any device / 同一段会话，任意设备** as the first pillar on `README.md`, `README.zh.md`, and `web/src/components/Home` — the codex session lives server-side, so the same conversation follows the user across CLI, Web, IM, and Jupyter.
- New **Cross-client session / 会话跨终端** column in the comparison table (READMEs + `HomeCompare.tsx`); only agentserver gets ✓ with `CLI / Web / IM / Jupyter`.
- Reworks the hero demo (`HomeHero.tsx` + `strings.ts`, zh + en) into a concrete narrative: morning office-macbook pauses `session#a3f` → evening WeChat reattaches → `pytest` ✓ 17/17 → pushed to `feature/weighted-loss`. Old thesis.pdf cross-device lookup didn't illustrate the new pillar.
- Pillar grid expanded from 3 → 4 (`md:grid-cols-2 lg:grid-cols-4`).

## Test plan

- [ ] `pnpm exec tsc --noEmit` passes (verified locally)
- [ ] `pnpm dev` — hero animation, pillars (2×2 on tablet / 4-up on desktop), compare table (5 columns) render in both zh and en
- [ ] README tables render correctly on GitHub (6 columns)

🤖 Generated with [Claude Code](https://claude.com/claude-code)