### PR TITLE
chore(chart): bump 0.64.32 → 0.65.0 to ship #222 #223 #224

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.64.32
-appVersion: "0.64.32"
+version: 0.65.0
+appVersion: "0.65.0"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
## Summary

Ship #222 + #223 + #224 by bumping the Helm chart to 0.65.0.

- #222 — scheduler routes via broker.Pool (drop \`codex exec\` subprocess) + \`CXG_BROKER_POOL_IDLE_TTL\` configurable, default 30m
- #223 — codex subprocess 0.133.0 → 0.134.0
- #224 — env-mcp concurrent \`tools/call\` dispatch + tee logger to \`<CODEX_HOME>/env-mcp.log\`

Minor bump (not patch) because #224 changes how env-mcp processes parallel tool calls inside one codex thread — previously serial, now concurrent — which is a meaningful production behavior change.

## Test plan

- [x] Chart.yaml diff verified
- [ ] CI green
- [ ] Tag \`v0.65.0\` on the merge commit after this PR lands
- [ ] Deploy + smoke test: a WeChat message that triggers list_environments while a slow shell is in flight — expect no 120s timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)