### PR TITLE
fix(mcppublic): serve PRM doc at RFC 9728 root path

### DIFF
--- a/internal/mcppublic/transport.go
+++ b/internal/mcppublic/transport.go
@@ -88,6 +88,31 @@ func (s *Server) Mount(authMW func(http.Handler) http.Handler) http.Handler {
 		w.WriteHeader(http.StatusOK)
 		_, _ = io.WriteString(w, "ok")
 	})
+	// Two paths serve the same Protected Resource Metadata doc:
+	//
+	//   /.well-known/oauth-protected-resource         — RFC 9728 §3.1
+	//                                                   spec-compliant location
+	//                                                   (resource root). Claude
+	//                                                   Code, ChatGPT MCP, and
+	//                                                   any client following
+	//                                                   2025-06-18 MCP authz
+	//                                                   spec read from here.
+	//   /v1/.well-known/oauth-protected-resource      — Earlier path we picked
+	//                                                   because /v1/mcp is the
+	//                                                   resource. Pre-existing
+	//                                                   deployments may have it
+	//                                                   wired into MCP_PUBLIC_
+	//                                                   RESOURCE_METADATA_URL,
+	//                                                   so we keep it as an
+	//                                                   alias rather than break
+	//                                                   the WWW-Authenticate
+	//                                                   contract those pods
+	//                                                   advertise.
+	//
+	// Without the root-path entry, Claude Code falls back to RFC 8414's
+	// "issuer = resource server URL" guess, then tries to wire OAuth at
+	// https://<resource>/authorize → 404 → user sees a broken page.
+	mux.HandleFunc("/.well-known/oauth-protected-resource", s.handleOAuthProtectedResource)
 	mux.HandleFunc("/v1/.well-known/oauth-protected-resource", s.handleOAuthProtectedResource)
 
 	mcp := http.HandlerFunc(s.handleMCP)

--- a/internal/mcppublic/transport_test.go
+++ b/internal/mcppublic/transport_test.go
@@ -211,6 +211,43 @@ func TestTransport_Healthz_Public(t *testing.T) {
 	}
 }
 
+// TestTransport_OAuthProtectedResource_RFC9728RootPath pins the
+// RFC 9728 §3.1 spec-compliant location of the Protected Resource
+// Metadata doc — at the resource server ROOT, not nested under
+// /v1/. Claude Code (and other MCP 2025-06-18-compliant clients)
+// look here first; if it 404s they fall back to RFC 8414's
+// "guess the AS by stripping path" path, which lands them at
+// https://mcp.<host>/authorize — a 404 page, broken UX.
+//
+// We keep /v1/.well-known/oauth-protected-resource as an alias for
+// the WWW-Authenticate header that older deployments wired in via
+// the MCP_PUBLIC_RESOURCE_METADATA_URL env var. Both paths must
+// return the same doc.
+func TestTransport_OAuthProtectedResource_RFC9728RootPath(t *testing.T) {
+	hs := newTestServer(t, nil, &stubBackend{}, principalReadOnly("ws_1"))
+	resp, err := http.Get(hs.URL + "/.well-known/oauth-protected-resource")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("root-path PRM should be 200; got %d", resp.StatusCode)
+	}
+	var doc struct {
+		Resource             string   `json:"resource"`
+		AuthorizationServers []string `json:"authorization_servers"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !strings.HasSuffix(doc.Resource, "/v1/mcp") {
+		t.Errorf("resource: %q must end in /v1/mcp", doc.Resource)
+	}
+	if len(doc.AuthorizationServers) == 0 || doc.AuthorizationServers[0] != "https://app.example.com" {
+		t.Errorf("authorization_servers wrong: %+v", doc.AuthorizationServers)
+	}
+}
+
 func TestTransport_OAuthProtectedResource_Public(t *testing.T) {
 	hs := newTestServer(t, nil, &stubBackend{}, principalReadOnly("ws_1"))
 	resp, err := http.Get(hs.URL + "/v1/.well-known/oauth-protected-resource")


### PR DESCRIPTION
Claude Code requests /.well-known/oauth-protected-resource per RFC 9728 §3.1. We only had it at /v1/.well-known/..., so it 404s and Claude Code falls back to legacy fallback discovery → lands at https://mcp.<host>/authorize (also 404) → broken OAuth page.

Fix: alias the handler to both root and /v1/ paths. Existing PR ships envmcp-public-gateway pods with MCP_PUBLIC_RESOURCE_METADATA_URL pointing at the /v1/ variant for WWW-Authenticate, so we keep that alias to not break already-handed-out 401 headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)