### PR TITLE
feat(envmcp-public-gateway): Streamable HTTP transport + cmd binary + Helm + docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -506,6 +506,41 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  build-envmcp-public-gateway:
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v6
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/agentserver/envmcp-public-gateway
+          tags: |
+            type=sha,prefix=
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile.envmcp-public-gateway
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   build-jupyter:
     runs-on: ubuntu-latest
     needs: [test]

--- a/Dockerfile.envmcp-public-gateway
+++ b/Dockerfile.envmcp-public-gateway
@@ -1,0 +1,16 @@
+# Build Go binary
+FROM golang:1.26-trixie AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' \
+    -o envmcp-public-gateway ./cmd/envmcp-public-gateway
+
+# Runtime image (minimal — Go binary + CA certs, nothing else)
+FROM debian:trixie-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /app/envmcp-public-gateway /usr/local/bin/envmcp-public-gateway
+EXPOSE 8090
+ENTRYPOINT ["envmcp-public-gateway"]

--- a/cmd/envmcp-public-gateway/main.go
+++ b/cmd/envmcp-public-gateway/main.go
@@ -1,0 +1,228 @@
+// Command envmcp-public-gateway runs the public-internet MCP server
+// that lets external clients (Codex CLI, Claude Desktop in dev-mode
+// via mcp-remote, etc.) call the agentserver workspace's env tools.
+//
+// Architecture (spec: docs/superpowers/specs/2026-06-09-envmcp-public-
+// gateway-design.md, with the 2026-06-15 1-PAT-1-workspace amendment):
+//
+//	external client ─Bearer agpat_xxx─▶ /v1/mcp
+//	   ▼
+//	mcppublic.Middleware  →  PATResolver  →  Principal{user, workspace}
+//	   ▼
+//	mcppublic.Server (Streamable HTTP, MCP 2025-06-18)
+//	   ▼
+//	mcppublic.Dispatcher
+//	   ├─ tools/list, list_environments     — in-process
+//	   └─ tools/call (others) ─▶ CapMinter ─▶ BridgeBackend
+//	                                              ▼
+//	                                       per-Principal toolkit
+//	                                       = bridge.Pool + nameresolver
+//	                                       + sessions + envtools/tools
+//	                                              ▼
+//	                                       codex-exec-gateway /bridge
+//
+// Required environment variables — every one is mandatory, the
+// gateway fails-closed on a missing knob. (Use Helm
+// templates/envmcp-public-gateway.yaml to wire them.)
+//
+//	DATABASE_URL                       — postgres for PAT validation
+//	CXG_LISTEN_ADDR                    — e.g. ":8090"
+//	CXG_CAPTOKEN_HMAC_SECRET           — shared with app-gateway + exec-gateway
+//	CXG_EXEC_GATEWAY_INTERNAL_URL      — http base for /api/codex-exec/*
+//	CXG_EXEC_GATEWAY_INTERNAL_SECRET   — X-Internal-Secret for the above
+//	CXG_BRIDGE_BASE_URL                — ws base for /bridge dials
+//	MCP_PUBLIC_RESOURCE_METADATA_URL   — full URL of /v1/.well-known/oauth-protected-resource
+//	                                     (advertised in 401 WWW-Authenticate)
+//	MCP_PUBLIC_ISSUER_URL              — agentserver web base (advertised in
+//	                                     the protected-resource doc)
+//
+// Optional:
+//
+//	CXG_LOG_LEVEL                      — debug / info / warn / error (default info)
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/agentserver/agentserver/internal/db"
+	"github.com/agentserver/agentserver/internal/envtools/bridge"
+	"github.com/agentserver/agentserver/internal/mcppublic"
+	"github.com/agentserver/agentserver/internal/server"
+)
+
+func main() {
+	logger := newLogger()
+	if err := run(logger); err != nil {
+		logger.Error("envmcp-public-gateway exited with error", "err", err)
+		os.Exit(1)
+	}
+}
+
+func run(logger *slog.Logger) error {
+	cfg, err := loadConfig()
+	if err != nil {
+		return fmt.Errorf("load config: %w", err)
+	}
+
+	dbConn, err := db.Open(cfg.DatabaseURL)
+	if err != nil {
+		return fmt.Errorf("open db: %w", err)
+	}
+	defer dbConn.Close()
+
+	// Auth layer: PATResolver hits ValidateMCPPATSecret +
+	// ListWorkspacesByUser on every request. The middleware emits
+	// `WWW-Authenticate: Bearer resource_metadata=…` on 401 so
+	// OAuth-capable clients (Claude Desktop 1P, Phase 2) can
+	// discover us.
+	patResolver := &mcppublic.PATResolver{DB: dbConn, Logger: logger}
+	authMW := mcppublic.AuthMiddleware(
+		[]mcppublic.PrincipalResolver{patResolver},
+		cfg.ResourceMetadataURL,
+		logger,
+	)
+
+	// Dispatcher pipeline: CapMinter → BridgeBackend → Tool[].Call.
+	minter, err := mcppublic.NewCapMinter(cfg.CapTokenHMACSecret)
+	if err != nil {
+		return fmt.Errorf("cap-minter: %w", err)
+	}
+	execClient := server.NewExecutorsClient(cfg.ExecGatewayInternalURL, cfg.ExecGatewayInternalSecret)
+	executors, err := mcppublic.NewHTTPExecutorsSource(execClient)
+	if err != nil {
+		return fmt.Errorf("executors source: %w", err)
+	}
+	// copy_path's HTTPS relay is per-workspace and authenticates
+	// with X-Internal-Secret — same one exec-gateway expects on
+	// /api/exec-gateway/relay/create. Per-workspace state lives on
+	// the RelayClient struct (workspaceID field), but we don't have
+	// a workspace at backend-construction time; PR F's BridgeBackend
+	// currently takes a single nil RelayClient and copy_path falls
+	// back to the ws cat-pump path. Wiring the per-workspace
+	// RelayClient at toolkit-build time is a follow-up — for v1 the
+	// fallback path is fine since copy_path is rarely used.
+	backend, err := mcppublic.NewBridgeBackend(cfg.BridgeBaseURL, executors, nil, logger)
+	if err != nil {
+		return fmt.Errorf("bridge backend: %w", err)
+	}
+	defer backend.Close()
+
+	dispatcher := mcppublic.NewDispatcher(
+		executors, minter, backend,
+		mcppublic.DefaultPublicToolMeta(),
+		logger,
+	)
+	srv := mcppublic.NewServer(dispatcher, cfg.IssuerURL, logger)
+
+	httpSrv := &http.Server{
+		Addr:              cfg.ListenAddr,
+		Handler:           srv.Mount(authMW),
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	errCh := make(chan error, 1)
+	go func() {
+		logger.Info("envmcp-public-gateway listening",
+			"addr", cfg.ListenAddr,
+			"resource_metadata_url", cfg.ResourceMetadataURL,
+			"exec_gateway_internal_url", cfg.ExecGatewayInternalURL,
+			"bridge_base_url", cfg.BridgeBaseURL,
+		)
+		if err := httpSrv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			errCh <- err
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+		logger.Info("envmcp-public-gateway: signal received, draining")
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		return httpSrv.Shutdown(shutdownCtx)
+	case err := <-errCh:
+		return fmt.Errorf("listen: %w", err)
+	}
+}
+
+// config is the env-var bag every gateway pod reads at boot. All
+// fields are required (fail-closed) except where noted.
+type config struct {
+	DatabaseURL               string
+	ListenAddr                string
+	CapTokenHMACSecret        []byte
+	ExecGatewayInternalURL    string
+	ExecGatewayInternalSecret string
+	BridgeBaseURL             string
+	ResourceMetadataURL       string
+	IssuerURL                 string
+}
+
+func loadConfig() (config, error) {
+	cfg := config{
+		DatabaseURL:               os.Getenv("DATABASE_URL"),
+		ListenAddr:                envOr("CXG_LISTEN_ADDR", ":8090"),
+		CapTokenHMACSecret:        []byte(os.Getenv("CXG_CAPTOKEN_HMAC_SECRET")),
+		ExecGatewayInternalURL:    os.Getenv("CXG_EXEC_GATEWAY_INTERNAL_URL"),
+		ExecGatewayInternalSecret: os.Getenv("CXG_EXEC_GATEWAY_INTERNAL_SECRET"),
+		BridgeBaseURL:             os.Getenv("CXG_BRIDGE_BASE_URL"),
+		ResourceMetadataURL:       os.Getenv("MCP_PUBLIC_RESOURCE_METADATA_URL"),
+		IssuerURL:                 os.Getenv("MCP_PUBLIC_ISSUER_URL"),
+	}
+	missing := []string{}
+	if cfg.DatabaseURL == "" {
+		missing = append(missing, "DATABASE_URL")
+	}
+	if len(cfg.CapTokenHMACSecret) == 0 {
+		missing = append(missing, "CXG_CAPTOKEN_HMAC_SECRET")
+	}
+	if cfg.ExecGatewayInternalURL == "" {
+		missing = append(missing, "CXG_EXEC_GATEWAY_INTERNAL_URL")
+	}
+	if cfg.ExecGatewayInternalSecret == "" {
+		missing = append(missing, "CXG_EXEC_GATEWAY_INTERNAL_SECRET")
+	}
+	if cfg.BridgeBaseURL == "" {
+		missing = append(missing, "CXG_BRIDGE_BASE_URL")
+	}
+	if len(missing) > 0 {
+		return cfg, fmt.Errorf("missing required env vars: %v", missing)
+	}
+	return cfg, nil
+}
+
+func envOr(k, def string) string {
+	if v := os.Getenv(k); v != "" {
+		return v
+	}
+	return def
+}
+
+func newLogger() *slog.Logger {
+	level := slog.LevelInfo
+	switch os.Getenv("CXG_LOG_LEVEL") {
+	case "debug":
+		level = slog.LevelDebug
+	case "warn":
+		level = slog.LevelWarn
+	case "error":
+		level = slog.LevelError
+	}
+	return slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: level}))
+}
+
+// Silence the unused-import warning for bridge if a future refactor
+// drops the explicit reference. (BridgeBackend uses it via the
+// internal package import path, but having an explicit reference here
+// makes the dependency obvious to `go mod tidy`.)
+var _ = bridge.Pool{}

--- a/cmd/envmcp-public-gateway/main.go
+++ b/cmd/envmcp-public-gateway/main.go
@@ -169,15 +169,21 @@ type config struct {
 }
 
 func loadConfig() (config, error) {
+	return loadConfigFromEnv(os.Getenv)
+}
+
+// loadConfigFromEnv lets tests inject a fake env-lookup function.
+// Production wiring just passes os.Getenv.
+func loadConfigFromEnv(getenv func(string) string) (config, error) {
 	cfg := config{
-		DatabaseURL:               os.Getenv("DATABASE_URL"),
-		ListenAddr:                envOr("CXG_LISTEN_ADDR", ":8090"),
-		CapTokenHMACSecret:        []byte(os.Getenv("CXG_CAPTOKEN_HMAC_SECRET")),
-		ExecGatewayInternalURL:    os.Getenv("CXG_EXEC_GATEWAY_INTERNAL_URL"),
-		ExecGatewayInternalSecret: os.Getenv("CXG_EXEC_GATEWAY_INTERNAL_SECRET"),
-		BridgeBaseURL:             os.Getenv("CXG_BRIDGE_BASE_URL"),
-		ResourceMetadataURL:       os.Getenv("MCP_PUBLIC_RESOURCE_METADATA_URL"),
-		IssuerURL:                 os.Getenv("MCP_PUBLIC_ISSUER_URL"),
+		DatabaseURL:               getenv("DATABASE_URL"),
+		ListenAddr:                getenvOr(getenv, "CXG_LISTEN_ADDR", ":8090"),
+		CapTokenHMACSecret:        []byte(getenv("CXG_CAPTOKEN_HMAC_SECRET")),
+		ExecGatewayInternalURL:    getenv("CXG_EXEC_GATEWAY_INTERNAL_URL"),
+		ExecGatewayInternalSecret: getenv("CXG_EXEC_GATEWAY_INTERNAL_SECRET"),
+		BridgeBaseURL:             getenv("CXG_BRIDGE_BASE_URL"),
+		ResourceMetadataURL:       getenv("MCP_PUBLIC_RESOURCE_METADATA_URL"),
+		IssuerURL:                 getenv("MCP_PUBLIC_ISSUER_URL"),
 	}
 	missing := []string{}
 	if cfg.DatabaseURL == "" {
@@ -195,14 +201,29 @@ func loadConfig() (config, error) {
 	if cfg.BridgeBaseURL == "" {
 		missing = append(missing, "CXG_BRIDGE_BASE_URL")
 	}
+	// The two MCP_PUBLIC_* vars are documented as required because
+	// missing them silently degrades the 401 WWW-Authenticate header
+	// (no `resource_metadata=` parameter) and the OAuth-protected-
+	// resource doc (no `authorization_servers` entry). Codex CLI
+	// ignores both today, but enforce fail-closed so Phase 2 clients
+	// (Claude Desktop 1P Custom Connectors) discover us correctly.
+	if cfg.ResourceMetadataURL == "" {
+		missing = append(missing, "MCP_PUBLIC_RESOURCE_METADATA_URL")
+	}
+	if cfg.IssuerURL == "" {
+		missing = append(missing, "MCP_PUBLIC_ISSUER_URL")
+	}
 	if len(missing) > 0 {
 		return cfg, fmt.Errorf("missing required env vars: %v", missing)
 	}
 	return cfg, nil
 }
 
-func envOr(k, def string) string {
-	if v := os.Getenv(k); v != "" {
+// getenvOr returns the value of the named env var, or def if empty.
+// Lookup goes through the injected `getenv` so loadConfigFromEnv's
+// test path stays hermetic (no actual os.Getenv calls in tests).
+func getenvOr(getenv func(string) string, k, def string) string {
+	if v := getenv(k); v != "" {
 		return v
 	}
 	return def

--- a/cmd/envmcp-public-gateway/main_test.go
+++ b/cmd/envmcp-public-gateway/main_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+// fullEnv is the canonical complete env-var set; every test starts
+// from this and mutates one var to exercise the failure cases.
+func fullEnv() map[string]string {
+	return map[string]string{
+		"DATABASE_URL":                     "postgres://x/y",
+		"CXG_LISTEN_ADDR":                  ":8090",
+		"CXG_CAPTOKEN_HMAC_SECRET":         "shhh",
+		"CXG_EXEC_GATEWAY_INTERNAL_URL":    "http://exec-gw:6060",
+		"CXG_EXEC_GATEWAY_INTERNAL_SECRET": "internal",
+		"CXG_BRIDGE_BASE_URL":              "ws://exec-gw:6060/bridge",
+		"MCP_PUBLIC_RESOURCE_METADATA_URL": "https://mcp.example.com/v1/.well-known/oauth-protected-resource",
+		"MCP_PUBLIC_ISSUER_URL":            "https://app.example.com",
+	}
+}
+
+func envFn(env map[string]string) func(string) string {
+	return func(k string) string { return env[k] }
+}
+
+func TestLoadConfig_FullEnvSucceeds(t *testing.T) {
+	cfg, err := loadConfigFromEnv(envFn(fullEnv()))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.DatabaseURL != "postgres://x/y" {
+		t.Errorf("DatabaseURL: %q", cfg.DatabaseURL)
+	}
+	if cfg.ResourceMetadataURL == "" || cfg.IssuerURL == "" {
+		t.Errorf("MCP_PUBLIC_* vars empty: %+v", cfg)
+	}
+}
+
+// TestLoadConfig_AllRequiredVarsEnforced sweeps every required env
+// var, deletes it, expects a fail-closed error naming the missing
+// var. Catches the H2 regression where the doc said vars were
+// required but loadConfig forgot to enforce them.
+func TestLoadConfig_AllRequiredVarsEnforced(t *testing.T) {
+	required := []string{
+		"DATABASE_URL",
+		"CXG_CAPTOKEN_HMAC_SECRET",
+		"CXG_EXEC_GATEWAY_INTERNAL_URL",
+		"CXG_EXEC_GATEWAY_INTERNAL_SECRET",
+		"CXG_BRIDGE_BASE_URL",
+		"MCP_PUBLIC_RESOURCE_METADATA_URL",
+		"MCP_PUBLIC_ISSUER_URL",
+	}
+	for _, missing := range required {
+		t.Run(missing, func(t *testing.T) {
+			env := fullEnv()
+			delete(env, missing)
+			_, err := loadConfigFromEnv(envFn(env))
+			if err == nil {
+				t.Fatalf("missing %s: want error, got nil", missing)
+			}
+			if !strings.Contains(err.Error(), missing) {
+				t.Errorf("error should name the missing var: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_ListenAddrDefaultsTo8090(t *testing.T) {
+	env := fullEnv()
+	delete(env, "CXG_LISTEN_ADDR")
+	cfg, err := loadConfigFromEnv(envFn(env))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ListenAddr != ":8090" {
+		t.Errorf("ListenAddr default: got %q, want :8090", cfg.ListenAddr)
+	}
+}

--- a/deploy/helm/agentserver/templates/envmcp-public-gateway.yaml
+++ b/deploy/helm/agentserver/templates/envmcp-public-gateway.yaml
@@ -1,0 +1,170 @@
+{{- if .Values.envmcpPublicGateway.enabled }}
+{{- /*
+envmcp-public-gateway — public-internet MCP endpoint for Codex CLI /
+Claude Desktop (3P via mcp-remote, 1P via Custom Connectors in Phase 2).
+
+Spec: docs/superpowers/specs/2026-06-09-envmcp-public-gateway-design.md
+(plus the 2026-06-15 amendment that pins one PAT to one workspace).
+
+Required values:
+  envmcpPublicGateway.enabled            — bool
+  envmcpPublicGateway.image.repository
+  envmcpPublicGateway.image.tag
+  envmcpPublicGateway.port               — default 8090
+  envmcpPublicGateway.publicHost         — default mcp.<gateway.host>
+  internal.apiSecret                     — for DB validation flow (same
+                                            secret agentserver-main holds)
+*/ -}}
+{{- $publicHost := .Values.envmcpPublicGateway.publicHost }}
+{{- if not $publicHost }}{{- $publicHost = printf "mcp.%s" .Values.gateway.host }}{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-envmcp-public-gateway
+  labels:
+    app: {{ .Release.Name }}-envmcp-public-gateway
+spec:
+  replicas: {{ .Values.envmcpPublicGateway.replicaCount | default 1 }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-envmcp-public-gateway
+  template:
+    metadata:
+      annotations:
+        agentserver.x-k8s.io/chart-version: {{ .Chart.AppVersion | quote }}
+      labels:
+        app: {{ .Release.Name }}-envmcp-public-gateway
+    spec:
+      serviceAccountName: {{ .Release.Name }}
+      terminationGracePeriodSeconds: 30
+      initContainers:
+        {{- if .Values.postgresql.enabled }}
+        - name: wait-for-postgresql
+          image: "{{ .Values.postgresql.image.repository }}:{{ .Values.postgresql.image.tag }}"
+          command:
+            - sh
+            - -c
+            - |
+              until pg_isready -h {{ .Release.Name }}-postgresql -p 5432 -U {{ .Values.postgresql.auth.username }}; do
+                echo "Waiting for PostgreSQL to be ready..."
+                sleep 2
+              done
+        {{- end }}
+      containers:
+        - name: envmcp-public-gateway
+          image: "{{ .Values.envmcpPublicGateway.image.repository }}:{{ .Values.envmcpPublicGateway.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.envmcpPublicGateway.image.pullPolicy | default "IfNotPresent" }}
+          ports:
+            - containerPort: {{ .Values.envmcpPublicGateway.port | default 8090 }}
+              name: http
+              protocol: TCP
+          env:
+            - name: CXG_LISTEN_ADDR
+              value: ":{{ .Values.envmcpPublicGateway.port | default 8090 }}"
+            # Postgres for PAT validation. Reuses agentserver-main's
+            # DSN (the mcp_pats table lives there); the public gateway
+            # does NOT need its own database since the schema +
+            # workspaces tables are shared.
+            - name: DATABASE_URL
+              value: {{ include "agentserver.databaseUrl" . | quote }}
+            # Cap-token HMAC secret — shared by app-gateway (signer)
+            # and exec-gateway + agentserver-main (verifiers). The
+            # public gateway is also a signer (mints cap-tokens for
+            # /bridge dials). Same K8s Secret key all four pods use.
+            - name: CXG_CAPTOKEN_HMAC_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-codex-gateway
+                  key: cap-token-hmac-secret
+            # Exec-gateway internal API URL — public gateway calls
+            # /api/codex-exec/workspaces/{wid}/executors for
+            # list_environments. In-cluster Service DNS.
+            - name: CXG_EXEC_GATEWAY_INTERNAL_URL
+              value: "http://{{ .Release.Name }}-codex-exec-gateway.{{ .Release.Namespace }}.svc:{{ .Values.codexExecGateway.port }}"
+            # ListBinding handler on exec-gateway expects
+            # X-Internal-Secret = .Values.internal.apiSecret (the
+            # same plain string codex-app-gateway and exec-gateway
+            # already wire as CXG_AGENTSERVER_INTERNAL_SECRET).
+            - name: CXG_EXEC_GATEWAY_INTERNAL_SECRET
+              value: {{ required "internal.apiSecret is required when envmcpPublicGateway.enabled is true" .Values.internal.apiSecret | quote }}
+            # Bridge WS base — public gateway's BridgeBackend dials
+            # /bridge/<exe_id> here per tools/call. Same hostport as
+            # codex-app-gateway uses for its in-pod env-mcp dials.
+            - name: CXG_BRIDGE_BASE_URL
+              value: "ws://{{ .Release.Name }}-codex-exec-gateway.{{ .Release.Namespace }}.svc:{{ .Values.codexExecGateway.port }}/bridge"
+            # Advertised in 401 WWW-Authenticate (so Claude Desktop 1P
+            # can OAuth-discover us once Phase 2 lands) + in the
+            # /v1/.well-known/oauth-protected-resource body.
+            - name: MCP_PUBLIC_RESOURCE_METADATA_URL
+              value: "https://{{ $publicHost }}/v1/.well-known/oauth-protected-resource"
+            # Issuer URL pointing back at agentserver web for PAT mint
+            # UX (the protected-resource doc's authorization_servers
+            # entry). Falls back to publicHost if no custom web URL.
+            - name: MCP_PUBLIC_ISSUER_URL
+              value: {{ default (printf "https://%s" .Values.gateway.host) .Values.envmcpPublicGateway.issuerURL | quote }}
+            {{- if .Values.envmcpPublicGateway.logLevel }}
+            - name: CXG_LOG_LEVEL
+              value: {{ .Values.envmcpPublicGateway.logLevel | quote }}
+            {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.envmcpPublicGateway.port | default 8090 }}
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.envmcpPublicGateway.port | default 8090 }}
+            initialDelaySeconds: 3
+            periodSeconds: 5
+          lifecycle:
+            # Graceful drain — give in-flight tools/call a moment to
+            # finish before SIGTERM. Matches the
+            # codex-exec-gateway lifecycle pattern.
+            preStop:
+              exec:
+                command: ["sh", "-c", "sleep 10"]
+          {{- with .Values.envmcpPublicGateway.resources }}
+          resources: {{- toYaml . | nindent 12 }}
+          {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-envmcp-public-gateway
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ .Values.envmcpPublicGateway.port | default 8090 }}
+      targetPort: {{ .Values.envmcpPublicGateway.port | default 8090 }}
+      protocol: TCP
+      name: http
+  selector:
+    app: {{ .Release.Name }}-envmcp-public-gateway
+{{- if .Values.gateway.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Release.Name }}-envmcp-public-gateway
+spec:
+  parentRefs:
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  hostnames:
+    - {{ $publicHost | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ .Release.Name }}-envmcp-public-gateway
+          port: {{ .Values.envmcpPublicGateway.port | default 8090 }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/agentserver/values.yaml
+++ b/deploy/helm/agentserver/values.yaml
@@ -352,6 +352,36 @@ codexExecGateway:
   relayMaxPerWorkspace: 0  # e.g. 16 — concurrent relays per workspace
   resources: {}
 
+# envmcp-public-gateway: public-internet MCP endpoint for external
+# clients (Codex CLI, Claude Desktop in 3P/dev-mode via mcp-remote,
+# Claude Desktop 1P via Custom Connectors once Phase 2 lands). Maps
+# inbound PAT bearers (`agpat_…`, one PAT = one workspace) to the
+# in-pod env-mcp tool surface (list_environments / shell / read_file /
+# write_stdin / read_output / terminate / exec_command / apply_patch /
+# copy_path). See docs/superpowers/specs/2026-06-09-envmcp-public-
+# gateway-design.md and docs/integrations/codex-cli.md.
+envmcpPublicGateway:
+  enabled: false
+  image:
+    repository: ghcr.io/agentserver/envmcp-public-gateway
+    tag: ""               # defaults to Chart.AppVersion via template, override here for testing
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+  port: 8090
+  logLevel: info
+  # External hostname for Codex CLI / Claude Desktop / mcp-remote
+  # config. Empty defaults to "mcp.<gateway.host>" (so users see
+  # https://mcp.agent.cs.ac.cn/v1/mcp on the standard deployment).
+  publicHost: ""
+  # Optional override for the agentserver web URL surfaced in the
+  # 401 WWW-Authenticate's resource_metadata + the OAuth-protected-
+  # resource doc's authorization_servers. Empty defaults to
+  # "https://<gateway.host>".
+  issuerURL: ""
+  resources:
+    requests: { cpu: "50m",  memory: "64Mi" }
+    limits:   { cpu: "500m", memory: "256Mi" }
+
 # codex-exec-edge: thin WS auth/proxy + register-retry layer in front of
 # codex-exec-gateway. Decouples connector lifecycle from gateway upgrades —
 # gateway can Recreate freely without killing connector processes (which

--- a/docs/integrations/claude-desktop-3p.md
+++ b/docs/integrations/claude-desktop-3p.md
@@ -1,0 +1,81 @@
+# Claude Desktop (3P / Developer Mode) integration
+
+If you run Claude Desktop in "Cowork on 3P" / Developer Mode, the Custom Connectors UI is **disabled** (that's a 1P-only feature, requires OAuth which the gateway will support in Phase 2). The official workaround is to bridge a remote MCP endpoint into a local stdio MCP server via `mcp-remote`.
+
+## Prerequisites
+
+- Claude Desktop in Developer / 3P mode
+- Node.js installed (for `npx`)
+- An agentserver PAT — see [the codex-cli guide](./codex-cli.md#step-1--mint-a-personal-access-token) for how to mint one
+
+## Configure
+
+Edit `claude_desktop_config.json` (on macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`; on Windows: `%APPDATA%\Claude\claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "agentserver": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://mcp.agent.cs.ac.cn/v1/mcp",
+        "--header",
+        "Authorization:${AGENTSERVER_PAT}"
+      ],
+      "env": {
+        "AGENTSERVER_PAT": "Bearer agpat_a1b2c3d4e5f6g7h8_X9y8Z7w6V5u4T3s2R1q0P9o8N7m6L5k4J3i2H1g0F9e8..."
+      }
+    }
+  }
+}
+```
+
+> **Note** the `Authorization:${AGENTSERVER_PAT}` (no space). Some `mcp-remote` versions on Windows / Cursor mangle the space in `Authorization: Bearer …` when expanding the env var — keeping the `Bearer ` prefix inside the env var value and joining with `:` (no space) sidesteps that.
+
+Restart Claude Desktop. The next time you start a conversation, the tools `agentserver_shell`, `agentserver_read_file`, etc. should be available.
+
+## Verify
+
+Same direct-curl smoke test as the Codex guide:
+
+```bash
+curl -s -X POST https://mcp.agent.cs.ac.cn/v1/mcp \
+  -H "Authorization: Bearer $(echo "$AGENTSERVER_PAT" | sed 's/^Bearer //')" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | jq
+```
+
+If that returns your 9 tool definitions but Claude Desktop says "tools not available", check Claude Desktop's logs (`~/Library/Logs/Claude/mcp.log` on macOS) for the `mcp-remote` subprocess output.
+
+## Multi-workspace setup
+
+One PAT per workspace, one entry per workspace:
+
+```json
+{
+  "mcpServers": {
+    "work": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://mcp.agent.cs.ac.cn/v1/mcp", "--header", "Authorization:${AGENTSERVER_PAT_WORK}"],
+      "env": { "AGENTSERVER_PAT_WORK": "Bearer agpat_work_…" }
+    },
+    "personal": {
+      "command": "npx",
+      "args": ["mcp-remote", "https://mcp.agent.cs.ac.cn/v1/mcp", "--header", "Authorization:${AGENTSERVER_PAT_PERSONAL}"],
+      "env": { "AGENTSERVER_PAT_PERSONAL": "Bearer agpat_personal_…" }
+    }
+  }
+}
+```
+
+Claude Desktop prefixes tool names by server entry, same as Codex (`work_shell`, `personal_shell`, …) — no name collisions even if both workspaces share an executor name.
+
+## Why this isn't via Custom Connectors
+
+Custom Connectors is 1P-only and expects an OAuth 2.1 + DCR flow. The gateway will support it in Phase 2 (Hydra-backed `/oauth/authorize` + `/oauth/token` + `.well-known/oauth-authorization-server`). Until then, 3P + `mcp-remote` is the supported path.
+
+## Related
+
+- [Codex CLI](./codex-cli.md) — same gateway from a different client
+- Spec: `docs/superpowers/specs/2026-06-09-envmcp-public-gateway-design.md`

--- a/docs/integrations/codex-cli.md
+++ b/docs/integrations/codex-cli.md
@@ -1,0 +1,132 @@
+# Codex CLI integration
+
+Run your agentserver workspaces' tools (`shell`, `read_file`, `apply_patch`, …) from inside Codex CLI, against any executor you've registered.
+
+## Prerequisites
+
+- A workspace + at least one registered executor in agentserver (Settings → Executors)
+- Codex CLI ≥ 0.137 (any version with `bearer_token_env_var` support for `[mcp_servers]`)
+
+## Step 1 — Mint a Personal Access Token
+
+PATs are **workspace-scoped** — one PAT covers exactly one workspace. If you want Codex to reach several workspaces, mint one PAT per workspace (see "Multi-workspace setup" below).
+
+Today the only PAT management UI is the REST API. Mint via your session cookie or a long-lived workspace API key:
+
+```bash
+# Via session cookie (paste from browser DevTools → agentserver origin)
+WID=ws_yourworkspaceid
+curl -X POST "https://app.agent.cs.ac.cn/api/workspaces/${WID}/mcp/pats" \
+  -H "Cookie: agentserver_session=..." \
+  -H "Content-Type: application/json" \
+  -d '{"name":"my-laptop-codex","scopes":["mcp:read","mcp:exec"],"expires_at":"2026-09-09T00:00:00Z"}'
+```
+
+Response (the `secret` is shown **once** — store it now):
+
+```json
+{
+  "id": "agpat_a1b2c3d4e5f6g7h8",
+  "name": "my-laptop-codex",
+  "prefix": "agpat_a1b2c3d4e5f6g7h8",
+  "workspace_id": "ws_yourworkspaceid",
+  "secret": "agpat_a1b2c3d4e5f6g7h8_X9y8Z7w6V5u4T3s2R1q0P9o8N7m6L5k4J3i2H1g0F9e8...",
+  "scopes": ["mcp:read","mcp:exec"],
+  "created_at": "2026-06-15T08:30:00Z",
+  "expires_at": "2026-09-09T00:00:00Z"
+}
+```
+
+### Scopes
+
+| Scope | Tools granted | Notes |
+|---|---|---|
+| `mcp:read` | `list_environments`, `read_file` | Side-effect-free |
+| `mcp:exec` | `shell`, `exec_command`, `write_stdin`, `read_output`, `terminate`, `apply_patch`, `copy_path` | **Full shell access on registered executors** — opt in explicitly |
+
+Default to `mcp:read` and only add `mcp:exec` when the agent actually needs to mutate state.
+
+### Workspace-level role required to mint
+
+You need `owner` or `maintainer` on the workspace. `developer` / `viewer` get a 403 — minting a PAT with `mcp:exec` is equivalent to handing out shell, so it follows the same admin gate as workspace API keys.
+
+## Step 2 — Add to `~/.codex/config.toml`
+
+```toml
+[mcp_servers.agentserver]
+url = "https://mcp.agent.cs.ac.cn/v1/mcp"
+bearer_token_env_var = "AGENTSERVER_PAT"
+```
+
+```bash
+export AGENTSERVER_PAT='agpat_a1b2c3d4e5f6g7h8_X9y8Z7w6V5u4T3s2R1q0P9o8N7m6L5k4J3i2H1g0F9e8...'
+```
+
+That's it. Next time you start Codex CLI, you'll see `agentserver_shell`, `agentserver_read_file`, `agentserver_list_environments`, etc. in the tool palette.
+
+## Step 3 — Verify
+
+In a Codex session:
+
+```
+> please list the environments I have access to
+```
+
+The LLM should call `agentserver_list_environments` and print your workspace's executors.
+
+Direct curl smoke test (skips the LLM):
+
+```bash
+curl -s -X POST https://mcp.agent.cs.ac.cn/v1/mcp \
+  -H "Authorization: Bearer $AGENTSERVER_PAT" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | jq
+```
+
+You should see your 9 tool definitions in the response.
+
+## Multi-workspace setup
+
+For each workspace, mint a PAT (Step 1) and add a separate `[mcp_servers.X]` entry where `X` is a short name you choose:
+
+```toml
+[mcp_servers.work]
+url = "https://mcp.agent.cs.ac.cn/v1/mcp"
+bearer_token_env_var = "AGENTSERVER_PAT_WORK"
+
+[mcp_servers.personal]
+url = "https://mcp.agent.cs.ac.cn/v1/mcp"
+bearer_token_env_var = "AGENTSERVER_PAT_PERSONAL"
+```
+
+```bash
+export AGENTSERVER_PAT_WORK=agpat_...
+export AGENTSERVER_PAT_PERSONAL=agpat_...
+```
+
+Codex auto-prefixes tool names by server: the LLM sees `work_shell`, `personal_shell`, etc. — visually distinct, no ambiguity even if both workspaces happen to have an executor named `laptop`.
+
+## Revoke
+
+Same workspace, same admin role:
+
+```bash
+curl -X DELETE "https://app.agent.cs.ac.cn/api/workspaces/${WID}/mcp/pats/agpat_a1b2c3d4e5f6g7h8" \
+  -H "Cookie: agentserver_session=..."
+```
+
+A revoked PAT stops working within ~one cap-token TTL window (≤10 min) on the gateway side.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| `401 unauthorized` on every request | Wrong PAT, expired, revoked, or you were removed from the workspace | Re-mint; verify with the curl smoke test above |
+| `tools/call ... not granted to this principal` | PAT lacks the `mcp:exec` scope | Re-mint with `["mcp:read","mcp:exec"]` |
+| `no environment named X` | The executor name isn't in `list_environments` output | Run `list_environments` first; copy a `name` value verbatim into your prompt |
+| `bridge dial timed out` | Executor offline or unreachable from the gateway | Check `Settings → Executors` — `last_seen` should be recent |
+
+## Related
+
+- [Claude Desktop (3P / Developer Mode)](./claude-desktop-3p.md) — same gateway, different client
+- Spec: `docs/superpowers/specs/2026-06-09-envmcp-public-gateway-design.md` (with 2026-06-15 amendment)

--- a/internal/mcppublic/dispatch.go
+++ b/internal/mcppublic/dispatch.go
@@ -209,9 +209,19 @@ func (d *Dispatcher) ToolsCall(ctx context.Context, p *Principal, params tools.M
 		Principal: p,
 	})
 	if err != nil {
+		// Log the full underlying error server-side (includes the
+		// dialer's TCP error which may name internal pod IPs, the
+		// bridge URL, etc.) but return only an opaque message to the
+		// public client. Including err.Error() in the wire response
+		// would leak our cluster topology (e.g. "dial tcp
+		// 10.0.5.7:6060: connection refused" → internal CIDR
+		// disclosure) to anyone holding a valid PAT.
 		d.Logger.Warn("mcppublic: tool backend error",
 			"tool", params.Name, "workspace_id", p.WorkspaceID, "err", err)
-		return nil, &jsonrpcErr{Code: codeToolExecutionFail, Message: params.Name + ": " + err.Error()}
+		return nil, &jsonrpcErr{
+			Code:    codeToolExecutionFail,
+			Message: params.Name + ": tool execution failed",
+		}
 	}
 	return &res, nil
 }
@@ -228,7 +238,13 @@ func (d *Dispatcher) ToolsCall(ctx context.Context, p *Principal, params tools.M
 func (d *Dispatcher) handleListEnvironments(ctx context.Context, p *Principal) (*tools.MCPCallToolResult, *jsonrpcErr) {
 	rows, err := d.Executors.ListWorkspaceExecutors(ctx, p.WorkspaceID)
 	if err != nil {
-		return nil, &jsonrpcErr{Code: codeUpstreamUnavail, Message: "list_environments: " + err.Error()}
+		// Same redaction rationale as ToolsCall's backend-error path:
+		// upstream errors can name internal hostnames (HTTPExecutors
+		// hits an in-cluster Service). Log full server-side, return
+		// generic to the client.
+		d.Logger.Warn("mcppublic: list_environments upstream error",
+			"workspace_id", p.WorkspaceID, "err", err)
+		return nil, &jsonrpcErr{Code: codeUpstreamUnavail, Message: "list_environments: upstream unavailable"}
 	}
 	type llmEntry struct {
 		Name        string `json:"name"`
@@ -250,7 +266,9 @@ func (d *Dispatcher) handleListEnvironments(ctx context.Context, p *Principal) (
 	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
 	body, err := json.Marshal(out)
 	if err != nil {
-		return nil, &jsonrpcErr{Code: codeInternal, Message: "marshal list_environments: " + err.Error()}
+		d.Logger.Error("mcppublic: marshal list_environments failed",
+			"workspace_id", p.WorkspaceID, "err", err)
+		return nil, &jsonrpcErr{Code: codeInternal, Message: "internal error"}
 	}
 	return &tools.MCPCallToolResult{
 		Content: []tools.MCPToolContent{{Type: "text", Text: string(body)}},

--- a/internal/mcppublic/dispatch_test.go
+++ b/internal/mcppublic/dispatch_test.go
@@ -199,8 +199,13 @@ func TestDispatcher_ToolsCall_HappyPathInvokesBackendWithMintedToken(t *testing.
 	}
 }
 
-func TestDispatcher_ToolsCall_BackendFailureSurfacesAsExecError(t *testing.T) {
-	backend := &stubBackend{err: errors.New("bridge dial timed out")}
+func TestDispatcher_ToolsCall_BackendFailureRedactsInternalDetails(t *testing.T) {
+	// The backend errors with text that names internal pod IPs (the
+	// kind of message net.Dial returns when an in-cluster Service is
+	// unreachable). The dispatcher must log that server-side but
+	// return only an opaque message to the public client — leaking
+	// internal CIDRs is a security finding.
+	backend := &stubBackend{err: errors.New("dial tcp 10.0.5.7:6060: connection refused")}
 	d := newTestDispatcher(t, nil, backend)
 	p := principalReadExec("ws_1")
 
@@ -211,8 +216,34 @@ func TestDispatcher_ToolsCall_BackendFailureSurfacesAsExecError(t *testing.T) {
 	if errObj == nil || errObj.Code != codeToolExecutionFail {
 		t.Fatalf("want codeToolExecutionFail, got %+v", errObj)
 	}
-	if !strings.Contains(errObj.Message, "bridge dial timed out") {
-		t.Errorf("error message should include backend cause: %s", errObj.Message)
+	// Must name the tool (so the LLM knows which call failed)…
+	if !strings.Contains(errObj.Message, "shell") {
+		t.Errorf("error message should name the tool: %s", errObj.Message)
+	}
+	// …but must NOT leak the internal IP / port / dial-error detail.
+	for _, leak := range []string{"10.0.5.7", "dial tcp", "6060", "connection refused"} {
+		if strings.Contains(errObj.Message, leak) {
+			t.Errorf("error message leaks internal detail %q: %s", leak, errObj.Message)
+		}
+	}
+}
+
+func TestDispatcher_ToolsCall_ListEnvironmentsUpstreamErrorRedacts(t *testing.T) {
+	// Same redaction rationale for the list_environments path: an
+	// upstream HTTPExecutorsSource error can name internal hostnames
+	// (it hits a Service.svc URL). Only opaque message to the wire.
+	src := &fakeExecutorsSource{err: errors.New("Get \"http://release-codex-exec-gateway.default.svc:6060/api/codex-exec/workspaces/ws_1/executors\": connection refused")}
+	d := newTestDispatcher(t, src, &stubBackend{})
+
+	_, errObj := d.ToolsCall(context.Background(), principalReadOnly("ws_1"),
+		tools.MCPCallToolParams{Name: "list_environments", Arguments: json.RawMessage(`{}`)})
+	if errObj == nil || errObj.Code != codeUpstreamUnavail {
+		t.Fatalf("want codeUpstreamUnavail, got %+v", errObj)
+	}
+	for _, leak := range []string{"release-codex-exec-gateway", ".svc", "6060", "connection refused"} {
+		if strings.Contains(errObj.Message, leak) {
+			t.Errorf("error message leaks internal detail %q: %s", leak, errObj.Message)
+		}
 	}
 }
 
@@ -287,17 +318,6 @@ func TestDispatcher_ToolsCall_ListEnvironmentsScopedToPrincipalsWorkspace(t *tes
 				t.Errorf("workspace %s: leaked cross-workspace row: %s", ws, gotName)
 			}
 		})
-	}
-}
-
-func TestDispatcher_ToolsCall_ListEnvironmentsUpstreamErrorIsServiceUnavailable(t *testing.T) {
-	src := &fakeExecutorsSource{err: errors.New("upstream down")}
-	d := newTestDispatcher(t, src, &stubBackend{})
-
-	_, errObj := d.ToolsCall(context.Background(), principalReadOnly("ws_1"),
-		tools.MCPCallToolParams{Name: "list_environments", Arguments: json.RawMessage(`{}`)})
-	if errObj == nil || errObj.Code != codeUpstreamUnavail {
-		t.Fatalf("want codeUpstreamUnavail, got %+v", errObj)
 	}
 }
 

--- a/internal/mcppublic/transport.go
+++ b/internal/mcppublic/transport.go
@@ -2,7 +2,6 @@ package mcppublic
 
 import (
 	"encoding/json"
-	"errors"
 	"io"
 	"log/slog"
 	"net/http"
@@ -284,7 +283,7 @@ func idOrNull(id json.RawMessage) json.RawMessage {
 // can mint a PAT manually.
 func (s *Server) handleOAuthProtectedResource(w http.ResponseWriter, r *http.Request) {
 	gatewayURL := "https://" + r.Host + "/v1/mcp"
-	if r.TLS == nil {
+	if !requestIsHTTPS(r) {
 		// Dev / port-forward case — keep things working over plain http.
 		gatewayURL = "http://" + r.Host + "/v1/mcp"
 	}
@@ -303,6 +302,32 @@ func (s *Server) handleOAuthProtectedResource(w http.ResponseWriter, r *http.Req
 	_ = json.NewEncoder(w).Encode(doc)
 }
 
+// requestIsHTTPS reports whether the original client request was over
+// TLS. The pod terminates TLS at the ingress layer (istio-ingress +
+// cert-manager) and arrives on the cleartext Service port, so
+// `r.TLS` is always nil in production — we have to trust the
+// `X-Forwarded-Proto` header the ingress sets. Trusting it is fine
+// here because the Service is only reachable through the ingress
+// (NetworkPolicy + HTTPRoute pin the path; no direct pod traffic
+// from outside the cluster).
+//
+// Order:
+//  1. X-Forwarded-Proto if set (production istio-ingress path)
+//  2. r.TLS != nil (httptest.NewTLSServer / standalone TLS)
+//  3. otherwise plain http (dev / port-forward / curl-against-Service)
+func requestIsHTTPS(r *http.Request) bool {
+	if xfp := r.Header.Get("X-Forwarded-Proto"); xfp != "" {
+		// Header may carry a comma-separated chain (RFC 7239-style);
+		// take the first entry which is the client-facing scheme.
+		first := xfp
+		if i := strings.IndexByte(xfp, ','); i >= 0 {
+			first = xfp[:i]
+		}
+		return strings.EqualFold(strings.TrimSpace(first), "https")
+	}
+	return r.TLS != nil
+}
+
 // AuthMiddleware constructs the auth.Middleware-equivalent http.Handler
 // wrapper. Exposed as a convenience so the cmd binary doesn't have to
 // know about the Middleware struct's fields directly — pass an empty
@@ -317,7 +342,3 @@ func AuthMiddleware(resolvers []PrincipalResolver, resourceMetadataURL string, l
 	return mw.Wrap
 }
 
-// ensure the errors package stays imported even if a future refactor
-// drops the only user — keeps `go vet` quiet without leaving an
-// unused-import landmine for the next editor.
-var _ = errors.New

--- a/internal/mcppublic/transport.go
+++ b/internal/mcppublic/transport.go
@@ -1,0 +1,323 @@
+package mcppublic
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"strings"
+
+	"github.com/agentserver/agentserver/internal/envtools/tools"
+)
+
+// Streamable HTTP transport for the public MCP gateway, targeting
+// the MCP protocol version `2025-06-18` (Codex CLI's default; see
+// codex-rs/codex-mcp/src/rmcp_client.rs:489-493).
+//
+// Endpoints on the gateway hostname (production: mcp.agent.cs.ac.cn):
+//
+//   POST /v1/mcp        — JSON-RPC request → JSON-RPC response.
+//                         Content-Type: application/json.
+//   GET  /v1/mcp        — 405. Stateless server, no SSE re-attach;
+//                         the spec marks GET as MAY for stateless.
+//   DELETE /v1/mcp      — 405. No Mcp-Session-Id support in this
+//                         transport; nothing to delete.
+//   GET  /healthz       — 200, plain text "ok". For K8s liveness +
+//                         istio readiness probes.
+//   GET  /v1/.well-known/oauth-protected-resource
+//                       — small JSON stub pointing at agentserver's
+//                         /api/workspaces/{wid}/mcp/pats minting UI.
+//                         Codex CLI ignores this and short-circuits
+//                         to bearer_token_env_var; Claude Desktop 1P
+//                         (Phase 2) will use it for OAuth discovery.
+//
+// Wire shape per JSON-RPC 2.0:
+//   {"jsonrpc":"2.0","id":<n>,"method":"<m>","params":<…>}
+//   {"jsonrpc":"2.0","id":<n>,"result":<…>}
+//   {"jsonrpc":"2.0","id":<n>,"error":{"code":<n>,"message":"<m>"}}
+//
+// Auth: the auth.Middleware (PR D) wraps this handler; by the time
+// ServeHTTP runs, the Principal is in r.Context() via PrincipalFromContext.
+
+// jsonrpcReq is the inbound wire envelope. We only need a handful of
+// fields; everything else is ignored.
+type jsonrpcReq struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"` // RawMessage so a string id round-trips
+	Method  string          `json:"method"`
+	Params  json.RawMessage `json:"params"`
+}
+
+// jsonrpcResp is the outbound envelope. Either Result or Error is
+// populated, never both. ID is echoed verbatim from the request
+// (null for notifications, which we don't actually reply to).
+type jsonrpcResp struct {
+	JSONRPC string          `json:"jsonrpc"`
+	ID      json.RawMessage `json:"id"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *jsonrpcErr     `json:"error,omitempty"`
+}
+
+// Server is the http.Handler that exposes Dispatcher over Streamable
+// HTTP MCP. Wrap it with auth.Middleware before mounting.
+type Server struct {
+	Dispatcher *Dispatcher
+	Logger     *slog.Logger
+
+	// IssuerURL, when non-empty, is the agentserver web base URL
+	// used to build the `resource_metadata` link advertised in 401
+	// WWW-Authenticate headers + the oauth-protected-resource doc.
+	// Typical value: "https://app.agent.cs.ac.cn".
+	IssuerURL string
+}
+
+// NewServer wires a transport in front of a dispatcher.
+func NewServer(d *Dispatcher, issuerURL string, logger *slog.Logger) *Server {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Server{Dispatcher: d, IssuerURL: issuerURL, Logger: logger}
+}
+
+// Mount returns an http.Handler with the gateway's routes. Mount
+// auth middleware around `/v1/mcp` separately so the well-known
+// metadata endpoint and /healthz stay public.
+func (s *Server) Mount(authMW func(http.Handler) http.Handler) http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok")
+	})
+	mux.HandleFunc("/v1/.well-known/oauth-protected-resource", s.handleOAuthProtectedResource)
+
+	mcp := http.HandlerFunc(s.handleMCP)
+	mux.Handle("/v1/mcp", authMW(mcp))
+	return mux
+}
+
+// handleMCP routes a single Streamable HTTP MCP request. POST is the
+// only verb that carries a JSON-RPC request; GET/DELETE return 405
+// since this transport is stateless (no session id, nothing to
+// stream server-initiated, nothing to delete).
+func (s *Server) handleMCP(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		s.handleJSONRPC(w, r)
+	case http.MethodGet, http.MethodDelete:
+		w.Header().Set("Allow", "POST")
+		http.Error(w, "method not allowed; this gateway is stateless (POST only)", http.StatusMethodNotAllowed)
+	default:
+		w.Header().Set("Allow", "POST")
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// handleJSONRPC reads one JSON-RPC request, dispatches by method,
+// writes one JSON-RPC response. JSON-RPC 2.0 batch (an array of
+// requests) is NOT supported — the MCP profile codex/mcp-remote
+// emit is always a single request per HTTP POST, and supporting
+// batch adds wire complexity for zero clients we care about.
+func (s *Server) handleJSONRPC(w http.ResponseWriter, r *http.Request) {
+	raw, err := io.ReadAll(io.LimitReader(r.Body, 1<<20)) // 1 MiB cap
+	if err != nil {
+		s.writeErr(w, nil, codeInternal, "read body: "+err.Error())
+		return
+	}
+	// Be tolerant of a stray BOM / whitespace — saves debugging a
+	// `null` request when a curl pipe adds CR.
+	raw = []byte(strings.TrimSpace(string(raw)))
+	if len(raw) == 0 {
+		s.writeErr(w, nil, codeInvalidRequest, "empty request body")
+		return
+	}
+	// Reject obvious JSON-RPC batch arrays early with a clear
+	// message — better than letting json.Unmarshal fail with a less
+	// actionable error.
+	if raw[0] == '[' {
+		s.writeErr(w, nil, codeInvalidRequest, "JSON-RPC batch is not supported on this gateway")
+		return
+	}
+
+	var req jsonrpcReq
+	if err := json.Unmarshal(raw, &req); err != nil {
+		s.writeErr(w, nil, codeParseError, "parse error: "+err.Error())
+		return
+	}
+	if req.JSONRPC != "" && req.JSONRPC != "2.0" {
+		// Codex sends "2.0"; tolerate empty (some clients omit it)
+		// but reject anything else.
+		s.writeErr(w, req.ID, codeInvalidRequest, `jsonrpc must be "2.0"`)
+		return
+	}
+
+	p := PrincipalFromContext(r.Context())
+
+	switch req.Method {
+	case "initialize":
+		res := s.Dispatcher.Initialize()
+		s.writeOK(w, req.ID, res)
+
+	case "notifications/initialized", "notifications/cancelled":
+		// JSON-RPC notification — id is absent. The MCP spec also
+		// permits no response body for notifications, but Codex
+		// happily accepts an empty 200 either way.
+		w.WriteHeader(http.StatusOK)
+
+	case "tools/list":
+		res := s.Dispatcher.ToolsList(p)
+		s.writeOK(w, req.ID, res)
+
+	case "tools/call":
+		var params tools.MCPCallToolParams
+		if len(req.Params) > 0 {
+			if err := json.Unmarshal(req.Params, &params); err != nil {
+				s.writeErr(w, req.ID, codeInvalidParams, "invalid tools/call params: "+err.Error())
+				return
+			}
+		}
+		res, jerr := s.Dispatcher.ToolsCall(r.Context(), p, params)
+		if jerr != nil {
+			s.writeErr(w, req.ID, jerr.Code, jerr.Message)
+			return
+		}
+		s.writeOK(w, req.ID, res)
+
+	case "prompts/list":
+		// MCP requires the server to answer the prompts/list probe
+		// even if it carries nothing. Empty list keeps clients happy.
+		s.writeOK(w, req.ID, map[string]any{"prompts": []any{}})
+
+	case "resources/list", "resources/templates/list":
+		s.writeOK(w, req.ID, map[string]any{"resources": []any{}})
+
+	case "ping":
+		// MCP's keepalive — Codex doesn't currently send it, but the
+		// spec mandates a server-side response.
+		s.writeOK(w, req.ID, map[string]any{})
+
+	default:
+		if len(req.ID) == 0 || string(req.ID) == "null" {
+			// Notification of an unknown method — drop silently.
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		s.writeErr(w, req.ID, codeMethodNotFound, "method not found: "+req.Method)
+	}
+}
+
+// JSON-RPC 2.0 standard error codes for transport-level problems
+// (these are distinct from dispatch.go's authorization codes).
+const (
+	codeParseError     = -32700
+	codeInvalidRequest = -32600
+	codeInvalidParams  = -32602
+)
+
+func (s *Server) writeOK(w http.ResponseWriter, id json.RawMessage, result any) {
+	body, err := json.Marshal(result)
+	if err != nil {
+		s.writeErr(w, id, codeInternal, "marshal result: "+err.Error())
+		return
+	}
+	resp := jsonrpcResp{
+		JSONRPC: "2.0",
+		ID:      idOrNull(id),
+		Result:  body,
+	}
+	envelope, err := json.Marshal(resp)
+	if err != nil {
+		// Fallback — shouldn't happen, but don't leave the wire empty.
+		s.Logger.Error("mcppublic: marshal envelope failed", "err", err)
+		http.Error(w, "internal", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write(envelope)
+}
+
+func (s *Server) writeErr(w http.ResponseWriter, id json.RawMessage, code int, msg string) {
+	resp := jsonrpcResp{
+		JSONRPC: "2.0",
+		ID:      idOrNull(id),
+		Error:   &jsonrpcErr{Code: code, Message: msg},
+	}
+	envelope, err := json.Marshal(resp)
+	if err != nil {
+		http.Error(w, "internal", http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	// JSON-RPC always uses 200 for "the protocol succeeded but the
+	// call errored"; per MCP spec, transport-level problems (parse
+	// error / no body) are likewise carried in-band rather than
+	// surfaced as HTTP 4xx. The only exceptions are the auth
+	// middleware's 401s and the 405s on GET/DELETE — those happen
+	// before we get here.
+	_, _ = w.Write(envelope)
+}
+
+// idOrNull echoes the request id verbatim, falling back to JSON null
+// when the request had no id (notification or malformed parse).
+func idOrNull(id json.RawMessage) json.RawMessage {
+	if len(id) == 0 {
+		return json.RawMessage("null")
+	}
+	return id
+}
+
+// handleOAuthProtectedResource serves the small JSON document the MCP
+// spec's authorization profile (2025-06-18) points clients at via
+// WWW-Authenticate. Codex CLI ignores this (it short-circuits to
+// bearer_token_env_var); Claude Desktop 1P (Phase 2) will use it.
+//
+// The minimal shape required by RFC 9728 / MCP's profile:
+//
+//	{
+//	  "resource": "<this-gateway-url>",
+//	  "authorization_servers": ["<issuer>"]
+//	}
+//
+// We don't run an OAuth server yet (Phase 2), so authorization_servers
+// points back at the agentserver web UI — clients that bother to
+// follow the link land on the workspace settings page where they
+// can mint a PAT manually.
+func (s *Server) handleOAuthProtectedResource(w http.ResponseWriter, r *http.Request) {
+	gatewayURL := "https://" + r.Host + "/v1/mcp"
+	if r.TLS == nil {
+		// Dev / port-forward case — keep things working over plain http.
+		gatewayURL = "http://" + r.Host + "/v1/mcp"
+	}
+	doc := map[string]any{
+		"resource": gatewayURL,
+		"authorization_servers": []string{
+			func() string {
+				if s.IssuerURL != "" {
+					return s.IssuerURL
+				}
+				return gatewayURL
+			}(),
+		},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(doc)
+}
+
+// AuthMiddleware constructs the auth.Middleware-equivalent http.Handler
+// wrapper. Exposed as a convenience so the cmd binary doesn't have to
+// know about the Middleware struct's fields directly — pass an empty
+// `resolvers` here and the gateway 401s every request, which is the
+// correct fail-closed posture if the cmd forgot to wire a PATResolver.
+func AuthMiddleware(resolvers []PrincipalResolver, resourceMetadataURL string, logger *slog.Logger) func(http.Handler) http.Handler {
+	mw := &Middleware{
+		Resolvers:           resolvers,
+		ResourceMetadataURL: resourceMetadataURL,
+		Logger:              logger,
+	}
+	return mw.Wrap
+}
+
+// ensure the errors package stays imported even if a future refactor
+// drops the only user — keeps `go vet` quiet without leaving an
+// unused-import landmine for the next editor.
+var _ = errors.New

--- a/internal/mcppublic/transport_test.go
+++ b/internal/mcppublic/transport_test.go
@@ -1,0 +1,271 @@
+package mcppublic
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/agentserver/agentserver/internal/envtools/tools"
+)
+
+// newTestServer wires Dispatcher + Server with the in-package fakes
+// from dispatch_test.go (fakeExecutorsSource, stubBackend).
+func newTestServer(t *testing.T, src *fakeExecutorsSource, backend ToolBackend, p *Principal) *httptest.Server {
+	t.Helper()
+	d := newTestDispatcher(t, src, backend)
+	srv := NewServer(d, "https://app.example.com", nil)
+
+	// "Auth middleware" for tests: just plant p in ctx and pass through.
+	stubAuth := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			next.ServeHTTP(w, r.WithContext(WithPrincipal(r.Context(), p)))
+		})
+	}
+	hs := httptest.NewServer(srv.Mount(stubAuth))
+	t.Cleanup(hs.Close)
+	return hs
+}
+
+// post is a small helper that POSTs a JSON-RPC envelope and returns
+// the parsed response.
+func post(t *testing.T, ts *httptest.Server, body string) (*http.Response, jsonrpcResp) {
+	t.Helper()
+	resp, err := http.Post(ts.URL+"/v1/mcp", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	t.Cleanup(func() { resp.Body.Close() })
+	var out jsonrpcResp
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	return resp, out
+}
+
+func TestTransport_Initialize_ReturnsProtocolVersion(t *testing.T) {
+	hs := newTestServer(t, nil, &stubBackend{}, principalReadOnly("ws_1"))
+	_, out := post(t, hs, `{"jsonrpc":"2.0","id":1,"method":"initialize"}`)
+	if out.Error != nil {
+		t.Fatalf("unexpected error: %+v", out.Error)
+	}
+	var init tools.MCPInitializeResult
+	_ = json.Unmarshal(out.Result, &init)
+	if init.ProtocolVersion != "2025-06-18" {
+		t.Errorf("ProtocolVersion: got %q, want 2025-06-18", init.ProtocolVersion)
+	}
+}
+
+func TestTransport_ToolsList_FilteredByPrincipal(t *testing.T) {
+	hs := newTestServer(t, nil, &stubBackend{}, principalReadOnly("ws_1"))
+	_, out := post(t, hs, `{"jsonrpc":"2.0","id":2,"method":"tools/list"}`)
+	if out.Error != nil {
+		t.Fatalf("unexpected error: %+v", out.Error)
+	}
+	var lr tools.MCPListToolsResult
+	_ = json.Unmarshal(out.Result, &lr)
+	names := toolNames(lr.Tools)
+	if !contains(names, "read_file") || !contains(names, "list_environments") {
+		t.Errorf("missing read-tools: %v", names)
+	}
+	if contains(names, "shell") {
+		t.Errorf("read-only principal saw shell: %v", names)
+	}
+}
+
+func TestTransport_ToolsCall_HappyPath(t *testing.T) {
+	backend := &stubBackend{result: tools.MCPCallToolResult{
+		Content: []tools.MCPToolContent{{Type: "text", Text: "ok"}},
+	}}
+	hs := newTestServer(t, nil, backend, principalReadExec("ws_1"))
+	_, out := post(t, hs, `{
+	  "jsonrpc":"2.0","id":3,"method":"tools/call",
+	  "params":{"name":"shell","arguments":{"environment_id":"laptop"}}
+	}`)
+	if out.Error != nil {
+		t.Fatalf("unexpected error: %+v", out.Error)
+	}
+	var res tools.MCPCallToolResult
+	_ = json.Unmarshal(out.Result, &res)
+	if len(res.Content) != 1 || res.Content[0].Text != "ok" {
+		t.Errorf("unexpected result: %+v", res)
+	}
+}
+
+func TestTransport_ToolsCall_ForbiddenToolReturnsJSONRPCError(t *testing.T) {
+	hs := newTestServer(t, nil, &stubBackend{}, principalReadOnly("ws_1"))
+	_, out := post(t, hs, `{
+	  "jsonrpc":"2.0","id":4,"method":"tools/call",
+	  "params":{"name":"shell","arguments":{"environment_id":"laptop"}}
+	}`)
+	if out.Error == nil {
+		t.Fatal("expected JSON-RPC error for forbidden tool")
+	}
+	if out.Error.Code != codeForbiddenTool {
+		t.Errorf("error code: got %d, want %d", out.Error.Code, codeForbiddenTool)
+	}
+}
+
+func TestTransport_UnknownMethod_ReturnsMethodNotFound(t *testing.T) {
+	hs := newTestServer(t, nil, &stubBackend{}, principalReadOnly("ws_1"))
+	_, out := post(t, hs, `{"jsonrpc":"2.0","id":5,"method":"frob/quux"}`)
+	if out.Error == nil || out.Error.Code != codeMethodNotFound {
+		t.Fatalf("want codeMethodNotFound, got %+v", out.Error)
+	}
+}
+
+func TestTransport_NotificationsInitialized_NoResponseBody(t *testing.T) {
+	hs := newTestServer(t, nil, &stubBackend{}, principalReadOnly("ws_1"))
+	resp, err := http.Post(hs.URL+"/v1/mcp", "application/json",
+		strings.NewReader(`{"jsonrpc":"2.0","method":"notifications/initialized"}`))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: %d", resp.StatusCode)
+	}
+}
+
+func TestTransport_MalformedJSON_ReturnsParseError(t *testing.T) {
+	hs := newTestServer(t, nil, &stubBackend{}, principalReadOnly("ws_1"))
+	_, out := post(t, hs, `{not even json`)
+	if out.Error == nil || out.Error.Code != codeParseError {
+		t.Fatalf("want codeParseError, got %+v", out.Error)
+	}
+	// id must be null since the request never parsed.
+	if string(out.ID) != "null" {
+		t.Errorf("id should be null on parse error, got %s", out.ID)
+	}
+}
+
+func TestTransport_EmptyBody_ReturnsInvalidRequest(t *testing.T) {
+	hs := newTestServer(t, nil, &stubBackend{}, principalReadOnly("ws_1"))
+	_, out := post(t, hs, "")
+	if out.Error == nil || out.Error.Code != codeInvalidRequest {
+		t.Fatalf("want codeInvalidRequest, got %+v", out.Error)
+	}
+}
+
+func TestTransport_BatchRequest_RejectedClearly(t *testing.T) {
+	hs := newTestServer(t, nil, &stubBackend{}, principalReadOnly("ws_1"))
+	_, out := post(t, hs, `[{"jsonrpc":"2.0","id":1,"method":"initialize"}]`)
+	if out.Error == nil || out.Error.Code != codeInvalidRequest {
+		t.Fatalf("want codeInvalidRequest for batch, got %+v", out.Error)
+	}
+	if !strings.Contains(out.Error.Message, "batch") {
+		t.Errorf("error should name 'batch': %s", out.Error.Message)
+	}
+}
+
+func TestTransport_BadJSONRPCVersion_Rejected(t *testing.T) {
+	hs := newTestServer(t, nil, &stubBackend{}, principalReadOnly("ws_1"))
+	_, out := post(t, hs, `{"jsonrpc":"1.0","id":6,"method":"initialize"}`)
+	if out.Error == nil || out.Error.Code != codeInvalidRequest {
+		t.Fatalf("want codeInvalidRequest, got %+v", out.Error)
+	}
+}
+
+func TestTransport_GET_Returns405(t *testing.T) {
+	hs := newTestServer(t, nil, &stubBackend{}, principalReadOnly("ws_1"))
+	resp, err := http.Get(hs.URL + "/v1/mcp")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("GET: want 405, got %d", resp.StatusCode)
+	}
+	if resp.Header.Get("Allow") != "POST" {
+		t.Errorf("Allow header: got %q, want POST", resp.Header.Get("Allow"))
+	}
+}
+
+func TestTransport_DELETE_Returns405(t *testing.T) {
+	hs := newTestServer(t, nil, &stubBackend{}, principalReadOnly("ws_1"))
+	req, _ := http.NewRequest(http.MethodDelete, hs.URL+"/v1/mcp", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("DELETE: want 405, got %d", resp.StatusCode)
+	}
+}
+
+func TestTransport_Healthz_Public(t *testing.T) {
+	hs := newTestServer(t, nil, &stubBackend{}, principalReadOnly("ws_1"))
+	resp, err := http.Get(hs.URL + "/healthz")
+	if err != nil {
+		t.Fatalf("GET /healthz: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK || strings.TrimSpace(string(body)) != "ok" {
+		t.Errorf("/healthz: status=%d body=%q", resp.StatusCode, body)
+	}
+}
+
+func TestTransport_OAuthProtectedResource_Public(t *testing.T) {
+	hs := newTestServer(t, nil, &stubBackend{}, principalReadOnly("ws_1"))
+	resp, err := http.Get(hs.URL + "/v1/.well-known/oauth-protected-resource")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: %d", resp.StatusCode)
+	}
+	var doc map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&doc)
+	if _, ok := doc["resource"]; !ok {
+		t.Errorf("missing resource field: %v", doc)
+	}
+	if _, ok := doc["authorization_servers"]; !ok {
+		t.Errorf("missing authorization_servers field: %v", doc)
+	}
+}
+
+func TestTransport_AuthMiddleware_401AdvertisesResourceMetadata(t *testing.T) {
+	// Verify the auth middleware emits WWW-Authenticate that points
+	// at our oauth-protected-resource doc. End-to-end-ish: mount the
+	// real Middleware + a resolver that always rejects, hit /v1/mcp,
+	// inspect the 401's headers.
+	d := newTestDispatcher(t, nil, &stubBackend{})
+	srv := NewServer(d, "https://app.example.com", nil)
+	resolver := stubResolverErr{err: ErrInvalid}
+	mw := AuthMiddleware([]PrincipalResolver{resolver},
+		"https://mcp.example.com/v1/.well-known/oauth-protected-resource", nil)
+	hs := httptest.NewServer(srv.Mount(mw))
+	defer hs.Close()
+
+	req, _ := http.NewRequest(http.MethodPost, hs.URL+"/v1/mcp",
+		bytes.NewReader([]byte(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`)))
+	req.Header.Set("Authorization", "Bearer some-thing")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("want 401, got %d", resp.StatusCode)
+	}
+	wa := resp.Header.Get("WWW-Authenticate")
+	if !strings.Contains(wa, "resource_metadata=") {
+		t.Errorf("WWW-Authenticate missing resource_metadata: %q", wa)
+	}
+}
+
+// stubResolverErr always returns the configured err — handy when a
+// test wants to exercise auth-failure paths without minting a real
+// PAT.
+type stubResolverErr struct{ err error }
+
+func (s stubResolverErr) Resolve(_ context.Context, _ string) (*Principal, error) {
+	return nil, s.err
+}

--- a/internal/mcppublic/transport_test.go
+++ b/internal/mcppublic/transport_test.go
@@ -221,13 +221,69 @@ func TestTransport_OAuthProtectedResource_Public(t *testing.T) {
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status: %d", resp.StatusCode)
 	}
-	var doc map[string]any
-	_ = json.NewDecoder(resp.Body).Decode(&doc)
-	if _, ok := doc["resource"]; !ok {
-		t.Errorf("missing resource field: %v", doc)
+	var doc struct {
+		Resource             string   `json:"resource"`
+		AuthorizationServers []string `json:"authorization_servers"`
 	}
-	if _, ok := doc["authorization_servers"]; !ok {
-		t.Errorf("missing authorization_servers field: %v", doc)
+	_ = json.NewDecoder(resp.Body).Decode(&doc)
+	// plain httptest server (no TLS, no X-Forwarded-Proto) → http://
+	if !strings.HasPrefix(doc.Resource, "http://") {
+		t.Errorf("plain-http resource: got %q, want http:// prefix", doc.Resource)
+	}
+	if !strings.HasSuffix(doc.Resource, "/v1/mcp") {
+		t.Errorf("resource missing /v1/mcp suffix: %q", doc.Resource)
+	}
+	if len(doc.AuthorizationServers) == 0 {
+		t.Errorf("no authorization_servers: %+v", doc)
+	}
+	if doc.AuthorizationServers[0] != "https://app.example.com" {
+		t.Errorf("authorization_servers[0]: got %q, want %q",
+			doc.AuthorizationServers[0], "https://app.example.com")
+	}
+}
+
+// TestTransport_OAuthProtectedResource_HonorsXForwardedProto pins the
+// production behavior behind istio-ingress (TLS terminated at ingress,
+// pod sees plain http but the X-Forwarded-Proto header tells us the
+// client connected over https). Without this honored, the protected-
+// resource doc would advertise http://mcp.agent.cs.ac.cn/v1/mcp and
+// OAuth clients would refuse to use it.
+func TestTransport_OAuthProtectedResource_HonorsXForwardedProto(t *testing.T) {
+	hs := newTestServer(t, nil, &stubBackend{}, principalReadOnly("ws_1"))
+	req, _ := http.NewRequest(http.MethodGet, hs.URL+"/v1/.well-known/oauth-protected-resource", nil)
+	req.Header.Set("X-Forwarded-Proto", "https")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	var doc struct {
+		Resource string `json:"resource"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&doc)
+	if !strings.HasPrefix(doc.Resource, "https://") {
+		t.Errorf("resource: got %q, want https:// prefix (X-Forwarded-Proto: https)", doc.Resource)
+	}
+}
+
+// TestTransport_OAuthProtectedResource_XForwardedProtoChain verifies
+// the comma-separated form (RFC 7239-style: "https, http") picks the
+// first entry, since proxies may chain.
+func TestTransport_OAuthProtectedResource_XForwardedProtoChain(t *testing.T) {
+	hs := newTestServer(t, nil, &stubBackend{}, principalReadOnly("ws_1"))
+	req, _ := http.NewRequest(http.MethodGet, hs.URL+"/v1/.well-known/oauth-protected-resource", nil)
+	req.Header.Set("X-Forwarded-Proto", "https, http")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	var doc struct {
+		Resource string `json:"resource"`
+	}
+	_ = json.NewDecoder(resp.Body).Decode(&doc)
+	if !strings.HasPrefix(doc.Resource, "https://") {
+		t.Errorf("chain header: got %q, want https:// prefix", doc.Resource)
 	}
 }
 


### PR DESCRIPTION
Final piece of the envmcp public gateway. After this lands the gateway is **end-to-end usable** from Codex CLI + Claude Desktop (3P via mcp-remote) without further work.

Stacked on #239 → #238 → #236 → #235 → #234.

> **Spec:** `docs/superpowers/specs/2026-06-09-envmcp-public-gateway-design.md` + the 2026-06-15 amendment (1 PAT = 1 workspace).

## What's here

| File | Purpose |
|---|---|
| `internal/mcppublic/transport.go` | Streamable HTTP MCP server (protocol `2025-06-18`, the version Codex CLI sends in `initialize`). POST `/v1/mcp` → JSON-RPC response; GET / DELETE → 405 (stateless); `/healthz` + `/v1/.well-known/oauth-protected-resource` public for probes + Phase 2 OAuth discovery |
| `internal/mcppublic/transport_test.go` | JSON-RPC framing, scope-filtered tools/list, error paths, GET/DELETE 405, healthz public, OAuth-protected-resource public + scheme correct under TLS / X-Forwarded-Proto / plain http |
| `cmd/envmcp-public-gateway/main.go` | env-config wiring with fail-closed required-vars check (all 7 listed below); builds DB → PATResolver → Middleware + CapMinter + HTTPExecutorsSource + BridgeBackend + Dispatcher + Server; graceful 15s drain on SIGTERM |
| `cmd/envmcp-public-gateway/main_test.go` | Table test sweeps every required env var, deletes it, asserts loadConfig errors and names the missing var |
| `Dockerfile.envmcp-public-gateway` | golang:1.26-trixie builder → debian:trixie-slim runtime + CA certs; pure Go binary, no codex shim; EXPOSE 8090 |
| `.github/workflows/build.yml` | New `build-envmcp-public-gateway` job alongside the others |
| `deploy/helm/agentserver/templates/envmcp-public-gateway.yaml` | Deployment + Service + HTTPRoute (when gateway.enabled). Wires `CXG_CAPTOKEN_HMAC_SECRET` from existing `release-codex-gateway` Secret; HTTPRoute on `mcp.<gateway.host>` (or `envmcpPublicGateway.publicHost` override) |
| `deploy/helm/agentserver/values.yaml` | `envmcpPublicGateway:` block, `enabled: false` until operator opts in |
| `docs/integrations/codex-cli.md` + `docs/integrations/claude-desktop-3p.md` | End-user guides — PAT mint via curl, config snippet, smoke test, multi-workspace, revoke, troubleshooting |

### Required env vars (all enforced fail-closed by loadConfig)

| Var | What |
|---|---|
| `DATABASE_URL` | Postgres DSN for PAT validation |
| `CXG_CAPTOKEN_HMAC_SECRET` | Shared with app-gateway (signer) + exec-gateway/agentserver-main (verifiers) |
| `CXG_EXEC_GATEWAY_INTERNAL_URL` | `http://release-codex-exec-gateway.<ns>.svc:6060` |
| `CXG_EXEC_GATEWAY_INTERNAL_SECRET` | `X-Internal-Secret` for ListBinding API |
| `CXG_BRIDGE_BASE_URL` | `ws://release-codex-exec-gateway.<ns>.svc:6060/bridge` |
| `MCP_PUBLIC_RESOURCE_METADATA_URL` | Advertised in 401 `WWW-Authenticate: Bearer resource_metadata=…` |
| `MCP_PUBLIC_ISSUER_URL` | agentserver web base URL for the protected-resource doc |

Plus optional: `CXG_LISTEN_ADDR` (default `:8090`), `CXG_LOG_LEVEL` (default `info`).

## Self-review fixes applied in this PR

- **H1** — `handleOAuthProtectedResource` advertised `http://` behind istio-ingress (TLS terminated at ingress, `r.TLS` always nil). Now honors `X-Forwarded-Proto` with fallback chain. Pinned by 3 test cases.
- **H2** — `MCP_PUBLIC_*` vars were doc'd required but loadConfig forgot to enforce. Fixed + table test.
- **L1** — Backend errors echoed `err.Error()` verbatim to public clients, leaking internal IPs / hostnames / ports. Now log full err server-side via slog, return opaque message. Two redaction tests sweep forbidden substrings (IPs, `.svc`, dial-error fragments).
- **L2** — Dead `errors` import removed.

## How to deploy

```yaml
# values
envmcpPublicGateway:
  enabled: true
  publicHost: mcp.agent.cs.ac.cn   # optional, defaults to mcp.<gateway.host>
```

1. DNS: `A`/`CNAME` `mcp.agent.cs.ac.cn` → istio-ingress IP (cert-manager auto-issues Let's Encrypt via existing wildcard pattern)
2. `pulumi up`
3. Smoke test:
   ```bash
   curl -s -X POST https://mcp.agent.cs.ac.cn/v1/mcp \
     -H "Authorization: Bearer $AGENTSERVER_PAT" \
     -H "Content-Type: application/json" \
     -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
   ```

## Known follow-ups (intentionally out of scope, all documented)

| | Why deferred |
|---|---|
| **PAT-revoke / cap-token cache eviction** — a revoked PAT's already-cached cap-token in `CapMinter.cache` + bridge.Pool in `BridgeBackend.toolkits` can survive up to 10 min (cap-token TTL) before the next mint hits the now-failing PATResolver lookup. Bounded; needs cross-pod cache invalidation event. | Real but bounded blast radius (≤10 min). |
| **`internal.apiSecret` as plaintext Helm value, not `secretKeyRef`** | **Pre-existing pattern** across 6 templates (codex-app-gateway, codex-exec-gateway, codex-exec-edge, deployment, imbridge, this PR's envmcp-public-gateway). Not a regression. Belongs in a separate cleanup PR that converts all 6 at once. |
| **End-to-end test (cmd binary + real DB + fake exec-gateway)** | Real prod-readiness gap. Reviewer recommendation. Scope is large; better as its own PR after this lands. |
| **Audit log** (`mcp_audit_log` table + write-side middleware). CapMinter sets `SkipAudit=true` on cap-tokens it mints, so today there's no audit trail for public-gateway tool calls. | Bigger surface, separate PR. |
| **Rate limiting** (token bucket per principal). Spec § 4.3 calls for 60/min default + per-workspace cap of 5 concurrent shell sessions. | Not blocking initial deployment. |
| **PAT management Web UI** (Settings → MCP Access). | curl works as the short-term fallback (covered in user docs). |
| **Phase 2 OAuth + DCR via Hydra** | Unblocks Claude Desktop 1P Custom Connectors UI; not needed for Codex CLI or Claude 3P (the 95% case). |
| **copy_path's HTTPS relay** | BridgeBackend passes `nil` RelayClient; WS cat-pump fallback works. Per-workspace RelayClient needs to be wired at toolkit-build time. Low-priority since copy_path is rarely used. |
| **Scheduling tools in public** | The 6 scheduling tools (schedule_task / list_tasks / cancel_task / pause_task / resume_task / update_task) only ship in in-pod env-mcp today. Their public wrapper needs an `HTTPSchedulingTransport` that calls `/api/internal/workspaces/{wid}/scheduled-tasks/*` with the workspace cap-token. Documented in `bridge_backend.go::DefaultPublicToolMeta`'s TODO comment. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)