### PR TITLE
feat(server): add agent whoami identity endpoint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,11 +58,10 @@ jobs:
         run: make api-docs-check
 
   db-integration:
-    # Runs internal/db tests that require a real PostgreSQL (gated by
-    # TEST_DATABASE_URL; otherwise t.Skip in newTestDB). Scoped narrowly
-    # to scheduled-tasks for now — broader db tests have pre-existing
-    # FK-setup rot and need a separate cleanup pass before they can
-    # all run in CI.
+    # Runs narrowly scoped tests that require a real PostgreSQL (gated by
+    # TEST_DATABASE_URL; otherwise t.Skip in test helpers). Broader db tests
+    # have pre-existing FK-setup rot and need a separate cleanup pass before
+    # they can all run in CI.
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -94,6 +93,11 @@ jobs:
         env:
           TEST_DATABASE_URL: postgres://test:test@localhost:5432/test?sslmode=disable
         run: go test ./internal/db/ -run '^TestScheduledTask' -count=1 -timeout 2m -v
+
+      - name: Agent whoami integration tests
+        env:
+          TEST_DATABASE_URL: postgres://test:test@localhost:5432/test?sslmode=disable
+        run: go test ./internal/server -run '^TestAgentWhoami' -count=1 -timeout 2m -v
 
   build-server:
     runs-on: ubuntu-latest

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1573,6 +1573,56 @@
         }
       }
     },
+    "/api/agent/whoami": {
+      "get": {
+        "tags": [
+          "Agent"
+        ],
+        "summary": "Inspect the calling agent identity (proxy_token auth)",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentWhoamiResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/agents/{sandboxId}": {
       "get": {
         "security": [
@@ -8588,6 +8638,48 @@
           "total_cost_usd": {
             "type": "number",
             "nullable": true
+          }
+        }
+      },
+      "AgentWhoamiResponse": {
+        "type": "object",
+        "required": [
+          "display_name",
+          "role",
+          "sandbox_id",
+          "short_id",
+          "user_id",
+          "workspace_id",
+          "workspace_name"
+        ],
+        "properties": {
+          "display_name": {
+            "type": "string",
+            "example": "Alice Driver"
+          },
+          "role": {
+            "type": "string",
+            "example": "developer"
+          },
+          "sandbox_id": {
+            "type": "string",
+            "example": "sbx_456"
+          },
+          "short_id": {
+            "type": "string",
+            "example": "alice-driver-01"
+          },
+          "user_id": {
+            "type": "string",
+            "example": "u_abc123"
+          },
+          "workspace_id": {
+            "type": "string",
+            "example": "ws_xyz789"
+          },
+          "workspace_name": {
+            "type": "string",
+            "example": "Alice's Workspace"
           }
         }
       },

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -945,6 +945,36 @@ paths:
       summary: Poll for pending tasks (proxy_token auth)
       tags:
         - Agent
+  /api/agent/whoami:
+    get:
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AgentWhoamiResponse"
+        "401":
+          description: unauthorized
+          content:
+            application/json:
+              schema:
+                type: string
+        "403":
+          description: forbidden
+          content:
+            application/json:
+              schema:
+                type: string
+        "500":
+          description: internal error
+          content:
+            application/json:
+              schema:
+                type: string
+      summary: Inspect the calling agent identity (proxy_token auth)
+      tags:
+        - Agent
   "/api/agents/{sandboxId}":
     get:
       parameters:
@@ -5270,6 +5300,38 @@ components:
           nullable: true
       required:
         - status
+      type: object
+    AgentWhoamiResponse:
+      properties:
+        display_name:
+          example: Alice Driver
+          type: string
+        role:
+          example: developer
+          type: string
+        sandbox_id:
+          example: sbx_456
+          type: string
+        short_id:
+          example: alice-driver-01
+          type: string
+        user_id:
+          example: u_abc123
+          type: string
+        workspace_id:
+          example: ws_xyz789
+          type: string
+        workspace_name:
+          example: Alice's Workspace
+          type: string
+      required:
+        - display_name
+        - role
+        - sandbox_id
+        - short_id
+        - user_id
+        - workspace_id
+        - workspace_name
       type: object
     AuditCallDetail:
       properties:

--- a/docs/api/reference/README.md
+++ b/docs/api/reference/README.md
@@ -23,7 +23,7 @@ This reference covers the **external developer surface** of agentserver: the end
 | Workspaces | 14 | [`workspaces.md`](workspaces.md) |
 | Workspace API Keys | 4 | [`workspace-api-keys.md`](workspace-api-keys.md) |
 | Sandboxes | 8 | [`sandboxes.md`](sandboxes.md) |
-| Agent | 15 | [`agent.md`](agent.md) |
+| Agent | 16 | [`agent.md`](agent.md) |
 | Codex Tokens | 3 | [`codex-tokens.md`](codex-tokens.md) |
 | Codex Browser Sessions | 1 | [`codex-browser-sessions.md`](codex-browser-sessions.md) |
 | IM Channels | 9 | [`im-channels.md`](im-channels.md) |

--- a/docs/api/reference/agent.md
+++ b/docs/api/reference/agent.md
@@ -17,6 +17,7 @@ Endpoints under the `Agent` tag. Auto-generated from [`docs/api/openapi.yaml`](.
 | `GET` | [`/api/agent/tasks/poll`](#op-get-api-agent-tasks-poll) | Poll for pending tasks (proxy_token auth) |
 | `GET` | [`/api/agent/tasks/{id}`](#op-get-api-agent-tasks-id) | Get a task by ID (proxy_token auth) |
 | `PUT` | [`/api/agent/tasks/{id}/status`](#op-put-api-agent-tasks-id-status) | Update task status (proxy_token auth) |
+| `GET` | [`/api/agent/whoami`](#op-get-api-agent-whoami) | Inspect the calling agent identity (proxy_token auth) |
 | `GET` | [`/api/agents/{sandboxId}`](#op-get-api-agents-sandboxid) | Get a single agent card by sandbox ID |
 | `GET` | [`/api/tasks/{id}`](#op-get-api-tasks-id) | Get a task by ID |
 | `POST` | [`/api/tasks/{id}/cancel`](#op-post-api-tasks-id-cancel) | Cancel a task |
@@ -252,6 +253,19 @@ Schema: [`AgentTaskStatusRequest`](#schema-agenttaskstatusrequest)
 | `200` | OK | — |
 | `400` | bad request | `string` |
 | `401` | unauthorized | `string` |
+| `500` | internal error | `string` |
+
+
+### `GET /api/agent/whoami` {#op-get-api-agent-whoami}
+Inspect the calling agent identity (proxy_token auth)
+
+**Responses**
+
+| Status | Description | Schema |
+|--------|-------------|--------|
+| `200` | OK | [`AgentWhoamiResponse`](#schema-agentwhoamiresponse) |
+| `401` | unauthorized | `string` |
+| `403` | forbidden | `string` |
 | `500` | internal error | `string` |
 
 
@@ -605,5 +619,19 @@ Schema: [`AgentTaskCreateRequest`](#schema-agenttaskcreaterequest)
   result?: any
   status: string
   total_cost_usd?: number
+}
+```
+
+### `AgentWhoamiResponse` {#schema-agentwhoamiresponse}
+
+```yaml
+{
+  display_name: string
+  role: string
+  sandbox_id: string
+  short_id: string
+  user_id: string
+  workspace_id: string
+  workspace_name: string
 }
 ```

--- a/docs/superpowers/plans/2026-06-04-agent-whoami-identity.md
+++ b/docs/superpowers/plans/2026-06-04-agent-whoami-identity.md
@@ -1,0 +1,741 @@
+# Agent Whoami Identity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `GET /api/agent/whoami` so observer can map a sandbox `proxy_token` to user, workspace, sandbox, display name, and role identity.
+
+**Architecture:** Persist `user_id` on sandbox-scoped `proxy_tokens` when tokens are created, then resolve whoami through a strict `proxy_tokens`-based DB helper that refuses `tunnel_token` and workspace-scoped tokens. The HTTP handler performs constant 401 responses for unknown/invalid tokens, 403 for known but unusable sandbox identities, and returns the exact seven-field JSON contract.
+
+**Tech Stack:** Go, net/http, chi, PostgreSQL migrations, swaggo OpenAPI annotations, generated docs via `make openapi` and `make api-docs`.
+
+---
+
+## File Map
+
+- Create `internal/db/migrations/034_proxy_token_user_id.sql`: nullable `proxy_tokens.user_id` and supporting indexes.
+- Modify `internal/db/proxy_tokens.go`: add `UserID` to `ProxyToken`, scan it, and update sandbox token insert helper signature.
+- Modify `internal/db/sandboxes.go`: accept `userID` in sandbox creation helpers and insert it into `proxy_tokens`.
+- Modify `internal/sbxstore/store.go`: accept and forward `userID` when creating cloud sandboxes.
+- Modify `internal/server/agent_register.go`: pass OAuth subject into `CreateLocalSandbox`.
+- Modify `internal/server/server.go`: pass session user into `Sandboxes.Create` and mount `GET /api/agent/whoami`.
+- Create `internal/db/agent_whoami.go`: strict lookup helper and result/status types.
+- Create `internal/server/agent_whoami.go`: handler, strict bearer parsing, response mapping, OpenAPI annotations.
+- Modify `internal/server/api_types.go`: add `AgentWhoamiResponse`.
+- Create `internal/server/agent_whoami_test.go`: handler/DB integration tests.
+- Update generated docs: `docs/api/openapi.yaml`, `docs/api/openapi.json`, `docs/api/reference/agent.md`.
+
+## Task 1: Persist User Lineage On Proxy Tokens
+
+**Files:**
+- Create: `internal/db/migrations/034_proxy_token_user_id.sql`
+- Modify: `internal/db/proxy_tokens.go`
+- Modify: `internal/db/sandboxes.go`
+- Modify: `internal/sbxstore/store.go`
+
+- [ ] **Step 1: Add the migration**
+
+Create `internal/db/migrations/034_proxy_token_user_id.sql`:
+
+```sql
+ALTER TABLE proxy_tokens
+  ADD COLUMN IF NOT EXISTS user_id TEXT REFERENCES users(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_proxy_tokens_user
+  ON proxy_tokens (user_id)
+  WHERE user_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_proxy_tokens_workspace_user
+  ON proxy_tokens (workspace_id, user_id)
+  WHERE user_id IS NOT NULL;
+```
+
+- [ ] **Step 2: Extend `ProxyToken` and its scan query**
+
+In `internal/db/proxy_tokens.go`, add:
+
+```go
+	UserID      sql.NullString
+```
+
+to `ProxyToken`, and change `GetProxyToken` to select and scan `user_id`:
+
+```go
+err := db.QueryRow(
+	`SELECT token, token_type, sandbox_id, workspace_id, user_id
+	   FROM proxy_tokens WHERE token = $1`, token,
+).Scan(&pt.Token, &pt.TokenType, &pt.SandboxID, &pt.WorkspaceID, &pt.UserID)
+```
+
+- [ ] **Step 3: Update the sandbox token insert helper**
+
+Change `CreateSandboxProxyToken` in `internal/db/proxy_tokens.go` to:
+
+```go
+func (db *DB) CreateSandboxProxyToken(token, sandboxID, workspaceID, userID string) error {
+	if token == "" {
+		return nil
+	}
+	_, err := db.Exec(
+		`INSERT INTO proxy_tokens (token, token_type, sandbox_id, workspace_id, user_id)
+		 VALUES ($1, 'sandbox', $2, $3, NULLIF($4, ''))
+		 ON CONFLICT (token) DO NOTHING`,
+		token, sandboxID, workspaceID, userID,
+	)
+	if err != nil {
+		return fmt.Errorf("create sandbox proxy token: %w", err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Thread `userID` through DB sandbox creation**
+
+In `internal/db/sandboxes.go`, change:
+
+```go
+func (db *DB) CreateSandbox(id, workspaceID, name, sandboxType, sandboxName, opencodeToken, proxyToken, openclawToken, shortID string, cpu int, memory int64, idleTimeout *int, metadata json.RawMessage) error
+```
+
+to:
+
+```go
+func (db *DB) CreateSandbox(id, workspaceID, userID, name, sandboxType, sandboxName, opencodeToken, proxyToken, openclawToken, shortID string, cpu int, memory int64, idleTimeout *int, metadata json.RawMessage) error
+```
+
+and change the proxy token insert to:
+
+```go
+`INSERT INTO proxy_tokens (token, token_type, sandbox_id, workspace_id, user_id)
+ VALUES ($1, 'sandbox', $2, $3, NULLIF($4, '')) ON CONFLICT (token) DO NOTHING`,
+proxyToken, id, workspaceID, userID,
+```
+
+Change `CreateLocalSandbox` to:
+
+```go
+func (db *DB) CreateLocalSandbox(id, workspaceID, userID, name, sandboxType, opencodeToken, proxyToken, tunnelToken, shortID string) error
+```
+
+and apply the same `user_id` insert pattern.
+
+- [ ] **Step 5: Thread `userID` through `sbxstore.Store.Create`**
+
+In `internal/sbxstore/store.go`, change:
+
+```go
+func (s *Store) Create(id, workspaceID, name, sandboxType, sandboxName, opencodeToken, proxyToken, openclawToken, shortID string, cpu int, memory int64, idleTimeout *int, metadata map[string]interface{}) (*Sandbox, error)
+```
+
+to:
+
+```go
+func (s *Store) Create(id, workspaceID, userID, name, sandboxType, sandboxName, opencodeToken, proxyToken, openclawToken, shortID string, cpu int, memory int64, idleTimeout *int, metadata map[string]interface{}) (*Sandbox, error)
+```
+
+and call:
+
+```go
+s.db.CreateSandbox(id, workspaceID, userID, name, sandboxType, sandboxName, opencodeToken, proxyToken, openclawToken, shortID, cpu, memory, idleTimeout, metaJSON)
+```
+
+- [ ] **Step 6: Run compile check for changed packages**
+
+Run:
+
+```bash
+go test ./internal/db ./internal/sbxstore
+```
+
+Expected: compile succeeds; DB integration tests may skip if `TEST_DATABASE_URL` is unset.
+
+- [ ] **Step 7: Commit Task 1**
+
+```bash
+git add internal/db/migrations/034_proxy_token_user_id.sql internal/db/proxy_tokens.go internal/db/sandboxes.go internal/sbxstore/store.go
+git commit -m "feat(db): record user lineage on sandbox proxy tokens"
+```
+
+## Task 2: Write User Lineage At Token Issuance
+
+**Files:**
+- Modify: `internal/server/agent_register.go`
+- Modify: `internal/server/server.go`
+
+- [ ] **Step 1: Update `/api/agent/register` local sandbox creation**
+
+In `internal/server/agent_register.go`, change:
+
+```go
+createErr = s.DB.CreateLocalSandbox(sandboxID, workspaceID, req.Name, sandboxType, opencodePassword, proxyToken, tunnelToken, sid)
+```
+
+to:
+
+```go
+createErr = s.DB.CreateLocalSandbox(sandboxID, workspaceID, userID, req.Name, sandboxType, opencodePassword, proxyToken, tunnelToken, sid)
+```
+
+- [ ] **Step 2: Update Web sandbox creation**
+
+In `internal/server/server.go`, inside `handleCreateSandbox`, add near the existing `wsID := chi.URLParam(r, "wid")`:
+
+```go
+userID := auth.UserIDFromContext(r.Context())
+```
+
+Then change the `s.Sandboxes.Create` call to include `userID`:
+
+```go
+sbx, createErr = s.Sandboxes.Create(id, wsID, userID, req.Name, sandboxType, sandboxName, opencodeToken, proxyToken, openclawToken, sid, cpuMillis, memBytes, idleTimeout, req.Metadata)
+```
+
+- [ ] **Step 3: Run compile check for server**
+
+Run:
+
+```bash
+go test ./internal/server
+```
+
+Expected: compile succeeds; integration tests may skip if `TEST_DATABASE_URL` is unset.
+
+- [ ] **Step 4: Commit Task 2**
+
+```bash
+git add internal/server/agent_register.go internal/server/server.go
+git commit -m "feat(server): write user lineage for agent proxy tokens"
+```
+
+## Task 3: Add Strict Whoami DB Helper
+
+**Files:**
+- Create: `internal/db/agent_whoami.go`
+
+- [ ] **Step 1: Add lookup result and state types**
+
+Create `internal/db/agent_whoami.go` with:
+
+```go
+package db
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+type AgentWhoamiLookupState string
+
+const (
+	AgentWhoamiOK        AgentWhoamiLookupState = "ok"
+	AgentWhoamiUnknown   AgentWhoamiLookupState = "unknown"
+	AgentWhoamiForbidden AgentWhoamiLookupState = "forbidden"
+)
+
+type AgentWhoami struct {
+	UserID        string
+	WorkspaceID   string
+	WorkspaceName string
+	SandboxID     string
+	ShortID       string
+	DisplayName   string
+	Role          string
+	SandboxStatus string
+}
+```
+
+- [ ] **Step 2: Add `GetAgentWhoamiByProxyToken`**
+
+Append this function to `internal/db/agent_whoami.go`:
+
+```go
+func (db *DB) GetAgentWhoamiByProxyToken(token string) (*AgentWhoami, AgentWhoamiLookupState, error) {
+	pt := &ProxyToken{}
+	err := db.QueryRow(
+		`SELECT token, token_type, sandbox_id, workspace_id, user_id
+		   FROM proxy_tokens WHERE token = $1`, token,
+	).Scan(&pt.Token, &pt.TokenType, &pt.SandboxID, &pt.WorkspaceID, &pt.UserID)
+	if err == sql.ErrNoRows {
+		return nil, AgentWhoamiUnknown, nil
+	}
+	if err != nil {
+		return nil, "", fmt.Errorf("get whoami proxy token: %w", err)
+	}
+	if pt.TokenType != ProxyTokenSandbox || !pt.SandboxID.Valid {
+		return nil, AgentWhoamiUnknown, nil
+	}
+	if !pt.UserID.Valid || pt.UserID.String == "" {
+		return nil, AgentWhoamiForbidden, nil
+	}
+
+	out := &AgentWhoami{}
+	err = db.QueryRow(
+		`SELECT pt.user_id,
+		        pt.workspace_id,
+		        w.name,
+		        s.id,
+		        COALESCE(s.short_id, ''),
+		        COALESCE(NULLIF(ac.display_name, ''), s.name, ''),
+		        wm.role,
+		        s.status
+		   FROM proxy_tokens pt
+		   JOIN sandboxes s
+		     ON s.id = pt.sandbox_id
+		    AND s.workspace_id = pt.workspace_id
+		   JOIN workspaces w
+		     ON w.id = pt.workspace_id
+		   JOIN workspace_members wm
+		     ON wm.workspace_id = pt.workspace_id
+		    AND wm.user_id = pt.user_id
+		   LEFT JOIN agent_cards ac
+		     ON ac.sandbox_id = s.id
+		  WHERE pt.token = $1
+		    AND pt.token_type = 'sandbox'`, token,
+	).Scan(&out.UserID, &out.WorkspaceID, &out.WorkspaceName, &out.SandboxID, &out.ShortID, &out.DisplayName, &out.Role, &out.SandboxStatus)
+	if err == sql.ErrNoRows {
+		return nil, AgentWhoamiForbidden, nil
+	}
+	if err != nil {
+		return nil, "", fmt.Errorf("get agent whoami: %w", err)
+	}
+	return out, AgentWhoamiOK, nil
+}
+```
+
+- [ ] **Step 3: Run DB compile check**
+
+Run:
+
+```bash
+go test ./internal/db
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit Task 3**
+
+```bash
+git add internal/db/agent_whoami.go
+git commit -m "feat(db): resolve agent whoami identity from proxy token"
+```
+
+## Task 4: Add Handler, Route, And Response Type
+
+**Files:**
+- Create: `internal/server/agent_whoami.go`
+- Modify: `internal/server/api_types.go`
+- Modify: `internal/server/server.go`
+
+- [ ] **Step 1: Add response type**
+
+In `internal/server/api_types.go`, after `AgentRegisterResponse`, add:
+
+```go
+// AgentWhoamiResponse is returned by GET /api/agent/whoami.
+// It contains the full public identity contract for a sandbox proxy token.
+type AgentWhoamiResponse struct {
+	UserID        string `json:"user_id" validate:"required" example:"u_abc123"`
+	WorkspaceID   string `json:"workspace_id" validate:"required" example:"ws_xyz789"`
+	WorkspaceName string `json:"workspace_name" validate:"required" example:"Alice's Workspace"`
+	SandboxID     string `json:"sandbox_id" validate:"required" example:"sbx_456"`
+	ShortID       string `json:"short_id" validate:"required" example:"alice-driver-01"`
+	DisplayName   string `json:"display_name" validate:"required" example:"Alice Driver"`
+	Role          string `json:"role" validate:"required" example:"developer"`
+} // @name AgentWhoamiResponse
+```
+
+- [ ] **Step 2: Add handler**
+
+Create `internal/server/agent_whoami.go`:
+
+```go
+package server
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/agentserver/agentserver/internal/db"
+)
+
+func strictBearerToken(r *http.Request) (string, bool) {
+	authz := r.Header.Get("Authorization")
+	if !strings.HasPrefix(authz, "Bearer ") {
+		return "", false
+	}
+	token := strings.TrimSpace(strings.TrimPrefix(authz, "Bearer "))
+	if token == "" {
+		return "", false
+	}
+	return token, true
+}
+
+func activeWhoamiSandboxStatus(status string) bool {
+	return status == "creating" || status == "running"
+}
+
+// handleAgentWhoami returns the identity represented by a sandbox proxy_token.
+// GET /api/agent/whoami
+//
+//	@Summary   Inspect the calling agent identity (proxy_token auth)
+//	@Tags      Agent
+//	@Produce   json
+//	@Success   200  {object}  AgentWhoamiResponse
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "forbidden"
+//	@Failure   500  {string}  string  "internal error"
+//	@Router    /api/agent/whoami [get]
+func (s *Server) handleAgentWhoami(w http.ResponseWriter, r *http.Request) {
+	token, ok := strictBearerToken(r)
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	who, state, err := s.DB.GetAgentWhoamiByProxyToken(token)
+	if err != nil {
+		log.Printf("agent whoami: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	switch state {
+	case db.AgentWhoamiUnknown:
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	case db.AgentWhoamiForbidden:
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+	if who == nil || !activeWhoamiSandboxStatus(who.SandboxStatus) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	json.NewEncoder(w).Encode(AgentWhoamiResponse{
+		UserID:        who.UserID,
+		WorkspaceID:   who.WorkspaceID,
+		WorkspaceName: who.WorkspaceName,
+		SandboxID:     who.SandboxID,
+		ShortID:       who.ShortID,
+		DisplayName:   who.DisplayName,
+		Role:          who.Role,
+	})
+}
+```
+
+- [ ] **Step 3: Mount route**
+
+In `internal/server/server.go`, after `r.Post("/api/agent/register", s.handleAgentRegister)`, add:
+
+```go
+	r.Get("/api/agent/whoami", s.handleAgentWhoami)
+```
+
+- [ ] **Step 4: Run server compile check**
+
+Run:
+
+```bash
+go test ./internal/server
+```
+
+Expected: PASS or integration-test skips only.
+
+- [ ] **Step 5: Commit Task 4**
+
+```bash
+git add internal/server/agent_whoami.go internal/server/api_types.go internal/server/server.go
+git commit -m "feat(server): add agent whoami endpoint"
+```
+
+## Task 5: Add Whoami Tests
+
+**Files:**
+- Create: `internal/server/agent_whoami_test.go`
+
+- [ ] **Step 1: Add integration test helpers**
+
+Create `internal/server/agent_whoami_test.go` with:
+
+```go
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func newWhoamiTestServer(t *testing.T) *Server {
+	t.Helper()
+	d := newCodexTestDBForServer(t)
+	t.Cleanup(func() {
+		d.Exec(`DELETE FROM agent_cards`)
+		d.Exec(`DELETE FROM proxy_tokens`)
+		d.Exec(`DELETE FROM sandboxes`)
+		d.Exec(`DELETE FROM workspace_members`)
+		d.Exec(`DELETE FROM workspaces`)
+		d.Exec(`DELETE FROM users`)
+	})
+	return &Server{DB: d}
+}
+
+func seedWhoamiSandbox(t *testing.T, srv *Server, token, tunnelToken, status, role, displayName string, withUser bool) {
+	t.Helper()
+	seedWorkspaceMember(t, srv.DB, "ws_whoami", "u_whoami", role)
+	if _, err := srv.DB.Exec(
+		`INSERT INTO sandboxes (id, workspace_id, name, type, status, proxy_token, tunnel_token, short_id)
+		 VALUES ('sbx_whoami', 'ws_whoami', 'Sandbox Name', 'custom', $1, $2, $3, 'short-whoami')
+		 ON CONFLICT (id) DO UPDATE SET status = EXCLUDED.status, proxy_token = EXCLUDED.proxy_token, tunnel_token = EXCLUDED.tunnel_token`,
+		status, token, tunnelToken,
+	); err != nil {
+		t.Fatalf("insert sandbox: %v", err)
+	}
+	userID := any(nil)
+	if withUser {
+		userID = "u_whoami"
+	}
+	if _, err := srv.DB.Exec(
+		`INSERT INTO proxy_tokens (token, token_type, sandbox_id, workspace_id, user_id)
+		 VALUES ($1, 'sandbox', 'sbx_whoami', 'ws_whoami', $2)
+		 ON CONFLICT (token) DO UPDATE SET user_id = EXCLUDED.user_id`,
+		token, userID,
+	); err != nil {
+		t.Fatalf("insert proxy token: %v", err)
+	}
+	if displayName != "" {
+		if _, err := srv.DB.Exec(
+			`INSERT INTO agent_cards (sandbox_id, workspace_id, agent_type, display_name)
+			 VALUES ('sbx_whoami', 'ws_whoami', 'custom', $1)
+			 ON CONFLICT (sandbox_id) DO UPDATE SET display_name = EXCLUDED.display_name`,
+			displayName,
+		); err != nil {
+			t.Fatalf("insert agent card: %v", err)
+		}
+	}
+}
+
+func callWhoami(t *testing.T, srv *Server, authz string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/agent/whoami", nil)
+	if authz != "" {
+		req.Header.Set("Authorization", authz)
+	}
+	rr := httptest.NewRecorder()
+	srv.handleAgentWhoami(rr, req)
+	return rr
+}
+```
+
+- [ ] **Step 2: Add happy-path test**
+
+Append:
+
+```go
+func TestAgentWhoami_HappyPath(t *testing.T) {
+	srv := newWhoamiTestServer(t)
+	seedWhoamiSandbox(t, srv, "proxy-good", "tunnel-good", "running", "developer", "Display Agent", true)
+
+	rr := callWhoami(t, srv, "Bearer proxy-good")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if rr.Header().Get("Cache-Control") != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", rr.Header().Get("Cache-Control"))
+	}
+	var out AgentWhoamiResponse
+	if err := json.NewDecoder(rr.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.UserID != "u_whoami" || out.WorkspaceID != "ws_whoami" || out.WorkspaceName != "test ws" ||
+		out.SandboxID != "sbx_whoami" || out.ShortID != "short-whoami" ||
+		out.DisplayName != "Display Agent" || out.Role != "developer" {
+		t.Fatalf("unexpected response: %+v", out)
+	}
+}
+```
+
+- [ ] **Step 3: Add auth failure tests**
+
+Append:
+
+```go
+func TestAgentWhoami_UnauthorizedCases(t *testing.T) {
+	srv := newWhoamiTestServer(t)
+	seedWhoamiSandbox(t, srv, "proxy-good", "tunnel-good", "running", "developer", "", true)
+	if _, err := srv.DB.Exec(
+		`INSERT INTO proxy_tokens (token, token_type, workspace_id)
+		 VALUES ('workspace-token', 'workspace', 'ws_whoami')
+		 ON CONFLICT DO NOTHING`,
+	); err != nil {
+		t.Fatalf("insert workspace token: %v", err)
+	}
+
+	cases := []struct {
+		name  string
+		authz string
+	}{
+		{"missing", ""},
+		{"malformed", "Basic proxy-good"},
+		{"empty bearer", "Bearer "},
+		{"unknown", "Bearer nope"},
+		{"workspace token", "Bearer workspace-token"},
+		{"tunnel token", "Bearer tunnel-good"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := callWhoami(t, srv, tc.authz)
+			if rr.Code != http.StatusUnauthorized {
+				t.Fatalf("want 401, got %d: %s", rr.Code, rr.Body.String())
+			}
+			if rr.Body.String() != "unauthorized\n" {
+				t.Fatalf("body = %q", rr.Body.String())
+			}
+		})
+	}
+}
+```
+
+- [ ] **Step 4: Add forbidden tests**
+
+Append:
+
+```go
+func TestAgentWhoami_ForbiddenCases(t *testing.T) {
+	for _, status := range []string{"paused", "offline", "deleting", "pausing"} {
+		t.Run("status_"+status, func(t *testing.T) {
+			srv := newWhoamiTestServer(t)
+			seedWhoamiSandbox(t, srv, "proxy-forbidden", "tunnel-forbidden", status, "developer", "", true)
+			rr := callWhoami(t, srv, "Bearer proxy-forbidden")
+			if rr.Code != http.StatusForbidden {
+				t.Fatalf("want 403, got %d: %s", rr.Code, rr.Body.String())
+			}
+		})
+	}
+
+	t.Run("legacy_null_user", func(t *testing.T) {
+		srv := newWhoamiTestServer(t)
+		seedWhoamiSandbox(t, srv, "proxy-legacy", "tunnel-legacy", "running", "developer", "", false)
+		rr := callWhoami(t, srv, "Bearer proxy-legacy")
+		if rr.Code != http.StatusForbidden {
+			t.Fatalf("want 403, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("membership_removed", func(t *testing.T) {
+		srv := newWhoamiTestServer(t)
+		seedWhoamiSandbox(t, srv, "proxy-removed", "tunnel-removed", "running", "developer", "", true)
+		if _, err := srv.DB.Exec(`DELETE FROM workspace_members WHERE workspace_id = 'ws_whoami' AND user_id = 'u_whoami'`); err != nil {
+			t.Fatalf("delete membership: %v", err)
+		}
+		rr := callWhoami(t, srv, "Bearer proxy-removed")
+		if rr.Code != http.StatusForbidden {
+			t.Fatalf("want 403, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+}
+```
+
+- [ ] **Step 5: Add display-name fallback test**
+
+Append:
+
+```go
+func TestAgentWhoami_DisplayNameFallsBackToSandboxName(t *testing.T) {
+	srv := newWhoamiTestServer(t)
+	seedWhoamiSandbox(t, srv, "proxy-fallback", "tunnel-fallback", "running", "developer", "", true)
+	rr := callWhoami(t, srv, "Bearer proxy-fallback")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var out AgentWhoamiResponse
+	if err := json.NewDecoder(rr.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.DisplayName != "Sandbox Name" {
+		t.Fatalf("display_name = %q, want Sandbox Name", out.DisplayName)
+	}
+}
+```
+
+- [ ] **Step 6: Run whoami tests**
+
+Run:
+
+```bash
+go test ./internal/server -run 'TestAgentWhoami'
+```
+
+Expected: PASS when `TEST_DATABASE_URL` is set; otherwise tests skip through the shared DB helper.
+
+- [ ] **Step 7: Commit Task 5**
+
+```bash
+git add internal/server/agent_whoami_test.go
+git commit -m "test(server): cover agent whoami endpoint"
+```
+
+## Task 6: Regenerate API Docs And Verify
+
+**Files:**
+- Modify: `docs/api/openapi.yaml`
+- Modify: `docs/api/openapi.json`
+- Modify: `docs/api/reference/agent.md`
+
+- [ ] **Step 1: Regenerate OpenAPI**
+
+Run:
+
+```bash
+make openapi
+```
+
+Expected: `docs/api/openapi.yaml` and `docs/api/openapi.json` include `GET /api/agent/whoami` and `AgentWhoamiResponse`.
+
+- [ ] **Step 2: Regenerate Markdown API reference**
+
+Run:
+
+```bash
+make api-docs
+```
+
+Expected: `docs/api/reference/agent.md` lists `GET /api/agent/whoami`.
+
+- [ ] **Step 3: Run verification**
+
+Run:
+
+```bash
+go test ./internal/db ./internal/sbxstore ./internal/server
+make openapi-check
+make api-docs-check
+```
+
+Expected: all commands pass; DB-backed tests skip if `TEST_DATABASE_URL` is unset.
+
+- [ ] **Step 4: Commit Task 6**
+
+```bash
+git add docs/api/openapi.yaml docs/api/openapi.json docs/api/reference/agent.md
+git commit -m "docs(api): document agent whoami endpoint"
+```
+
+## Self-Review
+
+Spec coverage:
+
+- The endpoint contract and seven fields are covered by Task 4.
+- User lineage persistence is covered by Tasks 1 and 2.
+- Strict `proxy_token` parsing and rejection of `tunnel_token` / workspace tokens are covered by Tasks 3, 4, and 5.
+- 401 and 403 semantics are covered by Tasks 4 and 5.
+- `display_name` fallback is covered by Tasks 3 and 5.
+- OpenAPI and generated reference docs are covered by Task 6.
+
+No placeholder steps remain. Type names are consistent across tasks:
+`AgentWhoami`, `AgentWhoamiLookupState`, `AgentWhoamiResponse`, and
+`handleAgentWhoami`.

--- a/docs/superpowers/specs/2026-06-04-agent-whoami-identity-design.md
+++ b/docs/superpowers/specs/2026-06-04-agent-whoami-identity-design.md
@@ -1,0 +1,276 @@
+# Agent Whoami Identity Design
+
+**Date:** 2026-06-04
+**Status:** Ready for review
+
+## Context
+
+Observer needs an authenticated public endpoint that maps an
+agentserver-issued sandbox `proxy_token` to the identity tuple:
+
+```json
+{
+  "user_id": "u_abc123",
+  "workspace_id": "ws_xyz789",
+  "workspace_name": "Alice's Workspace",
+  "sandbox_id": "sbx_456",
+  "short_id": "alice-driver-01",
+  "role": "developer"
+}
+```
+
+`POST /internal/validate-proxy-token` is not suitable for this cross-trust-domain
+consumer. Audit H-19 identifies it as unauthenticated and useful for token
+probing / sandbox metadata enumeration. The new endpoint should live under the
+public agent API surface:
+
+```http
+GET /api/agent/whoami
+Authorization: Bearer <proxy_token>
+```
+
+## Current State
+
+Agentserver already has public `/api/agent/*` routes authenticated by sandbox
+tokens, but the current helper is too broad for this contract:
+
+- `extractProxyTokenSandbox` calls `GetSandboxByAnyToken`.
+- `GetSandboxByAnyToken` accepts both `proxy_token` and `tunnel_token`.
+- Existing agent routes do not consistently gate on sandbox lifecycle status.
+- `proxy_tokens` and `sandboxes` contain `workspace_id` and `sandbox_id`, but do
+  not contain a reliable `user_id` lineage.
+
+`/api/agent/register` has the OAuth subject at registration time and verifies
+the user's workspace role, but the subject is not persisted when the sandbox and
+proxy token are created. Web-created sandboxes have the session user in request
+context, but that user is also not persisted into token lineage.
+
+This means agentserver can currently resolve `workspace_id`, `sandbox_id`,
+`short_id`, sandbox status, and workspace name from a proxy token, but cannot
+reliably resolve `user_id` or `workspace_members.role`.
+
+## Goals
+
+- Add `GET /api/agent/whoami` for sandbox-scoped `proxy_token` identity
+  introspection.
+- Make agentserver the source of truth for observer's user / workspace /
+  sandbox identity mapping.
+- Return exactly the six documented fields.
+- Do not return secrets or token expiry / TTL information.
+- Do not extend `/internal/validate-proxy-token`.
+- Avoid accepting `tunnel_token` or workspace-scoped tokens for this endpoint.
+- Preserve existing `validate-proxy-token` behavior for llmproxy and
+  credentialproxy callers.
+
+## Non-Goals
+
+- No observer-side user table.
+- No cache TTL contract in the response body.
+- No attempt to infer a user for historical tokens without recorded lineage.
+- No broad refactor of all existing `/api/agent/*` handlers in the first
+  implementation. The whoami endpoint gets strict auth semantics; broader
+  unification can follow separately.
+
+## Recommended Approach
+
+Add user lineage to sandbox proxy tokens and implement a strict whoami resolver
+against `proxy_tokens`.
+
+### Schema
+
+Add `user_id` to `proxy_tokens`:
+
+```sql
+ALTER TABLE proxy_tokens
+  ADD COLUMN IF NOT EXISTS user_id TEXT REFERENCES users(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_proxy_tokens_user
+  ON proxy_tokens (user_id)
+  WHERE user_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_proxy_tokens_workspace_user
+  ON proxy_tokens (workspace_id, user_id)
+  WHERE user_id IS NOT NULL;
+```
+
+`user_id` is nullable so existing rows remain valid. New sandbox-scoped tokens
+must write it. Workspace-scoped tokens may keep it null because they are not a
+sandbox identity and are out of scope for whoami.
+
+### Token Issuance
+
+Update sandbox token creation paths to persist the current user:
+
+- `/api/agent/register`: use the OAuth introspection subject.
+- `POST /api/workspaces/{wid}/sandboxes`: use `auth.UserIDFromContext`.
+- Any direct DB/store helper that creates a sandbox proxy token should accept a
+  `userID` parameter and write it to `proxy_tokens.user_id`.
+
+The denormalized `sandboxes.proxy_token` column can remain unchanged. The
+authoritative identity lineage for whoami is `proxy_tokens.user_id`.
+
+### Legacy Tokens
+
+Existing tokens with `proxy_tokens.user_id IS NULL` cannot be mapped to a user
+without guesswork. The endpoint must return `403 forbidden` for those rows.
+Operators can restore whoami eligibility by recreating or re-registering the
+sandbox so a new token is minted with user lineage.
+
+Do not backfill historical rows by choosing a workspace owner or first member.
+That would produce plausible but false identity data.
+
+### Strict Resolver
+
+Add a new DB helper such as `GetAgentWhoamiByProxyToken(token string)`.
+
+It should:
+
+1. Look up the token in `proxy_tokens`.
+2. Require `token_type = 'sandbox'`.
+3. Require a non-null `sandbox_id` and `user_id`.
+4. Join to `sandboxes`, `workspaces`, and `workspace_members`.
+5. Require `workspace_members.workspace_id = proxy_tokens.workspace_id`.
+6. Require `workspace_members.user_id = proxy_tokens.user_id`.
+7. Return the sandbox status for handler-side lifecycle gating.
+
+Do not use `GetSandboxByAnyToken`, because that accepts `tunnel_token`.
+
+### Endpoint Contract
+
+```http
+GET /api/agent/whoami
+Authorization: Bearer <proxy_token>
+```
+
+Successful response:
+
+```json
+{
+  "user_id": "u_abc123",
+  "workspace_id": "ws_xyz789",
+  "workspace_name": "Alice's Workspace",
+  "sandbox_id": "sbx_456",
+  "short_id": "alice-driver-01",
+  "role": "developer"
+}
+```
+
+`workspace_name` and `short_id` should serialize as empty strings when the
+database value is empty or null.
+
+The response should set:
+
+```http
+Content-Type: application/json
+Cache-Control: no-store
+```
+
+The endpoint is read-only and idempotent, but it is an authenticated identity
+response. It should not be stored by shared HTTP caches. Observer can still
+apply its own local TTL cache.
+
+### Error Semantics
+
+Return a constant 401 body for all unauthenticated token failures:
+
+- Missing Authorization header.
+- Malformed Authorization header.
+- Unknown token.
+- Token exists but is not a sandbox-scoped proxy token.
+
+```http
+401 Unauthorized
+
+unauthorized
+```
+
+Return 403 when the token is known as a sandbox proxy token but the current
+identity is not usable:
+
+- Sandbox status is not `creating` or `running`.
+- `proxy_tokens.user_id` is null.
+- The recorded user is no longer a workspace member.
+- The joined workspace or sandbox row is missing due to inconsistent state.
+
+```http
+403 Forbidden
+
+forbidden
+```
+
+The original issue's "workspace removed returns 403" should be interpreted as
+"workspace identity is no longer usable returns 403." With the current schema,
+workspace deletion normally cascades `proxy_tokens`, so the token may instead
+become unknown and return 401.
+
+### OpenAPI And Docs
+
+Add `AgentWhoamiResponse` to `internal/server/api_types.go` and annotate the
+handler with swag comments under the `Agent` tag.
+
+Regenerate:
+
+```bash
+make openapi
+make api-docs
+```
+
+The generated docs should include the new operation in
+`docs/api/reference/agent.md`.
+
+## Alternatives Considered
+
+### Reuse `GetSandboxByAnyToken` and infer user from workspace membership
+
+Rejected. It would accept `tunnel_token` and cannot uniquely identify a user in
+multi-member workspaces. Returning an owner or first member would create false
+identity data.
+
+### Add `created_by_user_id` to `sandboxes`
+
+Viable, but less directly tied to the credential being introspected. The
+contract asks what identity a `proxy_token` represents; storing lineage on
+`proxy_tokens` keeps the credential as the source of truth and naturally
+supports future token rotation.
+
+### Extend `/internal/validate-proxy-token`
+
+Rejected. That endpoint is unauthenticated internal surface and is already used
+by llmproxy and credentialproxy. Adding auth plus expanding the response would
+couple unrelated callers and risk breaking existing integrations.
+
+## Testing
+
+Add focused handler / DB integration tests:
+
+- Valid sandbox proxy token with recorded user lineage returns 200 and exactly
+  the six response fields.
+- Missing header returns `401 unauthorized`.
+- Malformed bearer returns `401 unauthorized`.
+- Unknown token returns `401 unauthorized`.
+- Workspace-scoped token returns `401 unauthorized`.
+- `tunnel_token` returns `401 unauthorized`.
+- Suspended statuses such as `paused`, `offline`, `deleting`, or `pausing`
+  return `403 forbidden`.
+- Legacy sandbox proxy token with null `user_id` returns `403 forbidden`.
+- Removing the recorded workspace member returns `403 forbidden`.
+- Response does not include token, upstream credentials, expiry, or TTL fields.
+
+Run at minimum:
+
+```bash
+go test ./internal/server ./internal/db
+make openapi-check
+make api-docs-check
+```
+
+## Rollout
+
+1. Deploy schema migration with nullable `proxy_tokens.user_id`.
+2. Deploy server changes that write `user_id` for new sandbox proxy tokens.
+3. Deploy whoami endpoint.
+4. Update observer to call whoami and treat 5xx as upstream unavailable.
+5. Re-register or recreate any legacy agents that need observer integration.
+
+No coordinated change is required for llmproxy or credentialproxy because
+`/internal/validate-proxy-token` remains unchanged.

--- a/docs/superpowers/specs/2026-06-04-agent-whoami-identity-design.md
+++ b/docs/superpowers/specs/2026-06-04-agent-whoami-identity-design.md
@@ -15,6 +15,7 @@ agentserver-issued sandbox `proxy_token` to the identity tuple:
   "workspace_name": "Alice's Workspace",
   "sandbox_id": "sbx_456",
   "short_id": "alice-driver-01",
+  "display_name": "Alice Driver",
   "role": "developer"
 }
 ```
@@ -46,8 +47,9 @@ proxy token are created. Web-created sandboxes have the session user in request
 context, but that user is also not persisted into token lineage.
 
 This means agentserver can currently resolve `workspace_id`, `sandbox_id`,
-`short_id`, sandbox status, and workspace name from a proxy token, but cannot
-reliably resolve `user_id` or `workspace_members.role`.
+`short_id`, sandbox status, sandbox name, card display name, and workspace name
+from a proxy token, but cannot reliably resolve `user_id` or
+`workspace_members.role`.
 
 ## Goals
 
@@ -55,7 +57,7 @@ reliably resolve `user_id` or `workspace_members.role`.
   introspection.
 - Make agentserver the source of truth for observer's user / workspace /
   sandbox identity mapping.
-- Return exactly the six documented fields.
+- Return exactly the seven documented fields.
 - Do not return secrets or token expiry / TTL information.
 - Do not extend `/internal/validate-proxy-token`.
 - Avoid accepting `tunnel_token` or workspace-scoped tokens for this endpoint.
@@ -129,9 +131,10 @@ It should:
 2. Require `token_type = 'sandbox'`.
 3. Require a non-null `sandbox_id` and `user_id`.
 4. Join to `sandboxes`, `workspaces`, and `workspace_members`.
-5. Require `workspace_members.workspace_id = proxy_tokens.workspace_id`.
-6. Require `workspace_members.user_id = proxy_tokens.user_id`.
-7. Return the sandbox status for handler-side lifecycle gating.
+5. Left join `agent_cards` on `agent_cards.sandbox_id = sandboxes.id`.
+6. Require `workspace_members.workspace_id = proxy_tokens.workspace_id`.
+7. Require `workspace_members.user_id = proxy_tokens.user_id`.
+8. Return the sandbox status for handler-side lifecycle gating.
 
 Do not use `GetSandboxByAnyToken`, because that accepts `tunnel_token`.
 
@@ -151,12 +154,21 @@ Successful response:
   "workspace_name": "Alice's Workspace",
   "sandbox_id": "sbx_456",
   "short_id": "alice-driver-01",
+  "display_name": "Alice Driver",
   "role": "developer"
 }
 ```
 
-`workspace_name` and `short_id` should serialize as empty strings when the
-database value is empty or null.
+`workspace_name`, `short_id`, and `display_name` should serialize as empty
+strings when the database value is empty or null. `display_name` is the
+human-facing agent name and should be resolved as:
+
+```sql
+COALESCE(agent_cards.display_name, sandboxes.name, '')
+```
+
+This prefers the capability card's display name when present and falls back to
+the sandbox name for agents that have not registered a card.
 
 The response should set:
 
@@ -244,7 +256,7 @@ couple unrelated callers and risk breaking existing integrations.
 Add focused handler / DB integration tests:
 
 - Valid sandbox proxy token with recorded user lineage returns 200 and exactly
-  the six response fields.
+  the seven response fields.
 - Missing header returns `401 unauthorized`.
 - Malformed bearer returns `401 unauthorized`.
 - Unknown token returns `401 unauthorized`.

--- a/internal/db/agent_whoami.go
+++ b/internal/db/agent_whoami.go
@@ -1,0 +1,78 @@
+package db
+
+import (
+	"database/sql"
+	"fmt"
+)
+
+type AgentWhoamiLookupState string
+
+const (
+	AgentWhoamiOK        AgentWhoamiLookupState = "ok"
+	AgentWhoamiUnknown   AgentWhoamiLookupState = "unknown"
+	AgentWhoamiForbidden AgentWhoamiLookupState = "forbidden"
+)
+
+type AgentWhoami struct {
+	UserID        string
+	WorkspaceID   string
+	WorkspaceName string
+	SandboxID     string
+	ShortID       string
+	DisplayName   string
+	Role          string
+	SandboxStatus string
+}
+
+func (db *DB) GetAgentWhoamiByProxyToken(token string) (*AgentWhoami, AgentWhoamiLookupState, error) {
+	pt := &ProxyToken{}
+	err := db.QueryRow(
+		`SELECT token, token_type, sandbox_id, workspace_id, user_id
+		   FROM proxy_tokens WHERE token = $1`, token,
+	).Scan(&pt.Token, &pt.TokenType, &pt.SandboxID, &pt.WorkspaceID, &pt.UserID)
+	if err == sql.ErrNoRows {
+		return nil, AgentWhoamiUnknown, nil
+	}
+	if err != nil {
+		return nil, "", fmt.Errorf("get whoami proxy token: %w", err)
+	}
+	if pt.TokenType != ProxyTokenSandbox || !pt.SandboxID.Valid {
+		return nil, AgentWhoamiUnknown, nil
+	}
+	if !pt.UserID.Valid || pt.UserID.String == "" {
+		return nil, AgentWhoamiForbidden, nil
+	}
+
+	out := &AgentWhoami{}
+	err = db.QueryRow(
+		`SELECT pt.user_id,
+		        pt.workspace_id,
+		        w.name,
+		        s.id,
+		        COALESCE(s.short_id, ''),
+		        COALESCE(NULLIF(ac.display_name, ''), s.name, ''),
+		        wm.role,
+		        s.status
+		   FROM proxy_tokens pt
+		   JOIN sandboxes s
+		     ON s.id = pt.sandbox_id
+		    AND s.workspace_id = pt.workspace_id
+		   JOIN workspaces w
+		     ON w.id = pt.workspace_id
+		   JOIN workspace_members wm
+		     ON wm.workspace_id = pt.workspace_id
+		    AND wm.user_id = pt.user_id
+		   LEFT JOIN agent_cards ac
+		     ON ac.sandbox_id = s.id
+		  WHERE pt.token = $1
+		    AND pt.token_type = 'sandbox'
+		    AND pt.user_id IS NOT NULL`, token,
+	).Scan(&out.UserID, &out.WorkspaceID, &out.WorkspaceName, &out.SandboxID, &out.ShortID, &out.DisplayName, &out.Role, &out.SandboxStatus)
+	if err == sql.ErrNoRows {
+		return nil, AgentWhoamiForbidden, nil
+	}
+	if err != nil {
+		return nil, "", fmt.Errorf("get agent whoami: %w", err)
+	}
+	return out, AgentWhoamiOK, nil
+}

--- a/internal/db/agent_whoami.go
+++ b/internal/db/agent_whoami.go
@@ -25,16 +25,12 @@ type AgentWhoami struct {
 }
 
 func (db *DB) GetAgentWhoamiByProxyToken(token string) (*AgentWhoami, AgentWhoamiLookupState, error) {
-	pt := &ProxyToken{}
-	err := db.QueryRow(
-		`SELECT token, token_type, sandbox_id, workspace_id, user_id
-		   FROM proxy_tokens WHERE token = $1`, token,
-	).Scan(&pt.Token, &pt.TokenType, &pt.SandboxID, &pt.WorkspaceID, &pt.UserID)
-	if err == sql.ErrNoRows {
-		return nil, AgentWhoamiUnknown, nil
-	}
+	pt, err := db.GetProxyToken(token)
 	if err != nil {
 		return nil, "", fmt.Errorf("get whoami proxy token: %w", err)
+	}
+	if pt == nil {
+		return nil, AgentWhoamiUnknown, nil
 	}
 	if pt.TokenType != ProxyTokenSandbox || !pt.SandboxID.Valid {
 		return nil, AgentWhoamiUnknown, nil

--- a/internal/db/migrations/034_proxy_token_user_id.sql
+++ b/internal/db/migrations/034_proxy_token_user_id.sql
@@ -1,0 +1,10 @@
+ALTER TABLE proxy_tokens
+  ADD COLUMN IF NOT EXISTS user_id TEXT REFERENCES users(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_proxy_tokens_user
+  ON proxy_tokens (user_id)
+  WHERE user_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_proxy_tokens_workspace_user
+  ON proxy_tokens (workspace_id, user_id)
+  WHERE user_id IS NOT NULL;

--- a/internal/db/proxy_tokens.go
+++ b/internal/db/proxy_tokens.go
@@ -25,6 +25,7 @@ type ProxyToken struct {
 	TokenType   ProxyTokenType
 	SandboxID   sql.NullString
 	WorkspaceID string
+	UserID      sql.NullString
 }
 
 // GetProxyToken looks up a token in the unified proxy_tokens table. Returns
@@ -33,9 +34,9 @@ type ProxyToken struct {
 func (db *DB) GetProxyToken(token string) (*ProxyToken, error) {
 	pt := &ProxyToken{}
 	err := db.QueryRow(
-		`SELECT token, token_type, sandbox_id, workspace_id
+		`SELECT token, token_type, sandbox_id, workspace_id, user_id
 		   FROM proxy_tokens WHERE token = $1`, token,
-	).Scan(&pt.Token, &pt.TokenType, &pt.SandboxID, &pt.WorkspaceID)
+	).Scan(&pt.Token, &pt.TokenType, &pt.SandboxID, &pt.WorkspaceID, &pt.UserID)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -48,15 +49,15 @@ func (db *DB) GetProxyToken(token string) (*ProxyToken, error) {
 // CreateSandboxProxyToken inserts a sandbox-scoped row into proxy_tokens.
 // CreateSandbox / CreateLocalSandbox call this in the same DB session as the
 // sandbox INSERT so the two tables stay in lockstep.
-func (db *DB) CreateSandboxProxyToken(token, sandboxID, workspaceID string) error {
+func (db *DB) CreateSandboxProxyToken(token, sandboxID, workspaceID, userID string) error {
 	if token == "" {
 		return nil
 	}
 	_, err := db.Exec(
-		`INSERT INTO proxy_tokens (token, token_type, sandbox_id, workspace_id)
-		 VALUES ($1, 'sandbox', $2, $3)
+		`INSERT INTO proxy_tokens (token, token_type, sandbox_id, workspace_id, user_id)
+		 VALUES ($1, 'sandbox', $2, $3, NULLIF($4, ''))
 		 ON CONFLICT (token) DO NOTHING`,
-		token, sandboxID, workspaceID,
+		token, sandboxID, workspaceID, userID,
 	)
 	if err != nil {
 		return fmt.Errorf("create sandbox proxy token: %w", err)

--- a/internal/db/sandboxes.go
+++ b/internal/db/sandboxes.go
@@ -8,31 +8,31 @@ import (
 )
 
 type Sandbox struct {
-	ID              string
-	WorkspaceID     string
-	Name            string
-	Type            string
-	Status          string
-	IsLocal         bool
-	ShortID         sql.NullString
-	SandboxName     sql.NullString
-	PodIP           sql.NullString
-	ProxyToken      sql.NullString
-	OpencodeToken   sql.NullString
-	OpenclawToken   sql.NullString
-	TunnelToken              sql.NullString
-	NanoclawBridgeSecret     sql.NullString
-	LastActivityAt  sql.NullTime
-	CreatedAt       time.Time
-	PausedAt        sql.NullTime
-	LastHeartbeatAt sql.NullTime
-	CPU         *int
-	Memory      *int64
-	IdleTimeout *int
-	Metadata    json.RawMessage
+	ID                   string
+	WorkspaceID          string
+	Name                 string
+	Type                 string
+	Status               string
+	IsLocal              bool
+	ShortID              sql.NullString
+	SandboxName          sql.NullString
+	PodIP                sql.NullString
+	ProxyToken           sql.NullString
+	OpencodeToken        sql.NullString
+	OpenclawToken        sql.NullString
+	TunnelToken          sql.NullString
+	NanoclawBridgeSecret sql.NullString
+	LastActivityAt       sql.NullTime
+	CreatedAt            time.Time
+	PausedAt             sql.NullTime
+	LastHeartbeatAt      sql.NullTime
+	CPU                  *int
+	Memory               *int64
+	IdleTimeout          *int
+	Metadata             json.RawMessage
 }
 
-func (db *DB) CreateSandbox(id, workspaceID, name, sandboxType, sandboxName, opencodeToken, proxyToken, openclawToken, shortID string, cpu int, memory int64, idleTimeout *int, metadata json.RawMessage) error {
+func (db *DB) CreateSandbox(id, workspaceID, userID, name, sandboxType, sandboxName, opencodeToken, proxyToken, openclawToken, shortID string, cpu int, memory int64, idleTimeout *int, metadata json.RawMessage) error {
 	if len(metadata) == 0 {
 		metadata = json.RawMessage("{}")
 	}
@@ -51,9 +51,9 @@ func (db *DB) CreateSandbox(id, workspaceID, name, sandboxType, sandboxName, ope
 	}
 	if proxyToken != "" {
 		if _, err := tx.Exec(
-			`INSERT INTO proxy_tokens (token, token_type, sandbox_id, workspace_id)
-			 VALUES ($1, 'sandbox', $2, $3) ON CONFLICT (token) DO NOTHING`,
-			proxyToken, id, workspaceID,
+			`INSERT INTO proxy_tokens (token, token_type, sandbox_id, workspace_id, user_id)
+			 VALUES ($1, 'sandbox', $2, $3, NULLIF($4, '')) ON CONFLICT (token) DO NOTHING`,
+			proxyToken, id, workspaceID, userID,
 		); err != nil {
 			return fmt.Errorf("create sandbox proxy token: %w", err)
 		}
@@ -273,7 +273,7 @@ func nullIfEmpty(s string) interface{} {
 }
 
 // CreateLocalSandbox inserts a local agent sandbox with is_local=true.
-func (db *DB) CreateLocalSandbox(id, workspaceID, name, sandboxType, opencodeToken, proxyToken, tunnelToken, shortID string) error {
+func (db *DB) CreateLocalSandbox(id, workspaceID, userID, name, sandboxType, opencodeToken, proxyToken, tunnelToken, shortID string) error {
 	tx, err := db.Begin()
 	if err != nil {
 		return fmt.Errorf("begin tx: %w", err)
@@ -289,9 +289,9 @@ func (db *DB) CreateLocalSandbox(id, workspaceID, name, sandboxType, opencodeTok
 	}
 	if proxyToken != "" {
 		if _, err := tx.Exec(
-			`INSERT INTO proxy_tokens (token, token_type, sandbox_id, workspace_id)
-			 VALUES ($1, 'sandbox', $2, $3) ON CONFLICT (token) DO NOTHING`,
-			proxyToken, id, workspaceID,
+			`INSERT INTO proxy_tokens (token, token_type, sandbox_id, workspace_id, user_id)
+			 VALUES ($1, 'sandbox', $2, $3, NULLIF($4, '')) ON CONFLICT (token) DO NOTHING`,
+			proxyToken, id, workspaceID, userID,
 		); err != nil {
 			return fmt.Errorf("create local sandbox proxy token: %w", err)
 		}

--- a/internal/sbxstore/store.go
+++ b/internal/sbxstore/store.go
@@ -9,28 +9,28 @@ import (
 
 // Sandbox represents a sandbox with its current state.
 type Sandbox struct {
-	ID              string     `json:"id"`
-	ShortID         string     `json:"short_id,omitempty"`
-	WorkspaceID     string     `json:"workspace_id"`
-	Name            string     `json:"name"`
-	Type            string     `json:"type"`
-	Status          string     `json:"status"`
-	SandboxName     string     `json:"sandbox_name,omitempty"`
-	PodIP           string     `json:"pod_ip,omitempty"`
-	ProxyToken      string     `json:"-"`
-	OpencodeToken   string     `json:"-"`
-	OpenclawToken        string     `json:"-"`
-	NanoclawBridgeSecret string     `json:"-"`
-	TunnelToken          string     `json:"-"`
-	CreatedAt       time.Time  `json:"created_at"`
-	LastActivityAt  *time.Time `json:"last_activity_at,omitempty"`
-	PausedAt        *time.Time `json:"paused_at,omitempty"`
-	IsLocal         bool       `json:"is_local"`
-	LastHeartbeatAt *time.Time `json:"last_heartbeat_at,omitempty"`
-	CPU             int                    `json:"cpu,omitempty"`
-	Memory          int64                  `json:"memory,omitempty"`
-	IdleTimeout     *int                   `json:"idle_timeout,omitempty"`
-	Metadata        map[string]interface{} `json:"metadata,omitempty"`
+	ID                   string                 `json:"id"`
+	ShortID              string                 `json:"short_id,omitempty"`
+	WorkspaceID          string                 `json:"workspace_id"`
+	Name                 string                 `json:"name"`
+	Type                 string                 `json:"type"`
+	Status               string                 `json:"status"`
+	SandboxName          string                 `json:"sandbox_name,omitempty"`
+	PodIP                string                 `json:"pod_ip,omitempty"`
+	ProxyToken           string                 `json:"-"`
+	OpencodeToken        string                 `json:"-"`
+	OpenclawToken        string                 `json:"-"`
+	NanoclawBridgeSecret string                 `json:"-"`
+	TunnelToken          string                 `json:"-"`
+	CreatedAt            time.Time              `json:"created_at"`
+	LastActivityAt       *time.Time             `json:"last_activity_at,omitempty"`
+	PausedAt             *time.Time             `json:"paused_at,omitempty"`
+	IsLocal              bool                   `json:"is_local"`
+	LastHeartbeatAt      *time.Time             `json:"last_heartbeat_at,omitempty"`
+	CPU                  int                    `json:"cpu,omitempty"`
+	Memory               int64                  `json:"memory,omitempty"`
+	IdleTimeout          *int                   `json:"idle_timeout,omitempty"`
+	Metadata             map[string]interface{} `json:"metadata,omitempty"`
 }
 
 // Store manages sandboxes via PostgreSQL.
@@ -43,33 +43,33 @@ func NewStore(database *db.DB) *Store {
 }
 
 // Create inserts a new sandbox into the DB with 'creating' status.
-func (s *Store) Create(id, workspaceID, name, sandboxType, sandboxName, opencodeToken, proxyToken, openclawToken, shortID string, cpu int, memory int64, idleTimeout *int, metadata map[string]interface{}) (*Sandbox, error) {
+func (s *Store) Create(id, workspaceID, userID, name, sandboxType, sandboxName, opencodeToken, proxyToken, openclawToken, shortID string, cpu int, memory int64, idleTimeout *int, metadata map[string]interface{}) (*Sandbox, error) {
 	var metaJSON json.RawMessage
 	if len(metadata) > 0 {
 		metaJSON, _ = json.Marshal(metadata)
 	}
-	if err := s.db.CreateSandbox(id, workspaceID, name, sandboxType, sandboxName, opencodeToken, proxyToken, openclawToken, shortID, cpu, memory, idleTimeout, metaJSON); err != nil {
+	if err := s.db.CreateSandbox(id, workspaceID, userID, name, sandboxType, sandboxName, opencodeToken, proxyToken, openclawToken, shortID, cpu, memory, idleTimeout, metaJSON); err != nil {
 		return nil, err
 	}
 
 	now := time.Now()
 	return &Sandbox{
-		ID:               id,
-		ShortID:          shortID,
-		WorkspaceID:      workspaceID,
-		Name:             name,
-		Type:             sandboxType,
-		Status:           StatusCreating,
-		SandboxName:      sandboxName,
-		OpencodeToken: opencodeToken,
-		ProxyToken:    proxyToken,
-		OpenclawToken: openclawToken,
-		CreatedAt:        now,
-		LastActivityAt:   &now,
-		CPU:              cpu,
-		Memory:           memory,
-		IdleTimeout:      idleTimeout,
-		Metadata:         metadata,
+		ID:             id,
+		ShortID:        shortID,
+		WorkspaceID:    workspaceID,
+		Name:           name,
+		Type:           sandboxType,
+		Status:         StatusCreating,
+		SandboxName:    sandboxName,
+		OpencodeToken:  opencodeToken,
+		ProxyToken:     proxyToken,
+		OpenclawToken:  openclawToken,
+		CreatedAt:      now,
+		LastActivityAt: &now,
+		CPU:            cpu,
+		Memory:         memory,
+		IdleTimeout:    idleTimeout,
+		Metadata:       metadata,
 	}, nil
 }
 

--- a/internal/server/agent_register.go
+++ b/internal/server/agent_register.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/google/uuid"
 	"github.com/agentserver/agentserver/internal/shortid"
+	"github.com/google/uuid"
 )
 
 // handleAgentRegister processes a CLI agent registration using an OAuth Bearer token.
@@ -120,7 +120,7 @@ func (s *Server) handleAgentRegister(w http.ResponseWriter, r *http.Request) {
 	sid := shortid.Generate()
 	var createErr error
 	for attempts := 0; attempts < 3; attempts++ {
-		createErr = s.DB.CreateLocalSandbox(sandboxID, workspaceID, req.Name, sandboxType, opencodePassword, proxyToken, tunnelToken, sid)
+		createErr = s.DB.CreateLocalSandbox(sandboxID, workspaceID, userID, req.Name, sandboxType, opencodePassword, proxyToken, tunnelToken, sid)
 		if createErr == nil {
 			break
 		}

--- a/internal/server/agent_whoami.go
+++ b/internal/server/agent_whoami.go
@@ -1,0 +1,76 @@
+package server
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/agentserver/agentserver/internal/db"
+)
+
+func strictBearerToken(r *http.Request) (string, bool) {
+	authz := r.Header.Get("Authorization")
+	if !strings.HasPrefix(authz, "Bearer ") {
+		return "", false
+	}
+	token := strings.TrimSpace(strings.TrimPrefix(authz, "Bearer "))
+	if token == "" {
+		return "", false
+	}
+	return token, true
+}
+
+func activeWhoamiSandboxStatus(status string) bool {
+	return status == "creating" || status == "running"
+}
+
+// handleAgentWhoami returns the identity represented by a sandbox proxy_token.
+// GET /api/agent/whoami
+//
+//	@Summary   Inspect the calling agent identity (proxy_token auth)
+//	@Tags      Agent
+//	@Produce   json
+//	@Success   200  {object}  AgentWhoamiResponse
+//	@Failure   401  {string}  string  "unauthorized"
+//	@Failure   403  {string}  string  "forbidden"
+//	@Failure   500  {string}  string  "internal error"
+//	@Router    /api/agent/whoami [get]
+func (s *Server) handleAgentWhoami(w http.ResponseWriter, r *http.Request) {
+	token, ok := strictBearerToken(r)
+	if !ok {
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	}
+
+	who, state, err := s.DB.GetAgentWhoamiByProxyToken(token)
+	if err != nil {
+		log.Printf("agent whoami: %v", err)
+		http.Error(w, "internal error", http.StatusInternalServerError)
+		return
+	}
+	switch state {
+	case db.AgentWhoamiUnknown:
+		http.Error(w, "unauthorized", http.StatusUnauthorized)
+		return
+	case db.AgentWhoamiForbidden:
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+	if who == nil || !activeWhoamiSandboxStatus(who.SandboxStatus) {
+		http.Error(w, "forbidden", http.StatusForbidden)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "no-store")
+	json.NewEncoder(w).Encode(AgentWhoamiResponse{
+		UserID:        who.UserID,
+		WorkspaceID:   who.WorkspaceID,
+		WorkspaceName: who.WorkspaceName,
+		SandboxID:     who.SandboxID,
+		ShortID:       who.ShortID,
+		DisplayName:   who.DisplayName,
+		Role:          who.Role,
+	})
+}

--- a/internal/server/agent_whoami_test.go
+++ b/internal/server/agent_whoami_test.go
@@ -1,0 +1,215 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func newWhoamiTestServer(t *testing.T) *Server {
+	t.Helper()
+	d := newCodexTestDBForServer(t)
+	t.Cleanup(func() {
+		d.Exec(`DELETE FROM agent_cards`)
+		d.Exec(`DELETE FROM proxy_tokens`)
+		d.Exec(`DELETE FROM sandboxes`)
+		d.Exec(`DELETE FROM workspace_members`)
+		d.Exec(`DELETE FROM workspaces`)
+		d.Exec(`DELETE FROM users`)
+	})
+	return &Server{DB: d}
+}
+
+func seedWhoamiSandbox(t *testing.T, srv *Server, token, tunnelToken, status, role, displayName string, withUser bool) {
+	t.Helper()
+	seedWorkspaceMember(t, srv.DB, "ws_whoami", "u_whoami", role)
+	if _, err := srv.DB.Exec(
+		`INSERT INTO sandboxes (id, workspace_id, name, type, status, proxy_token, tunnel_token, short_id)
+		 VALUES ('sbx_whoami', 'ws_whoami', 'Sandbox Name', 'custom', $1, $2, $3, 'short-whoami')
+		 ON CONFLICT (id) DO UPDATE SET status = EXCLUDED.status, proxy_token = EXCLUDED.proxy_token, tunnel_token = EXCLUDED.tunnel_token`,
+		status, token, tunnelToken,
+	); err != nil {
+		t.Fatalf("insert sandbox: %v", err)
+	}
+	userID := any(nil)
+	if withUser {
+		userID = "u_whoami"
+	}
+	if _, err := srv.DB.Exec(
+		`INSERT INTO proxy_tokens (token, token_type, sandbox_id, workspace_id, user_id)
+		 VALUES ($1, 'sandbox', 'sbx_whoami', 'ws_whoami', $2)
+		 ON CONFLICT (token) DO UPDATE SET user_id = EXCLUDED.user_id`,
+		token, userID,
+	); err != nil {
+		t.Fatalf("insert proxy token: %v", err)
+	}
+	if displayName != "" {
+		if _, err := srv.DB.Exec(
+			`INSERT INTO agent_cards (sandbox_id, workspace_id, agent_type, display_name)
+			 VALUES ('sbx_whoami', 'ws_whoami', 'custom', $1)
+			 ON CONFLICT (sandbox_id) DO UPDATE SET display_name = EXCLUDED.display_name`,
+			displayName,
+		); err != nil {
+			t.Fatalf("insert agent card: %v", err)
+		}
+	}
+}
+
+func callWhoami(t *testing.T, srv *Server, authz string) *httptest.ResponseRecorder {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/api/agent/whoami", nil)
+	if authz != "" {
+		req.Header.Set("Authorization", authz)
+	}
+	rr := httptest.NewRecorder()
+	srv.handleAgentWhoami(rr, req)
+	return rr
+}
+
+func TestStrictBearerToken(t *testing.T) {
+	cases := []struct {
+		name      string
+		authz     string
+		wantToken string
+		wantOK    bool
+	}{
+		{"missing", "", "", false},
+		{"basic", "Basic token", "", false},
+		{"empty bearer", "Bearer ", "", false},
+		{"valid", "Bearer proxy-token", "proxy-token", true},
+		{"trims token spaces", "Bearer   proxy-token  ", "proxy-token", true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet, "/api/agent/whoami", nil)
+			if tc.authz != "" {
+				req.Header.Set("Authorization", tc.authz)
+			}
+			got, ok := strictBearerToken(req)
+			if got != tc.wantToken || ok != tc.wantOK {
+				t.Fatalf("strictBearerToken() = (%q, %v), want (%q, %v)", got, ok, tc.wantToken, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestActiveWhoamiSandboxStatus(t *testing.T) {
+	for _, status := range []string{"creating", "running"} {
+		if !activeWhoamiSandboxStatus(status) {
+			t.Fatalf("%q should be active", status)
+		}
+	}
+	for _, status := range []string{"paused", "offline", "deleting", "pausing", ""} {
+		if activeWhoamiSandboxStatus(status) {
+			t.Fatalf("%q should not be active", status)
+		}
+	}
+}
+
+func TestAgentWhoami_HappyPath(t *testing.T) {
+	srv := newWhoamiTestServer(t)
+	seedWhoamiSandbox(t, srv, "proxy-good", "tunnel-good", "running", "developer", "Display Agent", true)
+
+	rr := callWhoami(t, srv, "Bearer proxy-good")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if rr.Header().Get("Cache-Control") != "no-store" {
+		t.Fatalf("Cache-Control = %q, want no-store", rr.Header().Get("Cache-Control"))
+	}
+	var out AgentWhoamiResponse
+	if err := json.NewDecoder(rr.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.UserID != "u_whoami" || out.WorkspaceID != "ws_whoami" || out.WorkspaceName != "test ws" ||
+		out.SandboxID != "sbx_whoami" || out.ShortID != "short-whoami" ||
+		out.DisplayName != "Display Agent" || out.Role != "developer" {
+		t.Fatalf("unexpected response: %+v", out)
+	}
+}
+
+func TestAgentWhoami_UnauthorizedCases(t *testing.T) {
+	srv := newWhoamiTestServer(t)
+	seedWhoamiSandbox(t, srv, "proxy-good", "tunnel-good", "running", "developer", "", true)
+	if _, err := srv.DB.Exec(
+		`INSERT INTO proxy_tokens (token, token_type, workspace_id)
+		 VALUES ('workspace-token', 'workspace', 'ws_whoami')
+		 ON CONFLICT DO NOTHING`,
+	); err != nil {
+		t.Fatalf("insert workspace token: %v", err)
+	}
+
+	cases := []struct {
+		name  string
+		authz string
+	}{
+		{"missing", ""},
+		{"malformed", "Basic proxy-good"},
+		{"empty bearer", "Bearer "},
+		{"unknown", "Bearer nope"},
+		{"workspace token", "Bearer workspace-token"},
+		{"tunnel token", "Bearer tunnel-good"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rr := callWhoami(t, srv, tc.authz)
+			if rr.Code != http.StatusUnauthorized {
+				t.Fatalf("want 401, got %d: %s", rr.Code, rr.Body.String())
+			}
+			if rr.Body.String() != "unauthorized\n" {
+				t.Fatalf("body = %q", rr.Body.String())
+			}
+		})
+	}
+}
+
+func TestAgentWhoami_ForbiddenCases(t *testing.T) {
+	for _, status := range []string{"paused", "offline", "deleting", "pausing"} {
+		t.Run("status_"+status, func(t *testing.T) {
+			srv := newWhoamiTestServer(t)
+			seedWhoamiSandbox(t, srv, "proxy-forbidden", "tunnel-forbidden", status, "developer", "", true)
+			rr := callWhoami(t, srv, "Bearer proxy-forbidden")
+			if rr.Code != http.StatusForbidden {
+				t.Fatalf("want 403, got %d: %s", rr.Code, rr.Body.String())
+			}
+		})
+	}
+
+	t.Run("legacy_null_user", func(t *testing.T) {
+		srv := newWhoamiTestServer(t)
+		seedWhoamiSandbox(t, srv, "proxy-legacy", "tunnel-legacy", "running", "developer", "", false)
+		rr := callWhoami(t, srv, "Bearer proxy-legacy")
+		if rr.Code != http.StatusForbidden {
+			t.Fatalf("want 403, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+
+	t.Run("membership_removed", func(t *testing.T) {
+		srv := newWhoamiTestServer(t)
+		seedWhoamiSandbox(t, srv, "proxy-removed", "tunnel-removed", "running", "developer", "", true)
+		if _, err := srv.DB.Exec(`DELETE FROM workspace_members WHERE workspace_id = 'ws_whoami' AND user_id = 'u_whoami'`); err != nil {
+			t.Fatalf("delete membership: %v", err)
+		}
+		rr := callWhoami(t, srv, "Bearer proxy-removed")
+		if rr.Code != http.StatusForbidden {
+			t.Fatalf("want 403, got %d: %s", rr.Code, rr.Body.String())
+		}
+	})
+}
+
+func TestAgentWhoami_DisplayNameFallsBackToSandboxName(t *testing.T) {
+	srv := newWhoamiTestServer(t)
+	seedWhoamiSandbox(t, srv, "proxy-fallback", "tunnel-fallback", "running", "developer", "", true)
+	rr := callWhoami(t, srv, "Bearer proxy-fallback")
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+	var out AgentWhoamiResponse
+	if err := json.NewDecoder(rr.Body).Decode(&out); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if out.DisplayName != "Sandbox Name" {
+		t.Fatalf("display_name = %q, want Sandbox Name", out.DisplayName)
+	}
+}

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -82,9 +82,9 @@ type MemberRoleUpdateRequest struct {
 // LLMWorkspaceQuotaPart is the per-workspace quota override stored in the
 // LLM proxy DB. max_rpd is null when no custom limit is configured.
 type LLMWorkspaceQuotaPart struct {
-	WorkspaceID string  `json:"workspace_id" validate:"required"`
-	MaxRPD      *int    `json:"max_rpd" extensions:"x-nullable=true"`
-	UpdatedAt   string  `json:"updated_at" validate:"required"`
+	WorkspaceID string `json:"workspace_id" validate:"required"`
+	MaxRPD      *int   `json:"max_rpd" extensions:"x-nullable=true"`
+	UpdatedAt   string `json:"updated_at" validate:"required"`
 } // @name LLMWorkspaceQuotaPart
 
 // LLMQuotaResponse mirrors the body the LLM proxy returns from its
@@ -135,11 +135,11 @@ type LLMConfigUpsertResponse struct {
 // All fields except name are optional and fall back to workspace/server defaults.
 type SandboxCreateRequest struct {
 	Name        string                 `json:"name" validate:"required" example:"my-sandbox"`
-	Type        string                 `json:"type" example:"opencode"`    // optional; default "opencode"
-	CPU         *int                   `json:"cpu"`                        // optional; millicores, e.g. 500 or 2000
-	Memory      *int64                 `json:"memory"`                     // optional; bytes, e.g. 536870912 (512Mi)
-	IdleTimeout *int                   `json:"idle_timeout"`               // optional; seconds
-	Metadata    map[string]interface{} `json:"metadata"`                   // optional; arbitrary key-value metadata
+	Type        string                 `json:"type" example:"opencode"` // optional; default "opencode"
+	CPU         *int                   `json:"cpu"`                     // optional; millicores, e.g. 500 or 2000
+	Memory      *int64                 `json:"memory"`                  // optional; bytes, e.g. 536870912 (512Mi)
+	IdleTimeout *int                   `json:"idle_timeout"`            // optional; seconds
+	Metadata    map[string]interface{} `json:"metadata"`                // optional; arbitrary key-value metadata
 } // @name SandboxCreateRequest
 
 // SandboxRenameRequest is the body for PATCH /api/sandboxes/{id}.
@@ -223,12 +223,12 @@ type IMWeixinQRStartResponse struct {
 // qrcode_url is only present when status is "expired" (new QR code generated).
 // bot_id and user_id are only present when status is "confirmed".
 type IMWeixinQRWaitResponse struct {
-	Connected  bool    `json:"connected" validate:"required"`
-	Status     string  `json:"status" validate:"required" example:"wait"`
-	Message    *string `json:"message,omitempty" extensions:"x-nullable=true"`
-	QRCodeURL  *string `json:"qrcode_url,omitempty" extensions:"x-nullable=true"`
-	BotID      *string `json:"bot_id,omitempty" extensions:"x-nullable=true"`
-	UserID     *string `json:"user_id,omitempty" extensions:"x-nullable=true"`
+	Connected bool    `json:"connected" validate:"required"`
+	Status    string  `json:"status" validate:"required" example:"wait"`
+	Message   *string `json:"message,omitempty" extensions:"x-nullable=true"`
+	QRCodeURL *string `json:"qrcode_url,omitempty" extensions:"x-nullable=true"`
+	BotID     *string `json:"bot_id,omitempty" extensions:"x-nullable=true"`
+	UserID    *string `json:"user_id,omitempty" extensions:"x-nullable=true"`
 } // @name IMWeixinQRWaitResponse
 
 // IMTelegramConfigureRequest is the body for POST .../im/telegram/configure.
@@ -325,6 +325,18 @@ type AgentRegisterResponse struct {
 	WorkspaceID string `json:"workspace_id" validate:"required"`
 	ShortID     string `json:"short_id" validate:"required"`
 } // @name AgentRegisterResponse
+
+// AgentWhoamiResponse is returned by GET /api/agent/whoami.
+// It contains the full public identity contract for a sandbox proxy token.
+type AgentWhoamiResponse struct {
+	UserID        string `json:"user_id" validate:"required" example:"u_abc123"`
+	WorkspaceID   string `json:"workspace_id" validate:"required" example:"ws_xyz789"`
+	WorkspaceName string `json:"workspace_name" validate:"required" example:"Alice's Workspace"`
+	SandboxID     string `json:"sandbox_id" validate:"required" example:"sbx_456"`
+	ShortID       string `json:"short_id" validate:"required" example:"alice-driver-01"`
+	DisplayName   string `json:"display_name" validate:"required" example:"Alice Driver"`
+	Role          string `json:"role" validate:"required" example:"developer"`
+} // @name AgentWhoamiResponse
 
 // AgentCardRegisterRequest is the body for POST /api/agent/discovery/cards.
 // card is an arbitrary JSON capability descriptor; defaults to {} when omitted.
@@ -500,13 +512,13 @@ type CodexBrowserItem struct {
 // GET /api/workspaces/{id}/credentials/{kind}.
 // public_meta is an arbitrary JSON object whose shape depends on the provider kind.
 type CredentialBindingItem struct {
-	ID          string          `json:"id" validate:"required"`
-	DisplayName string          `json:"display_name" validate:"required"`
-	ServerURL   string          `json:"server_url"`
-	AuthType    string          `json:"auth_type" validate:"required" example:"static"`
-	PublicMeta  interface{}     `json:"public_meta"`
-	IsDefault   bool            `json:"is_default"`
-	CreatedAt   string          `json:"created_at" validate:"required"`
+	ID          string      `json:"id" validate:"required"`
+	DisplayName string      `json:"display_name" validate:"required"`
+	ServerURL   string      `json:"server_url"`
+	AuthType    string      `json:"auth_type" validate:"required" example:"static"`
+	PublicMeta  interface{} `json:"public_meta"`
+	IsDefault   bool        `json:"is_default"`
+	CreatedAt   string      `json:"created_at" validate:"required"`
 } // @name CredentialBindingItem
 
 // CredentialBindingCreateRequest is the body for POST /api/workspaces/{id}/credentials/{kind}.
@@ -637,7 +649,7 @@ type ExecutorRegisterResponse struct {
 	ExeID            string                  `json:"exe_id" validate:"required"`
 	ConnectCommand   string                  `json:"connect_command,omitempty"`
 	AgentIdentityJWT string                  `json:"agent_identity_jwt,omitempty"`
-	ConnectCommands  ExecutorConnectCommands  `json:"connect_commands,omitempty"`
+	ConnectCommands  ExecutorConnectCommands `json:"connect_commands,omitempty"`
 } // @name ExecutorRegisterResponse
 
 // ModelServerStatusResponse is returned by GET /api/workspaces/{id}/modelserver/status.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -15,9 +15,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-chi/chi/v5"
-	"github.com/go-chi/chi/v5/middleware"
-	"github.com/google/uuid"
 	"github.com/agentserver/agentserver/internal/auth"
 	"github.com/agentserver/agentserver/internal/codexauth"
 	"github.com/agentserver/agentserver/internal/db"
@@ -28,25 +25,28 @@ import (
 	"github.com/agentserver/agentserver/internal/shortid"
 	"github.com/agentserver/agentserver/internal/storage"
 	"github.com/agentserver/agentserver/internal/tunnel"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/google/uuid"
 )
 
 type Server struct {
-	Auth             *auth.Auth
-	OIDC             *auth.OIDCManager
-	DB               *db.DB
-	Sandboxes        *sbxstore.Store
-	ProcessManager   process.Manager
-	DriveManager     storage.DriveManager
-	NamespaceManager *namespace.Manager
-	TunnelRegistry   *tunnel.Registry
-	StaticFS         fs.FS
-	BaseDomains              []string // e.g. ["agentserver.dev", "agent.cs.ac.cn"] (first is primary)
-	OpencodeSubdomainPrefix  string   // e.g. "code" — subdomain: code-{id}.{baseDomain}
-	OpenclawSubdomainPrefix    string // e.g. "claw" — subdomain: claw-{id}.{baseDomain}
-	ClaudeCodeSubdomainPrefix  string // e.g. "claude" — subdomain: claude-{id}.{baseDomain}
-	JupyterSubdomainPrefix     string // e.g. "jupyter" — subdomain: jupyter-{id}.{baseDomain}
-	PasswordAuthEnabled      bool   // when false, /api/auth/login and /api/auth/register are not registered
-	LLMProxyURL              string // base URL for the llmproxy service (e.g. "http://agentserver-llmproxy:8081")
+	Auth                      *auth.Auth
+	OIDC                      *auth.OIDCManager
+	DB                        *db.DB
+	Sandboxes                 *sbxstore.Store
+	ProcessManager            process.Manager
+	DriveManager              storage.DriveManager
+	NamespaceManager          *namespace.Manager
+	TunnelRegistry            *tunnel.Registry
+	StaticFS                  fs.FS
+	BaseDomains               []string // e.g. ["agentserver.dev", "agent.cs.ac.cn"] (first is primary)
+	OpencodeSubdomainPrefix   string   // e.g. "code" — subdomain: code-{id}.{baseDomain}
+	OpenclawSubdomainPrefix   string   // e.g. "claw" — subdomain: claw-{id}.{baseDomain}
+	ClaudeCodeSubdomainPrefix string   // e.g. "claude" — subdomain: claude-{id}.{baseDomain}
+	JupyterSubdomainPrefix    string   // e.g. "jupyter" — subdomain: jupyter-{id}.{baseDomain}
+	PasswordAuthEnabled       bool     // when false, /api/auth/login and /api/auth/register are not registered
+	LLMProxyURL               string   // base URL for the llmproxy service (e.g. "http://agentserver-llmproxy:8081")
 
 	// IMBridgeURL is the base URL of the standalone imbridge service
 	// (e.g. "http://agentserver-imbridge:8083"). When set, IM API routes
@@ -61,14 +61,14 @@ type Server struct {
 	ModelserverOAuthIntrospectURL string
 	ModelserverOAuthRedirectURI   string
 	ModelserverProxyURL           string
-	DatabaseURL                  string // PostgreSQL connection URL (needed for Matrix E2EE crypto DB)
+	DatabaseURL                   string // PostgreSQL connection URL (needed for Matrix E2EE crypto DB)
 
 	// Hydra OAuth2 (for agent Device Flow)
 	HydraClient    *auth.HydraClient
 	HydraPublicURL string // internal URL for reverse proxy (e.g. "http://hydra-public:4444")
 
 	// Credential proxy
-	EncryptionKey    []byte // AES-256 key for credential_bindings auth_blob
+	EncryptionKey      []byte // AES-256 key for credential_bindings auth_blob
 	CredproxyPublicURL string // URL sandboxes use to reach credentialproxy
 
 	// Codex exec gateway
@@ -397,6 +397,7 @@ func (s *Server) Router() http.Handler {
 
 	// Agent registration (auth via OAuth Bearer token).
 	r.Post("/api/agent/register", s.handleAgentRegister)
+	r.Get("/api/agent/whoami", s.handleAgentWhoami)
 
 	// Self-hosted codex 0.132+ auth shim under /codex-auth/*.
 	// All sub-routes are public — each handler resolves session itself
@@ -482,7 +483,7 @@ func (s *Server) Router() http.Handler {
 		r.Get("/api/auth/oidc/providers", func(w http.ResponseWriter, r *http.Request) {
 			w.Header().Set("Content-Type", "application/json")
 			json.NewEncoder(w).Encode(map[string]interface{}{
-				"providers":      []string{},
+				"providers":     []string{},
 				"password_auth": s.PasswordAuthEnabled,
 			})
 		})
@@ -894,25 +895,25 @@ type imBindingResponse struct {
 } // @name IMBinding
 
 type sandboxResponse struct {
-	ID              string  `json:"id" validate:"required"`
-	ShortID         string  `json:"short_id,omitempty"`
-	WorkspaceID     string  `json:"workspace_id" validate:"required"`
-	Name            string  `json:"name" validate:"required"`
-	Type            string  `json:"type" validate:"required"`
-	Status          string  `json:"status" validate:"required"`
-	OpencodeURL     string  `json:"opencode_url,omitempty"`
-	OpenclawURL     string  `json:"openclaw_url,omitempty"`
-	ClaudeCodeURL   string  `json:"claudecode_url,omitempty"`
-	JupyterURL      string  `json:"jupyter_url,omitempty"`
-	CustomURL       string  `json:"custom_url,omitempty"`
-	CreatedAt       string  `json:"created_at" validate:"required"`
-	LastActivityAt  *string `json:"last_activity_at" extensions:"x-nullable=true"`
-	PausedAt        *string `json:"paused_at" extensions:"x-nullable=true"`
-	IsLocal         bool    `json:"is_local" validate:"required"`
-	LastHeartbeatAt *string `json:"last_heartbeat_at,omitempty"`
-	CPU             int     `json:"cpu,omitempty"`
-	Memory          int64   `json:"memory,omitempty"`
-	IdleTimeout     *int    `json:"idle_timeout,omitempty"`
+	ID              string                 `json:"id" validate:"required"`
+	ShortID         string                 `json:"short_id,omitempty"`
+	WorkspaceID     string                 `json:"workspace_id" validate:"required"`
+	Name            string                 `json:"name" validate:"required"`
+	Type            string                 `json:"type" validate:"required"`
+	Status          string                 `json:"status" validate:"required"`
+	OpencodeURL     string                 `json:"opencode_url,omitempty"`
+	OpenclawURL     string                 `json:"openclaw_url,omitempty"`
+	ClaudeCodeURL   string                 `json:"claudecode_url,omitempty"`
+	JupyterURL      string                 `json:"jupyter_url,omitempty"`
+	CustomURL       string                 `json:"custom_url,omitempty"`
+	CreatedAt       string                 `json:"created_at" validate:"required"`
+	LastActivityAt  *string                `json:"last_activity_at" extensions:"x-nullable=true"`
+	PausedAt        *string                `json:"paused_at" extensions:"x-nullable=true"`
+	IsLocal         bool                   `json:"is_local" validate:"required"`
+	LastHeartbeatAt *string                `json:"last_heartbeat_at,omitempty"`
+	CPU             int                    `json:"cpu,omitempty"`
+	Memory          int64                  `json:"memory,omitempty"`
+	IdleTimeout     *int                   `json:"idle_timeout,omitempty"`
 	AgentInfo       *agentInfoResponse     `json:"agent_info,omitempty"`
 	WeixinBindings  []imBindingResponse    `json:"weixin_bindings,omitempty"`
 	IMBindings      []imBindingResponse    `json:"im_bindings,omitempty"`
@@ -1084,13 +1085,13 @@ func (s *Server) requireWorkspaceRole(w http.ResponseWriter, r *http.Request, wo
 
 // --- Workspace handlers ---
 
-//	@Summary    Get per-user workspace quota
-//	@Tags       Workspaces
-//	@Produce    json
-//	@Success    200  {object}  WorkspaceQuotaResponse
-//	@Failure    500  {string}  string  "internal error"
-//	@Security   CookieAuth
-//	@Router     /api/workspaces/quota [get]
+// @Summary    Get per-user workspace quota
+// @Tags       Workspaces
+// @Produce    json
+// @Success    200  {object}  WorkspaceQuotaResponse
+// @Failure    500  {string}  string  "internal error"
+// @Security   CookieAuth
+// @Router     /api/workspaces/quota [get]
 func (s *Server) handleGetWorkspacesQuota(w http.ResponseWriter, r *http.Request) {
 	userID := auth.UserIDFromContext(r.Context())
 	maxWs, err := s.effectiveQuota(userID)
@@ -1109,13 +1110,13 @@ func (s *Server) handleGetWorkspacesQuota(w http.ResponseWriter, r *http.Request
 	json.NewEncoder(w).Encode(WorkspaceQuotaResponse{Current: current, Max: maxWs})
 }
 
-//	@Summary    List workspaces for the current user
-//	@Tags       Workspaces
-//	@Produce    json
-//	@Success    200  {array}   Workspace
-//	@Failure    500  {string}  string  "internal error"
-//	@Security   CookieAuth
-//	@Router     /api/workspaces [get]
+// @Summary    List workspaces for the current user
+// @Tags       Workspaces
+// @Produce    json
+// @Success    200  {array}   Workspace
+// @Failure    500  {string}  string  "internal error"
+// @Security   CookieAuth
+// @Router     /api/workspaces [get]
 func (s *Server) handleListWorkspaces(w http.ResponseWriter, r *http.Request) {
 	userID := auth.UserIDFromContext(r.Context())
 	workspaces, err := s.DB.ListWorkspacesByUser(userID)
@@ -1132,18 +1133,18 @@ func (s *Server) handleListWorkspaces(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(resp)
 }
 
-//	@Summary    Create a new workspace
-//	@Description Creator is auto-added as owner. May fail with 403 if the per-user workspace quota is exceeded.
-//	@Tags       Workspaces
-//	@Accept     json
-//	@Produce    json
-//	@Param      body  body      WorkspaceCreateRequest  true  "Workspace name"
-//	@Success    201   {object}  Workspace
-//	@Failure    400   {string}  string  "bad request / empty name"
-//	@Failure    403   {string}  string  "workspace quota exceeded"
-//	@Failure    500   {string}  string  "internal error"
-//	@Security   CookieAuth
-//	@Router     /api/workspaces [post]
+// @Summary    Create a new workspace
+// @Description Creator is auto-added as owner. May fail with 403 if the per-user workspace quota is exceeded.
+// @Tags       Workspaces
+// @Accept     json
+// @Produce    json
+// @Param      body  body      WorkspaceCreateRequest  true  "Workspace name"
+// @Success    201   {object}  Workspace
+// @Failure    400   {string}  string  "bad request / empty name"
+// @Failure    403   {string}  string  "workspace quota exceeded"
+// @Failure    500   {string}  string  "internal error"
+// @Security   CookieAuth
+// @Router     /api/workspaces [post]
 func (s *Server) handleCreateWorkspace(w http.ResponseWriter, r *http.Request) {
 	userID := auth.UserIDFromContext(r.Context())
 
@@ -1217,16 +1218,16 @@ func (s *Server) handleCreateWorkspace(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(s.toWorkspaceResponse(ws))
 }
 
-//	@Summary    Get a workspace by id
-//	@Tags       Workspaces
-//	@Produce    json
-//	@Param      id  path  string  true  "Workspace id"
-//	@Success    200  {object}  Workspace
-//	@Failure    403  {string}  string  "not a member"
-//	@Failure    404  {string}  string  "workspace not found"
-//	@Failure    500  {string}  string  "internal error"
-//	@Security   CookieAuth
-//	@Router     /api/workspaces/{id} [get]
+// @Summary    Get a workspace by id
+// @Tags       Workspaces
+// @Produce    json
+// @Param      id  path  string  true  "Workspace id"
+// @Success    200  {object}  Workspace
+// @Failure    403  {string}  string  "not a member"
+// @Failure    404  {string}  string  "workspace not found"
+// @Failure    500  {string}  string  "internal error"
+// @Security   CookieAuth
+// @Router     /api/workspaces/{id} [get]
 func (s *Server) handleGetWorkspace(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	if _, ok := s.requireWorkspaceMember(w, r, id); !ok {
@@ -1243,18 +1244,18 @@ func (s *Server) handleGetWorkspace(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(s.toWorkspaceResponse(ws))
 }
 
-//	@Summary    Rename a workspace
-//	@Tags       Workspaces
-//	@Accept     json
-//	@Produce    json
-//	@Param      id    path      string                  true  "Workspace id"
-//	@Param      body  body      WorkspaceRenameRequest  true  "New name"
-//	@Success    200   {object}  Workspace
-//	@Failure    400   {string}  string  "empty name"
-//	@Failure    403   {string}  string  "owner or maintainer required"
-//	@Failure    500   {string}  string  "internal error"
-//	@Security   CookieAuth
-//	@Router     /api/workspaces/{id} [patch]
+// @Summary    Rename a workspace
+// @Tags       Workspaces
+// @Accept     json
+// @Produce    json
+// @Param      id    path      string                  true  "Workspace id"
+// @Param      body  body      WorkspaceRenameRequest  true  "New name"
+// @Success    200   {object}  Workspace
+// @Failure    400   {string}  string  "empty name"
+// @Failure    403   {string}  string  "owner or maintainer required"
+// @Failure    500   {string}  string  "internal error"
+// @Security   CookieAuth
+// @Router     /api/workspaces/{id} [patch]
 func (s *Server) handleRenameWorkspace(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	if !s.requireWorkspaceRole(w, r, id, "owner", "maintainer") {
@@ -1279,14 +1280,14 @@ func (s *Server) handleRenameWorkspace(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(s.toWorkspaceResponse(ws))
 }
 
-//	@Summary    Delete a workspace (owner only; cascades to sandboxes + namespace)
-//	@Tags       Workspaces
-//	@Param      id   path  string  true  "Workspace id"
-//	@Success    204
-//	@Failure    403  {string}  string  "owner only"
-//	@Failure    500  {string}  string  "internal error"
-//	@Security   CookieAuth
-//	@Router     /api/workspaces/{id} [delete]
+// @Summary    Delete a workspace (owner only; cascades to sandboxes + namespace)
+// @Tags       Workspaces
+// @Param      id   path  string  true  "Workspace id"
+// @Success    204
+// @Failure    403  {string}  string  "owner only"
+// @Failure    500  {string}  string  "internal error"
+// @Security   CookieAuth
+// @Router     /api/workspaces/{id} [delete]
 func (s *Server) handleDeleteWorkspace(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	if !s.requireWorkspaceRole(w, r, id, "owner") {
@@ -1350,15 +1351,15 @@ func (s *Server) handleDeleteWorkspace(w http.ResponseWriter, r *http.Request) {
 
 // --- Member handlers ---
 
-//	@Summary    List members of a workspace
-//	@Tags       Workspaces
-//	@Produce    json
-//	@Param      id  path  string  true  "Workspace id"
-//	@Success    200  {array}   WorkspaceMember
-//	@Failure    403  {string}  string  "not a member"
-//	@Failure    500  {string}  string  "internal error"
-//	@Security   CookieAuth
-//	@Router     /api/workspaces/{id}/members [get]
+// @Summary    List members of a workspace
+// @Tags       Workspaces
+// @Produce    json
+// @Param      id  path  string  true  "Workspace id"
+// @Success    200  {array}   WorkspaceMember
+// @Failure    403  {string}  string  "not a member"
+// @Failure    500  {string}  string  "internal error"
+// @Security   CookieAuth
+// @Router     /api/workspaces/{id}/members [get]
 func (s *Server) handleListMembers(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "id")
 	if _, ok := s.requireWorkspaceMember(w, r, wsID); !ok {
@@ -1393,20 +1394,20 @@ func (s *Server) handleListMembers(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(resp)
 }
 
-//	@Summary    Add a member to a workspace
-//	@Description Looks up the user by email. Default role is "developer" if omitted.
-//	@Tags       Workspaces
-//	@Accept     json
-//	@Produce    json
-//	@Param      id    path      string            true  "Workspace id"
-//	@Param      body  body      MemberAddRequest  true  "Email and optional role"
-//	@Success    201   {object}  WorkspaceMember
-//	@Failure    400   {string}  string  "bad request"
-//	@Failure    403   {string}  string  "owner or maintainer required"
-//	@Failure    404   {string}  string  "user not found"
-//	@Failure    500   {string}  string  "internal error"
-//	@Security   CookieAuth
-//	@Router     /api/workspaces/{id}/members [post]
+// @Summary    Add a member to a workspace
+// @Description Looks up the user by email. Default role is "developer" if omitted.
+// @Tags       Workspaces
+// @Accept     json
+// @Produce    json
+// @Param      id    path      string            true  "Workspace id"
+// @Param      body  body      MemberAddRequest  true  "Email and optional role"
+// @Success    201   {object}  WorkspaceMember
+// @Failure    400   {string}  string  "bad request"
+// @Failure    403   {string}  string  "owner or maintainer required"
+// @Failure    404   {string}  string  "user not found"
+// @Failure    500   {string}  string  "internal error"
+// @Security   CookieAuth
+// @Router     /api/workspaces/{id}/members [post]
 func (s *Server) handleAddMember(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "id")
 	if !s.requireWorkspaceRole(w, r, wsID, "owner", "maintainer") {
@@ -1444,18 +1445,18 @@ func (s *Server) handleAddMember(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-//	@Summary    Change a member's role (owner only)
-//	@Tags       Workspaces
-//	@Accept     json
-//	@Param      id      path  string                   true  "Workspace id"
-//	@Param      userId  path  string                   true  "User id"
-//	@Param      body    body  MemberRoleUpdateRequest  true  "New role"
-//	@Success    204
-//	@Failure    400  {string}  string  "empty role"
-//	@Failure    403  {string}  string  "owner only"
-//	@Failure    500  {string}  string  "internal error"
-//	@Security   CookieAuth
-//	@Router     /api/workspaces/{id}/members/{userId} [put]
+// @Summary    Change a member's role (owner only)
+// @Tags       Workspaces
+// @Accept     json
+// @Param      id      path  string                   true  "Workspace id"
+// @Param      userId  path  string                   true  "User id"
+// @Param      body    body  MemberRoleUpdateRequest  true  "New role"
+// @Success    204
+// @Failure    400  {string}  string  "empty role"
+// @Failure    403  {string}  string  "owner only"
+// @Failure    500  {string}  string  "internal error"
+// @Security   CookieAuth
+// @Router     /api/workspaces/{id}/members/{userId} [put]
 func (s *Server) handleUpdateMemberRole(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "id")
 	if !s.requireWorkspaceRole(w, r, wsID, "owner") {
@@ -1478,15 +1479,15 @@ func (s *Server) handleUpdateMemberRole(w http.ResponseWriter, r *http.Request) 
 	w.WriteHeader(http.StatusNoContent)
 }
 
-//	@Summary    Remove a member (owner only)
-//	@Tags       Workspaces
-//	@Param      id      path  string  true  "Workspace id"
-//	@Param      userId  path  string  true  "User id"
-//	@Success    204
-//	@Failure    403  {string}  string  "owner only"
-//	@Failure    500  {string}  string  "internal error"
-//	@Security   CookieAuth
-//	@Router     /api/workspaces/{id}/members/{userId} [delete]
+// @Summary    Remove a member (owner only)
+// @Tags       Workspaces
+// @Param      id      path  string  true  "Workspace id"
+// @Param      userId  path  string  true  "User id"
+// @Success    204
+// @Failure    403  {string}  string  "owner only"
+// @Failure    500  {string}  string  "internal error"
+// @Security   CookieAuth
+// @Router     /api/workspaces/{id}/members/{userId} [delete]
 func (s *Server) handleRemoveMember(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "id")
 	if !s.requireWorkspaceRole(w, r, wsID, "owner") {
@@ -1512,6 +1513,7 @@ func (s *Server) handleRemoveMember(w http.ResponseWriter, r *http.Request) {
 //	@Failure    500  {string}  string  "internal error"
 //	@Security   CookieAuth
 //	@Router     /api/workspaces/{id}/llm-quota [get]
+//
 // handleGetWorkspaceLLMQuota returns the LLM RPD quota for a workspace (read-only for members).
 func (s *Server) handleGetWorkspaceLLMQuota(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "id")
@@ -1530,16 +1532,16 @@ func maskAPIKey(key string) string {
 	return key[:3] + "..." + key[len(key)-4:]
 }
 
-//	@Summary    Get workspace LLM config (owner/maintainer)
-//	@Description The returned api_key is masked (first 3 + "..." + last 4). updated_at is null when no config is set.
-//	@Tags       Workspaces
-//	@Produce    json
-//	@Param      id  path  string  true  "Workspace id"
-//	@Success    200  {object}  LLMConfigResponse
-//	@Failure    403  {string}  string  "insufficient role"
-//	@Failure    500  {string}  string  "internal error"
-//	@Security   CookieAuth
-//	@Router     /api/workspaces/{id}/llm-config [get]
+// @Summary    Get workspace LLM config (owner/maintainer)
+// @Description The returned api_key is masked (first 3 + "..." + last 4). updated_at is null when no config is set.
+// @Tags       Workspaces
+// @Produce    json
+// @Param      id  path  string  true  "Workspace id"
+// @Success    200  {object}  LLMConfigResponse
+// @Failure    403  {string}  string  "insufficient role"
+// @Failure    500  {string}  string  "internal error"
+// @Security   CookieAuth
+// @Router     /api/workspaces/{id}/llm-config [get]
 func (s *Server) handleGetWorkspaceLLMConfig(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "id")
 	if !s.requireWorkspaceRole(w, r, wsID, "owner", "maintainer") {
@@ -1571,19 +1573,19 @@ func (s *Server) handleGetWorkspaceLLMConfig(w http.ResponseWriter, r *http.Requ
 	})
 }
 
-//	@Summary    Upsert workspace LLM config (owner/maintainer)
-//	@Description On update, omitting api_key retains the existing key.
-//	@Tags       Workspaces
-//	@Accept     json
-//	@Produce    json
-//	@Param      id    path      string                  true  "Workspace id"
-//	@Param      body  body      LLMConfigUpsertRequest  true  "Config payload"
-//	@Success    200   {object}  LLMConfigUpsertResponse
-//	@Failure    400   {string}  string  "validation error (invalid URL / missing field / too many models)"
-//	@Failure    403   {string}  string  "insufficient role"
-//	@Failure    500   {string}  string  "internal error"
-//	@Security   CookieAuth
-//	@Router     /api/workspaces/{id}/llm-config [put]
+// @Summary    Upsert workspace LLM config (owner/maintainer)
+// @Description On update, omitting api_key retains the existing key.
+// @Tags       Workspaces
+// @Accept     json
+// @Produce    json
+// @Param      id    path      string                  true  "Workspace id"
+// @Param      body  body      LLMConfigUpsertRequest  true  "Config payload"
+// @Success    200   {object}  LLMConfigUpsertResponse
+// @Failure    400   {string}  string  "validation error (invalid URL / missing field / too many models)"
+// @Failure    403   {string}  string  "insufficient role"
+// @Failure    500   {string}  string  "internal error"
+// @Security   CookieAuth
+// @Router     /api/workspaces/{id}/llm-config [put]
 func (s *Server) handleSetWorkspaceLLMConfig(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "id")
 	if !s.requireWorkspaceRole(w, r, wsID, "owner", "maintainer") {
@@ -1640,14 +1642,14 @@ func (s *Server) handleSetWorkspaceLLMConfig(w http.ResponseWriter, r *http.Requ
 	json.NewEncoder(w).Encode(LLMConfigUpsertResponse{OK: true})
 }
 
-//	@Summary    Delete workspace LLM config (owner/maintainer)
-//	@Tags       Workspaces
-//	@Param      id  path  string  true  "Workspace id"
-//	@Success    204
-//	@Failure    403  {string}  string  "insufficient role"
-//	@Failure    500  {string}  string  "internal error"
-//	@Security   CookieAuth
-//	@Router     /api/workspaces/{id}/llm-config [delete]
+// @Summary    Delete workspace LLM config (owner/maintainer)
+// @Tags       Workspaces
+// @Param      id  path  string  true  "Workspace id"
+// @Success    204
+// @Failure    403  {string}  string  "insufficient role"
+// @Failure    500  {string}  string  "internal error"
+// @Security   CookieAuth
+// @Router     /api/workspaces/{id}/llm-config [delete]
 func (s *Server) handleDeleteWorkspaceLLMConfig(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "id")
 	if !s.requireWorkspaceRole(w, r, wsID, "owner", "maintainer") {
@@ -1663,16 +1665,16 @@ func (s *Server) handleDeleteWorkspaceLLMConfig(w http.ResponseWriter, r *http.R
 
 // --- Sandbox handlers ---
 
-//	@Summary   Get workspace quota defaults and current sandbox count
-//	@Tags      Misc
-//	@Produce   json
-//	@Param     wid  path  string  true  "Workspace ID"
-//	@Success   200  {object}  WorkspaceDefaultsResponse
-//	@Failure   401  {string}  string  "unauthorized"
-//	@Failure   403  {string}  string  "insufficient role"
-//	@Failure   500  {string}  string  "internal error"
-//	@Security  CookieAuth
-//	@Router    /api/workspaces/{wid}/defaults [get]
+// @Summary   Get workspace quota defaults and current sandbox count
+// @Tags      Misc
+// @Produce   json
+// @Param     wid  path  string  true  "Workspace ID"
+// @Success   200  {object}  WorkspaceDefaultsResponse
+// @Failure   401  {string}  string  "unauthorized"
+// @Failure   403  {string}  string  "insufficient role"
+// @Failure   500  {string}  string  "internal error"
+// @Security  CookieAuth
+// @Router    /api/workspaces/{wid}/defaults [get]
 func (s *Server) handleGetWorkspaceDefaults(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "wid")
 	if !s.requireWorkspaceRole(w, r, wsID, "owner", "maintainer", "developer") {
@@ -1703,15 +1705,15 @@ func (s *Server) handleGetWorkspaceDefaults(w http.ResponseWriter, r *http.Reque
 	})
 }
 
-//	@Summary   List sandboxes in a workspace
-//	@Tags      Sandboxes
-//	@Produce   json
-//	@Param     wid  path  string  true  "Workspace id"
-//	@Success   200  {array}   Sandbox
-//	@Failure   403  {string}  string  "not a member"
-//	@Failure   500  {string}  string  "internal error"
-//	@Security  CookieAuth
-//	@Router    /api/workspaces/{wid}/sandboxes [get]
+// @Summary   List sandboxes in a workspace
+// @Tags      Sandboxes
+// @Produce   json
+// @Param     wid  path  string  true  "Workspace id"
+// @Success   200  {array}   Sandbox
+// @Failure   403  {string}  string  "not a member"
+// @Failure   500  {string}  string  "internal error"
+// @Security  CookieAuth
+// @Router    /api/workspaces/{wid}/sandboxes [get]
 func (s *Server) handleListSandboxes(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "wid")
 	if _, ok := s.requireWorkspaceMember(w, r, wsID); !ok {
@@ -1729,21 +1731,22 @@ func (s *Server) handleListSandboxes(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(resp)
 }
 
-//	@Summary     Create a sandbox in a workspace
-//	@Description Validates type / CPU / memory / idle_timeout / quota / budget. Returns 201 immediately with status="provisioning"; container starts asynchronously.
-//	@Tags        Sandboxes
-//	@Accept      json
-//	@Produce     json
-//	@Param       wid   path      string                true  "Workspace id"
-//	@Param       body  body      SandboxCreateRequest  true  "Create payload"
-//	@Success     201   {object}  Sandbox
-//	@Failure     400   {string}  string  "validation error (type/cpu/memory/idle_timeout)"
-//	@Failure     403   {string}  string  "insufficient role / quota / budget"
-//	@Failure     500   {string}  string  "internal error"
-//	@Security    CookieAuth
-//	@Router      /api/workspaces/{wid}/sandboxes [post]
+// @Summary     Create a sandbox in a workspace
+// @Description Validates type / CPU / memory / idle_timeout / quota / budget. Returns 201 immediately with status="provisioning"; container starts asynchronously.
+// @Tags        Sandboxes
+// @Accept      json
+// @Produce     json
+// @Param       wid   path      string                true  "Workspace id"
+// @Param       body  body      SandboxCreateRequest  true  "Create payload"
+// @Success     201   {object}  Sandbox
+// @Failure     400   {string}  string  "validation error (type/cpu/memory/idle_timeout)"
+// @Failure     403   {string}  string  "insufficient role / quota / budget"
+// @Failure     500   {string}  string  "internal error"
+// @Security    CookieAuth
+// @Router      /api/workspaces/{wid}/sandboxes [post]
 func (s *Server) handleCreateSandbox(w http.ResponseWriter, r *http.Request) {
 	wsID := chi.URLParam(r, "wid")
+	userID := auth.UserIDFromContext(r.Context())
 	if !s.requireWorkspaceRole(w, r, wsID, "owner", "maintainer", "developer") {
 		return
 	}
@@ -1905,7 +1908,7 @@ func (s *Server) handleCreateSandbox(w http.ResponseWriter, r *http.Request) {
 	var sbx *sbxstore.Sandbox
 	var createErr error
 	for attempts := 0; attempts < 3; attempts++ {
-		sbx, createErr = s.Sandboxes.Create(id, wsID, req.Name, sandboxType, sandboxName, opencodeToken, proxyToken, openclawToken, sid, cpuMillis, memBytes, idleTimeout, req.Metadata)
+		sbx, createErr = s.Sandboxes.Create(id, wsID, userID, req.Name, sandboxType, sandboxName, opencodeToken, proxyToken, openclawToken, sid, cpuMillis, memBytes, idleTimeout, req.Metadata)
 		if createErr == nil {
 			break
 		}
@@ -2006,16 +2009,16 @@ func (s *Server) handleCreateSandbox(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(s.toSandboxResponse(r, sbx, authTokenFromRequest(r)))
 }
 
-//	@Summary   Get a sandbox by id
-//	@Tags      Sandboxes
-//	@Produce   json
-//	@Param     id  path  string  true  "Sandbox id"
-//	@Success   200  {object}  Sandbox
-//	@Failure   403  {string}  string  "not a member"
-//	@Failure   404  {string}  string  "sandbox not found"
-//	@Failure   500  {string}  string  "internal error"
-//	@Security  CookieAuth
-//	@Router    /api/sandboxes/{id} [get]
+// @Summary   Get a sandbox by id
+// @Tags      Sandboxes
+// @Produce   json
+// @Param     id  path  string  true  "Sandbox id"
+// @Success   200  {object}  Sandbox
+// @Failure   403  {string}  string  "not a member"
+// @Failure   404  {string}  string  "sandbox not found"
+// @Failure   500  {string}  string  "internal error"
+// @Security  CookieAuth
+// @Router    /api/sandboxes/{id} [get]
 func (s *Server) handleGetSandbox(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	sbx, ok := s.Sandboxes.Get(id)
@@ -2032,19 +2035,19 @@ func (s *Server) handleGetSandbox(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(resp)
 }
 
-//	@Summary   Rename a sandbox
-//	@Tags      Sandboxes
-//	@Accept    json
-//	@Produce   json
-//	@Param     id    path      string                true  "Sandbox id"
-//	@Param     body  body      SandboxRenameRequest  true  "New name"
-//	@Success   200   {object}  Sandbox
-//	@Failure   400   {string}  string  "name required"
-//	@Failure   403   {string}  string  "not a member"
-//	@Failure   404   {string}  string  "sandbox not found"
-//	@Failure   500   {string}  string  "internal error"
-//	@Security  CookieAuth
-//	@Router    /api/sandboxes/{id} [patch]
+// @Summary   Rename a sandbox
+// @Tags      Sandboxes
+// @Accept    json
+// @Produce   json
+// @Param     id    path      string                true  "Sandbox id"
+// @Param     body  body      SandboxRenameRequest  true  "New name"
+// @Success   200   {object}  Sandbox
+// @Failure   400   {string}  string  "name required"
+// @Failure   403   {string}  string  "not a member"
+// @Failure   404   {string}  string  "sandbox not found"
+// @Failure   500   {string}  string  "internal error"
+// @Security  CookieAuth
+// @Router    /api/sandboxes/{id} [patch]
 func (s *Server) handleRenameSandbox(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	sbx, ok := s.Sandboxes.Get(id)
@@ -2070,15 +2073,15 @@ func (s *Server) handleRenameSandbox(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(s.toSandboxResponse(r, sbx, authTokenFromRequest(r)))
 }
 
-//	@Summary   Delete a sandbox
-//	@Tags      Sandboxes
-//	@Param     id  path  string  true  "Sandbox id"
-//	@Success   204
-//	@Failure   403  {string}  string  "not a member"
-//	@Failure   404  {string}  string  "sandbox not found"
-//	@Failure   500  {string}  string  "internal error"
-//	@Security  CookieAuth
-//	@Router    /api/sandboxes/{id} [delete]
+// @Summary   Delete a sandbox
+// @Tags      Sandboxes
+// @Param     id  path  string  true  "Sandbox id"
+// @Success   204
+// @Failure   403  {string}  string  "not a member"
+// @Failure   404  {string}  string  "sandbox not found"
+// @Failure   500  {string}  string  "internal error"
+// @Security  CookieAuth
+// @Router    /api/sandboxes/{id} [delete]
 func (s *Server) handleDeleteSandbox(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	sbx, ok := s.Sandboxes.Get(id)
@@ -2133,19 +2136,19 @@ func (s *Server) handleDeleteSandbox(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 }
 
-//	@Summary     Pause a sandbox (cloud sandboxes only)
-//	@Description Initiates pause transition; returns {"status":"pausing"}. Final state lands asynchronously.
-//	@Tags        Sandboxes
-//	@Produce     json
-//	@Param       id  path  string  true  "Sandbox id"
-//	@Success     200  {object}  SandboxLifecycleStatusResponse
-//	@Failure     400  {string}  string  "local sandbox cannot be paused"
-//	@Failure     403  {string}  string  "not a member"
-//	@Failure     404  {string}  string  "sandbox not found"
-//	@Failure     409  {string}  string  "invalid state for pause"
-//	@Failure     500  {string}  string  "internal error"
-//	@Security    CookieAuth
-//	@Router      /api/sandboxes/{id}/pause [post]
+// @Summary     Pause a sandbox (cloud sandboxes only)
+// @Description Initiates pause transition; returns {"status":"pausing"}. Final state lands asynchronously.
+// @Tags        Sandboxes
+// @Produce     json
+// @Param       id  path  string  true  "Sandbox id"
+// @Success     200  {object}  SandboxLifecycleStatusResponse
+// @Failure     400  {string}  string  "local sandbox cannot be paused"
+// @Failure     403  {string}  string  "not a member"
+// @Failure     404  {string}  string  "sandbox not found"
+// @Failure     409  {string}  string  "invalid state for pause"
+// @Failure     500  {string}  string  "internal error"
+// @Security    CookieAuth
+// @Router      /api/sandboxes/{id}/pause [post]
 func (s *Server) handlePauseSandbox(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	sbx, ok := s.Sandboxes.Get(id)
@@ -2195,19 +2198,19 @@ func (s *Server) handlePauseSandbox(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(SandboxLifecycleStatusResponse{Status: "pausing"})
 }
 
-//	@Summary     Resume a paused sandbox (cloud sandboxes only)
-//	@Description Initiates resume transition; returns {"status":"resuming"}. Final state lands asynchronously.
-//	@Tags        Sandboxes
-//	@Produce     json
-//	@Param       id  path  string  true  "Sandbox id"
-//	@Success     200  {object}  SandboxLifecycleStatusResponse
-//	@Failure     400  {string}  string  "local sandbox cannot be resumed"
-//	@Failure     403  {string}  string  "not a member"
-//	@Failure     404  {string}  string  "sandbox not found"
-//	@Failure     409  {string}  string  "invalid state for resume"
-//	@Failure     500  {string}  string  "internal error"
-//	@Security    CookieAuth
-//	@Router      /api/sandboxes/{id}/resume [post]
+// @Summary     Resume a paused sandbox (cloud sandboxes only)
+// @Description Initiates resume transition; returns {"status":"resuming"}. Final state lands asynchronously.
+// @Tags        Sandboxes
+// @Produce     json
+// @Param       id  path  string  true  "Sandbox id"
+// @Success     200  {object}  SandboxLifecycleStatusResponse
+// @Failure     400  {string}  string  "local sandbox cannot be resumed"
+// @Failure     403  {string}  string  "not a member"
+// @Failure     404  {string}  string  "sandbox not found"
+// @Failure     409  {string}  string  "invalid state for resume"
+// @Failure     500  {string}  string  "internal error"
+// @Security    CookieAuth
+// @Router      /api/sandboxes/{id}/resume [post]
 func (s *Server) handleResumeSandbox(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	sbx, ok := s.Sandboxes.Get(id)
@@ -2278,16 +2281,16 @@ func (s *Server) handleResumeSandbox(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(SandboxLifecycleStatusResponse{Status: "resuming"})
 }
 
-//	@Summary   Get sandbox usage stats
-//	@Tags      Sandboxes
-//	@Produce   json
-//	@Param     id  path  string  true  "Sandbox id"
-//	@Success   200  {object}  SandboxUsage
-//	@Failure   403  {string}  string  "not a member"
-//	@Failure   404  {string}  string  "sandbox not found"
-//	@Failure   500  {string}  string  "internal error"
-//	@Security  CookieAuth
-//	@Router    /api/sandboxes/{id}/usage [get]
+// @Summary   Get sandbox usage stats
+// @Tags      Sandboxes
+// @Produce   json
+// @Param     id  path  string  true  "Sandbox id"
+// @Success   200  {object}  SandboxUsage
+// @Failure   403  {string}  string  "not a member"
+// @Failure   404  {string}  string  "sandbox not found"
+// @Failure   500  {string}  string  "internal error"
+// @Security  CookieAuth
+// @Router    /api/sandboxes/{id}/usage [get]
 func (s *Server) handleSandboxUsage(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	sbx, ok := s.Sandboxes.Get(id)
@@ -2306,19 +2309,19 @@ func (s *Server) handleSandboxUsage(w http.ResponseWriter, r *http.Request) {
 	s.proxyLLMRequest(w, proxyURL)
 }
 
-//	@Summary   List LLM traces for a sandbox
-//	@Tags      Misc
-//	@Produce   json
-//	@Param     id      path   string  true   "Sandbox ID"
-//	@Param     limit   query  int     false  "Max entries to return"
-//	@Param     offset  query  int     false  "Pagination offset"
-//	@Success   200  {object}  TraceListResponse
-//	@Failure   401  {string}  string  "unauthorized"
-//	@Failure   403  {string}  string  "not a workspace member"
-//	@Failure   404  {string}  string  "sandbox not found"
-//	@Failure   503  {string}  string  "llmproxy not configured"
-//	@Security  CookieAuth
-//	@Router    /api/sandboxes/{id}/traces [get]
+// @Summary   List LLM traces for a sandbox
+// @Tags      Misc
+// @Produce   json
+// @Param     id      path   string  true   "Sandbox ID"
+// @Param     limit   query  int     false  "Max entries to return"
+// @Param     offset  query  int     false  "Pagination offset"
+// @Success   200  {object}  TraceListResponse
+// @Failure   401  {string}  string  "unauthorized"
+// @Failure   403  {string}  string  "not a workspace member"
+// @Failure   404  {string}  string  "sandbox not found"
+// @Failure   503  {string}  string  "llmproxy not configured"
+// @Security  CookieAuth
+// @Router    /api/sandboxes/{id}/traces [get]
 func (s *Server) handleSandboxTraces(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	sbx, ok := s.Sandboxes.Get(id)
@@ -2343,18 +2346,18 @@ func (s *Server) handleSandboxTraces(w http.ResponseWriter, r *http.Request) {
 	s.proxyLLMRequest(w, proxyURL)
 }
 
-//	@Summary   Get a single LLM trace for a sandbox
-//	@Tags      Misc
-//	@Produce   json
-//	@Param     id       path  string  true  "Sandbox ID"
-//	@Param     traceId  path  string  true  "Trace ID"
-//	@Success   200  {object}  TraceDetailResponse
-//	@Failure   401  {string}  string  "unauthorized"
-//	@Failure   403  {string}  string  "not a workspace member"
-//	@Failure   404  {string}  string  "sandbox not found"
-//	@Failure   503  {string}  string  "llmproxy not configured"
-//	@Security  CookieAuth
-//	@Router    /api/sandboxes/{id}/traces/{traceId} [get]
+// @Summary   Get a single LLM trace for a sandbox
+// @Tags      Misc
+// @Produce   json
+// @Param     id       path  string  true  "Sandbox ID"
+// @Param     traceId  path  string  true  "Trace ID"
+// @Success   200  {object}  TraceDetailResponse
+// @Failure   401  {string}  string  "unauthorized"
+// @Failure   403  {string}  string  "not a workspace member"
+// @Failure   404  {string}  string  "sandbox not found"
+// @Failure   503  {string}  string  "llmproxy not configured"
+// @Security  CookieAuth
+// @Router    /api/sandboxes/{id}/traces/{traceId} [get]
 func (s *Server) handleTraceDetail(w http.ResponseWriter, r *http.Request) {
 	id := chi.URLParam(r, "id")
 	sbx, ok := s.Sandboxes.Get(id)
@@ -2374,18 +2377,18 @@ func (s *Server) handleTraceDetail(w http.ResponseWriter, r *http.Request) {
 	s.proxyLLMRequest(w, proxyURL)
 }
 
-//	@Summary   List LLM traces for a workspace
-//	@Tags      Misc
-//	@Produce   json
-//	@Param     wid     path   string  true   "Workspace ID"
-//	@Param     limit   query  int     false  "Max entries to return"
-//	@Param     offset  query  int     false  "Pagination offset"
-//	@Success   200  {object}  TraceListResponse
-//	@Failure   401  {string}  string  "unauthorized"
-//	@Failure   403  {string}  string  "not a workspace member"
-//	@Failure   503  {string}  string  "llmproxy not configured"
-//	@Security  CookieAuth
-//	@Router    /api/workspaces/{wid}/traces [get]
+// @Summary   List LLM traces for a workspace
+// @Tags      Misc
+// @Produce   json
+// @Param     wid     path   string  true   "Workspace ID"
+// @Param     limit   query  int     false  "Max entries to return"
+// @Param     offset  query  int     false  "Pagination offset"
+// @Success   200  {object}  TraceListResponse
+// @Failure   401  {string}  string  "unauthorized"
+// @Failure   403  {string}  string  "not a workspace member"
+// @Failure   503  {string}  string  "llmproxy not configured"
+// @Security  CookieAuth
+// @Router    /api/workspaces/{wid}/traces [get]
 func (s *Server) handleWorkspaceTraces(w http.ResponseWriter, r *http.Request) {
 	wid := chi.URLParam(r, "wid")
 	if _, ok := s.requireWorkspaceMember(w, r, wid); !ok {
@@ -2405,17 +2408,17 @@ func (s *Server) handleWorkspaceTraces(w http.ResponseWriter, r *http.Request) {
 	s.proxyLLMRequest(w, proxyURL)
 }
 
-//	@Summary   Get a single LLM trace for a workspace
-//	@Tags      Misc
-//	@Produce   json
-//	@Param     wid      path  string  true  "Workspace ID"
-//	@Param     traceId  path  string  true  "Trace ID"
-//	@Success   200  {object}  TraceDetailResponse
-//	@Failure   401  {string}  string  "unauthorized"
-//	@Failure   403  {string}  string  "not a workspace member"
-//	@Failure   503  {string}  string  "llmproxy not configured"
-//	@Security  CookieAuth
-//	@Router    /api/workspaces/{wid}/traces/{traceId} [get]
+// @Summary   Get a single LLM trace for a workspace
+// @Tags      Misc
+// @Produce   json
+// @Param     wid      path  string  true  "Workspace ID"
+// @Param     traceId  path  string  true  "Trace ID"
+// @Success   200  {object}  TraceDetailResponse
+// @Failure   401  {string}  string  "unauthorized"
+// @Failure   403  {string}  string  "not a workspace member"
+// @Failure   503  {string}  string  "llmproxy not configured"
+// @Security  CookieAuth
+// @Router    /api/workspaces/{wid}/traces/{traceId} [get]
 func (s *Server) handleWorkspaceTraceDetail(w http.ResponseWriter, r *http.Request) {
 	wid := chi.URLParam(r, "wid")
 	if _, ok := s.requireWorkspaceMember(w, r, wid); !ok {


### PR DESCRIPTION
## Summary
- Add `GET /api/agent/whoami` for sandbox proxy-token identity introspection.
- Track `proxy_tokens.user_id` for new sandbox tokens and resolve `user_id`, workspace, sandbox, `display_name`, and role from agentserver.
- Document the endpoint in OpenAPI/reference docs and run whoami DB-backed integration tests in CI.

## Test Plan
- `go test ./... -count=1`
- `go test ./internal/db ./internal/sbxstore ./internal/server -count=1`
- `PATH=/tmp/jq-preserve:/root/go/bin:$PATH make openapi-check`
- `make api-docs-check`
- `TEST_DATABASE_URL=postgres://test:test@127.0.0.1:55432/test?sslmode=disable go test ./internal/server -run '^TestAgentWhoami' -count=1 -timeout 2m -v`\n- `TEST_DATABASE_URL=postgres://test:test@127.0.0.1:55432/test?sslmode=disable go test ./internal/db/ -run '^TestScheduledTask' -count=1 -timeout 2m -v`