### PR TITLE
refactor(mcp-oauth): three-way client split (claude-code/codex/claude-desktop)

### DIFF
--- a/deploy/helm/agentserver/templates/hydra.yaml
+++ b/deploy/helm/agentserver/templates/hydra.yaml
@@ -199,13 +199,27 @@ spec:
               hydra update oauth2-client agentserver-agent-cli --endpoint "$ENDPOINT" $CLI_FLAGS 2>/dev/null || \
               hydra create oauth2-client --endpoint "$ENDPOINT" --id agentserver-agent-cli $CLI_FLAGS
 
-              # MCP OAuth clients — split by surface so each can be
-              # audited/revoked independently and the redirect_uris
-              # stay minimal-per-surface (Hydra string-matches the full
-              # URL including path, so unioning them on one client
-              # makes any one client's compromise a wider blast).
+              # MCP OAuth clients — one per (vendor × surface) combo:
               #
-              # Common to both:
+              #   agentserver-mcp-claude-code     /callback        Claude Code CLI
+              #   agentserver-mcp-codex           /callback        Codex CLI + Codex Desktop
+              #   agentserver-mcp-claude-desktop  /oauth/callback  Claude Desktop via mcp-remote
+              #
+              # Why split this way:
+              #   - Claude Code and Claude Desktop have separate configs
+              #     and separate token stores; users almost always set up
+              #     them independently. Splitting client_ids lets ops
+              #     audit / revoke per surface.
+              #   - Codex CLI and Codex Desktop share ~/.codex/config.toml
+              #     and the same OAuth callback code path (see codex-rs
+              #     /app-server/src/request_processors/mcp_processor.rs).
+              #     Splitting them would force users to maintain two
+              #     configs for no benefit — keep as one `codex` client.
+              #   - Claude Desktop via mcp-remote uses callback path
+              #     /oauth/callback (mcp-remote convention), distinct
+              #     from Claude Code / Codex which use /callback.
+              #
+              # Common to all three:
               #   - PKCE-protected (token_endpoint_auth_method=none).
               #   - Audience pinned to mcp.<domain>/mcp (RFC 8707).
               #   - Pinned port 20202 (ory/hydra#1732: no RFC 8252 §7.3
@@ -214,11 +228,12 @@ spec:
               #   - scope: openid + offline_access (refresh tokens) +
               #     mcp:read + mcp:exec.
               #
-              # ── 2a. agentserver-mcp-cli ──────────────────────────────
-              # For Claude Code CLI + Codex CLI. They bind callback at
-              # /callback (Claude Code's literal --callback-port path,
-              # Codex uses the same convention).
-              MCP_CLI_FLAGS="--name Agentserver_MCP_CLI \
+              # Idempotent: update first, fall back to create. The
+              # cleanup deletes obsolete client_ids from older chart
+              # versions; best-effort, ignore not-found.
+
+              # ── agentserver-mcp-claude-code ─────────────────────────
+              CLAUDE_CODE_FLAGS="--name Agentserver_MCP_Claude_Code \
                 --grant-type authorization_code \
                 --grant-type refresh_token \
                 --response-type code \
@@ -227,16 +242,24 @@ spec:
                 --redirect-uri http://127.0.0.1:20202/callback \
                 --token-endpoint-auth-method none \
                 --audience https://mcp.{{ .Values.platform.domain }}/mcp"
-              hydra update oauth2-client agentserver-mcp-cli --endpoint "$ENDPOINT" $MCP_CLI_FLAGS 2>/dev/null || \
-              hydra create oauth2-client --endpoint "$ENDPOINT" --id agentserver-mcp-cli $MCP_CLI_FLAGS
+              hydra update oauth2-client agentserver-mcp-claude-code --endpoint "$ENDPOINT" $CLAUDE_CODE_FLAGS 2>/dev/null || \
+              hydra create oauth2-client --endpoint "$ENDPOINT" --id agentserver-mcp-claude-code $CLAUDE_CODE_FLAGS
 
-              # ── 2b. agentserver-mcp-desktop ──────────────────────────
-              # For Claude Desktop via the `mcp-remote` stdio bridge.
-              # mcp-remote uses /oauth/callback (different path from
-              # Claude Code's /callback). Same port (20202), different
-              # path — keeps the two surfaces' OAuth tokens distinct,
-              # so a desktop logout doesn't invalidate the CLI session.
-              MCP_DESKTOP_FLAGS="--name Agentserver_MCP_Desktop \
+              # ── agentserver-mcp-codex (CLI + Desktop) ───────────────
+              CODEX_FLAGS="--name Agentserver_MCP_Codex \
+                --grant-type authorization_code \
+                --grant-type refresh_token \
+                --response-type code \
+                --scope openid --scope offline_access --scope mcp:read --scope mcp:exec \
+                --redirect-uri http://localhost:20202/callback \
+                --redirect-uri http://127.0.0.1:20202/callback \
+                --token-endpoint-auth-method none \
+                --audience https://mcp.{{ .Values.platform.domain }}/mcp"
+              hydra update oauth2-client agentserver-mcp-codex --endpoint "$ENDPOINT" $CODEX_FLAGS 2>/dev/null || \
+              hydra create oauth2-client --endpoint "$ENDPOINT" --id agentserver-mcp-codex $CODEX_FLAGS
+
+              # ── agentserver-mcp-claude-desktop (via mcp-remote) ─────
+              CLAUDE_DESKTOP_FLAGS="--name Agentserver_MCP_Claude_Desktop \
                 --grant-type authorization_code \
                 --grant-type refresh_token \
                 --response-type code \
@@ -245,13 +268,14 @@ spec:
                 --redirect-uri http://127.0.0.1:20202/oauth/callback \
                 --token-endpoint-auth-method none \
                 --audience https://mcp.{{ .Values.platform.domain }}/mcp"
-              hydra update oauth2-client agentserver-mcp-desktop --endpoint "$ENDPOINT" $MCP_DESKTOP_FLAGS 2>/dev/null || \
-              hydra create oauth2-client --endpoint "$ENDPOINT" --id agentserver-mcp-desktop $MCP_DESKTOP_FLAGS
+              hydra update oauth2-client agentserver-mcp-claude-desktop --endpoint "$ENDPOINT" $CLAUDE_DESKTOP_FLAGS 2>/dev/null || \
+              hydra create oauth2-client --endpoint "$ENDPOINT" --id agentserver-mcp-claude-desktop $CLAUDE_DESKTOP_FLAGS
 
-              # Cleanup: drop the old combined `agentserver-mcp` client
-              # if it still exists from earlier chart versions. Best-
-              # effort; ignore not-found.
-              hydra delete oauth2-client agentserver-mcp --endpoint "$ENDPOINT" 2>/dev/null || true
+              # Cleanup obsolete client_ids from earlier chart versions.
+              # Best-effort; ignore not-found.
+              for old in agentserver-mcp agentserver-mcp-cli agentserver-mcp-desktop; do
+                hydra delete oauth2-client "$old" --endpoint "$ENDPOINT" 2>/dev/null || true
+              done
 ---
 # --- Hydra Public Service ---
 apiVersion: v1

--- a/docs/integrations/claude-code-cli.md
+++ b/docs/integrations/claude-code-cli.md
@@ -13,12 +13,12 @@ Run your agentserver workspaces' tools (`shell`, `read_file`, `apply_patch`, …
 ```bash
 claude mcp add --transport http agentserver \
   https://mcp.agent.cs.ac.cn/mcp \
-  --client-id agentserver-mcp-cli \
+  --client-id agentserver-mcp-claude-code \
   --callback-port 20202
 ```
 
 Notes:
-- `client_id = "agentserver-mcp-cli"` is a fixed, public value shared by all users (same shape as gh CLI's hard-coded GitHub OAuth client). It has no auth power on its own — the OAuth flow's user login + workspace consent screen is what authorizes.
+- `client_id = "agentserver-mcp-claude-code"` is a fixed, public value shared by all users (same shape as gh CLI's hard-coded GitHub OAuth client). It has no auth power on its own — the OAuth flow's user login + workspace consent screen is what authorizes.
 - `--callback-port 20202` is required and the port number is **not arbitrary** — Hydra v2 doesn't implement RFC 8252 §7.3 (loopback-any-port), so the server only accepts callbacks on the exact port registered with the OAuth client. We registered port 20202 (rare enough to dodge dev-server collisions on 3000/8080/5173/etc.). If 20202 is taken on your machine, file an issue.
 - No `--client-secret`: the shared client is a **public** OAuth client (PKCE-protected).
 
@@ -43,7 +43,7 @@ The first time it talks to `agentserver`, a browser opens. Log in to agentserver
       "type": "http",
       "url": "https://mcp.agent.cs.ac.cn/mcp",
       "oauth": {
-        "client_id": "agentserver-mcp-cli",
+        "client_id": "agentserver-mcp-claude-code",
         "callback_port": 20202
       }
     }

--- a/docs/integrations/claude-desktop.md
+++ b/docs/integrations/claude-desktop.md
@@ -13,12 +13,12 @@ Path A is officially supported by Anthropic since 2026; Path B is the community 
 
 ## Path A — Native Custom Connector
 
-**Status: not enabled on agentserver yet.** Path A requires us to register `https://claude.ai/api/mcp/auth_callback` (and `https://claude.com/api/mcp/auth_callback`) as redirect URIs on the `agentserver-mcp-desktop` Hydra client. That's a one-line helm change we haven't done because the security implications (Anthropic cloud holds your tokens + initiates all MCP traffic from cloud IPs) need an explicit go-ahead. If you want Path A enabled, ping the agentserver maintainer.
+**Status: not enabled on agentserver yet.** Path A requires us to register `https://claude.ai/api/mcp/auth_callback` (and `https://claude.com/api/mcp/auth_callback`) as redirect URIs on the `agentserver-mcp-claude-desktop` Hydra client. That's a one-line helm change we haven't done because the security implications (Anthropic cloud holds your tokens + initiates all MCP traffic from cloud IPs) need an explicit go-ahead. If you want Path A enabled, ping the agentserver maintainer.
 
 After enablement, the flow is:
 - Settings → Connectors → "Add custom connector"
 - URL: `https://mcp.agent.cs.ac.cn/mcp`
-- Advanced settings → OAuth Client ID: `agentserver-mcp-desktop`
+- Advanced settings → OAuth Client ID: `agentserver-mcp-claude-desktop`
 - OAuth Client Secret: **leave empty** (public client, PKCE)
 - Click "Connect" — browser does OAuth, picks workspace, grants scopes.
 
@@ -46,7 +46,7 @@ Edit `claude_desktop_config.json` (on macOS: `~/Library/Application Support/Clau
         "https://mcp.agent.cs.ac.cn/mcp",
         "20202",
         "--static-oauth-client-info",
-        "{\"client_id\":\"agentserver-mcp-desktop\"}",
+        "{\"client_id\":\"agentserver-mcp-claude-desktop\"}",
         "--transport",
         "http-only"
       ]
@@ -63,7 +63,7 @@ What each arg does:
 | `mcp-remote` | npm package name |
 | `https://mcp.agent.cs.ac.cn/mcp` | remote MCP server URL |
 | `20202` | **positional**: local OAuth callback port (mcp-remote default is 3334; we override because Hydra registers exactly 20202) |
-| `--static-oauth-client-info '{"client_id":"agentserver-mcp-desktop"}'` | use the pre-registered Hydra client; skip DCR |
+| `--static-oauth-client-info '{"client_id":"agentserver-mcp-claude-desktop"}'` | use the pre-registered Hydra client; skip DCR |
 | `--transport http-only` | server speaks Streamable HTTP, not SSE |
 
 **Completely quit Claude Desktop** (Cmd-Q on macOS, system-tray Quit on Windows — closing the window isn't enough) and reopen. On the next chat, mcp-remote starts up, gets a 401 from `mcp.agent.cs.ac.cn/mcp`, and opens a browser to `https://agent.cs.ac.cn/oauth2/auth?...`. Log in if needed, pick the workspace, click **Allow**. Browser jumps to `localhost:20202/oauth/callback`, mcp-remote stores the token under `~/.mcp-auth/<server-hash>/`, and Claude Desktop's tool palette gets `agentserver_shell`, `agentserver_read_file`, etc. populated.
@@ -99,14 +99,14 @@ Each `mcpServers` entry can target a different workspace by going through OAuth 
     "agentserver-work": {
       "command": "npx",
       "args": ["-y", "mcp-remote", "https://mcp.agent.cs.ac.cn/mcp", "20202",
-               "--static-oauth-client-info", "{\"client_id\":\"agentserver-mcp-desktop\"}",
+               "--static-oauth-client-info", "{\"client_id\":\"agentserver-mcp-claude-desktop\"}",
                "--transport", "http-only",
                "--resource", "work"]
     },
     "agentserver-personal": {
       "command": "npx",
       "args": ["-y", "mcp-remote", "https://mcp.agent.cs.ac.cn/mcp", "20202",
-               "--static-oauth-client-info", "{\"client_id\":\"agentserver-mcp-desktop\"}",
+               "--static-oauth-client-info", "{\"client_id\":\"agentserver-mcp-claude-desktop\"}",
                "--transport", "http-only",
                "--resource", "personal"]
     }
@@ -166,6 +166,6 @@ The colon-no-space `Authorization:${AGENTSERVER_PAT}` syntax dodges a Windows en
 
 ## Related
 
-- [Codex CLI](./codex-cli.md) — `agentserver-mcp-cli` client, callback at `/callback`
-- [Claude Code CLI](./claude-code-cli.md) — `agentserver-mcp-cli` client, same as Codex
+- [Codex CLI](./codex-cli.md) — `agentserver-mcp-codex` client, callback at `/callback`
+- [Claude Code CLI](./claude-code-cli.md) — `agentserver-mcp-claude-code` client, also `/callback` path
 - Spec: `docs/superpowers/specs/2026-06-17-mcp-oauth-design.md`

--- a/docs/integrations/codex-cli.md
+++ b/docs/integrations/codex-cli.md
@@ -18,7 +18,7 @@ url = "https://mcp.agent.cs.ac.cn/mcp"
 oauth_resource = "https://mcp.agent.cs.ac.cn/mcp"
 
 [mcp_servers.agentserver.oauth]
-client_id = "agentserver-mcp-cli"
+client_id = "agentserver-mcp-codex"
 ```
 
 The `client_id` is a fixed, public value shared by all users (same shape as `gh` CLI's hard-coded GitHub OAuth client). It carries no auth power on its own — the OAuth flow's user login + workspace consent screen is what actually authorizes the issued token.
@@ -66,13 +66,13 @@ Each `[mcp_servers.X]` entry corresponds to one workspace (workspace is selected
 url = "https://mcp.agent.cs.ac.cn/mcp"
 oauth_resource = "https://mcp.agent.cs.ac.cn/mcp"
 [mcp_servers.work.oauth]
-client_id = "agentserver-mcp-cli"
+client_id = "agentserver-mcp-codex"
 
 [mcp_servers.personal]
 url = "https://mcp.agent.cs.ac.cn/mcp"
 oauth_resource = "https://mcp.agent.cs.ac.cn/mcp"
 [mcp_servers.personal.oauth]
-client_id = "agentserver-mcp-cli"
+client_id = "agentserver-mcp-codex"
 ```
 
 ```bash
@@ -116,7 +116,7 @@ export AGENTSERVER_PAT='agpat_...'
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| `Incompatible auth server: does not support dynamic client registration` | Forgot `oauth.client_id` in config | Add `[mcp_servers.agentserver.oauth] client_id = "agentserver-mcp-cli"` |
+| `Incompatible auth server: does not support dynamic client registration` | Forgot `oauth.client_id` in config | Add `[mcp_servers.agentserver.oauth] client_id = "agentserver-mcp-codex"` |
 | `audience mismatch` in gateway logs | Forgot `oauth_resource` in config | Add `oauth_resource = "https://mcp.agent.cs.ac.cn/mcp"` |
 | Browser opens, redirects to a Hydra error page about `redirect_uri` | Codex bound a different port than 20202 | Add `mcp_oauth_callback_port = 20202` to `~/.codex/config.toml` (Hydra registers exactly that one port — RFC 8252 §7.3 isn't implemented in Hydra v2). |
 | Browser opens but never returns | Network blocks codex's callback port 20202 | The port is fixed; ensure 20202 is reachable from your browser to Codex's local server (firewall / VPN config). |

--- a/docs/superpowers/specs/2026-06-17-mcp-oauth-design.md
+++ b/docs/superpowers/specs/2026-06-17-mcp-oauth-design.md
@@ -118,3 +118,40 @@ not enabled yet) and the mcp-remote bridge path (Path B, default).
 OAuthResolver in mcppublic accepts both client_ids transparently —
 it never inspects `client_id`, only the introspected `sub` /
 `workspace_id` / `aud` / `scope` claims.
+
+---
+
+## Amendment 2026-06-18 (refined) — three-way split: claude-code, codex, claude-desktop
+
+The 2026-06-18 amendment above split `agentserver-mcp` into two
+clients (`-cli` + `-desktop`). After confirming Codex Desktop's MCP
+OAuth code path is identical to Codex CLI's (both use the same
+`~/.codex/config.toml` `mcp_oauth_callback_port` / `_url`; see
+`codex-rs/app-server/src/request_processors/mcp_processor.rs:172`),
+refined to a three-way split that respects the actual
+config-store boundaries each vendor draws:
+
+| client_id | callback path | surface |
+|---|---|---|
+| `agentserver-mcp-claude-code` | `/callback` | Claude Code CLI |
+| `agentserver-mcp-codex` | `/callback` | Codex CLI **and** Codex Desktop (shared config) |
+| `agentserver-mcp-claude-desktop` | `/oauth/callback` | Claude Desktop via `mcp-remote` |
+
+Why not split Codex into CLI + Desktop:
+- They share `~/.codex/config.toml` and the same OAuth callback code
+  (Desktop's `mcpServer/oauth/login` JSON-RPC delegates to the same
+  CLI path). Splitting would force users to maintain two configs
+  for no audit benefit (a single user's Codex install IS a single
+  user/machine).
+
+Why split Claude Code vs Claude Desktop:
+- Different config stores (`~/.claude/` vs OS-app-data dir).
+- Claude Desktop's only working OAuth path today is mcp-remote
+  bridge, which uses `/oauth/callback` path — naturally distinct.
+- Independent revocation (`hydra delete oauth2-client
+  agentserver-mcp-claude-desktop`) without affecting CLI.
+
+The hydra-client-setup helm job creates all three, deletes
+obsolete `agentserver-mcp`, `agentserver-mcp-cli`,
+`agentserver-mcp-desktop` from the 2026-06-17 and 2026-06-18 first
+amendments (idempotent best-effort).

--- a/internal/mcppublic/auth_oauth.go
+++ b/internal/mcppublic/auth_oauth.go
@@ -229,7 +229,8 @@ func (r *OAuthResolver) Resolve(ctx context.Context, raw string) (*Principal, er
 	// !!! SECURITY: This empty-aud branch is a fail-open relaxation.
 	// It is only safe because:
 	//   1. Single-tenant: exactly one MCP gateway exists on this
-	//      Hydra (both agentserver-mcp-cli and agentserver-mcp-desktop
+	//      Hydra (agentserver-mcp-claude-code,
+	//      agentserver-mcp-codex, agentserver-mcp-claude-desktop all
 	//      target mcp.<host>/mcp). A token from our consent flow can
 	//      only have been meant for here.
 	//   2. DCR is OFF (#258, hydra.yaml comment): nobody can

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -456,13 +456,14 @@ func (s *Server) Router() http.Handler {
 		r.Get("/.well-known/jwks.json", hydraPassthrough)
 		// NOTE: /oauth2/register is intentionally NOT reverse-proxied.
 		// DCR is off chart-wide (see hydra.yaml comment); the static-
-		// public-client replacement is two shared OAuth clients
-		// (`agentserver-mcp-cli` for Claude Code / Codex,
-		// `agentserver-mcp-desktop` for Claude Desktop via
-		// mcp-remote) provisioned by the hydra-client-setup helm job
-		// (see hydra.yaml). Users just paste the right fixed
-		// client_id into their CLI config — no API
-		// call needed.
+		// public-client replacement is three shared OAuth clients:
+		//   - agentserver-mcp-claude-code (Claude Code CLI)
+		//   - agentserver-mcp-codex (Codex CLI + Desktop)
+		//   - agentserver-mcp-claude-desktop (Claude Desktop via
+		//     mcp-remote — uses /oauth/callback path)
+		// All provisioned by the hydra-client-setup helm job (see
+		// hydra.yaml). Users paste the right fixed client_id into
+		// their client config — no API call needed.
 
 		// Browser authorize endpoint — Hydra runs the full login + consent
 		// dance against our handleOAuthLogin / handleOAuthConsent providers,
@@ -671,10 +672,11 @@ func (s *Server) Router() http.Handler {
 		r.Post("/api/workspaces/{wid}/mcp/pats", s.handleMintMCPPAT)
 		r.Delete("/api/workspaces/{wid}/mcp/pats/{id}", s.handleRevokeMCPPAT)
 
-		// MCP OAuth clients — envmcp public gateway uses two shared
-		// public OAuth2 clients (`agentserver-mcp-cli` for Claude Code
-		// / Codex, `agentserver-mcp-desktop` for Claude Desktop via
-		// mcp-remote) baked into the chart's hydra-client-setup job.
+		// MCP OAuth clients — envmcp public gateway uses three shared
+		// public OAuth2 clients (`agentserver-mcp-claude-code` for
+		// Claude Code CLI, `agentserver-mcp-codex` for Codex CLI +
+		// Desktop, `agentserver-mcp-claude-desktop` for Claude Desktop
+		// via mcp-remote) baked into the chart's hydra-client-setup job.
 		// Same shape as gh CLI / GitHub Desktop: client_id is published
 		// in the docs, users paste it into their config. The OAuth
 		// flow's user login + workspace consent screen is what actually


### PR DESCRIPTION
Revised yesterday's 2-way (cli + desktop) split — Codex Desktop shares CLI's config + OAuth code path, so it stays on one `codex` client. Claude Code and Claude Desktop split because they have separate config stores + distinct callback paths.

3 clients, all live-patched + chart-tracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)