### PR TITLE
fix(cxg): env-mcp concurrent dispatch + log file for ops visibility

### DIFF
--- a/cmd/codex-app-gateway/main.go
+++ b/cmd/codex-app-gateway/main.go
@@ -65,7 +65,12 @@ func runEnvMcp(rawArgs []string) {
 		fmt.Fprintln(os.Stderr, "codex-app-gateway env-mcp:", err)
 		os.Exit(2)
 	}
-	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	sink, sinkErr := envmcp.OpenLogSink(os.Stderr, args.LogFile)
+	logger := slog.New(slog.NewTextHandler(sink, &slog.HandlerOptions{Level: slog.LevelInfo})).
+		With("pid", os.Getpid(), "workspace_id", args.WorkspaceID)
+	if sinkErr != nil {
+		logger.Warn("env-mcp: log file open failed; falling back to stderr only", "err", sinkErr)
+	}
 	ctx, cancel := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer cancel()
 	if err := envmcp.Run(ctx, args, os.Stdin, os.Stdout, os.Stderr, logger); err != nil {
@@ -131,6 +136,7 @@ func parseEnvMcpArgs(rawArgs []string) (envmcp.RunArgs, error) {
 	loopbackTokenEnv := fs.String("loopback-token-env", "", "env var name holding the loopback token (required)")
 	execGatewayInternalURL := fs.String("exec-gateway-internal-url", "", "http base URL for codex-exec-gateway internal API (optional; enables HTTP relay copy_path)")
 	execGatewayInternalSecretEnv := fs.String("exec-gateway-internal-secret-env", "", "env var name holding the exec-gateway internal shared secret (optional)")
+	logFile := fs.String("log-file", "", "if set, the env-mcp logger writes to this file (append) in addition to stderr — codex hides MCP-child stderr, so this is the only ops-visible log")
 	if err := fs.Parse(rawArgs); err != nil {
 		return envmcp.RunArgs{}, err
 	}
@@ -156,5 +162,6 @@ func parseEnvMcpArgs(rawArgs []string) (envmcp.RunArgs, error) {
 		LoopbackTokenEnv:          *loopbackTokenEnv,
 		ExecGatewayInternalURL:    *execGatewayInternalURL,
 		ExecGatewayInternalSecret: *execGatewayInternalSecretEnv,
+		LogFile:                   *logFile,
 	}, nil
 }

--- a/cmd/codex-app-gateway/main_test.go
+++ b/cmd/codex-app-gateway/main_test.go
@@ -80,6 +80,23 @@ func TestParseEnvMcpArgs_RejectsTrailingPositional(t *testing.T) {
 	}
 }
 
+func TestParseEnvMcpArgs_LogFile(t *testing.T) {
+	args, err := parseEnvMcpArgs([]string{
+		"--workspace-id", "w",
+		"--exec-gateway-url", "wss://x/bridge",
+		"--app-gateway-internal", "http://127.0.0.1:8086",
+		"--workspace-token-env", "WT",
+		"--loopback-token-env", "LT",
+		"--log-file", "/tmp/env-mcp.log",
+	})
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if args.LogFile != "/tmp/env-mcp.log" {
+		t.Errorf("LogFile = %q", args.LogFile)
+	}
+}
+
 func TestParseEnvMcpArgs_UnknownFlag_NoStderrLeak(t *testing.T) {
 	_, err := parseEnvMcpArgs([]string{"--bogus", "x"})
 	if err == nil {

--- a/internal/codexappgateway/codexhome/codexhome.go
+++ b/internal/codexappgateway/codexhome/codexhome.go
@@ -35,6 +35,10 @@ type AgentServerMCP struct {
 	// flag and secret; copy_path falls back to ws cat-pump.
 	ExecGatewayInternalURL    string
 	ExecGatewayInternalSecret string // written verbatim into env-mcp's env block
+	// LogFile, when non-empty, adds `--log-file <path>` to the env-mcp
+	// args. WriteConfig auto-injects this with `<codexHome>/env-mcp.log`
+	// when the caller leaves it empty, so callers normally don't set it.
+	LogFile string
 }
 
 type ConfigInput struct {
@@ -77,7 +81,16 @@ func (m *Manager) RemoveTmpDir(path string) error {
 }
 
 // WriteConfig renders `config.toml` into the given CODEX_HOME dir.
+// Side effect: if the caller didn't supply AgentServer.LogFile, it is
+// filled in with `<codexHome>/env-mcp.log` so env-mcp's logger fans
+// out to a file the operator can `kubectl exec ... cat`. Callers that
+// want a different path (or no file at all — set to "/dev/null") can
+// pre-populate the field. Mutation is on the local copy (ConfigInput
+// is passed by value), so the caller's struct is unaffected.
 func (m *Manager) WriteConfig(codexHome string, cfg ConfigInput) error {
+	if cfg.AgentServer.CodexBin != "" && cfg.AgentServer.LogFile == "" {
+		cfg.AgentServer.LogFile = filepath.Join(codexHome, "env-mcp.log")
+	}
 	out, err := RenderConfigTOML(cfg)
 	if err != nil {
 		return err
@@ -145,6 +158,9 @@ func RenderConfigTOML(cfg ConfigInput) (string, error) {
 				"--exec-gateway-internal-url", m.ExecGatewayInternalURL,
 				"--exec-gateway-internal-secret-env", "CXG_EXEC_GATEWAY_INTERNAL_SECRET",
 			)
+		}
+		if m.LogFile != "" {
+			args = append(args, "--log-file", m.LogFile)
 		}
 		b.WriteString("args = [")
 		for i, a := range args {

--- a/internal/codexappgateway/codexhome/codexhome_test.go
+++ b/internal/codexappgateway/codexhome/codexhome_test.go
@@ -112,6 +112,93 @@ func TestRenderConfigTOML_DisablesBuiltinShellAndRegistersAgentserverMCP(t *test
 	}
 }
 
+func TestRenderConfigTOML_LogFileEmitsFlag(t *testing.T) {
+	cfg := ConfigInput{
+		ModelProvider: "modelserver",
+		Model:         "gpt-5.5",
+		AgentServer: AgentServerMCP{
+			CodexBin:              "/usr/local/bin/codex-app-gateway",
+			WorkspaceID:           "ws_a",
+			ExecGatewayURL:        "wss://exec-gw.example/bridge",
+			AppGatewayInternalURL: "http://127.0.0.1:8086",
+			WorkspaceToken:        "wstok",
+			LoopbackToken:         "lbtok",
+			LogFile:               "/tmp/codex-app-gateway/ws_a/env-mcp.log",
+		},
+	}
+	out, err := RenderConfigTOML(cfg)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	for _, want := range []string{
+		`"--log-file"`,
+		`"/tmp/codex-app-gateway/ws_a/env-mcp.log"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderConfigTOML_LogFileOmittedWhenEmpty(t *testing.T) {
+	cfg := ConfigInput{
+		ModelProvider: "modelserver",
+		Model:         "gpt-5.5",
+		AgentServer: AgentServerMCP{
+			CodexBin:              "/usr/local/bin/codex-app-gateway",
+			WorkspaceID:           "ws_a",
+			ExecGatewayURL:        "wss://exec-gw.example/bridge",
+			AppGatewayInternalURL: "http://127.0.0.1:8086",
+			WorkspaceToken:        "wstok",
+			LoopbackToken:         "lbtok",
+		},
+	}
+	out, err := RenderConfigTOML(cfg)
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if strings.Contains(out, "--log-file") {
+		t.Errorf("unexpected --log-file in:\n%s", out)
+	}
+}
+
+func TestWriteConfig_AutoInjectsLogFileFromCodexHome(t *testing.T) {
+	root := t.TempDir()
+	m := NewManager(root)
+	codexHome, err := m.NewTmpDir("ws_a")
+	if err != nil {
+		t.Fatalf("NewTmpDir: %v", err)
+	}
+	cfg := ConfigInput{
+		ModelProvider: "modelserver",
+		Model:         "gpt-5.5",
+		AgentServer: AgentServerMCP{
+			CodexBin:              "/usr/local/bin/codex-app-gateway",
+			WorkspaceID:           "ws_a",
+			ExecGatewayURL:        "wss://exec-gw.example/bridge",
+			AppGatewayInternalURL: "http://127.0.0.1:8086",
+			WorkspaceToken:        "wstok",
+			LoopbackToken:         "lbtok",
+			// LogFile deliberately empty — WriteConfig should fill it
+			// in from codexHome.
+		},
+	}
+	if err := m.WriteConfig(codexHome, cfg); err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(codexHome, "config.toml"))
+	if err != nil {
+		t.Fatalf("read config.toml: %v", err)
+	}
+	want := filepath.Join(codexHome, "env-mcp.log")
+	if !strings.Contains(string(body), `"--log-file"`) {
+		t.Errorf("missing --log-file flag in:\n%s", body)
+	}
+	if !strings.Contains(string(body), `"`+want+`"`) {
+		t.Errorf("missing log path %q in:\n%s", want, body)
+	}
+}
+
 func TestRenderConfigTOML_HTTPRelayEnabledEmitsFlagAndEnv(t *testing.T) {
 	cfg := ConfigInput{
 		ModelProvider: "modelserver",

--- a/internal/codexappgateway/envmcp/envmcp.go
+++ b/internal/codexappgateway/envmcp/envmcp.go
@@ -20,6 +20,23 @@ import (
 	"github.com/agentserver/agentserver/internal/envtools/tools"
 )
 
+// OpenLogSink returns a writer that fans out logger output to stderr
+// and, when path is non-empty, to the file at path (opened append).
+// On file-open failure it falls back to stderr-only and returns a
+// non-nil error so the caller can log the degradation. Exported so
+// `runEnvMcp` in cmd/codex-app-gateway can build the slog handler
+// before envmcp.Run takes over.
+func OpenLogSink(stderr io.Writer, path string) (io.Writer, error) {
+	if path == "" {
+		return stderr, nil
+	}
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return stderr, fmt.Errorf("open log file %q: %w", path, err)
+	}
+	return io.MultiWriter(stderr, f), nil
+}
+
 // RunArgs is the parsed CLI input for `codex-app-gateway env-mcp`.
 // Per the 2026-05-16 fixed-tools redesign, env-mcp is workspace-scoped
 // rather than per-executor; one child binary handles every executor in
@@ -30,6 +47,14 @@ type RunArgs struct {
 	AppGatewayInternal string // --app-gateway-internal; list_environments calls /internal/connected here
 	WorkspaceTokenEnv  string // --workspace-token-env (workspace-scoped cap token)
 	LoopbackTokenEnv   string // --loopback-token-env (for /internal/connected)
+	// LogFile, when non-empty, is opened in append mode and added to the
+	// logger's writer alongside stderr. Codex pipes MCP-child stderr into
+	// its own buffer where it is invisible from outside the codex process,
+	// so without this knob env-mcp is effectively logless from an ops
+	// standpoint. The file lives under the per-workspace CODEX_HOME so it
+	// is co-located with the rest of the subprocess state and reaped with
+	// the subprocess.
+	LogFile string // --log-file (optional)
 	// ExecGatewayInternalURL is the http(s):// base for codex-exec-gateway's
 	// internal API (NOT the ws /bridge URL). copy_path's HTTP relay path
 	// POSTs to <base>/api/exec-gateway/relay/create here. Empty disables

--- a/internal/codexappgateway/envmcp/mcp_server.go
+++ b/internal/codexappgateway/envmcp/mcp_server.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"unicode/utf8"
 
 	"github.com/agentserver/agentserver/internal/envtools/bridge"
@@ -17,9 +18,14 @@ import (
 
 // MCPServer is a minimal newline-delimited JSON-RPC stdio MCP server
 // that exposes a fixed set of tools through a registry. Concurrency:
-// requests are handled sequentially in the order they arrive; this
-// matches the MCP stdio model and keeps the server free of
-// intra-process synchronization other than the write-mutex.
+// `tools/call` requests run in their own goroutine so a slow tool
+// (e.g. a long-running shell) does not block faster tools (e.g.
+// list_environments) arriving behind it on stdin. The MCP/JSON-RPC
+// stdio protocol pairs responses to requests by id, so out-of-order
+// responses are fine on the wire; writes to stdout are serialized
+// through writeMu so concurrent responders don't interleave bytes.
+// Trivial RPC methods (initialize, tools/list, prompts/list, ...)
+// stay inline since they don't block.
 type MCPServer struct {
 	name    string // surfaces in initialize/serverInfo
 	tools   map[string]tools.Tool
@@ -62,12 +68,45 @@ func previewLine(line []byte) string {
 
 // Serve reads requests from in until EOF and writes responses to out.
 // Returns nil on clean EOF, error on unrecoverable read/write failure.
+// In-flight `tools/call` goroutines observe ctx cancellation; Serve
+// waits for them to drain before returning so the caller can rely on
+// "Serve returned" meaning "no goroutine is still writing to out".
+//
+// If any response write fails (stdout pipe gone), Serve records the
+// first error, cancels the per-Serve ctx so in-flight tool calls
+// abort promptly, and stops dispatching new tools/call work. We don't
+// own `in`, so the read loop only unblocks once stdin closes — but no
+// further responses are emitted in the interim, and Serve returns
+// the original write error rather than scanner.Err().
 func (s *MCPServer) Serve(ctx context.Context, in io.Reader, out io.Writer) error {
+	// Per-Serve ctx so cancelling Serve (or a fatal write error)
+	// signals every in-flight tool call. Order of these two defers
+	// matters: defers run LIFO, so the LAST one registered runs
+	// FIRST. We want cancelCalls() to run BEFORE wg.Wait() so
+	// in-flight goroutines observe ctx.Done() and exit promptly;
+	// hence cancelCalls is the last defer here.
+	callCtx, cancelCalls := context.WithCancel(ctx)
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	defer cancelCalls()
+
+	var fatalErr atomic.Pointer[error]
+	onWriteErr := func(err error) {
+		s.logger.Warn("mcp: write response failed", "err", err)
+		// CAS so we only record + cancel once; subsequent failures are
+		// just logged. cancelCalls is idempotent but repeated logging
+		// would be noisy.
+		if fatalErr.CompareAndSwap(nil, &err) {
+			cancelCalls()
+		}
+	}
+
 	scanner := bufio.NewScanner(in)
 	scanner.Buffer(make([]byte, 0, 1<<20), 16<<20)
 	for scanner.Scan() {
-		if ctx.Err() != nil {
-			return ctx.Err()
+		if callCtx.Err() != nil {
+			// outer ctx cancelled OR a prior write failed
+			break
 		}
 		line := scanner.Bytes()
 		if len(line) == 0 {
@@ -78,24 +117,38 @@ func (s *MCPServer) Serve(ctx context.Context, in io.Reader, out io.Writer) erro
 			s.logger.Warn("mcp: dropping malformed JSON-RPC line", "err", err, "preview", previewLine(line))
 			continue
 		}
-		if err := s.dispatch(ctx, &req, out); err != nil {
-			return err
-		}
+		s.dispatch(callCtx, &req, out, &wg, onWriteErr)
+	}
+	if e := fatalErr.Load(); e != nil {
+		return *e
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 	return scanner.Err()
 }
 
-func (s *MCPServer) dispatch(ctx context.Context, req *bridge.JSONRPCMessage, out io.Writer) error {
+// dispatch handles one JSON-RPC request. `tools/call` runs in its own
+// goroutine (tracked by wg) so slow tools don't block the read loop;
+// every other method runs inline since the body is trivial. Response
+// writes go through s.respond which holds writeMu. Write failures are
+// reported to onWriteErr so Serve can stop accepting new work.
+func (s *MCPServer) dispatch(ctx context.Context, req *bridge.JSONRPCMessage, out io.Writer, wg *sync.WaitGroup, onWriteErr func(error)) {
+	send := func(id *int64, result any, errObj *bridge.JSONRPCError) {
+		if err := s.respond(out, id, result, errObj); err != nil {
+			onWriteErr(err)
+		}
+	}
 	switch req.Method {
 	case "initialize":
-		return s.respond(out, req.ID, tools.MCPInitializeResult{
+		send(req.ID, tools.MCPInitializeResult{
 			ProtocolVersion: "2025-06-18",
 			Capabilities:    map[string]any{"tools": map[string]any{}},
 			ServerInfo:      tools.MCPServerInfo{Name: s.name, Version: "0.2"},
 		}, nil)
 
 	case "notifications/initialized":
-		return nil // notification
+		// notification — nothing to send back
 
 	case "tools/list":
 		list := make([]tools.MCPTool, 0, len(s.order))
@@ -107,38 +160,47 @@ func (s *MCPServer) dispatch(ctx context.Context, req *bridge.JSONRPCMessage, ou
 				InputSchema: t.InputSchema(),
 			})
 		}
-		return s.respond(out, req.ID, tools.MCPListToolsResult{Tools: list}, nil)
+		send(req.ID, tools.MCPListToolsResult{Tools: list}, nil)
 
 	case "tools/call":
 		var p tools.MCPCallToolParams
 		if err := json.Unmarshal(req.Params, &p); err != nil {
-			return s.respond(out, req.ID, nil, &bridge.JSONRPCError{Code: -32602, Message: "invalid params: " + err.Error()})
+			send(req.ID, nil, &bridge.JSONRPCError{Code: -32602, Message: "invalid params: " + err.Error()})
+			return
 		}
 		t, ok := s.tools[p.Name]
 		if !ok {
-			return s.respond(out, req.ID, nil, &bridge.JSONRPCError{Code: -32601, Message: "unknown tool: " + p.Name})
+			send(req.ID, nil, &bridge.JSONRPCError{Code: -32601, Message: "unknown tool: " + p.Name})
+			return
 		}
-		res, err := t.Call(ctx, p.Arguments)
-		if err != nil {
-			// Tool returned a hard error (not an isError content) — surface
-			// as JSON-RPC error so the LLM sees a clear protocol failure
-			// rather than a silently-empty content list.
-			return s.respond(out, req.ID, nil, &bridge.JSONRPCError{Code: -32000, Message: p.Name + ": " + err.Error()})
-		}
-		return s.respond(out, req.ID, res, nil)
+		id, name := req.ID, p.Name
+		args := p.Arguments
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			res, err := t.Call(ctx, args)
+			if err != nil {
+				// Tool returned a hard error (not an isError content) —
+				// surface as JSON-RPC error so the LLM sees a clear
+				// protocol failure rather than a silently-empty content list.
+				send(id, nil, &bridge.JSONRPCError{Code: -32000, Message: name + ": " + err.Error()})
+				return
+			}
+			send(id, res, nil)
+		}()
 
 	case "prompts/list":
-		return s.respond(out, req.ID, map[string]any{"prompts": []any{}}, nil)
+		send(req.ID, map[string]any{"prompts": []any{}}, nil)
 	case "resources/list":
-		return s.respond(out, req.ID, map[string]any{"resources": []any{}}, nil)
+		send(req.ID, map[string]any{"resources": []any{}}, nil)
 	case "resources/templates/list":
-		return s.respond(out, req.ID, map[string]any{"resourceTemplates": []any{}}, nil)
+		send(req.ID, map[string]any{"resourceTemplates": []any{}}, nil)
 
 	default:
 		if req.ID == nil {
-			return nil // notification of unknown method — drop
+			return // notification of unknown method — drop
 		}
-		return s.respond(out, req.ID, nil, &bridge.JSONRPCError{Code: -32601, Message: "method not found: " + req.Method})
+		send(req.ID, nil, &bridge.JSONRPCError{Code: -32601, Message: "method not found: " + req.Method})
 	}
 }
 

--- a/internal/codexappgateway/envmcp/mcp_server_test.go
+++ b/internal/codexappgateway/envmcp/mcp_server_test.go
@@ -2,16 +2,70 @@ package envmcp
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/agentserver/agentserver/internal/envtools/bridge"
 	"github.com/agentserver/agentserver/internal/envtools/tools"
 )
+
+func TestOpenLogSink_EmptyPathReturnsStderrOnly(t *testing.T) {
+	var stderr bytes.Buffer
+	w, err := OpenLogSink(&stderr, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := w.Write([]byte("hello")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if stderr.String() != "hello" {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+}
+
+func TestOpenLogSink_PathTeesToFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "env-mcp.log")
+	var stderr bytes.Buffer
+	w, err := OpenLogSink(&stderr, path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := w.Write([]byte("line\n")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if stderr.String() != "line\n" {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+	body, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read log file: %v", err)
+	}
+	if string(body) != "line\n" {
+		t.Errorf("file = %q", body)
+	}
+}
+
+func TestOpenLogSink_BadPathFallsBackToStderr(t *testing.T) {
+	var stderr bytes.Buffer
+	w, err := OpenLogSink(&stderr, "/nonexistent-dir-that-does-not-exist/log.txt")
+	if err == nil {
+		t.Fatal("expected error opening unwritable path")
+	}
+	if _, werr := w.Write([]byte("still works")); werr != nil {
+		t.Fatalf("write: %v", werr)
+	}
+	if stderr.String() != "still works" {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+}
 
 // blockingTool blocks Call until release is signalled, then returns text.
 type blockingTool struct {

--- a/internal/codexappgateway/envmcp/mcp_server_test.go
+++ b/internal/codexappgateway/envmcp/mcp_server_test.go
@@ -1,0 +1,261 @@
+package envmcp
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/agentserver/agentserver/internal/envtools/bridge"
+	"github.com/agentserver/agentserver/internal/envtools/tools"
+)
+
+// blockingTool blocks Call until release is signalled, then returns text.
+type blockingTool struct {
+	name    string
+	release <-chan struct{}
+	text    string
+}
+
+func (t *blockingTool) Name() string                 { return t.name }
+func (t *blockingTool) Description() string          { return "blocking" }
+func (t *blockingTool) InputSchema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
+func (t *blockingTool) Call(ctx context.Context, _ json.RawMessage) (tools.MCPCallToolResult, error) {
+	select {
+	case <-t.release:
+	case <-ctx.Done():
+		return tools.MCPCallToolResult{}, ctx.Err()
+	}
+	return tools.MCPCallToolResult{Content: []tools.MCPToolContent{{Type: "text", Text: t.text}}}, nil
+}
+
+// instantTool returns text immediately.
+type instantTool struct {
+	name string
+	text string
+}
+
+func (t *instantTool) Name() string                 { return t.name }
+func (t *instantTool) Description() string          { return "instant" }
+func (t *instantTool) InputSchema() json.RawMessage { return json.RawMessage(`{"type":"object"}`) }
+func (t *instantTool) Call(_ context.Context, _ json.RawMessage) (tools.MCPCallToolResult, error) {
+	return tools.MCPCallToolResult{Content: []tools.MCPToolContent{{Type: "text", Text: t.text}}}, nil
+}
+
+func encodeCall(id int64, toolName string) []byte {
+	params, _ := json.Marshal(tools.MCPCallToolParams{Name: toolName, Arguments: json.RawMessage(`{}`)})
+	msg := bridge.JSONRPCMessage{JSONRPC: "2.0", ID: &id, Method: "tools/call", Params: params}
+	out, _ := json.Marshal(&msg)
+	return append(out, '\n')
+}
+
+func decodeResponse(t *testing.T, line []byte) (id int64, text string) {
+	t.Helper()
+	var env bridge.JSONRPCMessage
+	if err := json.Unmarshal(line, &env); err != nil {
+		t.Fatalf("decode envelope: %v (line=%q)", err, line)
+	}
+	if env.ID == nil {
+		t.Fatalf("response missing id: %q", line)
+	}
+	if env.Error != nil {
+		t.Fatalf("response had error: %+v", env.Error)
+	}
+	var res tools.MCPCallToolResult
+	if err := json.Unmarshal(env.Result, &res); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if len(res.Content) == 0 {
+		t.Fatalf("result has no content")
+	}
+	return *env.ID, res.Content[0].Text
+}
+
+// TestMCPServer_ConcurrentToolsCall verifies a slow tools/call does not
+// block a fast tools/call that arrives behind it on the same stdin.
+// Under serial dispatch the fast call would queue behind the slow one
+// and the test would deadlock.
+func TestMCPServer_ConcurrentToolsCall(t *testing.T) {
+	release := make(chan struct{})
+	srv := NewMCPServer("test",
+		[]tools.Tool{
+			&blockingTool{name: "slow", release: release, text: "slow-done"},
+			&instantTool{name: "fast", text: "fast-done"},
+		},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+
+	serveErr := make(chan error, 1)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	go func() {
+		serveErr <- srv.Serve(ctx, inR, outW)
+		_ = outW.Close()
+	}()
+
+	if _, err := inW.Write(encodeCall(1, "slow")); err != nil {
+		t.Fatalf("write slow: %v", err)
+	}
+	if _, err := inW.Write(encodeCall(2, "fast")); err != nil {
+		t.Fatalf("write fast: %v", err)
+	}
+
+	reader := bufio.NewReader(outR)
+	// Expect the fast response back BEFORE we release slow.
+	line, err := reader.ReadBytes('\n')
+	if err != nil {
+		t.Fatalf("read first response: %v", err)
+	}
+	id, text := decodeResponse(t, line)
+	if id != 2 || text != "fast-done" {
+		t.Fatalf("expected fast response first (id=2 text=fast-done), got id=%d text=%q", id, text)
+	}
+
+	close(release)
+	line, err = reader.ReadBytes('\n')
+	if err != nil {
+		t.Fatalf("read second response: %v", err)
+	}
+	id, text = decodeResponse(t, line)
+	if id != 1 || text != "slow-done" {
+		t.Fatalf("expected slow response second (id=1 text=slow-done), got id=%d text=%q", id, text)
+	}
+
+	_ = inW.Close()
+	select {
+	case err := <-serveErr:
+		if err != nil {
+			t.Fatalf("Serve returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Serve did not return after stdin close")
+	}
+}
+
+// TestMCPServer_EOFCancelsInflightToolCalls verifies that closing
+// stdin (with the outer ctx still alive) cancels in-flight tool
+// goroutines via the per-Serve ctx, so Serve does not hang waiting
+// for a stuck tool to return on its own. Defer order in Serve must be
+// `defer wg.Wait(); defer cancelCalls()` so cancel runs FIRST under LIFO.
+func TestMCPServer_EOFCancelsInflightToolCalls(t *testing.T) {
+	release := make(chan struct{}) // never closed; tool MUST exit via ctx.Done
+	srv := NewMCPServer("test",
+		[]tools.Tool{&blockingTool{name: "slow", release: release, text: "unused"}},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+
+	serveErr := make(chan error, 1)
+	// Outer ctx stays alive — only stdin EOF drives shutdown.
+	go func() {
+		serveErr <- srv.Serve(context.Background(), inR, outW)
+		_ = outW.Close()
+	}()
+	// Drain stdout so the cancel-error response doesn't block on a full pipe.
+	go func() { _, _ = io.Copy(io.Discard, outR) }()
+
+	if _, err := inW.Write(encodeCall(1, "slow")); err != nil {
+		t.Fatalf("write slow: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	_ = inW.Close()
+
+	select {
+	case err := <-serveErr:
+		if err != nil {
+			t.Fatalf("Serve returned error: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Serve hung after EOF — in-flight tool was not cancelled")
+	}
+}
+
+// failingWriter returns an error from Write after failAfter successful writes.
+type failingWriter struct{ failAfter int }
+
+func (w *failingWriter) Write(p []byte) (int, error) {
+	w.failAfter--
+	if w.failAfter < 0 {
+		return 0, io.ErrClosedPipe
+	}
+	return len(p), nil
+}
+
+// TestMCPServer_WriteFailureStopsAcceptingNewWork verifies that a
+// stdout write failure signals Serve to stop accepting new work and
+// surface the error on return. Without this, codex sees N requests
+// turn into 0 responses because every Write error gets silently logged.
+func TestMCPServer_WriteFailureStopsAcceptingNewWork(t *testing.T) {
+	srv := NewMCPServer("test",
+		[]tools.Tool{&instantTool{name: "fast", text: "ok"}},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+
+	inR, inW := io.Pipe()
+	out := &failingWriter{failAfter: 0} // first Write fails
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- srv.Serve(context.Background(), inR, out)
+	}()
+
+	if _, err := inW.Write(encodeCall(1, "fast")); err != nil {
+		t.Fatalf("write 1: %v", err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	_ = inW.Close()
+
+	select {
+	case err := <-serveErr:
+		if err == nil {
+			t.Fatalf("Serve returned nil; want error reflecting stdout write failure")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Serve hung after stdin close")
+	}
+}
+
+// TestMCPServer_InflightCancelOnShutdown verifies that in-flight tool
+// calls observe ctx cancellation when Serve's outer context is
+// cancelled, and that Serve waits for them to drain before returning.
+func TestMCPServer_InflightCancelOnShutdown(t *testing.T) {
+	release := make(chan struct{}) // never closed; tool only returns via ctx.Done
+	srv := NewMCPServer("test",
+		[]tools.Tool{&blockingTool{name: "slow", release: release, text: "unused"}},
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
+
+	inR, inW := io.Pipe()
+	outR, outW := io.Pipe()
+
+	serveCtx, cancelServe := context.WithCancel(context.Background())
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- srv.Serve(serveCtx, inR, outW)
+		_ = outW.Close()
+	}()
+	go func() { _, _ = io.Copy(io.Discard, outR) }()
+
+	if _, err := inW.Write(encodeCall(1, "slow")); err != nil {
+		t.Fatalf("write slow: %v", err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	cancelServe()
+	_ = inW.Close()
+
+	select {
+	case <-serveErr:
+		// expected
+	case <-time.After(2 * time.Second):
+		t.Fatalf("Serve did not return after ctx cancel + EOF")
+	}
+}


### PR DESCRIPTION
## Summary

Two related changes to the env-mcp child process that runs inside each codex app-server subprocess.

### 1. Concurrent `tools/call` dispatch (commit 1)

`MCPServer.Serve` used to run every JSON-RPC request — including `tools/call` — synchronously in its scanner loop. A single long shell or exec_command on a remote executor blocked every subsequent request on the same env-mcp child (one per codex thread), including `list_environments`. Codex's MCP client timed the queued calls out at 120s; users saw "list_environments 超时".

Each `tools/call` now runs in its own goroutine, tracked by a `WaitGroup`. Trivial methods (`initialize`, `tools/list`, `prompts/list`, …) stay inline. The existing `writeMu` finally serializes stdout writes from concurrent responders.

Two correctness details called out by self-review:

- **Defer order** in `Serve` — `defer wg.Wait()` is registered BEFORE `defer cancelCalls()` so cancelCalls runs FIRST under LIFO. Without that, EOF shutdown hangs on a stuck tool because in-flight goroutines never see `ctx.Done()`.
- **Write-failure propagation** — first write error trips an `atomic.Pointer[error]` + cancels the per-Serve ctx; the read loop notices on its next iteration and `Serve` returns the original error. Without that, a half-closed stdout pipe turned every response into a Warn line and codex hung waiting for ids that would never arrive.

Covered by 4 new tests: concurrent ordering, EOF-driven cancellation of in-flight calls, stdout-write-failure propagation, outer-ctx cancellation drain semantics.

### 2. Tee env-mcp logger to `<CODEX_HOME>/env-mcp.log` (commit 2)

Codex captures its MCP children's stderr into its own log stream which agentserver does not expose, so env-mcp's `logger.Info`/`logger.Warn` output was invisible from outside the codex process. That made the recent "list_environments stuck" incident undebuggable.

Add `--log-file <path>` (`envmcp.RunArgs.LogFile`) + the plumbing:

- `codexhome.WriteConfig` auto-injects `<codexHome>/env-mcp.log` when `AgentServer.LogFile` is empty (every caller today). Log lives inside the per-workspace CODEX_HOME so it's reaped with the subprocess.
- `codexhome.RenderConfigTOML` emits `"--log-file" "<path>"` in the `[mcp_servers.agentserver].args` array when set.
- `cmd/codex-app-gateway runEnvMcp` opens the path via `envmcp.OpenLogSink` (io.MultiWriter over stderr + file, append mode, falls back to stderr-only on open failure) and tags every line with `pid` + `workspace_id` so multiple env-mcp instances sharing a codex parent's log file are disambiguable.

Covered by 4 new tests (CLI flag parsing, render emits/omits, WriteConfig auto-injection, OpenLogSink fallback paths).

## Test plan

- [x] `go test -race ./internal/codexappgateway/... ./cmd/codex-app-gateway/...` — green
- [x] `go vet ./...` — clean
- [ ] Manual: deploy this image to a dev cluster, send a WeChat message that calls `list_environments` while a slow `shell` is in flight — expect both to return rather than the second one timing out at 120s
- [ ] Manual: `kubectl exec` into the gateway pod, `cat /tmp/codex-app-gateway/<workspace>/env-mcp.log` — expect to see env-mcp's startup line + tool call traces

🤖 Generated with [Claude Code](https://claude.com/claude-code)