### PR TITLE
chore(chart): bump 0.67.0 → 0.67.1 to ship #251

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.67.0
-appVersion: "0.67.0"
+version: 0.67.1
+appVersion: "0.67.1"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
Hotfix: advertise registration_endpoint in AS metadata so MCP clients see it during discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)