### PR TITLE
chore(chart): bump 0.64.25 → 0.64.26 to ship #215

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.25
-appVersion: "0.64.25"
+version: 0.64.26
+appVersion: "0.64.26"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
Bumps the chart so #215 (codex-exec-edge) ships.

Tag `v0.64.26` will be pushed after merge to trigger image build for all services including the new `codex-exec-edge`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)