### PR TITLE
fix(mcppublic): accept OAuth tokens with empty aud (Hydra lacks RFC 8707)

### DIFF
--- a/internal/mcppublic/auth_oauth.go
+++ b/internal/mcppublic/auth_oauth.go
@@ -212,17 +212,37 @@ func (r *OAuthResolver) Resolve(ctx context.Context, raw string) (*Principal, er
 		return nil, ErrInvalid
 	}
 
-	// RFC 8707 resource-indicator binding. Without this, a user who
-	// holds a token issued for a different MCP server in the same
-	// Hydra deployment could replay it here. Hydra populates `aud`
-	// from the client's registered audiences + the `resource`
-	// parameter the client passed to /oauth2/auth.
-	if r.ExpectedAudience != "" {
+	// RFC 8707 resource-indicator binding. Defensive but lenient:
+	//
+	//   - If the token carries an `aud` claim, it MUST contain our
+	//     ExpectedAudience. Hard-fail on mismatch to keep replay
+	//     defense for any token that does properly identify a
+	//     resource.
+	//   - If `aud` is empty, allow through with a warn log. Hydra/
+	//     fosite v2.x does NOT implement RFC 8707 — the `resource`
+	//     query parameter every spec-compliant MCP client sends
+	//     (Claude Code, Codex CLI's `oauth_resource =`) is silently
+	//     dropped by Hydra and the issued token has no audience.
+	//     See ory/fosite#879 (still in draft, CLA blocked, opened
+	//     2026-05-25) for the upstream fix.
+	//
+	// This is single-tenant safe: there's exactly one MCP gateway in
+	// our Hydra deployment, so a token issued through this consent
+	// flow can only have been meant for this gateway anyway. If we
+	// ever add a second MCP server on the same Hydra, this WILL be a
+	// real cross-resource replay risk — at that point, either fosite
+	// has merged RFC 8707 (delete the empty-aud branch) or we'll
+	// patch the consent handler to inject GrantAccessTokenAudience
+	// based on the requested scope set.
+	if r.ExpectedAudience != "" && len(intro.Audience) > 0 {
 		if !audienceContains(intro.Audience, r.ExpectedAudience) {
 			log.Info("mcppublic.OAuth: audience mismatch",
 				"sub", intro.Subject, "want", r.ExpectedAudience, "got", []string(intro.Audience))
 			return nil, ErrInvalid
 		}
+	} else if r.ExpectedAudience != "" {
+		log.Warn("mcppublic.OAuth: token has no audience claim, accepting (Hydra lacks RFC 8707)",
+			"sub", intro.Subject, "want", r.ExpectedAudience, "client_id", intro.ClientID)
 	}
 
 	// Pull the consent-screen-selected workspace from ext claims. The

--- a/internal/mcppublic/auth_oauth_test.go
+++ b/internal/mcppublic/auth_oauth_test.go
@@ -145,6 +145,36 @@ func TestOAuthResolver_AudienceMismatchIsErrInvalid(t *testing.T) {
 	}
 }
 
+// TestOAuthResolver_EmptyAudienceAccepted — Hydra v2.x (via fosite)
+// doesn't implement RFC 8707 Resource Indicators yet, so the
+// `resource=...` parameter from spec-compliant MCP clients is
+// silently dropped and the issued token has no `aud` claim. We
+// accept these tokens with a warning (single-tenant Hydra: any
+// token through our consent flow can only have been meant for our
+// MCP gateway). If `aud` IS present, mismatch is still a hard fail
+// (other test pins that). Delete this branch when ory/fosite#879
+// merges and tokens reliably carry `aud`.
+func TestOAuthResolver_EmptyAudienceAccepted(t *testing.T) {
+	f := &fakeDB{workspaces: []*db.Workspace{{ID: "ws_42"}}}
+	s := &stubIntrospector{
+		res: &IntrospectionResult{
+			Active:   true,
+			Subject:  "user_abc",
+			Scope:    "mcp:read",
+			Audience: audience{}, // empty — Hydra didn't process `resource=`
+			Ext:      map[string]interface{}{"workspace_id": "ws_42", "workspace_role": "developer"},
+		},
+	}
+	r := newOAuthResolver(f, s)
+	p, err := r.Resolve(context.Background(), "ory_at_noaud")
+	if err != nil {
+		t.Fatalf("empty aud should be accepted (Hydra no RFC 8707): %v", err)
+	}
+	if p.WorkspaceID != "ws_42" {
+		t.Errorf("unexpected principal: %+v", p)
+	}
+}
+
 // TestOAuthResolver_AudienceArrayMatches — `aud` may be a JSON
 // array; the resolver must accept a match anywhere in the list, not
 // just the first entry. This is the common case for Hydra clients


### PR DESCRIPTION
**The bug**: every OAuth token gets 401 because aud is empty.

```
mcppublic.OAuth: audience mismatch  sub=... want="https://mcp.agent.cs.ac.cn/mcp" got=[]
```

**Root cause**: Hydra v2 / fosite v0.x don't implement RFC 8707. The `resource=...` query param spec-compliant MCP clients send is silently dropped. The token therefore has no audience.

Upstream fix: [ory/fosite#879](https://github.com/ory/fosite/pull/879) — opened 2026-05-25, still draft, CLA blocked.

**Workaround**: `OAuthResolver` now accepts empty-aud tokens (with a warn log). Non-empty aud still hard-matched. Safe for single-tenant deploys (we have one MCP server on this Hydra).

🤖 Generated with [Claude Code](https://claude.com/claude-code)