### PR TITLE
fix(llmproxy): shrink modelserver-token cache TTL 5min → 10s

### DIFF
--- a/internal/llmproxy/modelserver.go
+++ b/internal/llmproxy/modelserver.go
@@ -27,8 +27,15 @@ func newModelserverTokenCache() *modelserverTokenCache {
 	}
 }
 
-// Get returns a cached token if it exists, was fetched less than 5 minutes ago,
-// and has at least 60 seconds before expiry.
+// Get returns a cached token if it exists, was fetched less than 10 seconds
+// ago, and has at least 60 seconds before expiry.
+//
+// 10s is short on purpose: agentserver's own /internal/.../modelserver-token
+// endpoint already caches in the DB (60s buffer + singleflight refresh), so
+// this layer is just here to coalesce bursts within a single codex turn —
+// not to hold tokens across modelserver-switch events. Anything longer
+// creates a death zone after the user reconnects to a different
+// modelserver, because cached tokens are bound to the old one.
 func (c *modelserverTokenCache) Get(workspaceID string) (string, bool) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
@@ -40,8 +47,7 @@ func (c *modelserverTokenCache) Get(workspaceID string) (string, bool) {
 
 	now := time.Now()
 
-	// Stale if fetched more than 5 minutes ago.
-	if now.Sub(tok.fetchedAt) > 5*time.Minute {
+	if now.Sub(tok.fetchedAt) > 10*time.Second {
 		return "", false
 	}
 


### PR DESCRIPTION
## Why

The 5-minute in-process cache created a 5-minute **death zone** after a user reconnected a workspace to a different modelserver. Today's symptom: wechat IM users hit `rate_limit_error` for ~5 min after the operator already migrated their workspace off the quota-exhausted modelserver.

## Root cause

This is a **double cache**. agentserver's own `/internal/workspaces/{id}/modelserver-token` endpoint already caches in the DB with:
- 60s freshness buffer (no refresh until <60s of expiry)
- singleflight-deduplicated OAuth refresh

(`internal/server/modelserver_token.go:30`)

The llmproxy in-process layer was redundant for cross-turn caching — its only real value is **coalescing the burst of LLM requests within a single codex turn**.

## Fix

5min → 10s. Burst-coalescing benefit preserved (a codex turn issues many requests per second), death zone shrinks to ≤10s. agentserver's DB cache + singleflight absorbs the per-turn-boundary load.

## Test plan
- [x] `go test ./internal/llmproxy/... -count=1` passes
- [ ] CI green
- [ ] Verify post-deploy: switching workspace modelserver takes effect within 10s

🤖 Generated with [Claude Code](https://claude.com/claude-code)