### PR TITLE
chore(chart): bump 0.64.26 → 0.64.27 to ship #217

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.26
-appVersion: "0.64.26"
+version: 0.64.27
+appVersion: "0.64.27"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
Ships the registerproxy retry-success log from #217. After merge, push v0.64.27 to trigger image build.