### PR TITLE
chore(cxg): bump codex subprocess 0.133.0 → 0.134.0

### DIFF
--- a/Dockerfile.codex-app-gateway
+++ b/Dockerfile.codex-app-gateway
@@ -11,7 +11,7 @@ RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' \
 # `codex app-server` per thread, so the runtime image must carry it.
 # Override at build time with --build-arg CODEX_VERSION=...
 FROM debian:trixie-slim AS codex
-ARG CODEX_VERSION=0.133.0
+ARG CODEX_VERSION=0.134.0
 ARG TARGETARCH
 RUN apt-get update \
  && apt-get install -y --no-install-recommends ca-certificates curl \

--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.31
-appVersion: "0.64.31"
+version: 0.64.32
+appVersion: "0.64.32"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
## Summary
Tracks upstream \`openai/codex@rust-v0.134.0\` (released 2026-05-26) for the \`codex app-server\` subprocess spawned per workspace in codex-app-gateway.

Chart bumped 0.64.31 → 0.64.32.

## Compatibility review (0.133.0..0.134.0)

| change | affects us |
|---|---|
| 0.134 **rejects legacy top-level \`profile = \"...\"\`** (#24051/#24055/#24059/#24067) | ❌ \`codexhome.RenderConfigTOML\` never emits it |
| new \`thread/search\` RPC (#23519) | ❌ broker doesn't call |
| \`Add trace_id to TurnStartedEvent\` (#23980) | ❌ broker doesn't listen for TurnStarted |
| \`ThreadStart/Resume/Fork/ReadParams\` add \`skip_serializing_if\` on bool defaults (#24099) | ❌ receiver-side cleanup; we don't send those fields |
| **Allow parallel MCP tool calls when annotated \`readOnlyHint\`** (#23750) | ❌ \`default_tools_approval_mode=\"approve\"\` still applies; no behavior change for our env-mcp tools |
| Enterprise requirement gate (#23736) | ❌ new optional Config field |
| exec-server reconnect (#23867) | ❌ codex-internal embedded sandbox executor, not our \`codex-exec-gateway\` |
| \`turn.rs\` / notification protocol shape | ❌ zero diffs |

Our config.toml shape (\`model_provider\`, \`model\`, \`model_reasoning_effort\`, \`[model_providers.X]\`, \`[projects.X]\`, \`[features]\`, \`[mcp_servers.X]\`, \`default_tools_approval_mode\`) is fully compatible — no \`[profiles.X]\` blocks, no top-level \`profile = \"...\"\`.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test -count=1 ./internal/codexappgateway/...\` (broker / scheduler / codexhome / supervisor / approvalfilter / auth)
- [ ] Post-deploy: a WeChat turn and a scheduled task each round-trip cleanly through the new codex 0.134.0 binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)