### PR TITLE
chore(cxg): bump bundled codex 0.134.0 → 0.137.0

### DIFF
--- a/Dockerfile.codex-app-gateway
+++ b/Dockerfile.codex-app-gateway
@@ -11,7 +11,7 @@ RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' \
 # `codex app-server` per thread, so the runtime image must carry it.
 # Override at build time with --build-arg CODEX_VERSION=...
 FROM debian:trixie-slim AS codex
-ARG CODEX_VERSION=0.134.0
+ARG CODEX_VERSION=0.137.0
 ARG TARGETARCH
 RUN apt-get update \
  && apt-get install -y --no-install-recommends ca-certificates curl \

--- a/docs/superpowers/plans/2026-06-08-cxg-codex-0.137-upgrade.md
+++ b/docs/superpowers/plans/2026-06-08-cxg-codex-0.137-upgrade.md
@@ -1,0 +1,347 @@
+# cxg codex 0.134.0 → 0.137.0 Upgrade Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bump cxg's bundled `codex` binary from 0.134.0 to 0.137.0 via a single Dockerfile ARG change, verify unit tests + image build + bundled `codex --version`, then commit / push / PR.
+
+**Architecture:** cxg pins upstream codex via `ARG CODEX_VERSION` in `Dockerfile.codex-app-gateway`. The runtime image's `codex` stage downloads `https://github.com/openai/codex/releases/download/rust-v${CODEX_VERSION}/codex-${arch_tag}.tar.gz`. cxg uses `codex app-server` as a per-thread subprocess and proxies its v2 JSON-RPC frames byte-for-byte (memory `codex_app_server_subprocess_path.md`) — broker uses `json.RawMessage` passthrough; intercept_local_io's block list pins method-name strings only. Spec §3 audited all 19 protocol-touching commits in `rust-v0.134.0..rust-v0.137.0` and found 0 breaking impacts on cxg's surface.
+
+**Tech Stack:** Docker BuildKit (`docker buildx build`), Go 1.26 (for unit tests), upstream `codex` 0.137.0 release tarball from GitHub.
+
+**Spec:** `docs/superpowers/specs/2026-06-08-cxg-codex-0.137-upgrade-design.md`
+
+**Branch:** `chore/cxg-codex-0.137` (already created off `github/main`; spec already committed at `fa9ba7e`).
+
+**Repo footprint (final):** modifications to `Dockerfile.codex-app-gateway` (1 line) and this plan (checkboxes ticked); plus the spec commit already on the branch.
+
+---
+
+## File Structure
+
+| Path | Role | Touched in this plan? |
+|---|---|---|
+| `Dockerfile.codex-app-gateway` | Multi-stage image: Go build → codex download → runtime. Pins `CODEX_VERSION` via ARG. | Modify (1 line) |
+| `docs/superpowers/plans/2026-06-08-cxg-codex-0.137-upgrade.md` | This plan — checkboxes ticked as we go. | Modify |
+| `docs/superpowers/specs/2026-06-08-cxg-codex-0.137-upgrade-design.md` | Spec. | Already committed at fa9ba7e; no further changes. |
+| `internal/codexappgateway/**/*_test.go` | Unit tests that freeze wire-shape assumptions; covered by Task 2's pass. | Read only |
+
+No new files, no Go code change, no Helm change, no fork change.
+
+---
+
+## Task 1: Bump the ARG default
+
+**Files:**
+- Modify: `Dockerfile.codex-app-gateway:13`
+
+- [ ] **Step 1: Read the current ARG line**
+
+Run:
+```bash
+grep -n 'ARG CODEX_VERSION' Dockerfile.codex-app-gateway
+```
+
+Expected: `13:ARG CODEX_VERSION=0.134.0` (the value, not the line number, is what matters — adjust the line cited in this task header if it has drifted).
+
+- [ ] **Step 2: Change the default to 0.137.0**
+
+Edit `Dockerfile.codex-app-gateway`: replace the line
+
+```dockerfile
+ARG CODEX_VERSION=0.134.0
+```
+
+with
+
+```dockerfile
+ARG CODEX_VERSION=0.137.0
+```
+
+Leave the surrounding comment block (lines 10-12, "Override at build time with --build-arg CODEX_VERSION=...") and the rest of the file unchanged.
+
+- [ ] **Step 3: Verify the diff is exactly one line**
+
+Run:
+```bash
+git diff Dockerfile.codex-app-gateway
+```
+
+Expected output (exactly one `-` line and one `+` line, nothing else):
+
+```diff
+diff --git a/Dockerfile.codex-app-gateway b/Dockerfile.codex-app-gateway
+index ...
+--- a/Dockerfile.codex-app-gateway
++++ b/Dockerfile.codex-app-gateway
+@@ -13,1 +13,1 @@ ...
+-ARG CODEX_VERSION=0.134.0
++ARG CODEX_VERSION=0.137.0
+```
+
+If any other lines differ, STOP and revert the unintended changes before proceeding.
+
+---
+
+## Task 2: Verify unit tests pass
+
+**Files:**
+- Read only: `internal/codexappgateway/**/*_test.go`
+
+- [ ] **Step 1: Run the cxg unit tests**
+
+Run:
+```bash
+cd /root/agentserver && go test ./internal/codexappgateway/...
+```
+
+Expected: all packages report `ok`. No `FAIL`, no `--- FAIL:` lines.
+
+The relevant tests for this bump are:
+- `TestParseInitializeClientInfo` in `server_initialize_test.go` — freezes the initialize-frame wire shape (`codex_cli_rs/<version>` UA construction).
+- Tests in `intercept_local_io_test.go` — freeze the block-list method strings.
+- Tests in `broker/*_test.go` (called via the package import path above) — exercise the RawMessage broker.
+
+These are pure-Go tests; they don't spawn `codex` and don't require the image. A green result means the wire-shape assumptions cxg holds are consistent with itself — it does NOT prove they're consistent with 0.137.0 (that's Task 3's job).
+
+- [ ] **Step 2: If tests fail, stop and report**
+
+If any test fails, do not proceed. Capture the failure output, revert the ARG change (`git checkout -- Dockerfile.codex-app-gateway`), and report the unexpected failure — it would mean the unit-test surface itself broke independent of any codex bump, which is news.
+
+---
+
+## Task 3: Build the image with the new codex
+
+**Files:**
+- Read only: `Dockerfile.codex-app-gateway`
+
+- [ ] **Step 1: Build for linux/amd64 with the new ARG**
+
+Run:
+```bash
+cd /root/agentserver && docker buildx build \
+  --platform linux/amd64 \
+  --build-arg CODEX_VERSION=0.137.0 \
+  -f Dockerfile.codex-app-gateway \
+  -t cxg-test:0.137.0 \
+  --load \
+  .
+```
+
+Expected: build succeeds, ending with `=> => exporting to image` / `=> => naming to docker.io/library/cxg-test:0.137.0`. No error from the `curl -fsSL "$url"` step in the `codex` stage (that would mean the upstream release tarball is missing for `linux/amd64` — the most likely real failure).
+
+- [ ] **Step 2: If the codex download step fails, stop and report**
+
+A `curl: (22)` from the tarball download indicates the upstream release URL is wrong (typo in version) or the asset for `x86_64-unknown-linux-musl` hasn't been published. Cross-check by visiting `https://github.com/openai/codex/releases/tag/rust-v0.137.0` and confirming the asset `codex-x86_64-unknown-linux-musl.tar.gz` is listed. If missing, abort the plan — do not pin to a non-existent release.
+
+- [ ] **Step 3: If anything else fails, stop and report**
+
+Go-build failures, apt failures, or anything else means something independent broke (not the bump). Capture the full build log, revert the Dockerfile change, and report.
+
+---
+
+## Task 4: Confirm the bundled codex is 0.137.0
+
+**Files:** none (runtime check)
+
+- [ ] **Step 1: Print the bundled codex's version**
+
+Run:
+```bash
+docker run --rm --entrypoint codex cxg-test:0.137.0 --version
+```
+
+Expected exact output (per spec §4 step 3 — clap prefixes version with the Cargo package name `codex-cli`, not the `bin_name = "codex"` invocation alias):
+
+```
+codex-cli 0.137.0
+```
+
+If the output is anything else (older version, an error, a different format), STOP and report. A mismatched version means the Dockerfile didn't actually pick up the ARG override, or the upstream tarball contained a different binary than the URL implies.
+
+- [ ] **Step 2: Sanity-check the image still has bubblewrap**
+
+Run:
+```bash
+docker run --rm --entrypoint bwrap cxg-test:0.137.0 --version
+```
+
+Expected: a `bubblewrap <version>` line. This is unchanged from 0.134, but it's worth a 1-second check because the runtime apt-install in the final stage is what makes the codex startup-sandbox probe not warn (per the Dockerfile comment around line 35). If `bwrap` is missing, the runtime apt list changed accidentally — revert and report.
+
+---
+
+## Task 5: Commit the change
+
+**Files:**
+- Modify: `Dockerfile.codex-app-gateway`
+
+- [ ] **Step 1: Stage and verify**
+
+Run:
+```bash
+git add Dockerfile.codex-app-gateway \
+        docs/superpowers/plans/2026-06-08-cxg-codex-0.137-upgrade.md
+git status -sb
+git diff --cached --stat
+```
+
+Expected:
+- `git status -sb` shows `M Dockerfile.codex-app-gateway` and `A docs/superpowers/plans/2026-06-08-cxg-codex-0.137-upgrade.md`, nothing else staged.
+- `git diff --cached --stat` shows two files: the Dockerfile (`1 insertion(+), 1 deletion(-)`) and this plan (new file).
+
+Confirm NOTHING else is staged. The unrelated untracked files (notebooks, image.png, the pre-existing `2026-05-22-remove-docker-runtime-support-design.md`) must stay unstaged — per the `git_add_check_diff_first` memory.
+
+- [ ] **Step 2: Commit**
+
+Run:
+```bash
+git commit -m "$(cat <<'EOF'
+chore(cxg): bump bundled codex 0.134.0 → 0.137.0
+
+cxg pins upstream codex via one ARG in Dockerfile.codex-app-gateway.
+0.134.0 was 3 minor releases and 310 commits behind today's
+rust-v0.137.0.
+
+Per spec section 3, all 19 protocol-touching commits in
+rust-v0.134.0..rust-v0.137.0 were audited. 11 are clearly off-path;
+the other 8 are additive (or remove the `persistExtendedHistory`
+flag, which cxg never set). No method strings cxg's
+intercept_local_io block list or broker constructs were renamed.
+cxg's broker uses json.RawMessage passthrough, so additive schema
+changes ride through transparently.
+
+Verified:
+- go test ./internal/codexappgateway/... — all green
+- docker buildx build --build-arg CODEX_VERSION=0.137.0 — succeeded
+- docker run --rm --entrypoint codex cxg-test:0.137.0 --version
+  → "codex-cli 0.137.0"
+- bwrap still present in runtime image
+
+Out of scope (separate concerns):
+- fork rebase at /root/codex (4 unrelated exec-server User-Agent
+  commits; rebased independently when needed)
+- -tags integration test (requires LLM API key)
+- Helm chart appVersion / image tag bump (handled by release flow
+  per agentserver_release_flow memory after PR merge)
+
+Spec: docs/superpowers/specs/2026-06-08-cxg-codex-0.137-upgrade-design.md
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+- [ ] **Step 3: Confirm the branch state**
+
+Run:
+```bash
+git log --oneline -3
+```
+
+Expected: two commits ahead of `github/main` —
+1. (newest) `chore(cxg): bump bundled codex 0.134.0 → 0.137.0`
+2. `fa9ba7e docs(superpowers): design — bump cxg's bundled codex 0.134.0 → 0.137.0`
+3. `0b148d2 fix: sync agent card status with tunnel lifecycle (#228)` (or whatever main's HEAD was)
+
+---
+
+## Task 6: Push and open PR
+
+- [ ] **Step 1: Push the branch**
+
+Run:
+```bash
+git push -u github chore/cxg-codex-0.137
+```
+
+Expected: `* [new branch]      chore/cxg-codex-0.137 -> chore/cxg-codex-0.137`.
+
+- [ ] **Step 2: Open the PR**
+
+Run:
+```bash
+gh pr create --base main --head chore/cxg-codex-0.137 \
+  --title "chore(cxg): bump bundled codex 0.134.0 → 0.137.0" \
+  --body "$(cat <<'EOF'
+Bumps the codex binary baked into Dockerfile.codex-app-gateway from
+0.134.0 to today's upstream stable rust-v0.137.0 (3 minor releases,
+310 commits forward).
+
+## Why now
+
+We've been on 0.134 since release; staying current gets us bug fixes
+and additive protocol features (e.g. `parent_thread_id` on Threads,
+`clientId` on UserInput, MCP server info in server status) for free,
+and shrinks the catch-up gap before the next upstream change that
+actually matters to cxg.
+
+## Risk
+
+Low. cxg uses upstream `codex app-server` as a per-thread subprocess
+and proxies v2 JSON-RPC frames byte-for-byte (per memory
+`codex_app_server_subprocess_path.md`). broker/protocol.go uses
+`json.RawMessage` passthrough; intercept_local_io's block list pins
+method-name strings only.
+
+Spec §3 audited every commit in `rust-v0.134.0..rust-v0.137.0` that
+touched `codex-rs/app-server-protocol/` (19 commits total). 11 are
+off-path (Windows sandbox, TUI MCP inventory, …); the remaining 8
+are all additive or remove a flag (`persistExtendedHistory`) cxg
+never set. **No method strings cxg depends on were renamed.**
+
+## Verified
+
+- `go test ./internal/codexappgateway/...` — all green
+- `docker buildx build --build-arg CODEX_VERSION=0.137.0` — succeeded
+- `docker run --rm --entrypoint codex cxg-test:0.137.0 --version` →
+  `codex-cli 0.137.0`
+- bubblewrap still present in the runtime image (sandbox-probe sanity)
+
+## Out of scope
+
+- Fork `/root/codex` rebase to rust-v0.137.0 — separate concern.
+- `-tags integration` test (`TestServer_RealCodexAppServer_FullRPCRoundtrip`)
+  — opt-in for a reason; requires LLM API key.
+- Helm chart `appVersion` / image tag bump — handled by release flow
+  per `agentserver_release_flow` memory after merge.
+
+## Rollback
+
+Single-line revert of the ARG default. No data migration, no Helm
+chart change, no protocol shim.
+
+## Spec
+
+docs/superpowers/specs/2026-06-08-cxg-codex-0.137-upgrade-design.md
+(committed first on this branch).
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: prints a PR URL like `https://github.com/agentserver/agentserver/pull/N`.
+
+- [ ] **Step 3: Done.**
+
+No follow-on tasks. After merge, the Helm release flow will pick up the new image when the chart is bumped per `agentserver_release_flow` memory.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §1 Problem → context only, no task needed.
+- §2 Scope (in: ARG bump, wire-shape audit, unit tests, image build, codex --version) → ARG bump = Task 1; wire-shape audit already in spec §3; unit tests = Task 2; image build = Task 3; `codex --version` = Task 4.
+- §2 Out-of-scope items → explicitly excluded in commit message (Task 5) and PR body (Task 6), and never invoked in any task.
+- §3 Wire-shape impact analysis → spec content, no task needed.
+- §4 Verification → Task 2 (step 1), Task 3 (step 1), Task 4 (step 1) match the three numbered verification steps exactly.
+- §5 Rollback → exit ramps in Task 2 step 2, Task 3 steps 2/3, Task 4 step 1 (each says "revert and report"); also called out in commit message and PR body.
+- §6 Out-of-repo / follow-on items → not in this PR by construction; explicitly excluded in §2 of plan + Task 5/6 messages.
+
+**Placeholder scan:** no TBD / "implement later" / "appropriate handling" markers. The "(or whatever main's HEAD was)" in Task 5 Step 3 is a tolerable acknowledgement that main moves; not a placeholder for behavior.
+
+**Type / symbol consistency:**
+- `ARG CODEX_VERSION=0.137.0` referenced identically across Tasks 1, 3, 5, 6.
+- Image tag `cxg-test:0.137.0` used identically in Tasks 3, 4.
+- Branch name `chore/cxg-codex-0.137` referenced identically in Tasks 5, 6.
+- Expected `codex --version` output `codex-cli 0.137.0` is consistent with the spec §4 step 3 derivation.

--- a/docs/superpowers/specs/2026-06-08-cxg-codex-0.137-upgrade-design.md
+++ b/docs/superpowers/specs/2026-06-08-cxg-codex-0.137-upgrade-design.md
@@ -1,0 +1,163 @@
+# codex-app-gateway: Upgrade Bundled `codex` from 0.134.0 → 0.137.0
+
+**Date:** 2026-06-08
+**Status:** Draft — design awaiting user sign-off
+**Author:** mryao + Claude (Opus 4.8)
+**Related memory:** `codex_app_server_subprocess_path.md`, `agentserver_release_flow.md`
+
+## 1. Problem Statement
+
+`Dockerfile.codex-app-gateway` pins upstream `codex` at 0.134.0. Three
+stable minor releases have shipped since (0.135, 0.136, 0.137), and
+the latest stable as of today is 0.137.0. cxg runs `codex app-server`
+as a per-thread subprocess and proxies its v2 JSON-RPC frames
+byte-for-byte (memory `codex_app_server_subprocess_path.md`), so most
+of upstream's churn is invisible to our code — but staying current
+gets us bug fixes, ServerNotification additions for free, and avoids
+a long-running drift gap.
+
+Bump scope is one line:
+
+```
+-ARG CODEX_VERSION=0.134.0
++ARG CODEX_VERSION=0.137.0
+```
+
+The whole spec exists to justify that "one line" via a wire-shape
+impact analysis, and to define verification cheaply enough that we
+catch quiet protocol drift before merge.
+
+## 2. Scope
+
+In-scope:
+
+- `Dockerfile.codex-app-gateway` ARG default bump 0.134.0 → 0.137.0.
+- A wire-shape impact analysis (§3) of every commit between
+  `rust-v0.134.0` and `rust-v0.137.0` that touched
+  `codex-rs/app-server-protocol/`.
+- Unit-test pass (`go test ./internal/codexappgateway/...`).
+- Manual image build + `codex --version` confirmation.
+
+Out-of-scope:
+
+- The fork at `/root/codex` (separately on `feat/exec-server-user-agent`,
+  based on `7d47056ea4`, 4 custom commits unrelated to cxg). Rebased
+  independently when needed.
+- The `-tags integration` test (`TestServer_RealCodexAppServer_FullRPCRoundtrip`)
+  — requires a working LLM API key and is heavier than this scope.
+- Dev-cluster smoke test.
+- Helm chart bump / cxg image tag release — handled separately per
+  `agentserver_release_flow.md` after PR merge.
+
+## 3. Wire-Shape Impact Analysis
+
+Between `rust-v0.134.0` and `rust-v0.137.0`, **310 upstream commits;
+19 touched `codex-rs/app-server-protocol/`** (the wire surface).
+11 of the 19 are clearly off-path for cxg (Windows sandbox tweaks,
+TUI MCP inventory, etc.). The remaining 8 are analyzed below.
+
+cxg's protocol exposure is two-fold:
+
+1. **Verbatim passthrough.** `broker/protocol.go` decodes only
+   `thread.id` and `turn.id` for routing; the rest of the Turn /
+   ServerNotification payload is held as `json.RawMessage` and handed
+   back to the REST caller. Additive schema changes are transparent.
+2. **Method-name filter.** `intercept_local_io.go` blocks 11 specific
+   client→server RPCs (`thread/shellCommand`, `command/exec/*`,
+   `fs/*`) at the cxg boundary. The filter triggers on `method`
+   string match; it is *insensitive* to params shape changes within
+   those methods (because it never forwards them) and to renames of
+   methods *outside* the blocked set.
+
+That two-fold exposure plus the use of `RawMessage` everywhere means
+the only failure modes from a 0.134→0.137 bump are:
+
+- A method we explicitly construct (`thread/start`, `turn/start`,
+  `turn/interrupt`) gets renamed or has its request schema break in
+  a way that affects the small fields we set.
+- A response/notification we *do* peek (`thread.id`, `turn.id`,
+  `item/completed.params.{threadId, turnId, item}`,
+  `turn/completed.params.threadId`, `turn.id`) gets that specific
+  field renamed.
+- A blocked method gets renamed *and* an unblocked synonym for the
+  same dangerous action is added.
+
+### 3.1 Per-commit assessment (8 commits with possible impact)
+
+| # | SHA | Title | Type | cxg impact |
+|---|---|---|---|---|
+| 1 | `9de568372d` | Propagate permission approval environment id (#25862) | Additive (new `environmentId` field on `request_permissions`) | None. cxg never constructs or peeks `request_permissions`; its passthrough copies the param unchanged. |
+| 2 | `4d80d808b4` | Add connector-level Guardian reviewer overrides (#25167) | Additive (new `[apps.connector_*]` config keys + 1 protocol enum variant in `v2/config.rs`) | None. cxg's `codexhome.WriteConfig` writes only model-provider / MCP / trusted-paths sections; no `approvals_reviewer` or `apps.connector_*` keys (verified by grep). The new enum variant on `v2/config.rs` reaches cxg only via Server status responses we passthrough as RawMessage. |
+| 3 | `11e0f3d3ae` | Remove experimental `persistExtendedHistory` flag (#25712) | **Removal** (deletes flag from `v2/thread.rs`) | None. cxg never set `persistExtendedHistory` — grep on `internal/codexappgateway/` returns zero hits. Removed default rollout policy unchanged for callers who didn't set the flag. |
+| 4 | `cf0911076f` | Store and expose `parent_thread_id` on Threads (#25113) | Additive (new field on `Thread` + `thread_data` rows) | None. cxg peeks only `thread.id`; the new field rides along on RawMessage. |
+| 5 | `8a556296f0` | Cloud-managed config layer support (#24620) | Additive (new `cloud_managed` layer source + config diagnostics on `v2/config.rs` + `v2/hook.rs`) | None. cxg's `codexhome.WriteConfig` uses standard `~/.codex/config.toml` layer, not the new cloud-managed layer. Diagnostics ride RawMessage. |
+| 6 | `e92c952b2e` | Add user input client ids (#24653) | Additive (optional `clientId` on `UserInput`, new fields on `thread_history`, `v2/item.rs`, `v2/turn.rs`) | None. cxg's broker passes the caller's `input` field verbatim as RawMessage via `turnStartParams.Input`; never inspects clientId. |
+| 7 | `8a827d6426` | Expose MCP server info as part of server status (#24698) | Additive (new fields on `v2/mcp.rs` server status) | None. cxg neither queries MCP server status nor parses it. |
+| 8 | `2a1158b8e2` | Include turns page on thread resume (#23534) | Additive (new `turnsPage` field on `thread/resume` response) | None. cxg doesn't call `thread/resume` (broker creates fresh threads via `thread/start`); even if a future caller did, RawMessage passthrough handles the additional field. |
+
+### 3.2 Method strings we depend on
+
+Verified still-present in upstream `rust-v0.137.0`
+(`codex-rs/app-server-protocol/src/protocol/v2/`):
+
+- `thread/start`, `turn/start`, `turn/interrupt` (broker requests)
+- `item/completed`, `turn/completed` (broker notification listeners)
+- `initialize` with `params.clientInfo.{name, version, title?}`
+  (server_initialize_test.go assumptions)
+- `thread/shellCommand`, `command/exec`, `command/exec/write`,
+  `command/exec/terminate`, `command/exec/resize`, `fs/readFile`,
+  `fs/writeFile`, `fs/createDirectory`, `fs/remove`, `fs/copy`,
+  `fs/readDirectory`, `fs/getMetadata`, `fs/watch`, `fs/unwatch`
+  (intercept_local_io.go block list — none renamed in this range)
+
+### 3.3 Conclusion
+
+All 8 impactful commits are additive and ride through cxg's RawMessage
+passthrough unchanged. The one removal (`persistExtendedHistory`) is
+not used by cxg. No method strings cxg depends on were renamed.
+**Wire-shape risk: very low.** Proceed with the ARG bump.
+
+## 4. Verification
+
+In order:
+
+1. `go test ./internal/codexappgateway/...` — must be all green.
+   Notably covers `server_initialize_test.go` (which freezes the
+   initialize-frame wire shape against codex_cli_rs v0.132+) and
+   `intercept_local_io_test.go` (which freezes the block-list method
+   strings).
+2. `docker buildx build --build-arg CODEX_VERSION=0.137.0 -f
+   Dockerfile.codex-app-gateway -t cxg-test:0.137.0 .` — must succeed
+   on at least linux/amd64.
+3. `docker run --rm --entrypoint codex cxg-test:0.137.0 --version`
+   — must print `codex-cli 0.137.0`. The prefix `codex-cli` comes from
+   clap's program name (derived from Cargo package name
+   `codex-cli`), not from the `bin_name = "codex"` invocation alias.
+   The binary file installed at `/usr/local/bin/codex` is unchanged;
+   only the help/version banner uses the package name. No functional
+   impact on cxg, which invokes `codex app-server`, not `codex --version`.
+
+Not run in this PR:
+
+- `-tags integration` test (`TestServer_RealCodexAppServer_FullRPCRoundtrip`).
+  It is opt-in for a reason and would require an LLM key in CI; deferred.
+- Dev-cluster smoke. Will happen organically when the next cxg release
+  is cut.
+
+## 5. Rollback
+
+Single-line revert of the ARG default. No data migration, no Helm
+chart change, no protocol shim. If a quiet drift surfaces in
+production after a release bump that bundles this change, the on-call
+revert is the same one-line change in reverse.
+
+## 6. Out-of-repo / follow-on items (not in this PR)
+
+- Fork `/root/codex` rebase to `rust-v0.137.0` — separate concern;
+  carries 4 unrelated `exec-server User-Agent` commits.
+- Helm chart `appVersion` / image tag bump — happens at next cxg
+  release per `agentserver_release_flow.md`.
+- Next-time pattern: this spec's §3 structure is reusable as a
+  template for future upstream bumps. Audit only commits touching
+  `codex-rs/app-server-protocol/`, judge against the verbatim-passthrough
+  contract + the small set of method strings we name.


### PR DESCRIPTION
Bumps the codex binary baked into Dockerfile.codex-app-gateway from
0.134.0 to today's upstream stable rust-v0.137.0 (3 minor releases,
310 commits forward).

## Why now

We've been on 0.134 since release; staying current gets us bug fixes
and additive protocol features (e.g. `parent_thread_id` on Threads,
`clientId` on UserInput, MCP server info in server status) for free,
and shrinks the catch-up gap before the next upstream change that
actually matters to cxg.

## Risk

Low. cxg uses upstream `codex app-server` as a per-thread subprocess
and proxies v2 JSON-RPC frames byte-for-byte (per memory
`codex_app_server_subprocess_path.md`). broker/protocol.go uses
`json.RawMessage` passthrough; intercept_local_io's block list pins
method-name strings only.

Spec §3 audited every commit in `rust-v0.134.0..rust-v0.137.0` that
touched `codex-rs/app-server-protocol/` (19 commits total). 11 are
off-path (Windows sandbox, TUI MCP inventory, …); the remaining 8
are all additive or remove a flag (`persistExtendedHistory`) cxg
never set. **No method strings cxg depends on were renamed.**

## Verified

- `go test ./internal/codexappgateway/...` — 9/9 packages ok
- `docker buildx build --build-arg CODEX_VERSION=0.137.0` — succeeded
  (linux/amd64; upstream tarball
  `codex-x86_64-unknown-linux-musl.tar.gz` exists for rust-v0.137.0)
- `docker run --rm --entrypoint codex cxg-test:0.137.0 --version`
  → `codex-cli 0.137.0`
- bubblewrap 0.11.0 still present in the runtime image (sandbox-probe sanity)

## Out of scope

- Fork `/root/codex` rebase to rust-v0.137.0 — separate concern.
- `-tags integration` test (`TestServer_RealCodexAppServer_FullRPCRoundtrip`)
  — opt-in for a reason; requires LLM API key.
- Helm chart `appVersion` / image tag bump — handled by release flow
  per `agentserver_release_flow` memory after merge.

## Rollback

Single-line revert of the ARG default. No data migration, no Helm
chart change, no protocol shim.

## Spec

docs/superpowers/specs/2026-06-08-cxg-codex-0.137-upgrade-design.md
(committed first on this branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)