### PR TITLE
chore(chart): bump 0.65.3 → 0.66.0 to ship #233 #234 #235 #236 #238 #239 #243

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.65.3
-appVersion: "0.65.3"
+version: 0.66.0
+appVersion: "0.66.0"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
## Summary

Minor bump (not patch) because this lands a brand-new pod and new public surface: **envmcp-public-gateway**, the MCP server external clients (Codex CLI, Claude Desktop in 3P via mcp-remote) hit at `https://mcp.<gateway.host>/v1/mcp`.

## What ships

- #233 refactor(captoken): extract `internal/captoken` shared package
- #234 feat(db): `mcp_pats` table + PAT storage (workspace-scoped)
- #235 feat(server): MCP PAT CRUD API (owner/maintainer-gated mint)
- #236 feat(mcppublic): `Principal` + PAT resolver + bearer middleware
- #238 feat(mcppublic): cap-token minter + tool dispatch
- #239 feat(mcppublic): HTTP executors source + per-Principal bridge toolkit
- #243 feat(envmcp-public-gateway): Streamable HTTP transport + cmd binary + Helm + docs

## How to enable

Default-off — zero-impact upgrade for operators who haven't opted in. To enable:

```yaml
envmcpPublicGateway:
  enabled: true
  publicHost: mcp.agent.cs.ac.cn   # optional
```

Then DNS + `pulumi up`. See `docs/integrations/codex-cli.md` and `claude-desktop-3p.md` for end-user setup.

## Test plan
- [ ] CI green
- [ ] Tag `v0.66.0` after merge
- [ ] /root/k8s pulumi up with `envmcpPublicGateway.enabled: true`
- [ ] Mint a PAT and connect from Codex CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)