### PR TITLE
chore(chart): bump 0.66.2 → 0.67.0 to ship #249 (MCP OAuth)

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.66.2
-appVersion: "0.66.2"
+version: 0.67.0
+appVersion: "0.67.0"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
Ships #249 — MCP OAuth 2.1 for envmcp-public-gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)