### PR TITLE
feat(cxg): set reasoning_effort=high for spawned codex

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.27
-appVersion: "0.64.27"
+version: 0.64.28
+appVersion: "0.64.28"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/deploy/helm/agentserver/templates/codex-app-gateway.yaml
+++ b/deploy/helm/agentserver/templates/codex-app-gateway.yaml
@@ -102,6 +102,10 @@ spec:
                   key: secret_access_key
             - name: CXG_MODEL
               value: {{ .Values.codexAppGateway.model | quote }}
+            {{- if .Values.codexAppGateway.reasoningEffort }}
+            - name: CXG_REASONING_EFFORT
+              value: {{ .Values.codexAppGateway.reasoningEffort | quote }}
+            {{- end }}
             - name: CXG_MODEL_PROVIDER
               value: {{ .Values.codexAppGateway.modelProvider | quote }}
             - name: CXG_MODEL_PROVIDER_BASE_URL

--- a/deploy/helm/agentserver/values.yaml
+++ b/deploy/helm/agentserver/values.yaml
@@ -284,6 +284,11 @@ codexAppGateway:
   modelProviderBaseUrl: ""        # default: http://{release}-llmproxy:{port}/v1
   modelProviderEnvKey: CODEX_API_KEY
   modelProviderWireApi: responses
+  # Optional. Writes `model_reasoning_effort = "<value>"` into each per-thread
+  # config.toml. Codex accepts minimal | low | medium | high. Empty = leave
+  # codex default (medium for gpt-5 family). Applies to every spawned codex
+  # app-server (workspace-wide), including WeChat inbound sessions.
+  reasoningEffort: high
   # API key the spawned codex uses to authenticate to the model provider.
   # Required for the subprocess to make any LLM call.
   codexApiKey: ""

--- a/internal/codexappgateway/codexhome/codexhome.go
+++ b/internal/codexappgateway/codexhome/codexhome.go
@@ -40,6 +40,7 @@ type AgentServerMCP struct {
 type ConfigInput struct {
 	ModelProvider       string
 	Model               string
+	ReasoningEffort     string // optional; emits `model_reasoning_effort = "..."` when non-empty
 	ModelProviders      map[string]ModelProvider
 	AgentServer         AgentServerMCP
 	ProjectTrustedPaths []string
@@ -100,7 +101,11 @@ func RenderConfigTOML(cfg ConfigInput) (string, error) {
 	}
 	var b strings.Builder
 	fmt.Fprintf(&b, "model_provider = %q\n", cfg.ModelProvider)
-	fmt.Fprintf(&b, "model = %q\n\n", cfg.Model)
+	fmt.Fprintf(&b, "model = %q\n", cfg.Model)
+	if cfg.ReasoningEffort != "" {
+		fmt.Fprintf(&b, "model_reasoning_effort = %q\n", cfg.ReasoningEffort)
+	}
+	b.WriteString("\n")
 
 	for name, p := range cfg.ModelProviders {
 		fmt.Fprintf(&b, "[model_providers.%s]\n", tomlKey(name))

--- a/internal/codexappgateway/codexhome/codexhome_test.go
+++ b/internal/codexappgateway/codexhome/codexhome_test.go
@@ -209,6 +209,43 @@ func TestWriteConfigEmitsDefaultToolsApprovalMode(t *testing.T) {
 	}
 }
 
+func TestRenderConfigTOML_ReasoningEffort(t *testing.T) {
+	base := ConfigInput{
+		ModelProvider: "modelserver",
+		Model:         "gpt-5.5",
+		AgentServer: AgentServerMCP{
+			CodexBin:              "/usr/local/bin/codex-app-gateway",
+			WorkspaceID:           "ws_a",
+			ExecGatewayURL:        "wss://exec-gw.example/bridge",
+			AppGatewayInternalURL: "http://127.0.0.1:8086",
+			WorkspaceToken:        "wstok",
+			LoopbackToken:         "lbtok",
+		},
+	}
+
+	t.Run("set", func(t *testing.T) {
+		cfg := base
+		cfg.ReasoningEffort = "high"
+		out, err := RenderConfigTOML(cfg)
+		if err != nil {
+			t.Fatalf("Render: %v", err)
+		}
+		if !strings.Contains(out, `model_reasoning_effort = "high"`) {
+			t.Errorf("missing model_reasoning_effort line:\n%s", out)
+		}
+	})
+
+	t.Run("empty omits line", func(t *testing.T) {
+		out, err := RenderConfigTOML(base)
+		if err != nil {
+			t.Fatalf("Render: %v", err)
+		}
+		if strings.Contains(out, "model_reasoning_effort") {
+			t.Errorf("unexpected model_reasoning_effort when ReasoningEffort empty:\n%s", out)
+		}
+	})
+}
+
 func TestManager_WriteConfig_ProducesUsableTOML(t *testing.T) {
 	root := t.TempDir()
 	m := NewManager(root)

--- a/internal/codexappgateway/config.go
+++ b/internal/codexappgateway/config.go
@@ -40,6 +40,7 @@ type ServeConfig struct {
 	// LLM gateway (typically llmproxy in-cluster).
 	ModelProvider        string
 	Model                string
+	ReasoningEffort      string // optional; writes `model_reasoning_effort` into per-thread config.toml
 	ModelProviderBaseURL string
 	ModelProviderEnvKey  string
 	ModelProviderWireAPI string
@@ -103,6 +104,7 @@ func LoadServeConfigFromEnv() (ServeConfig, error) {
 		CapTokenHMACSecret:        []byte(os.Getenv("CXG_CAPTOKEN_HMAC_SECRET")),
 		ModelProvider:             envOr("CXG_MODEL_PROVIDER", "modelserver"),
 		Model:                     envOr("CXG_MODEL", "gpt-5.5"),
+		ReasoningEffort:           os.Getenv("CXG_REASONING_EFFORT"),
 		ModelProviderBaseURL:      envOr("CXG_MODEL_PROVIDER_BASE_URL", "http://llmproxy:8085/v1"),
 		ModelProviderEnvKey:       envOr("CXG_MODEL_PROVIDER_ENV_KEY", "CODEX_API_KEY"),
 		ModelProviderWireAPI:      envOr("CXG_MODEL_PROVIDER_WIRE_API", "responses"),

--- a/internal/codexappgateway/server.go
+++ b/internal/codexappgateway/server.go
@@ -190,8 +190,9 @@ func makeBuildConfig(cfg ServeConfig, _ connectedClient, wsTokenClient workspace
 
 		return supervisor.SpawnConfig{
 			Config: codexhome.ConfigInput{
-				ModelProvider: cfg.ModelProvider,
-				Model:         cfg.Model,
+				ModelProvider:   cfg.ModelProvider,
+				Model:           cfg.Model,
+				ReasoningEffort: cfg.ReasoningEffort,
 				ModelProviders: map[string]codexhome.ModelProvider{
 					cfg.ModelProvider: {
 						Name:    cfg.ModelProvider,


### PR DESCRIPTION
## Summary
- Adds optional `ReasoningEffort` on `codexhome.ConfigInput`; renders `model_reasoning_effort = \"<value>\"` into each per-thread `config.toml` only when non-empty.
- Wires it through `CXG_REASONING_EFFORT` env (empty default = preserve codex's own default) and Helm `codexAppGateway.reasoningEffort`, set to `high` in values.yaml.
- Chart bumped 0.64.27 → 0.64.28 so the new env block ships.

## Motivation
微信会话经 agentserver → codex-app-gateway → codex app-server 这条链路，每轮只发 `{input:[...]}`，没有 model/effort 覆写。先前 effort 谁都没设，跟 codex 默认（gpt-5 系列默认 medium）。这个 PR 让 ops 通过 helm 把 effort 抬到 high（spawn 期写入 config.toml），微信入站会话同步受益，且不动 agentserver / broker 任何代码。

需要按对话动态切 effort 时再走 per-turn 覆写路径（broker `mergeTurnParams` 已经支持任意非 `threadId` 字段透传）。

## Test plan
- [x] `go test ./internal/codexappgateway/...`
- [ ] Helm dry-run renders `CXG_REASONING_EFFORT=high` env block when `reasoningEffort` set, omits it when empty
- [ ] Spot-check a spawned codex pod's `config.toml` contains `model_reasoning_effort = \"high\"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)