### PR TITLE
chore(chart): bump 0.69.1 → 0.69.2 to ship #270 + #271

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.69.1
-appVersion: "0.69.1"
+version: 0.69.2
+appVersion: "0.69.2"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
Ships the per-surface OAuth client split and the /oauth/callback redirect-uri addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)