### PR TITLE
fix(hydra): pin MCP OAuth callback port to 20202

### DIFF
--- a/deploy/helm/agentserver/templates/hydra.yaml
+++ b/deploy/helm/agentserver/templates/hydra.yaml
@@ -215,20 +215,31 @@ spec:
               #   - Audience pinned to mcp.<domain>/mcp so a token
               #     issued for this client can't replay against any
               #     other MCP server on the same Hydra (RFC 8707).
-              #   - Loopback redirect URIs only — host-only, RFC 8252
-              #     §7.3 lets Hydra accept any port the CLI binds.
+              #   - Pinned callback port 20202 — Hydra v2 does NOT
+              #     implement RFC 8252 §7.3 (loopback any-port — see
+              #     ory/hydra#1732), so we have to register the exact
+              #     redirect_uri the CLI binds. Docs tell users to
+              #     pass --callback-port 20202 / mcp_oauth_callback_
+              #     port = 20202. 20202 is rare enough to avoid
+              #     collisions with the usual dev-server ports
+              #     (3000/8080/5173/etc).
               #
               # Idempotent: update first, fall back to create. Helm
               # reruns the job on every chart upgrade so the flag set
               # below is the source of truth (drift is silently
               # corrected).
+              # offline_access is required for refresh_token issuance — Claude
+              # Code requests it unconditionally so it can silently refresh
+              # access tokens (1h TTL) without re-prompting the browser. Without
+              # it advertised on the client, Hydra returns invalid_scope and
+              # the entire OAuth flow fails at the authorize step.
               MCP_FLAGS="--name Agentserver_MCP \
                 --grant-type authorization_code \
                 --grant-type refresh_token \
                 --response-type code \
-                --scope openid --scope mcp:read --scope mcp:exec \
-                --redirect-uri http://localhost/callback \
-                --redirect-uri http://127.0.0.1/callback \
+                --scope openid --scope offline_access --scope mcp:read --scope mcp:exec \
+                --redirect-uri http://localhost:20202/callback \
+                --redirect-uri http://127.0.0.1:20202/callback \
                 --token-endpoint-auth-method none \
                 --audience https://mcp.{{ .Values.platform.domain }}/mcp"
               hydra update oauth2-client agentserver-mcp --endpoint "$ENDPOINT" $MCP_FLAGS 2>/dev/null || \

--- a/docs/integrations/claude-code-cli.md
+++ b/docs/integrations/claude-code-cli.md
@@ -14,12 +14,12 @@ Run your agentserver workspaces' tools (`shell`, `read_file`, `apply_patch`, …
 claude mcp add --transport http agentserver \
   https://mcp.agent.cs.ac.cn/mcp \
   --client-id agentserver-mcp \
-  --callback-port 3000
+  --callback-port 20202
 ```
 
 Notes:
 - `client_id = "agentserver-mcp"` is a fixed, public value shared by all users (same shape as gh CLI's hard-coded GitHub OAuth client). It has no auth power on its own — the OAuth flow's user login + workspace consent screen is what authorizes.
-- `--callback-port` is required: Claude Code binds the OAuth callback on this exact port. Any free port works (we register loopback host-only with Hydra, so any port is accepted per RFC 8252).
+- `--callback-port 20202` is required and the port number is **not arbitrary** — Hydra v2 doesn't implement RFC 8252 §7.3 (loopback-any-port), so the server only accepts callbacks on the exact port registered with the OAuth client. We registered port 20202 (rare enough to dodge dev-server collisions on 3000/8080/5173/etc.). If 20202 is taken on your machine, file an issue.
 - No `--client-secret`: the shared client is a **public** OAuth client (PKCE-protected).
 
 ## First connect triggers OAuth
@@ -44,7 +44,7 @@ The first time it talks to `agentserver`, a browser opens. Log in to agentserver
       "url": "https://mcp.agent.cs.ac.cn/mcp",
       "oauth": {
         "client_id": "agentserver-mcp",
-        "callback_port": 3000
+        "callback_port": 20202
       }
     }
   }
@@ -76,7 +76,7 @@ Local clear: `claude mcp remove agentserver`. For workspace-membership-based rev
 | Symptom | Fix |
 |---|---|
 | `Incompatible auth server: does not support dynamic client registration` | Forgot `--client-id`; re-add with the flag |
-| `invalid_redirect_uri` | `--callback-port` didn't match what Claude Code actually bound; pick any free port and retry |
+| `invalid_redirect_uri` | `--callback-port` must be exactly 20202 (Hydra registers that one port, not any-loopback). |
 | Token works once then fails | Check gateway logs for `audience mismatch` — Claude Code currently doesn't pass `oauth_resource`. Tracked in follow-up. |
 
 ## Related

--- a/docs/integrations/codex-cli.md
+++ b/docs/integrations/codex-cli.md
@@ -11,6 +11,8 @@ Run your agentserver workspaces' tools (`shell`, `read_file`, `apply_patch`, …
 ## Step 1 — Add to `~/.codex/config.toml`
 
 ```toml
+mcp_oauth_callback_port = 20202
+
 [mcp_servers.agentserver]
 url = "https://mcp.agent.cs.ac.cn/mcp"
 oauth_resource = "https://mcp.agent.cs.ac.cn/mcp"
@@ -20,6 +22,8 @@ client_id = "agentserver-mcp"
 ```
 
 The `client_id` is a fixed, public value shared by all users (same shape as `gh` CLI's hard-coded GitHub OAuth client). It carries no auth power on its own — the OAuth flow's user login + workspace consent screen is what actually authorizes the issued token.
+
+`mcp_oauth_callback_port = 20202` pins Codex's local OAuth callback to port 20202 (the only port our Hydra accepts — RFC 8252 §7.3 "any loopback port" is not implemented in Hydra v2, so the server has exactly one pre-registered redirect URI per host).
 
 The `oauth_resource` (RFC 8707) binds the token to this gateway's URL — without it, the gateway's resolver rejects every request because the token's `aud` claim is empty.
 
@@ -114,7 +118,8 @@ export AGENTSERVER_PAT='agpat_...'
 |---|---|---|
 | `Incompatible auth server: does not support dynamic client registration` | Forgot `oauth.client_id` in config | Add `[mcp_servers.agentserver.oauth] client_id = "agentserver-mcp"` |
 | `audience mismatch` in gateway logs | Forgot `oauth_resource` in config | Add `oauth_resource = "https://mcp.agent.cs.ac.cn/mcp"` |
-| Browser opens but never returns | Network blocks codex's callback port | Set `mcp_oauth_callback_port = 8765` (or any reachable port) in config |
+| Browser opens, redirects to a Hydra error page about `redirect_uri` | Codex bound a different port than 20202 | Add `mcp_oauth_callback_port = 20202` to `~/.codex/config.toml` (Hydra registers exactly that one port — RFC 8252 §7.3 isn't implemented in Hydra v2). |
+| Browser opens but never returns | Network blocks codex's callback port 20202 | The port is fixed; ensure 20202 is reachable from your browser to Codex's local server (firewall / VPN config). |
 | `401 unauthorized` after successful login | Token expired or workspace membership lost | Re-run `codex mcp login agentserver` |
 | `tools/call ... not granted to this principal` | Granted only `mcp:read` on consent | Re-login, grant both scopes |
 | `no environment named X` | Executor name not in `list_environments` | Run `list_environments` first; copy a `name` verbatim |


### PR DESCRIPTION
Hydra v2 doesn't implement RFC 8252 §7.3 (any-loopback-port) — verified live: `claude mcp add ... --callback-port 20202` against v0.69.0 returns `invalid_redirect_uri` because the OAuth client's redirect_uris are host-only (no port).

Fix: register exact `http://localhost:20202/callback` + `http://127.0.0.1:20202/callback`. Docs updated to require users set callback port to 20202.

Picked 20202 because it dodges 3000/5173/8080/etc. dev-server collisions.

Cluster has the client manually patched to :20202 already so the live deploy works; this PR makes it survive future helm upgrades.

🤖 Generated with [Claude Code](https://claude.com/claude-code)