### PR TITLE
chore(chart): bump 0.69.0 → 0.69.1 to ship #266 + #267

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.69.0
-appVersion: "0.69.0"
+version: 0.69.1
+appVersion: "0.69.1"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
Ships the two OAuth fixes for end-to-end MCP flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)