### PR TITLE
fix(hydra): also register /oauth/callback redirect URI (mcp-remote)

### DIFF
--- a/deploy/helm/agentserver/templates/hydra.yaml
+++ b/deploy/helm/agentserver/templates/hydra.yaml
@@ -240,6 +240,8 @@ spec:
                 --scope openid --scope offline_access --scope mcp:read --scope mcp:exec \
                 --redirect-uri http://localhost:20202/callback \
                 --redirect-uri http://127.0.0.1:20202/callback \
+                --redirect-uri http://localhost:20202/oauth/callback \
+                --redirect-uri http://127.0.0.1:20202/oauth/callback \
                 --token-endpoint-auth-method none \
                 --audience https://mcp.{{ .Values.platform.domain }}/mcp"
               hydra update oauth2-client agentserver-mcp --endpoint "$ENDPOINT" $MCP_FLAGS 2>/dev/null || \


### PR DESCRIPTION
mcp-remote uses /oauth/callback path (Claude Code uses /callback). Add both so Claude Desktop + mcp-remote bridge works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)