### PR TITLE
chore(chart): bump 0.65.2 → 0.65.3 to ship #240 #241

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.65.2
-appVersion: "0.65.2"
+version: 0.65.3
+appVersion: "0.65.3"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
Ships:
- #240 — drop /internal/connected loopback
- #241 — drop all remaining env-mcp loopbacks (scheduling + dead SDK)

Rollout note: short ~1-2min window during helm rolling update where one of the three pods may be on the new code and another on the old; scheduling / list_environments may 401 in that window. Retries recover once all three are on 0.65.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)