### PR TITLE
chore(chart): bump 0.65.1 → 0.65.2 to ship #231

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.65.1
-appVersion: "0.65.1"
+version: 0.65.2
+appVersion: "0.65.2"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
Ships #231 (cxg codex 0.134.0 → 0.137.0).

Per agentserver_release_flow memory: chart bump → merge → push `v0.65.2` git tag (the only path that produces version-tagged images so /root/k8s/stacks/agentserver.ts can pull them).

🤖 Generated with [Claude Code](https://claude.com/claude-code)