### PR TITLE
chore(chart): bump 0.67.2 → 0.67.3 (re-cut)

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.67.2
-appVersion: "0.67.2"
+version: 0.67.3
+appVersion: "0.67.3"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
v0.67.2 was tagged at the commit with conflict markers in Chart.yaml. Re-cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)