### PR TITLE
chore(chart): bump 0.66.1 → 0.66.2 to ship #247

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.66.1
-appVersion: "0.66.1"
+version: 0.66.2
+appVersion: "0.66.2"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
Ships #247 (llmproxy modelserver-token cache TTL 5min → 10s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)