### PR TITLE
chore(chart): bump 0.69.2 → 0.69.3 to ship #273

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.69.2
-appVersion: "0.69.2"
+version: 0.69.3
+appVersion: "0.69.3"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
Ships three-way OAuth client split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)