### PR TITLE
chore(chart): bump 0.64.24 → 0.64.25 to ship #209 #212 #213

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.24
-appVersion: "0.64.24"
+version: 0.64.25
+appVersion: "0.64.25"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
## Summary
- Bump chart `version`/`appVersion` 0.64.24 → 0.64.25.

## Shipping
- #209 fix(imbridge): seed BridgeBinding.RoutingMode from DB on channel create
- #212 feat(web): workspace overview — getting started card
- #213 Home/README: 'One session, any device' pillar + compare column