### PR TITLE
Fix agent card status sync with tunnel lifecycle

### DIFF
--- a/internal/db/agent_cards.go
+++ b/internal/db/agent_cards.go
@@ -91,6 +91,7 @@ func (db *DB) UpsertAgentCardFromCapabilities(sandboxID, workspaceID, displayNam
 		 VALUES ($1, $2, 'claudecode', $3, $4, 'available', 1)
 		 ON CONFLICT (sandbox_id) DO UPDATE SET
 		   card_json = EXCLUDED.card_json,
+		   agent_status = 'available',
 		   version = agent_cards.version + 1,
 		   updated_at = NOW()`,
 		sandboxID, workspaceID, displayName, cardJSON,

--- a/internal/db/agent_cards_test.go
+++ b/internal/db/agent_cards_test.go
@@ -1,0 +1,145 @@
+package db
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"encoding/json"
+	"errors"
+	"os"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+const agentCardsCaptureDriverName = "agent_cards_capture"
+
+var (
+	registerAgentCardsCaptureDriver sync.Once
+	agentCardsCapture               struct {
+		sync.Mutex
+		query string
+	}
+)
+
+type agentCardsDriver struct{}
+
+func (agentCardsDriver) Open(string) (driver.Conn, error) {
+	return agentCardsConn{}, nil
+}
+
+type agentCardsConn struct{}
+
+func (agentCardsConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("Prepare should not be called")
+}
+
+func (agentCardsConn) Close() error { return nil }
+
+func (agentCardsConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("Begin should not be called")
+}
+
+func (agentCardsConn) ExecContext(_ context.Context, query string, _ []driver.NamedValue) (driver.Result, error) {
+	agentCardsCapture.Lock()
+	defer agentCardsCapture.Unlock()
+	agentCardsCapture.query = query
+	return driver.RowsAffected(1), nil
+}
+
+func TestUpsertAgentCardFromCapabilitiesRestoresAvailableOnExistingCard(t *testing.T) {
+	registerAgentCardsCaptureDriver.Do(func() {
+		sql.Register(agentCardsCaptureDriverName, agentCardsDriver{})
+	})
+
+	agentCardsCapture.Lock()
+	agentCardsCapture.query = ""
+	agentCardsCapture.Unlock()
+
+	sqlDB, err := sql.Open(agentCardsCaptureDriverName, "")
+	if err != nil {
+		t.Fatalf("open capture db: %v", err)
+	}
+	t.Cleanup(func() { _ = sqlDB.Close() })
+
+	d := &DB{DB: sqlDB}
+	if err := d.UpsertAgentCardFromCapabilities("sbx_1", "ws_1", "agent", []byte(`{}`)); err != nil {
+		t.Fatalf("upsert from capabilities: %v", err)
+	}
+
+	agentCardsCapture.Lock()
+	query := agentCardsCapture.query
+	agentCardsCapture.Unlock()
+
+	if !strings.Contains(query, "agent_status = 'available'") {
+		t.Fatalf("conflict update did not restore agent_status to available:\n%s", query)
+	}
+}
+
+func TestUpsertAgentCardFromCapabilitiesRestoresAvailableInPostgres(t *testing.T) {
+	url := os.Getenv("TEST_DATABASE_URL")
+	if url == "" {
+		t.Skip("TEST_DATABASE_URL not set")
+	}
+	d, err := Open(url)
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+
+	suffix := strconv.FormatInt(time.Now().UnixNano(), 10)
+	workspaceID := "ws_card_restore_" + suffix
+	userID := "u_card_restore_" + suffix
+	sandboxID := "sbx_card_restore_" + suffix
+	proxyToken := "proxy_card_restore_" + suffix
+	tunnelToken := "tunnel_card_restore_" + suffix
+
+	t.Cleanup(func() {
+		_, _ = d.Exec(`DELETE FROM agent_cards WHERE sandbox_id = $1`, sandboxID)
+		_, _ = d.Exec(`DELETE FROM proxy_tokens WHERE token IN ($1, $2)`, proxyToken, tunnelToken)
+		_, _ = d.Exec(`DELETE FROM sandboxes WHERE id = $1`, sandboxID)
+		_, _ = d.Exec(`DELETE FROM workspace_members WHERE workspace_id = $1 OR user_id = $2`, workspaceID, userID)
+		_, _ = d.Exec(`DELETE FROM workspaces WHERE id = $1`, workspaceID)
+		_, _ = d.Exec(`DELETE FROM users WHERE id = $1`, userID)
+	})
+
+	if _, err := d.Exec(`INSERT INTO workspaces (id, name) VALUES ($1, 'card restore test')`, workspaceID); err != nil {
+		t.Fatalf("insert workspace: %v", err)
+	}
+	if _, err := d.Exec(`INSERT INTO users (id, email) VALUES ($1, $2)`, userID, userID+"@test"); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	if _, err := d.Exec(`INSERT INTO workspace_members (workspace_id, user_id, role) VALUES ($1, $2, 'developer')`, workspaceID, userID); err != nil {
+		t.Fatalf("insert workspace member: %v", err)
+	}
+	if err := d.CreateLocalSandbox(sandboxID, workspaceID, userID, "card-restore-agent", "custom", "", proxyToken, tunnelToken, "cr"+suffix[len(suffix)-8:]); err != nil {
+		t.Fatalf("create local sandbox: %v", err)
+	}
+	if err := d.UpsertAgentCard(&AgentCard{
+		SandboxID:   sandboxID,
+		WorkspaceID: workspaceID,
+		AgentType:   "custom",
+		DisplayName: "card-restore-agent",
+		CardJSON:    json.RawMessage(`{"old":true}`),
+		AgentStatus: "offline",
+	}); err != nil {
+		t.Fatalf("upsert offline card: %v", err)
+	}
+
+	if err := d.UpsertAgentCardFromCapabilities(sandboxID, workspaceID, "card-restore-agent", json.RawMessage(`{"restored":true}`)); err != nil {
+		t.Fatalf("upsert card from capabilities: %v", err)
+	}
+
+	card, err := d.GetAgentCard(sandboxID)
+	if err != nil {
+		t.Fatalf("get agent card: %v", err)
+	}
+	if card == nil {
+		t.Fatal("agent card missing")
+	}
+	if card.AgentStatus != "available" {
+		t.Fatalf("agent card status = %q, want available", card.AgentStatus)
+	}
+}

--- a/internal/sandboxproxy/tunnel.go
+++ b/internal/sandboxproxy/tunnel.go
@@ -10,10 +10,10 @@ import (
 
 	"encoding/base64"
 
-	"github.com/go-chi/chi/v5"
 	"github.com/agentserver/agentserver/internal/db"
 	"github.com/agentserver/agentserver/internal/sbxstore"
 	"github.com/agentserver/agentserver/internal/tunnel"
+	"github.com/go-chi/chi/v5"
 	"nhooyr.io/websocket"
 )
 
@@ -125,6 +125,9 @@ func (s *Server) handleTunnel(w http.ResponseWriter, r *http.Request) {
 
 	if wasActive {
 		s.Sandboxes.UpdateStatus(sandboxID, sbxstore.StatusOffline)
+		if err := s.DB.UpdateAgentCardStatus(sandboxID, "offline"); err != nil {
+			log.Printf("tunnel %s: failed to mark agent card offline: %v", sandboxID, err)
+		}
 	}
 	log.Printf("tunnel disconnected: sandbox %s (was_active=%v)", sandboxID, wasActive)
 }

--- a/internal/sandboxproxy/tunnel_test.go
+++ b/internal/sandboxproxy/tunnel_test.go
@@ -1,0 +1,119 @@
+package sandboxproxy
+
+import (
+	"context"
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentserver/agentserver/internal/db"
+	"github.com/agentserver/agentserver/internal/sbxstore"
+	"github.com/agentserver/agentserver/internal/tunnel"
+	"nhooyr.io/websocket"
+)
+
+func openTunnelTestDB(t *testing.T) *db.DB {
+	t.Helper()
+	url := os.Getenv("TEST_DATABASE_URL")
+	if url == "" {
+		t.Skip("TEST_DATABASE_URL not set")
+	}
+	d, err := db.Open(url)
+	if err != nil {
+		t.Fatalf("open test db: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+	return d
+}
+
+func TestTunnelDisconnectMarksAgentCardOffline(t *testing.T) {
+	d := openTunnelTestDB(t)
+
+	suffix := strconv.FormatInt(time.Now().UnixNano(), 10)
+	workspaceID := "ws_tunnel_card_" + suffix
+	userID := "u_tunnel_card_" + suffix
+	sandboxID := "sbx_tunnel_card_" + suffix
+	proxyToken := "proxy_tunnel_card_" + suffix
+	tunnelToken := "tunnel_tunnel_card_" + suffix
+
+	t.Cleanup(func() {
+		_, _ = d.Exec(`DELETE FROM agent_cards WHERE sandbox_id = $1`, sandboxID)
+		_, _ = d.Exec(`DELETE FROM proxy_tokens WHERE token IN ($1, $2)`, proxyToken, tunnelToken)
+		_, _ = d.Exec(`DELETE FROM sandboxes WHERE id = $1`, sandboxID)
+		_, _ = d.Exec(`DELETE FROM workspace_members WHERE workspace_id = $1 OR user_id = $2`, workspaceID, userID)
+		_, _ = d.Exec(`DELETE FROM workspaces WHERE id = $1`, workspaceID)
+		_, _ = d.Exec(`DELETE FROM users WHERE id = $1`, userID)
+	})
+
+	if _, err := d.Exec(`INSERT INTO workspaces (id, name) VALUES ($1, 'tunnel card test')`, workspaceID); err != nil {
+		t.Fatalf("insert workspace: %v", err)
+	}
+	if _, err := d.Exec(`INSERT INTO users (id, email) VALUES ($1, $2)`, userID, userID+"@test"); err != nil {
+		t.Fatalf("insert user: %v", err)
+	}
+	if _, err := d.Exec(`INSERT INTO workspace_members (workspace_id, user_id, role) VALUES ($1, $2, 'developer')`, workspaceID, userID); err != nil {
+		t.Fatalf("insert workspace member: %v", err)
+	}
+	if err := d.CreateLocalSandbox(sandboxID, workspaceID, userID, "tunnel-card-agent", "custom", "", proxyToken, tunnelToken, "tc"+suffix[len(suffix)-8:]); err != nil {
+		t.Fatalf("create local sandbox: %v", err)
+	}
+	if err := d.UpsertAgentCard(&db.AgentCard{
+		SandboxID:   sandboxID,
+		WorkspaceID: workspaceID,
+		AgentType:   "custom",
+		DisplayName: "tunnel-card-agent",
+		CardJSON:    json.RawMessage(`{}`),
+		AgentStatus: "available",
+	}); err != nil {
+		t.Fatalf("upsert agent card: %v", err)
+	}
+
+	srv := New(Config{}, nil, d, sbxstore.NewStore(d), tunnel.NewRegistry(), nil)
+	httpSrv := httptest.NewServer(srv.Router())
+	t.Cleanup(httpSrv.Close)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	wsURL := "ws" + strings.TrimPrefix(httpSrv.URL, "http") + "/api/tunnel/" + sandboxID + "?token=" + tunnelToken
+	conn, _, err := websocket.Dial(ctx, wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial tunnel: %v", err)
+	}
+	_ = conn.Close(websocket.StatusNormalClosure, "test disconnect")
+
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		sbx, err := d.GetSandbox(sandboxID)
+		if err != nil {
+			t.Fatalf("get sandbox: %v", err)
+		}
+		if sbx != nil && sbx.Status == sbxstore.StatusOffline {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("sandbox did not go offline after tunnel disconnect; got status %q", sbx.Status)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+
+	for {
+		card, err := d.GetAgentCard(sandboxID)
+		if err != nil {
+			t.Fatalf("get agent card: %v", err)
+		}
+		if card == nil {
+			t.Fatal("agent card missing")
+		}
+		if card.AgentStatus == "offline" {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("agent card status = %q, want offline after active tunnel disconnect", card.AgentStatus)
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -25,6 +25,7 @@ import { SandboxDetail } from './components/SandboxDetail'
 import { ManageWorkspaces } from './components/ManageWorkspaces'
 import { AdminPanel } from './components/AdminPanel'
 import { WorkspaceDetail, tabFromSlug, type Tab as WorkspaceTab } from './components/WorkspaceDetail'
+import { sandboxStatusPollIntervalMs } from './lib/sandboxPolling'
 
 export interface UserInfo {
   id: string
@@ -218,15 +219,12 @@ export default function App() {
     }
   }, [selectedWorkspaceId, refreshSandboxes])
 
-  // Poll while any sandbox is in a transitional state (creating, pausing,
-  // resuming). Lives at app level so it ticks regardless of which page is
-  // mounted — list, detail, or any other workspace tab.
+  // Poll status-changing sandboxes at app level so it ticks regardless of
+  // which page is mounted.
   useEffect(() => {
-    const hasTransitional = sandboxes.some(
-      (s) => s.status === 'creating' || s.status === 'pausing' || s.status === 'resuming',
-    )
-    if (!hasTransitional) return
-    const id = window.setInterval(refreshSandboxes, 2000)
+    const intervalMs = sandboxStatusPollIntervalMs(sandboxes)
+    if (intervalMs == null) return
+    const id = window.setInterval(refreshSandboxes, intervalMs)
     return () => window.clearInterval(id)
   }, [sandboxes, refreshSandboxes])
 

--- a/web/src/components/SandboxList.tsx
+++ b/web/src/components/SandboxList.tsx
@@ -10,6 +10,7 @@ import {
 } from '../lib/api'
 import { CreateSandboxModal } from './CreateSandboxModal'
 import { ConfirmModal } from './Modals'
+import { sandboxStatusPollIntervalMs } from '../lib/sandboxPolling'
 
 interface SandboxListProps {
   selectedWorkspaceId: string | null
@@ -59,14 +60,12 @@ export function SandboxList({
   const [showAgentConnect, setShowAgentConnect] = useState(false)
   const [quotaError, setQuotaError] = useState<string | null>(null)
 
-  // Poll when any sandbox is in a transitional state.
+  // Poll status-changing sandboxes when this list owns its refresh loop.
   useEffect(() => {
-    const hasTransitional = sandboxes.some(
-      (s) => s.status === 'pausing' || s.status === 'resuming' || s.status === 'creating'
-    )
-    if (hasTransitional) {
+    const intervalMs = sandboxStatusPollIntervalMs(sandboxes)
+    if (intervalMs != null) {
       if (!pollRef.current) {
-        pollRef.current = setInterval(onRefreshSandboxes, 2000)
+        pollRef.current = setInterval(onRefreshSandboxes, intervalMs)
       }
     } else {
       if (pollRef.current) {

--- a/web/src/lib/sandboxPolling.ts
+++ b/web/src/lib/sandboxPolling.ts
@@ -1,0 +1,24 @@
+const TRANSITIONAL_SANDBOX_STATUSES = new Set(['creating', 'pausing', 'resuming'])
+const LOCAL_AGENT_LIVE_STATUSES = new Set(['running', 'offline'])
+
+type SandboxStatusPollItem = {
+  status: string
+  is_local: boolean
+}
+
+export function shouldPollSandboxStatuses(sandboxes: SandboxStatusPollItem[]): boolean {
+  return sandboxes.some((sandbox) => {
+    if (TRANSITIONAL_SANDBOX_STATUSES.has(sandbox.status)) return true
+    return sandbox.is_local && LOCAL_AGENT_LIVE_STATUSES.has(sandbox.status)
+  })
+}
+
+export function sandboxStatusPollIntervalMs(sandboxes: SandboxStatusPollItem[]): number | null {
+  if (sandboxes.some((sandbox) => TRANSITIONAL_SANDBOX_STATUSES.has(sandbox.status))) {
+    return 2000
+  }
+  if (sandboxes.some((sandbox) => sandbox.is_local && LOCAL_AGENT_LIVE_STATUSES.has(sandbox.status))) {
+    return 10000
+  }
+  return null
+}

--- a/web/test/sandboxPolling.test.ts
+++ b/web/test/sandboxPolling.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { sandboxStatusPollIntervalMs, shouldPollSandboxStatuses } from '../src/lib/sandboxPolling.js'
+
+test('polls local running and offline agents so status changes refresh', () => {
+  assert.equal(shouldPollSandboxStatuses([{ status: 'running', is_local: true }]), true)
+  assert.equal(shouldPollSandboxStatuses([{ status: 'offline', is_local: true }]), true)
+  assert.equal(sandboxStatusPollIntervalMs([{ status: 'running', is_local: true }]), 10000)
+})
+
+test('keeps fast polling for transitional sandbox states', () => {
+  assert.equal(shouldPollSandboxStatuses([{ status: 'pausing', is_local: false }]), true)
+  assert.equal(sandboxStatusPollIntervalMs([{ status: 'pausing', is_local: false }]), 2000)
+})
+
+test('does not keep polling stable cloud or paused local sandboxes', () => {
+  assert.equal(shouldPollSandboxStatuses([{ status: 'running', is_local: false }]), false)
+  assert.equal(shouldPollSandboxStatuses([{ status: 'paused', is_local: true }]), false)
+  assert.equal(sandboxStatusPollIntervalMs([{ status: 'paused', is_local: true }]), null)
+})


### PR DESCRIPTION
## Summary
- Mark agent discovery cards offline when the active tunnel disconnects.
- Restore capability-derived agent cards to available when the agent reports capabilities again.
- Keep local sandbox cards refreshed in the UI for running/offline status changes.

## Test Plan
- `go test -count=1 ./internal/sandboxproxy ./internal/db ./internal/server`
- `cd web && pnpm exec tsc --module ESNext --moduleResolution Bundler --target ES2022 --types node --outDir /tmp/agentserver-web-tests src/lib/sandboxPolling.ts test/sandboxPolling.test.ts && node --test /tmp/agentserver-web-tests/test/sandboxPolling.test.js`
- `cd web && pnpm run build`
- `TEST_DATABASE_URL=postgres://agentserver:agentserver@127.0.0.1:55434/agentserver?sslmode=disable go test -p=1 -count=1 -v ./internal/db ./internal/sandboxproxy -run 'TestUpsertAgentCardFromCapabilitiesRestoresAvailableInPostgres|TestTunnelDisconnectMarksAgentCardOffline'`

## Notes
- Full `pnpm run lint` still reports existing repository lint issues unrelated to this change; targeted lint for the changed frontend polling files passes.
