### PR TITLE
chore(chart): bump 0.68.0 → 0.68.1 to ship #258

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.68.0
-appVersion: "0.68.0"
+version: 0.68.1
+appVersion: "0.68.1"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
Ships #258 — shared MCP OAuth client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)