### PR TITLE
chore(chart): bump 0.68.3 → 0.69.0 to ship #264

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.68.3
-appVersion: "0.68.3"
+version: 0.69.0
+appVersion: "0.69.0"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
Breaking change: MCP path /v1/mcp → /mcp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)