### PR TITLE
chore(mcp-oauth): rename agentserver-mcp-shared → agentserver-mcp

### DIFF
--- a/deploy/helm/agentserver/templates/hydra.yaml
+++ b/deploy/helm/agentserver/templates/hydra.yaml
@@ -199,7 +199,7 @@ spec:
               hydra update oauth2-client agentserver-agent-cli --endpoint "$ENDPOINT" $CLI_FLAGS 2>/dev/null || \
               hydra create oauth2-client --endpoint "$ENDPOINT" --id agentserver-agent-cli $CLI_FLAGS
 
-              # 2. agentserver-mcp-shared — single shared public OAuth
+              # 2. agentserver-mcp — single shared public OAuth
               # client all MCP clients (Codex CLI, Claude Code, Claude
               # Desktop via mcp-remote) use against envmcp-public-
               # gateway. client_id is published in the docs and pasted
@@ -222,7 +222,7 @@ spec:
               # reruns the job on every chart upgrade so the flag set
               # below is the source of truth (drift is silently
               # corrected).
-              MCP_FLAGS="--name Agentserver_MCP_Shared_Client \
+              MCP_FLAGS="--name Agentserver_MCP \
                 --grant-type authorization_code \
                 --grant-type refresh_token \
                 --response-type code \
@@ -231,8 +231,8 @@ spec:
                 --redirect-uri http://127.0.0.1/callback \
                 --token-endpoint-auth-method none \
                 --audience https://mcp.{{ .Values.platform.domain }}/v1/mcp"
-              hydra update oauth2-client agentserver-mcp-shared --endpoint "$ENDPOINT" $MCP_FLAGS 2>/dev/null || \
-              hydra create oauth2-client --endpoint "$ENDPOINT" --id agentserver-mcp-shared $MCP_FLAGS
+              hydra update oauth2-client agentserver-mcp --endpoint "$ENDPOINT" $MCP_FLAGS 2>/dev/null || \
+              hydra create oauth2-client --endpoint "$ENDPOINT" --id agentserver-mcp $MCP_FLAGS
 ---
 # --- Hydra Public Service ---
 apiVersion: v1

--- a/docs/integrations/claude-code-cli.md
+++ b/docs/integrations/claude-code-cli.md
@@ -13,12 +13,12 @@ Run your agentserver workspaces' tools (`shell`, `read_file`, `apply_patch`, …
 ```bash
 claude mcp add --transport http agentserver \
   https://mcp.agent.cs.ac.cn/v1/mcp \
-  --client-id agentserver-mcp-shared \
+  --client-id agentserver-mcp \
   --callback-port 3000
 ```
 
 Notes:
-- `client_id = "agentserver-mcp-shared"` is a fixed, public value shared by all users (same shape as gh CLI's hard-coded GitHub OAuth client). It has no auth power on its own — the OAuth flow's user login + workspace consent screen is what authorizes.
+- `client_id = "agentserver-mcp"` is a fixed, public value shared by all users (same shape as gh CLI's hard-coded GitHub OAuth client). It has no auth power on its own — the OAuth flow's user login + workspace consent screen is what authorizes.
 - `--callback-port` is required: Claude Code binds the OAuth callback on this exact port. Any free port works (we register loopback host-only with Hydra, so any port is accepted per RFC 8252).
 - No `--client-secret`: the shared client is a **public** OAuth client (PKCE-protected).
 
@@ -43,7 +43,7 @@ The first time it talks to `agentserver`, a browser opens. Log in to agentserver
       "type": "http",
       "url": "https://mcp.agent.cs.ac.cn/v1/mcp",
       "oauth": {
-        "client_id": "agentserver-mcp-shared",
+        "client_id": "agentserver-mcp",
         "callback_port": 3000
       }
     }

--- a/docs/integrations/codex-cli.md
+++ b/docs/integrations/codex-cli.md
@@ -16,7 +16,7 @@ url = "https://mcp.agent.cs.ac.cn/v1/mcp"
 oauth_resource = "https://mcp.agent.cs.ac.cn/v1/mcp"
 
 [mcp_servers.agentserver.oauth]
-client_id = "agentserver-mcp-shared"
+client_id = "agentserver-mcp"
 ```
 
 The `client_id` is a fixed, public value shared by all users (same shape as `gh` CLI's hard-coded GitHub OAuth client). It carries no auth power on its own — the OAuth flow's user login + workspace consent screen is what actually authorizes the issued token.
@@ -62,13 +62,13 @@ Each `[mcp_servers.X]` entry corresponds to one workspace (workspace is selected
 url = "https://mcp.agent.cs.ac.cn/v1/mcp"
 oauth_resource = "https://mcp.agent.cs.ac.cn/v1/mcp"
 [mcp_servers.work.oauth]
-client_id = "agentserver-mcp-shared"
+client_id = "agentserver-mcp"
 
 [mcp_servers.personal]
 url = "https://mcp.agent.cs.ac.cn/v1/mcp"
 oauth_resource = "https://mcp.agent.cs.ac.cn/v1/mcp"
 [mcp_servers.personal.oauth]
-client_id = "agentserver-mcp-shared"
+client_id = "agentserver-mcp"
 ```
 
 ```bash
@@ -112,7 +112,7 @@ export AGENTSERVER_PAT='agpat_...'
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| `Incompatible auth server: does not support dynamic client registration` | Forgot `oauth.client_id` in config | Add `[mcp_servers.agentserver.oauth] client_id = "agentserver-mcp-shared"` |
+| `Incompatible auth server: does not support dynamic client registration` | Forgot `oauth.client_id` in config | Add `[mcp_servers.agentserver.oauth] client_id = "agentserver-mcp"` |
 | `audience mismatch` in gateway logs | Forgot `oauth_resource` in config | Add `oauth_resource = "https://mcp.agent.cs.ac.cn/v1/mcp"` |
 | Browser opens but never returns | Network blocks codex's callback port | Set `mcp_oauth_callback_port = 8765` (or any reachable port) in config |
 | `401 unauthorized` after successful login | Token expired or workspace membership lost | Re-run `codex mcp login agentserver` |

--- a/docs/superpowers/specs/2026-06-17-mcp-oauth-design.md
+++ b/docs/superpowers/specs/2026-06-17-mcp-oauth-design.md
@@ -57,7 +57,7 @@ So this amendment **deletes the per-user table + REST surface from
 #256** and replaces it with a single shared client provisioned by the
 existing `hydra-client-setup` Helm job:
 
-- `client_id = "agentserver-mcp-shared"`
+- `client_id = "agentserver-mcp"`
 - `token_endpoint_auth_method = none` (public client, PKCE-protected)
 - `redirect_uris = [http://localhost/callback, http://127.0.0.1/callback]`
   — host-only per RFC 8252 §7.3 so Hydra accepts any port the CLI

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -457,7 +457,7 @@ func (s *Server) Router() http.Handler {
 		// NOTE: /oauth2/register is intentionally NOT reverse-proxied.
 		// DCR is off chart-wide (see hydra.yaml comment); the static-
 		// public-client replacement is a single shared OAuth client
-		// (`agentserver-mcp-shared`) provisioned by the
+		// (`agentserver-mcp`) provisioned by the
 		// hydra-client-setup helm job (see hydra.yaml). Users just
 		// paste that fixed client_id into their CLI config — no API
 		// call needed.
@@ -670,7 +670,7 @@ func (s *Server) Router() http.Handler {
 		r.Delete("/api/workspaces/{wid}/mcp/pats/{id}", s.handleRevokeMCPPAT)
 
 		// MCP OAuth client — the envmcp public gateway uses ONE shared
-		// public OAuth2 client (id `agentserver-mcp-shared`) baked into
+		// public OAuth2 client (id `agentserver-mcp`) baked into
 		// the chart's hydra-client-setup job. Same shape as GitHub
 		// Desktop / gh CLI: client_id is published in the docs, users
 		// just paste it into ~/.codex/config.toml or `claude mcp add


### PR DESCRIPTION
Drop the redundant '-shared' suffix. Hydra job is idempotent so the rename is seamless on next chart upgrade; old name stays orphaned until manually deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)