### PR TITLE
refactor(mcp)!: switch path /v1/mcp → /mcp (BREAKING)

### DIFF
--- a/cmd/envmcp-public-gateway/main.go
+++ b/cmd/envmcp-public-gateway/main.go
@@ -5,7 +5,7 @@
 // Architecture (spec: docs/superpowers/specs/2026-06-09-envmcp-public-
 // gateway-design.md, with the 2026-06-15 1-PAT-1-workspace amendment):
 //
-//	external client ─Bearer agpat_xxx─▶ /v1/mcp
+//	external client ─Bearer agpat_xxx─▶ /mcp
 //	   ▼
 //	mcppublic.Middleware  →  PATResolver  →  Principal{user, workspace}
 //	   ▼
@@ -31,7 +31,7 @@
 //	CXG_EXEC_GATEWAY_INTERNAL_URL      — http base for /api/codex-exec/*
 //	CXG_EXEC_GATEWAY_INTERNAL_SECRET   — X-Internal-Secret for the above
 //	CXG_BRIDGE_BASE_URL                — ws base for /bridge dials
-//	MCP_PUBLIC_RESOURCE_METADATA_URL   — full URL of /v1/.well-known/oauth-protected-resource
+//	MCP_PUBLIC_RESOURCE_METADATA_URL   — full URL of /.well-known/oauth-protected-resource
 //	                                     (advertised in 401 WWW-Authenticate)
 //	MCP_PUBLIC_ISSUER_URL              — agentserver web base (advertised in
 //	                                     the protected-resource doc)
@@ -203,7 +203,7 @@ type config struct {
 	// OAuthExpectedAudience is the canonical resource URL clients are
 	// expected to bind their tokens to via RFC 8707 (same URL the
 	// protected-resource doc returns as `resource` — typically
-	// https://mcp.<gateway.host>/v1/mcp). Tokens whose `aud` claim
+	// https://mcp.<gateway.host>/mcp). Tokens whose `aud` claim
 	// does not contain this URL are rejected. Empty disables the
 	// check — dev only; never leave unset in prod.
 	OAuthExpectedAudience string

--- a/cmd/envmcp-public-gateway/main_test.go
+++ b/cmd/envmcp-public-gateway/main_test.go
@@ -15,7 +15,7 @@ func fullEnv() map[string]string {
 		"CXG_EXEC_GATEWAY_INTERNAL_URL":    "http://exec-gw:6060",
 		"CXG_EXEC_GATEWAY_INTERNAL_SECRET": "internal",
 		"CXG_BRIDGE_BASE_URL":              "ws://exec-gw:6060/bridge",
-		"MCP_PUBLIC_RESOURCE_METADATA_URL": "https://mcp.example.com/v1/.well-known/oauth-protected-resource",
+		"MCP_PUBLIC_RESOURCE_METADATA_URL": "https://mcp.example.com/.well-known/oauth-protected-resource",
 		"MCP_PUBLIC_ISSUER_URL":            "https://app.example.com",
 	}
 }

--- a/deploy/helm/agentserver/templates/envmcp-public-gateway.yaml
+++ b/deploy/helm/agentserver/templates/envmcp-public-gateway.yaml
@@ -99,9 +99,9 @@ spec:
               value: "ws://{{ .Release.Name }}-codex-exec-gateway.{{ .Release.Namespace }}.svc:{{ .Values.codexExecGateway.port }}/bridge"
             # Advertised in 401 WWW-Authenticate (so Claude Desktop 1P
             # can OAuth-discover us once Phase 2 lands) + in the
-            # /v1/.well-known/oauth-protected-resource body.
+            # /.well-known/oauth-protected-resource body.
             - name: MCP_PUBLIC_RESOURCE_METADATA_URL
-              value: "https://{{ $publicHost }}/v1/.well-known/oauth-protected-resource"
+              value: "https://{{ $publicHost }}/.well-known/oauth-protected-resource"
             # Issuer URL — base URL of the agentserver web app. The
             # protected-resource doc returns this in
             # `authorization_servers`, so MCP clients hit
@@ -135,13 +135,13 @@ spec:
             - name: HYDRA_ADMIN_URL
               value: "http://{{ .Release.Name }}-hydra-admin:{{ .Values.hydra.adminPort }}"
             # RFC 8707 audience binding. Must match the `resource`
-            # field in /v1/.well-known/oauth-protected-resource (the
+            # field in /.well-known/oauth-protected-resource (the
             # canonical gateway URL the protected-resource doc emits).
             # OAuth clients pass this as `resource=...` on
             # /oauth2/auth, Hydra puts it in the token's `aud` claim,
             # and the resolver checks them on every request.
             - name: OAUTH_EXPECTED_AUDIENCE
-              value: "https://{{ $publicHost }}/v1/mcp"
+              value: "https://{{ $publicHost }}/mcp"
             {{- end }}
             {{- if .Values.envmcpPublicGateway.logLevel }}
             - name: CXG_LOG_LEVEL

--- a/deploy/helm/agentserver/templates/hydra.yaml
+++ b/deploy/helm/agentserver/templates/hydra.yaml
@@ -212,7 +212,7 @@ spec:
               #     consent screen is what actually authorizes the
               #     issued token. Same shape gh/git-credential-manager
               #     use.
-              #   - Audience pinned to mcp.<domain>/v1/mcp so a token
+              #   - Audience pinned to mcp.<domain>/mcp so a token
               #     issued for this client can't replay against any
               #     other MCP server on the same Hydra (RFC 8707).
               #   - Loopback redirect URIs only — host-only, RFC 8252
@@ -230,7 +230,7 @@ spec:
                 --redirect-uri http://localhost/callback \
                 --redirect-uri http://127.0.0.1/callback \
                 --token-endpoint-auth-method none \
-                --audience https://mcp.{{ .Values.platform.domain }}/v1/mcp"
+                --audience https://mcp.{{ .Values.platform.domain }}/mcp"
               hydra update oauth2-client agentserver-mcp --endpoint "$ENDPOINT" $MCP_FLAGS 2>/dev/null || \
               hydra create oauth2-client --endpoint "$ENDPOINT" --id agentserver-mcp $MCP_FLAGS
 ---

--- a/deploy/helm/agentserver/values.yaml
+++ b/deploy/helm/agentserver/values.yaml
@@ -371,7 +371,7 @@ envmcpPublicGateway:
   logLevel: info
   # External hostname for Codex CLI / Claude Desktop / mcp-remote
   # config. Empty defaults to "mcp.<gateway.host>" (so users see
-  # https://mcp.agent.cs.ac.cn/v1/mcp on the standard deployment).
+  # https://mcp.agent.cs.ac.cn/mcp on the standard deployment).
   publicHost: ""
   # Optional override for the agentserver web URL surfaced in the
   # 401 WWW-Authenticate's resource_metadata + the OAuth-protected-

--- a/docs/integrations/claude-code-cli.md
+++ b/docs/integrations/claude-code-cli.md
@@ -12,7 +12,7 @@ Run your agentserver workspaces' tools (`shell`, `read_file`, `apply_patch`, â€¦
 
 ```bash
 claude mcp add --transport http agentserver \
-  https://mcp.agent.cs.ac.cn/v1/mcp \
+  https://mcp.agent.cs.ac.cn/mcp \
   --client-id agentserver-mcp \
   --callback-port 3000
 ```
@@ -41,7 +41,7 @@ The first time it talks to `agentserver`, a browser opens. Log in to agentserver
   "mcpServers": {
     "agentserver": {
       "type": "http",
-      "url": "https://mcp.agent.cs.ac.cn/v1/mcp",
+      "url": "https://mcp.agent.cs.ac.cn/mcp",
       "oauth": {
         "client_id": "agentserver-mcp",
         "callback_port": 3000
@@ -60,7 +60,7 @@ For CI / headless environments, use a PAT instead of OAuth (see [Codex CLI doc Â
   "mcpServers": {
     "agentserver": {
       "type": "http",
-      "url": "https://mcp.agent.cs.ac.cn/v1/mcp",
+      "url": "https://mcp.agent.cs.ac.cn/mcp",
       "headers": { "Authorization": "Bearer agpat_..." }
     }
   }

--- a/docs/integrations/claude-desktop-3p.md
+++ b/docs/integrations/claude-desktop-3p.md
@@ -9,7 +9,7 @@ If you run Claude Desktop in "Cowork on 3P" / Developer Mode, the Custom Connect
   "mcpServers": {
     "agentserver": {
       "command": "npx",
-      "args": ["mcp-remote", "https://mcp.agent.cs.ac.cn/v1/mcp"]
+      "args": ["mcp-remote", "https://mcp.agent.cs.ac.cn/mcp"]
     }
   }
 }
@@ -34,7 +34,7 @@ Edit `claude_desktop_config.json` (on macOS: `~/Library/Application Support/Clau
       "command": "npx",
       "args": [
         "mcp-remote",
-        "https://mcp.agent.cs.ac.cn/v1/mcp",
+        "https://mcp.agent.cs.ac.cn/mcp",
         "--header",
         "Authorization:${AGENTSERVER_PAT}"
       ],
@@ -55,7 +55,7 @@ Restart Claude Desktop. The next time you start a conversation, the tools `agent
 Same direct-curl smoke test as the Codex guide:
 
 ```bash
-curl -s -X POST https://mcp.agent.cs.ac.cn/v1/mcp \
+curl -s -X POST https://mcp.agent.cs.ac.cn/mcp \
   -H "Authorization: Bearer $(echo "$AGENTSERVER_PAT" | sed 's/^Bearer //')" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | jq
@@ -72,12 +72,12 @@ One PAT per workspace, one entry per workspace:
   "mcpServers": {
     "work": {
       "command": "npx",
-      "args": ["mcp-remote", "https://mcp.agent.cs.ac.cn/v1/mcp", "--header", "Authorization:${AGENTSERVER_PAT_WORK}"],
+      "args": ["mcp-remote", "https://mcp.agent.cs.ac.cn/mcp", "--header", "Authorization:${AGENTSERVER_PAT_WORK}"],
       "env": { "AGENTSERVER_PAT_WORK": "Bearer agpat_work_…" }
     },
     "personal": {
       "command": "npx",
-      "args": ["mcp-remote", "https://mcp.agent.cs.ac.cn/v1/mcp", "--header", "Authorization:${AGENTSERVER_PAT_PERSONAL}"],
+      "args": ["mcp-remote", "https://mcp.agent.cs.ac.cn/mcp", "--header", "Authorization:${AGENTSERVER_PAT_PERSONAL}"],
       "env": { "AGENTSERVER_PAT_PERSONAL": "Bearer agpat_personal_…" }
     }
   }

--- a/docs/integrations/codex-cli.md
+++ b/docs/integrations/codex-cli.md
@@ -12,8 +12,8 @@ Run your agentserver workspaces' tools (`shell`, `read_file`, `apply_patch`, …
 
 ```toml
 [mcp_servers.agentserver]
-url = "https://mcp.agent.cs.ac.cn/v1/mcp"
-oauth_resource = "https://mcp.agent.cs.ac.cn/v1/mcp"
+url = "https://mcp.agent.cs.ac.cn/mcp"
+oauth_resource = "https://mcp.agent.cs.ac.cn/mcp"
 
 [mcp_servers.agentserver.oauth]
 client_id = "agentserver-mcp"
@@ -45,7 +45,7 @@ Direct curl smoke test (skips the LLM):
 
 ```bash
 TOKEN=$(jq -r .access_token ~/.codex/mcp_oauth/agentserver.json)
-curl -s -X POST https://mcp.agent.cs.ac.cn/v1/mcp \
+curl -s -X POST https://mcp.agent.cs.ac.cn/mcp \
   -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | jq
@@ -59,14 +59,14 @@ Each `[mcp_servers.X]` entry corresponds to one workspace (workspace is selected
 
 ```toml
 [mcp_servers.work]
-url = "https://mcp.agent.cs.ac.cn/v1/mcp"
-oauth_resource = "https://mcp.agent.cs.ac.cn/v1/mcp"
+url = "https://mcp.agent.cs.ac.cn/mcp"
+oauth_resource = "https://mcp.agent.cs.ac.cn/mcp"
 [mcp_servers.work.oauth]
 client_id = "agentserver-mcp"
 
 [mcp_servers.personal]
-url = "https://mcp.agent.cs.ac.cn/v1/mcp"
-oauth_resource = "https://mcp.agent.cs.ac.cn/v1/mcp"
+url = "https://mcp.agent.cs.ac.cn/mcp"
+oauth_resource = "https://mcp.agent.cs.ac.cn/mcp"
 [mcp_servers.personal.oauth]
 client_id = "agentserver-mcp"
 ```
@@ -100,7 +100,7 @@ Then:
 
 ```toml
 [mcp_servers.agentserver]
-url = "https://mcp.agent.cs.ac.cn/v1/mcp"
+url = "https://mcp.agent.cs.ac.cn/mcp"
 bearer_token_env_var = "AGENTSERVER_PAT"
 ```
 
@@ -113,7 +113,7 @@ export AGENTSERVER_PAT='agpat_...'
 | Symptom | Likely cause | Fix |
 |---|---|---|
 | `Incompatible auth server: does not support dynamic client registration` | Forgot `oauth.client_id` in config | Add `[mcp_servers.agentserver.oauth] client_id = "agentserver-mcp"` |
-| `audience mismatch` in gateway logs | Forgot `oauth_resource` in config | Add `oauth_resource = "https://mcp.agent.cs.ac.cn/v1/mcp"` |
+| `audience mismatch` in gateway logs | Forgot `oauth_resource` in config | Add `oauth_resource = "https://mcp.agent.cs.ac.cn/mcp"` |
 | Browser opens but never returns | Network blocks codex's callback port | Set `mcp_oauth_callback_port = 8765` (or any reachable port) in config |
 | `401 unauthorized` after successful login | Token expired or workspace membership lost | Re-run `codex mcp login agentserver` |
 | `tools/call ... not granted to this principal` | Granted only `mcp:read` on consent | Re-login, grant both scopes |

--- a/docs/superpowers/specs/2026-06-09-envmcp-public-gateway-design.md
+++ b/docs/superpowers/specs/2026-06-09-envmcp-public-gateway-design.md
@@ -87,9 +87,9 @@ Endpoints on `https://mcp.agent.cs.ac.cn`:
 
 | Path | Method | Purpose |
 |---|---|---|
-| `/v1/mcp` | POST | MCP JSON-RPC request → JSON-RPC response (single-shot) |
-| `/v1/mcp` | GET | SSE stream for server-initiated messages (mostly idle; reserved for future server→client notifications) |
-| `/v1/mcp` | DELETE | Session termination (per spec) |
+| `/mcp` | POST | MCP JSON-RPC request → JSON-RPC response (single-shot) |
+| `/mcp` | GET | SSE stream for server-initiated messages (mostly idle; reserved for future server→client notifications) |
+| `/mcp` | DELETE | Session termination (per spec) |
 | `/.well-known/oauth-authorization-server` | GET | OAuth 2.1 metadata (RFC 8414) |
 | `/.well-known/oauth-protected-resource` | GET | Resource metadata (RFC 9728) |
 | `/oauth/authorize` | GET | OAuth authorization code endpoint (delegates to Hydra) |
@@ -98,7 +98,7 @@ Endpoints on `https://mcp.agent.cs.ac.cn`:
 
 ## Authentication
 
-**Two paths accepted on `/v1/mcp`. Both produce the same internal principal (`user_id + workspace_ids + tool_allowlist`); rest of the gateway doesn't care which path you took.**
+**Two paths accepted on `/mcp`. Both produce the same internal principal (`user_id + workspace_ids + tool_allowlist`); rest of the gateway doesn't care which path you took.**
 
 ### Path A — OAuth 2.1 + DCR (primary, recommended for interactive clients)
 
@@ -106,13 +106,13 @@ For Claude Desktop UI Connectors and any client that wants zero-touch auth.
 
 Flow (standard MCP 2025-11-25 authorization):
 
-1. Client (Claude Desktop / mcp-remote / etc.) POSTs `/v1/mcp` with no auth → gateway returns `401 WWW-Authenticate: Bearer resource_metadata="https://mcp.agent.cs.ac.cn/.well-known/oauth-protected-resource"`
+1. Client (Claude Desktop / mcp-remote / etc.) POSTs `/mcp` with no auth → gateway returns `401 WWW-Authenticate: Bearer resource_metadata="https://mcp.agent.cs.ac.cn/.well-known/oauth-protected-resource"`
 2. Client fetches `/.well-known/oauth-protected-resource` → discovers our authorization server URL
 3. Client fetches `/.well-known/oauth-authorization-server` → discovers `/oauth/register`, `/oauth/authorize`, `/oauth/token`
 4. Client POSTs `/oauth/register` (DCR) → gateway forwards to Hydra → returns `client_id` (no client_secret; public client w/ PKCE)
-5. Client opens browser to `/oauth/authorize?...&resource=https://mcp.agent.cs.ac.cn/v1/mcp` (RFC 8707) → user logs in to agentserver (existing session reused if any) → consent screen → redirect to client callback with code
+5. Client opens browser to `/oauth/authorize?...&resource=https://mcp.agent.cs.ac.cn/mcp` (RFC 8707) → user logs in to agentserver (existing session reused if any) → consent screen → redirect to client callback with code
 6. Client exchanges code at `/oauth/token` → gets access_token + refresh_token
-7. Subsequent `/v1/mcp` calls send `Authorization: Bearer <access_token>`; gateway introspects via Hydra → resolves to user_id
+7. Subsequent `/mcp` calls send `Authorization: Bearer <access_token>`; gateway introspects via Hydra → resolves to user_id
 8. On 401 (expired), client uses refresh_token to get a new access_token automatically
 
 Scopes:
@@ -257,7 +257,7 @@ Unblocks Claude Desktop 1P "Add Custom Connector" UI path (zero JSON, browser-ba
 **Codex Desktop / CLI** (`~/.codex/config.toml`):
 ```toml
 [mcp_servers.agentserver]
-url = "https://mcp.agent.cs.ac.cn/v1/mcp"
+url = "https://mcp.agent.cs.ac.cn/mcp"
 bearer_token_env_var = "AGENTSERVER_PAT"
 ```
 Set `AGENTSERVER_PAT=agpat_xxx` in shell env or use `codex mcp login agentserver` once Phase 2 lands.
@@ -270,7 +270,7 @@ Set `AGENTSERVER_PAT=agpat_xxx` in shell env or use `codex mcp login agentserver
       "command": "npx",
       "args": [
         "mcp-remote",
-        "https://mcp.agent.cs.ac.cn/v1/mcp",
+        "https://mcp.agent.cs.ac.cn/mcp",
         "--header", "Authorization: Bearer ${AGENTSERVER_PAT}"
       ],
       "env": { "AGENTSERVER_PAT": "agpat_xxx" }
@@ -281,7 +281,7 @@ Set `AGENTSERVER_PAT=agpat_xxx` in shell env or use `codex mcp login agentserver
 
 **Claude Desktop 1P** (Phase 2, UI):
 1. Settings → Customize → Connectors → "+" → "Add custom connector"
-2. URL: `https://mcp.agent.cs.ac.cn/v1/mcp`
+2. URL: `https://mcp.agent.cs.ac.cn/mcp`
 3. Browser opens to agentserver login → consent → done
 
 ## Open questions
@@ -332,11 +332,11 @@ A user with N workspaces who wants Codex CLI access to all of them now needs N P
 
 ```toml
 [mcp_servers.work]
-url = "https://mcp.agent.cs.ac.cn/v1/mcp"
+url = "https://mcp.agent.cs.ac.cn/mcp"
 bearer_token_env_var = "AGENTSERVER_PAT_WORK"
 
 [mcp_servers.personal]
-url = "https://mcp.agent.cs.ac.cn/v1/mcp"
+url = "https://mcp.agent.cs.ac.cn/mcp"
 bearer_token_env_var = "AGENTSERVER_PAT_PERSONAL"
 ```
 

--- a/docs/superpowers/specs/2026-06-17-mcp-oauth-design.md
+++ b/docs/superpowers/specs/2026-06-17-mcp-oauth-design.md
@@ -63,7 +63,7 @@ existing `hydra-client-setup` Helm job:
   — host-only per RFC 8252 §7.3 so Hydra accepts any port the CLI
   binds
 - `scope = "openid mcp:read mcp:exec"`
-- `audience = ["https://mcp.<domain>/v1/mcp"]` so issued tokens
+- `audience = ["https://mcp.<domain>/mcp"]` so issued tokens
   carry the RFC 8707 `aud` claim our resolver enforces
 
 Docs (codex-cli.md, claude-code-cli.md) updated to point to the

--- a/internal/auth/hydra.go
+++ b/internal/auth/hydra.go
@@ -51,7 +51,7 @@ type ConsentRequest struct {
 	RequestedScope []string `json:"requested_scope"`
 	// RequestedAccessTokenAudience is the `resource` parameter the
 	// client sent on /oauth2/auth (RFC 8707). MCP clients set it to
-	// the canonical gateway URL (e.g. https://mcp.agent.cs.ac.cn/v1/mcp).
+	// the canonical gateway URL (e.g. https://mcp.agent.cs.ac.cn/mcp).
 	// We grant whatever the client requested unmodified — the gateway
 	// rejects mismatched audiences at resolve time, so there's no
 	// security benefit to filtering here.

--- a/internal/mcppublic/auth_oauth.go
+++ b/internal/mcppublic/auth_oauth.go
@@ -165,7 +165,7 @@ type OAuthResolver struct {
 
 	// ExpectedAudience is the canonical resource URL our gateway
 	// publishes in the `oauth-protected-resource` doc, e.g.
-	// "https://mcp.agent.cs.ac.cn/v1/mcp". Tokens whose `aud` claim
+	// "https://mcp.agent.cs.ac.cn/mcp". Tokens whose `aud` claim
 	// does not contain this string are rejected per RFC 8707. Empty
 	// disables the check (dev only; never leave unset in prod —
 	// without it a token issued for a different MCP server would

--- a/internal/mcppublic/auth_oauth_test.go
+++ b/internal/mcppublic/auth_oauth_test.go
@@ -32,7 +32,7 @@ func newOAuthResolver(f *fakeDB, s *stubIntrospector) *OAuthResolver {
 	return &OAuthResolver{
 		DB:               f,
 		Introspector:     s,
-		ExpectedAudience: "https://mcp.example.com/v1/mcp",
+		ExpectedAudience: "https://mcp.example.com/mcp",
 	}
 }
 
@@ -41,7 +41,7 @@ func newOAuthResolver(f *fakeDB, s *stubIntrospector) *OAuthResolver {
 // without HYDRA_ADMIN_URL). Without this the middleware would 500
 // every request the moment OAuth is "disabled".
 func TestOAuthResolver_NilIntrospectorIsErrUnknown(t *testing.T) {
-	r := OAuthResolver{DB: &fakeDB{}, ExpectedAudience: "https://x/v1/mcp"}
+	r := OAuthResolver{DB: &fakeDB{}, ExpectedAudience: "https://x/mcp"}
 	_, err := r.Resolve(context.Background(), "ory_at_anything")
 	if !errors.Is(err, ErrUnknown) {
 		t.Fatalf("want ErrUnknown when introspector unset, got %v", err)
@@ -83,7 +83,7 @@ func TestOAuthResolver_HappyPath(t *testing.T) {
 			Subject:  "user_abc",
 			ClientID: "client_xyz",
 			Scope:    "mcp:read mcp:exec openid",
-			Audience: audience{"https://mcp.example.com/v1/mcp"},
+			Audience: audience{"https://mcp.example.com/mcp"},
 			Ext: map[string]interface{}{
 				"workspace_id":   "ws_42",
 				"workspace_role": "developer",
@@ -134,7 +134,7 @@ func TestOAuthResolver_AudienceMismatchIsErrInvalid(t *testing.T) {
 			Active:   true,
 			Subject:  "user_abc",
 			Scope:    "mcp:read",
-			Audience: audience{"https://other-mcp.example.com/v1/mcp"},
+			Audience: audience{"https://other-mcp.example.com/mcp"},
 			Ext:      map[string]interface{}{"workspace_id": "ws_42", "workspace_role": "developer"},
 		},
 	}
@@ -156,7 +156,7 @@ func TestOAuthResolver_AudienceArrayMatches(t *testing.T) {
 			Active:   true,
 			Subject:  "user_abc",
 			Scope:    "mcp:read",
-			Audience: audience{"https://something-else", "https://mcp.example.com/v1/mcp"},
+			Audience: audience{"https://something-else", "https://mcp.example.com/mcp"},
 			Ext:      map[string]interface{}{"workspace_id": "ws_42", "workspace_role": "developer"},
 		},
 	}
@@ -175,7 +175,7 @@ func TestOAuthResolver_MissingWorkspaceClaimIsErrInvalid(t *testing.T) {
 			Active:   true,
 			Subject:  "user_abc",
 			Scope:    "mcp:read",
-			Audience: audience{"https://mcp.example.com/v1/mcp"},
+			Audience: audience{"https://mcp.example.com/mcp"},
 			Ext:      map[string]interface{}{}, // no workspace_id
 		},
 	}
@@ -200,7 +200,7 @@ func TestOAuthResolver_KickedOutUserIsErrInvalid(t *testing.T) {
 			Active:   true,
 			Subject:  "user_abc",
 			Scope:    "mcp:read",
-			Audience: audience{"https://mcp.example.com/v1/mcp"},
+			Audience: audience{"https://mcp.example.com/mcp"},
 			Ext:      map[string]interface{}{"workspace_id": "ws_42", "workspace_role": "developer"},
 		},
 	}
@@ -237,7 +237,7 @@ func TestOAuthResolver_OnlyReadScopeWithdrawsExecTools(t *testing.T) {
 			Active:   true,
 			Subject:  "user_abc",
 			Scope:    "mcp:read", // no exec
-			Audience: audience{"https://mcp.example.com/v1/mcp"},
+			Audience: audience{"https://mcp.example.com/mcp"},
 			Ext:      map[string]interface{}{"workspace_id": "ws_42", "workspace_role": "developer"},
 		},
 	}

--- a/internal/mcppublic/auth_test.go
+++ b/internal/mcppublic/auth_test.go
@@ -276,7 +276,7 @@ func TestMiddleware_NoAuthHeader(t *testing.T) {
 	h := &noopHandler{}
 	mw := &Middleware{Resolvers: []PrincipalResolver{stubResolver{p: &Principal{UserID: "u"}}}}
 	w := httptest.NewRecorder()
-	mw.Wrap(h).ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/v1/mcp", nil))
+	mw.Wrap(h).ServeHTTP(w, httptest.NewRequest(http.MethodPost, "/mcp", nil))
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("want 401, got %d", w.Code)
 	}
@@ -293,7 +293,7 @@ func TestMiddleware_MalformedScheme(t *testing.T) {
 		t.Run(h, func(t *testing.T) {
 			handler := &noopHandler{}
 			mw := &Middleware{Resolvers: []PrincipalResolver{stubResolver{p: &Principal{UserID: "u"}}}}
-			r := httptest.NewRequest(http.MethodPost, "/v1/mcp", nil)
+			r := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 			r.Header.Set("Authorization", h)
 			w := httptest.NewRecorder()
 			mw.Wrap(handler).ServeHTTP(w, r)
@@ -313,7 +313,7 @@ func TestMiddleware_ResolverReturnsErrUnknown_FallsThrough(t *testing.T) {
 		stubResolver{p: wantP},
 	}}
 	h := &noopHandler{}
-	r := httptest.NewRequest(http.MethodPost, "/v1/mcp", nil)
+	r := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 	r.Header.Set("Authorization", "Bearer something")
 	w := httptest.NewRecorder()
 	mw.Wrap(h).ServeHTTP(w, r)
@@ -337,7 +337,7 @@ func TestMiddleware_ResolverReturnsErrInvalid_NoFallthrough(t *testing.T) {
 		}),
 	}}
 	h := &noopHandler{}
-	r := httptest.NewRequest(http.MethodPost, "/v1/mcp", nil)
+	r := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 	r.Header.Set("Authorization", "Bearer agpat_revoked")
 	w := httptest.NewRecorder()
 	mw.Wrap(h).ServeHTTP(w, r)
@@ -354,7 +354,7 @@ func TestMiddleware_AdvertisesResourceMetadata(t *testing.T) {
 		Resolvers:           []PrincipalResolver{stubResolver{err: ErrInvalid}},
 		ResourceMetadataURL: "https://mcp.example.com/.well-known/oauth-protected-resource",
 	}
-	r := httptest.NewRequest(http.MethodPost, "/v1/mcp", nil)
+	r := httptest.NewRequest(http.MethodPost, "/mcp", nil)
 	r.Header.Set("Authorization", "Bearer x")
 	w := httptest.NewRecorder()
 	mw.Wrap(&noopHandler{}).ServeHTTP(w, r)

--- a/internal/mcppublic/transport.go
+++ b/internal/mcppublic/transport.go
@@ -16,15 +16,15 @@ import (
 //
 // Endpoints on the gateway hostname (production: mcp.agent.cs.ac.cn):
 //
-//   POST /v1/mcp        — JSON-RPC request → JSON-RPC response.
+//   POST /mcp        — JSON-RPC request → JSON-RPC response.
 //                         Content-Type: application/json.
-//   GET  /v1/mcp        — 405. Stateless server, no SSE re-attach;
+//   GET  /mcp        — 405. Stateless server, no SSE re-attach;
 //                         the spec marks GET as MAY for stateless.
-//   DELETE /v1/mcp      — 405. No Mcp-Session-Id support in this
+//   DELETE /mcp      — 405. No Mcp-Session-Id support in this
 //                         transport; nothing to delete.
 //   GET  /healthz       — 200, plain text "ok". For K8s liveness +
 //                         istio readiness probes.
-//   GET  /v1/.well-known/oauth-protected-resource
+//   GET  /.well-known/oauth-protected-resource
 //                       — small JSON stub pointing at agentserver's
 //                         /api/workspaces/{wid}/mcp/pats minting UI.
 //                         Codex CLI ignores this and short-circuits
@@ -80,7 +80,7 @@ func NewServer(d *Dispatcher, issuerURL string, logger *slog.Logger) *Server {
 }
 
 // Mount returns an http.Handler with the gateway's routes. Mount
-// auth middleware around `/v1/mcp` separately so the well-known
+// auth middleware around `/mcp` separately so the well-known
 // metadata endpoint and /healthz stay public.
 func (s *Server) Mount(authMW func(http.Handler) http.Handler) http.Handler {
 	mux := http.NewServeMux()
@@ -88,35 +88,17 @@ func (s *Server) Mount(authMW func(http.Handler) http.Handler) http.Handler {
 		w.WriteHeader(http.StatusOK)
 		_, _ = io.WriteString(w, "ok")
 	})
-	// Two paths serve the same Protected Resource Metadata doc:
-	//
-	//   /.well-known/oauth-protected-resource         — RFC 9728 §3.1
-	//                                                   spec-compliant location
-	//                                                   (resource root). Claude
-	//                                                   Code, ChatGPT MCP, and
-	//                                                   any client following
-	//                                                   2025-06-18 MCP authz
-	//                                                   spec read from here.
-	//   /v1/.well-known/oauth-protected-resource      — Earlier path we picked
-	//                                                   because /v1/mcp is the
-	//                                                   resource. Pre-existing
-	//                                                   deployments may have it
-	//                                                   wired into MCP_PUBLIC_
-	//                                                   RESOURCE_METADATA_URL,
-	//                                                   so we keep it as an
-	//                                                   alias rather than break
-	//                                                   the WWW-Authenticate
-	//                                                   contract those pods
-	//                                                   advertise.
-	//
-	// Without the root-path entry, Claude Code falls back to RFC 8414's
-	// "issuer = resource server URL" guess, then tries to wire OAuth at
-	// https://<resource>/authorize → 404 → user sees a broken page.
+	// RFC 9728 §3.1: the Protected Resource Metadata doc lives at
+	// /.well-known/oauth-protected-resource on the resource server
+	// root. MCP clients (Claude Code, ChatGPT MCP, anything following
+	// MCP 2025-06-18 authz) read it before starting OAuth — without
+	// this, they fall back to RFC 8414's "issuer = resource server
+	// URL" guess and wire OAuth at https://<resource>/authorize, which
+	// is a 404.
 	mux.HandleFunc("/.well-known/oauth-protected-resource", s.handleOAuthProtectedResource)
-	mux.HandleFunc("/v1/.well-known/oauth-protected-resource", s.handleOAuthProtectedResource)
 
 	mcp := http.HandlerFunc(s.handleMCP)
-	mux.Handle("/v1/mcp", authMW(mcp))
+	mux.Handle("/mcp", authMW(mcp))
 	return mux
 }
 
@@ -315,10 +297,10 @@ func idOrNull(id json.RawMessage) json.RawMessage {
 // listing them here is what makes Codex request the right ones
 // without users having to remember to pass `--scopes`.
 func (s *Server) handleOAuthProtectedResource(w http.ResponseWriter, r *http.Request) {
-	gatewayURL := "https://" + r.Host + "/v1/mcp"
+	gatewayURL := "https://" + r.Host + "/mcp"
 	if !requestIsHTTPS(r) {
 		// Dev / port-forward case — keep things working over plain http.
-		gatewayURL = "http://" + r.Host + "/v1/mcp"
+		gatewayURL = "http://" + r.Host + "/mcp"
 	}
 	authServer := s.IssuerURL
 	if authServer == "" {

--- a/internal/mcppublic/transport_test.go
+++ b/internal/mcppublic/transport_test.go
@@ -35,7 +35,7 @@ func newTestServer(t *testing.T, src *fakeExecutorsSource, backend ToolBackend, 
 // the parsed response.
 func post(t *testing.T, ts *httptest.Server, body string) (*http.Response, jsonrpcResp) {
 	t.Helper()
-	resp, err := http.Post(ts.URL+"/v1/mcp", "application/json", strings.NewReader(body))
+	resp, err := http.Post(ts.URL+"/mcp", "application/json", strings.NewReader(body))
 	if err != nil {
 		t.Fatalf("POST: %v", err)
 	}
@@ -120,7 +120,7 @@ func TestTransport_UnknownMethod_ReturnsMethodNotFound(t *testing.T) {
 
 func TestTransport_NotificationsInitialized_NoResponseBody(t *testing.T) {
 	hs := newTestServer(t, nil, &stubBackend{}, principalReadOnly("ws_1"))
-	resp, err := http.Post(hs.URL+"/v1/mcp", "application/json",
+	resp, err := http.Post(hs.URL+"/mcp", "application/json",
 		strings.NewReader(`{"jsonrpc":"2.0","method":"notifications/initialized"}`))
 	if err != nil {
 		t.Fatalf("POST: %v", err)
@@ -172,7 +172,7 @@ func TestTransport_BadJSONRPCVersion_Rejected(t *testing.T) {
 
 func TestTransport_GET_Returns405(t *testing.T) {
 	hs := newTestServer(t, nil, &stubBackend{}, principalReadOnly("ws_1"))
-	resp, err := http.Get(hs.URL + "/v1/mcp")
+	resp, err := http.Get(hs.URL + "/mcp")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -187,7 +187,7 @@ func TestTransport_GET_Returns405(t *testing.T) {
 
 func TestTransport_DELETE_Returns405(t *testing.T) {
 	hs := newTestServer(t, nil, &stubBackend{}, principalReadOnly("ws_1"))
-	req, _ := http.NewRequest(http.MethodDelete, hs.URL+"/v1/mcp", nil)
+	req, _ := http.NewRequest(http.MethodDelete, hs.URL+"/mcp", nil)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("DELETE: %v", err)
@@ -219,7 +219,7 @@ func TestTransport_Healthz_Public(t *testing.T) {
 // "guess the AS by stripping path" path, which lands them at
 // https://mcp.<host>/authorize — a 404 page, broken UX.
 //
-// We keep /v1/.well-known/oauth-protected-resource as an alias for
+// We keep /.well-known/oauth-protected-resource as an alias for
 // the WWW-Authenticate header that older deployments wired in via
 // the MCP_PUBLIC_RESOURCE_METADATA_URL env var. Both paths must
 // return the same doc.
@@ -240,8 +240,8 @@ func TestTransport_OAuthProtectedResource_RFC9728RootPath(t *testing.T) {
 	if err := json.NewDecoder(resp.Body).Decode(&doc); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	if !strings.HasSuffix(doc.Resource, "/v1/mcp") {
-		t.Errorf("resource: %q must end in /v1/mcp", doc.Resource)
+	if !strings.HasSuffix(doc.Resource, "/mcp") {
+		t.Errorf("resource: %q must end in /mcp", doc.Resource)
 	}
 	if len(doc.AuthorizationServers) == 0 || doc.AuthorizationServers[0] != "https://app.example.com" {
 		t.Errorf("authorization_servers wrong: %+v", doc.AuthorizationServers)
@@ -250,7 +250,7 @@ func TestTransport_OAuthProtectedResource_RFC9728RootPath(t *testing.T) {
 
 func TestTransport_OAuthProtectedResource_Public(t *testing.T) {
 	hs := newTestServer(t, nil, &stubBackend{}, principalReadOnly("ws_1"))
-	resp, err := http.Get(hs.URL + "/v1/.well-known/oauth-protected-resource")
+	resp, err := http.Get(hs.URL + "/.well-known/oauth-protected-resource")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -267,8 +267,8 @@ func TestTransport_OAuthProtectedResource_Public(t *testing.T) {
 	if !strings.HasPrefix(doc.Resource, "http://") {
 		t.Errorf("plain-http resource: got %q, want http:// prefix", doc.Resource)
 	}
-	if !strings.HasSuffix(doc.Resource, "/v1/mcp") {
-		t.Errorf("resource missing /v1/mcp suffix: %q", doc.Resource)
+	if !strings.HasSuffix(doc.Resource, "/mcp") {
+		t.Errorf("resource missing /mcp suffix: %q", doc.Resource)
 	}
 	if len(doc.AuthorizationServers) == 0 {
 		t.Errorf("no authorization_servers: %+v", doc)
@@ -283,11 +283,11 @@ func TestTransport_OAuthProtectedResource_Public(t *testing.T) {
 // production behavior behind istio-ingress (TLS terminated at ingress,
 // pod sees plain http but the X-Forwarded-Proto header tells us the
 // client connected over https). Without this honored, the protected-
-// resource doc would advertise http://mcp.agent.cs.ac.cn/v1/mcp and
+// resource doc would advertise http://mcp.agent.cs.ac.cn/mcp and
 // OAuth clients would refuse to use it.
 func TestTransport_OAuthProtectedResource_HonorsXForwardedProto(t *testing.T) {
 	hs := newTestServer(t, nil, &stubBackend{}, principalReadOnly("ws_1"))
-	req, _ := http.NewRequest(http.MethodGet, hs.URL+"/v1/.well-known/oauth-protected-resource", nil)
+	req, _ := http.NewRequest(http.MethodGet, hs.URL+"/.well-known/oauth-protected-resource", nil)
 	req.Header.Set("X-Forwarded-Proto", "https")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -318,7 +318,7 @@ func TestTransport_OAuthProtectedResource_HonorsXForwardedProto(t *testing.T) {
 // query-string-bearer attempts that the resolver doesn't honor.
 func TestTransport_OAuthProtectedResource_AdvertisesScopesAndBearerMethods(t *testing.T) {
 	hs := newTestServer(t, nil, &stubBackend{}, principalReadOnly("ws_1"))
-	resp, err := http.Get(hs.URL + "/v1/.well-known/oauth-protected-resource")
+	resp, err := http.Get(hs.URL + "/.well-known/oauth-protected-resource")
 	if err != nil {
 		t.Fatalf("GET: %v", err)
 	}
@@ -357,7 +357,7 @@ func TestTransport_OAuthProtectedResource_AdvertisesScopesAndBearerMethods(t *te
 // first entry, since proxies may chain.
 func TestTransport_OAuthProtectedResource_XForwardedProtoChain(t *testing.T) {
 	hs := newTestServer(t, nil, &stubBackend{}, principalReadOnly("ws_1"))
-	req, _ := http.NewRequest(http.MethodGet, hs.URL+"/v1/.well-known/oauth-protected-resource", nil)
+	req, _ := http.NewRequest(http.MethodGet, hs.URL+"/.well-known/oauth-protected-resource", nil)
 	req.Header.Set("X-Forwarded-Proto", "https, http")
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -376,17 +376,17 @@ func TestTransport_OAuthProtectedResource_XForwardedProtoChain(t *testing.T) {
 func TestTransport_AuthMiddleware_401AdvertisesResourceMetadata(t *testing.T) {
 	// Verify the auth middleware emits WWW-Authenticate that points
 	// at our oauth-protected-resource doc. End-to-end-ish: mount the
-	// real Middleware + a resolver that always rejects, hit /v1/mcp,
+	// real Middleware + a resolver that always rejects, hit /mcp,
 	// inspect the 401's headers.
 	d := newTestDispatcher(t, nil, &stubBackend{})
 	srv := NewServer(d, "https://app.example.com", nil)
 	resolver := stubResolverErr{err: ErrInvalid}
 	mw := AuthMiddleware([]PrincipalResolver{resolver},
-		"https://mcp.example.com/v1/.well-known/oauth-protected-resource", nil)
+		"https://mcp.example.com/.well-known/oauth-protected-resource", nil)
 	hs := httptest.NewServer(srv.Mount(mw))
 	defer hs.Close()
 
-	req, _ := http.NewRequest(http.MethodPost, hs.URL+"/v1/mcp",
+	req, _ := http.NewRequest(http.MethodPost, hs.URL+"/mcp",
 		bytes.NewReader([]byte(`{"jsonrpc":"2.0","id":1,"method":"initialize"}`)))
 	req.Header.Set("Authorization", "Bearer some-thing")
 	resp, err := http.DefaultClient.Do(req)


### PR DESCRIPTION
Drop the redundant `/v1` prefix. Industry default is `/mcp` (Linear, GitHub, spec examples); MCP already versions itself via `protocolVersion` in JSON-RPC.

## BREAKING

Existing OAuth tokens have `aud=https://mcp/v1/mcp`; resolver now requires `/mcp`. Every existing token gets 401 after deploy. Users re-OAuth in 10 seconds (`claude mcp remove agentserver && claude mcp add ...` with new URL).

PATs unaffected (no aud claim).

## Verified

- build + all unit tests pass with new path
- helm template renders `MCP_PUBLIC_RESOURCE_METADATA_URL`, `OAUTH_EXPECTED_AUDIENCE`, hydra `--audience` all to `/mcp` / `/.well-known/oauth-protected-resource`
- openapi-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)