### PR TITLE
refactor(mcp-oauth): drop redundant agentserver- prefix from MCP clients

### DIFF
--- a/deploy/helm/agentserver/templates/hydra.yaml
+++ b/deploy/helm/agentserver/templates/hydra.yaml
@@ -201,9 +201,9 @@ spec:
 
               # MCP OAuth clients — one per (vendor × surface) combo:
               #
-              #   agentserver-mcp-claude-code     /callback        Claude Code CLI
-              #   agentserver-mcp-codex           /callback        Codex CLI + Codex Desktop
-              #   agentserver-mcp-claude-desktop  /oauth/callback  Claude Desktop via mcp-remote
+              #   mcp-claude-code     /callback        Claude Code CLI
+              #   mcp-codex           /callback        Codex CLI + Codex Desktop
+              #   mcp-claude-desktop  /oauth/callback  Claude Desktop via mcp-remote
               #
               # Why split this way:
               #   - Claude Code and Claude Desktop have separate configs
@@ -232,7 +232,7 @@ spec:
               # cleanup deletes obsolete client_ids from older chart
               # versions; best-effort, ignore not-found.
 
-              # ── agentserver-mcp-claude-code ─────────────────────────
+              # ── mcp-claude-code ─────────────────────────
               CLAUDE_CODE_FLAGS="--name Agentserver_MCP_Claude_Code \
                 --grant-type authorization_code \
                 --grant-type refresh_token \
@@ -242,10 +242,10 @@ spec:
                 --redirect-uri http://127.0.0.1:20202/callback \
                 --token-endpoint-auth-method none \
                 --audience https://mcp.{{ .Values.platform.domain }}/mcp"
-              hydra update oauth2-client agentserver-mcp-claude-code --endpoint "$ENDPOINT" $CLAUDE_CODE_FLAGS 2>/dev/null || \
-              hydra create oauth2-client --endpoint "$ENDPOINT" --id agentserver-mcp-claude-code $CLAUDE_CODE_FLAGS
+              hydra update oauth2-client mcp-claude-code --endpoint "$ENDPOINT" $CLAUDE_CODE_FLAGS 2>/dev/null || \
+              hydra create oauth2-client --endpoint "$ENDPOINT" --id mcp-claude-code $CLAUDE_CODE_FLAGS
 
-              # ── agentserver-mcp-codex (CLI + Desktop) ───────────────
+              # ── mcp-codex (CLI + Desktop) ───────────────
               CODEX_FLAGS="--name Agentserver_MCP_Codex \
                 --grant-type authorization_code \
                 --grant-type refresh_token \
@@ -255,10 +255,10 @@ spec:
                 --redirect-uri http://127.0.0.1:20202/callback \
                 --token-endpoint-auth-method none \
                 --audience https://mcp.{{ .Values.platform.domain }}/mcp"
-              hydra update oauth2-client agentserver-mcp-codex --endpoint "$ENDPOINT" $CODEX_FLAGS 2>/dev/null || \
-              hydra create oauth2-client --endpoint "$ENDPOINT" --id agentserver-mcp-codex $CODEX_FLAGS
+              hydra update oauth2-client mcp-codex --endpoint "$ENDPOINT" $CODEX_FLAGS 2>/dev/null || \
+              hydra create oauth2-client --endpoint "$ENDPOINT" --id mcp-codex $CODEX_FLAGS
 
-              # ── agentserver-mcp-claude-desktop (via mcp-remote) ─────
+              # ── mcp-claude-desktop (via mcp-remote) ─────
               CLAUDE_DESKTOP_FLAGS="--name Agentserver_MCP_Claude_Desktop \
                 --grant-type authorization_code \
                 --grant-type refresh_token \
@@ -268,12 +268,19 @@ spec:
                 --redirect-uri http://127.0.0.1:20202/oauth/callback \
                 --token-endpoint-auth-method none \
                 --audience https://mcp.{{ .Values.platform.domain }}/mcp"
-              hydra update oauth2-client agentserver-mcp-claude-desktop --endpoint "$ENDPOINT" $CLAUDE_DESKTOP_FLAGS 2>/dev/null || \
-              hydra create oauth2-client --endpoint "$ENDPOINT" --id agentserver-mcp-claude-desktop $CLAUDE_DESKTOP_FLAGS
+              hydra update oauth2-client mcp-claude-desktop --endpoint "$ENDPOINT" $CLAUDE_DESKTOP_FLAGS 2>/dev/null || \
+              hydra create oauth2-client --endpoint "$ENDPOINT" --id mcp-claude-desktop $CLAUDE_DESKTOP_FLAGS
 
               # Cleanup obsolete client_ids from earlier chart versions.
               # Best-effort; ignore not-found.
-              for old in agentserver-mcp agentserver-mcp-cli agentserver-mcp-desktop; do
+              for old in \
+                agentserver-mcp \
+                agentserver-mcp-cli \
+                agentserver-mcp-desktop \
+                agentserver-mcp-claude-code \
+                agentserver-mcp-codex \
+                agentserver-mcp-claude-desktop \
+              ; do
                 hydra delete oauth2-client "$old" --endpoint "$ENDPOINT" 2>/dev/null || true
               done
 ---

--- a/docs/integrations/claude-code-cli.md
+++ b/docs/integrations/claude-code-cli.md
@@ -13,12 +13,12 @@ Run your agentserver workspaces' tools (`shell`, `read_file`, `apply_patch`, …
 ```bash
 claude mcp add --transport http agentserver \
   https://mcp.agent.cs.ac.cn/mcp \
-  --client-id agentserver-mcp-claude-code \
+  --client-id mcp-claude-code \
   --callback-port 20202
 ```
 
 Notes:
-- `client_id = "agentserver-mcp-claude-code"` is a fixed, public value shared by all users (same shape as gh CLI's hard-coded GitHub OAuth client). It has no auth power on its own — the OAuth flow's user login + workspace consent screen is what authorizes.
+- `client_id = "mcp-claude-code"` is a fixed, public value shared by all users (same shape as gh CLI's hard-coded GitHub OAuth client). It has no auth power on its own — the OAuth flow's user login + workspace consent screen is what authorizes.
 - `--callback-port 20202` is required and the port number is **not arbitrary** — Hydra v2 doesn't implement RFC 8252 §7.3 (loopback-any-port), so the server only accepts callbacks on the exact port registered with the OAuth client. We registered port 20202 (rare enough to dodge dev-server collisions on 3000/8080/5173/etc.). If 20202 is taken on your machine, file an issue.
 - No `--client-secret`: the shared client is a **public** OAuth client (PKCE-protected).
 
@@ -43,7 +43,7 @@ The first time it talks to `agentserver`, a browser opens. Log in to agentserver
       "type": "http",
       "url": "https://mcp.agent.cs.ac.cn/mcp",
       "oauth": {
-        "client_id": "agentserver-mcp-claude-code",
+        "client_id": "mcp-claude-code",
         "callback_port": 20202
       }
     }

--- a/docs/integrations/claude-desktop.md
+++ b/docs/integrations/claude-desktop.md
@@ -13,12 +13,12 @@ Path A is officially supported by Anthropic since 2026; Path B is the community 
 
 ## Path A — Native Custom Connector
 
-**Status: not enabled on agentserver yet.** Path A requires us to register `https://claude.ai/api/mcp/auth_callback` (and `https://claude.com/api/mcp/auth_callback`) as redirect URIs on the `agentserver-mcp-claude-desktop` Hydra client. That's a one-line helm change we haven't done because the security implications (Anthropic cloud holds your tokens + initiates all MCP traffic from cloud IPs) need an explicit go-ahead. If you want Path A enabled, ping the agentserver maintainer.
+**Status: not enabled on agentserver yet.** Path A requires us to register `https://claude.ai/api/mcp/auth_callback` (and `https://claude.com/api/mcp/auth_callback`) as redirect URIs on the `mcp-claude-desktop` Hydra client. That's a one-line helm change we haven't done because the security implications (Anthropic cloud holds your tokens + initiates all MCP traffic from cloud IPs) need an explicit go-ahead. If you want Path A enabled, ping the agentserver maintainer.
 
 After enablement, the flow is:
 - Settings → Connectors → "Add custom connector"
 - URL: `https://mcp.agent.cs.ac.cn/mcp`
-- Advanced settings → OAuth Client ID: `agentserver-mcp-claude-desktop`
+- Advanced settings → OAuth Client ID: `mcp-claude-desktop`
 - OAuth Client Secret: **leave empty** (public client, PKCE)
 - Click "Connect" — browser does OAuth, picks workspace, grants scopes.
 
@@ -46,7 +46,7 @@ Edit `claude_desktop_config.json` (on macOS: `~/Library/Application Support/Clau
         "https://mcp.agent.cs.ac.cn/mcp",
         "20202",
         "--static-oauth-client-info",
-        "{\"client_id\":\"agentserver-mcp-claude-desktop\"}",
+        "{\"client_id\":\"mcp-claude-desktop\"}",
         "--transport",
         "http-only"
       ]
@@ -63,7 +63,7 @@ What each arg does:
 | `mcp-remote` | npm package name |
 | `https://mcp.agent.cs.ac.cn/mcp` | remote MCP server URL |
 | `20202` | **positional**: local OAuth callback port (mcp-remote default is 3334; we override because Hydra registers exactly 20202) |
-| `--static-oauth-client-info '{"client_id":"agentserver-mcp-claude-desktop"}'` | use the pre-registered Hydra client; skip DCR |
+| `--static-oauth-client-info '{"client_id":"mcp-claude-desktop"}'` | use the pre-registered Hydra client; skip DCR |
 | `--transport http-only` | server speaks Streamable HTTP, not SSE |
 
 **Completely quit Claude Desktop** (Cmd-Q on macOS, system-tray Quit on Windows — closing the window isn't enough) and reopen. On the next chat, mcp-remote starts up, gets a 401 from `mcp.agent.cs.ac.cn/mcp`, and opens a browser to `https://agent.cs.ac.cn/oauth2/auth?...`. Log in if needed, pick the workspace, click **Allow**. Browser jumps to `localhost:20202/oauth/callback`, mcp-remote stores the token under `~/.mcp-auth/<server-hash>/`, and Claude Desktop's tool palette gets `agentserver_shell`, `agentserver_read_file`, etc. populated.
@@ -99,14 +99,14 @@ Each `mcpServers` entry can target a different workspace by going through OAuth 
     "agentserver-work": {
       "command": "npx",
       "args": ["-y", "mcp-remote", "https://mcp.agent.cs.ac.cn/mcp", "20202",
-               "--static-oauth-client-info", "{\"client_id\":\"agentserver-mcp-claude-desktop\"}",
+               "--static-oauth-client-info", "{\"client_id\":\"mcp-claude-desktop\"}",
                "--transport", "http-only",
                "--resource", "work"]
     },
     "agentserver-personal": {
       "command": "npx",
       "args": ["-y", "mcp-remote", "https://mcp.agent.cs.ac.cn/mcp", "20202",
-               "--static-oauth-client-info", "{\"client_id\":\"agentserver-mcp-claude-desktop\"}",
+               "--static-oauth-client-info", "{\"client_id\":\"mcp-claude-desktop\"}",
                "--transport", "http-only",
                "--resource", "personal"]
     }
@@ -166,6 +166,6 @@ The colon-no-space `Authorization:${AGENTSERVER_PAT}` syntax dodges a Windows en
 
 ## Related
 
-- [Codex CLI](./codex-cli.md) — `agentserver-mcp-codex` client, callback at `/callback`
-- [Claude Code CLI](./claude-code-cli.md) — `agentserver-mcp-claude-code` client, also `/callback` path
+- [Codex CLI](./codex-cli.md) — `mcp-codex` client, callback at `/callback`
+- [Claude Code CLI](./claude-code-cli.md) — `mcp-claude-code` client, also `/callback` path
 - Spec: `docs/superpowers/specs/2026-06-17-mcp-oauth-design.md`

--- a/docs/integrations/codex-cli.md
+++ b/docs/integrations/codex-cli.md
@@ -18,7 +18,7 @@ url = "https://mcp.agent.cs.ac.cn/mcp"
 oauth_resource = "https://mcp.agent.cs.ac.cn/mcp"
 
 [mcp_servers.agentserver.oauth]
-client_id = "agentserver-mcp-codex"
+client_id = "mcp-codex"
 ```
 
 The `client_id` is a fixed, public value shared by all users (same shape as `gh` CLI's hard-coded GitHub OAuth client). It carries no auth power on its own — the OAuth flow's user login + workspace consent screen is what actually authorizes the issued token.
@@ -66,13 +66,13 @@ Each `[mcp_servers.X]` entry corresponds to one workspace (workspace is selected
 url = "https://mcp.agent.cs.ac.cn/mcp"
 oauth_resource = "https://mcp.agent.cs.ac.cn/mcp"
 [mcp_servers.work.oauth]
-client_id = "agentserver-mcp-codex"
+client_id = "mcp-codex"
 
 [mcp_servers.personal]
 url = "https://mcp.agent.cs.ac.cn/mcp"
 oauth_resource = "https://mcp.agent.cs.ac.cn/mcp"
 [mcp_servers.personal.oauth]
-client_id = "agentserver-mcp-codex"
+client_id = "mcp-codex"
 ```
 
 ```bash
@@ -116,7 +116,7 @@ export AGENTSERVER_PAT='agpat_...'
 
 | Symptom | Likely cause | Fix |
 |---|---|---|
-| `Incompatible auth server: does not support dynamic client registration` | Forgot `oauth.client_id` in config | Add `[mcp_servers.agentserver.oauth] client_id = "agentserver-mcp-codex"` |
+| `Incompatible auth server: does not support dynamic client registration` | Forgot `oauth.client_id` in config | Add `[mcp_servers.agentserver.oauth] client_id = "mcp-codex"` |
 | `audience mismatch` in gateway logs | Forgot `oauth_resource` in config | Add `oauth_resource = "https://mcp.agent.cs.ac.cn/mcp"` |
 | Browser opens, redirects to a Hydra error page about `redirect_uri` | Codex bound a different port than 20202 | Add `mcp_oauth_callback_port = 20202` to `~/.codex/config.toml` (Hydra registers exactly that one port — RFC 8252 §7.3 isn't implemented in Hydra v2). |
 | Browser opens but never returns | Network blocks codex's callback port 20202 | The port is fixed; ensure 20202 is reachable from your browser to Codex's local server (firewall / VPN config). |

--- a/docs/superpowers/specs/2026-06-17-mcp-oauth-design.md
+++ b/docs/superpowers/specs/2026-06-17-mcp-oauth-design.md
@@ -133,9 +133,9 @@ config-store boundaries each vendor draws:
 
 | client_id | callback path | surface |
 |---|---|---|
-| `agentserver-mcp-claude-code` | `/callback` | Claude Code CLI |
-| `agentserver-mcp-codex` | `/callback` | Codex CLI **and** Codex Desktop (shared config) |
-| `agentserver-mcp-claude-desktop` | `/oauth/callback` | Claude Desktop via `mcp-remote` |
+| `mcp-claude-code` | `/callback` | Claude Code CLI |
+| `mcp-codex` | `/callback` | Codex CLI **and** Codex Desktop (shared config) |
+| `mcp-claude-desktop` | `/oauth/callback` | Claude Desktop via `mcp-remote` |
 
 Why not split Codex into CLI + Desktop:
 - They share `~/.codex/config.toml` and the same OAuth callback code
@@ -149,9 +149,30 @@ Why split Claude Code vs Claude Desktop:
 - Claude Desktop's only working OAuth path today is mcp-remote
   bridge, which uses `/oauth/callback` path — naturally distinct.
 - Independent revocation (`hydra delete oauth2-client
-  agentserver-mcp-claude-desktop`) without affecting CLI.
+  mcp-claude-desktop`) without affecting CLI.
 
 The hydra-client-setup helm job creates all three, deletes
 obsolete `agentserver-mcp`, `agentserver-mcp-cli`,
 `agentserver-mcp-desktop` from the 2026-06-17 and 2026-06-18 first
 amendments (idempotent best-effort).
+
+---
+
+## Amendment 2026-06-18 (cosmetic) — drop `agentserver-` prefix
+
+All MCP OAuth clients live in agentserver's own Hydra instance —
+the `agentserver-` prefix is redundant. Rename:
+
+  agentserver-mcp-claude-code     → mcp-claude-code
+  agentserver-mcp-codex           → mcp-codex
+  agentserver-mcp-claude-desktop  → mcp-claude-desktop
+
+`agentserver-agent-cli` (device flow for `codex login`) keeps its
+name — separate concern, separate scope (`agent:register`), not part
+of the MCP set; renaming would break existing codex installs.
+
+The chart's cleanup loop now sweeps both the original prefixed names
+AND the older `-cli` / `-desktop` from the two-way split, so any
+order of upgrade path lands clean.
+
+Docs and code comments updated.

--- a/internal/mcppublic/auth_oauth.go
+++ b/internal/mcppublic/auth_oauth.go
@@ -229,8 +229,8 @@ func (r *OAuthResolver) Resolve(ctx context.Context, raw string) (*Principal, er
 	// !!! SECURITY: This empty-aud branch is a fail-open relaxation.
 	// It is only safe because:
 	//   1. Single-tenant: exactly one MCP gateway exists on this
-	//      Hydra (agentserver-mcp-claude-code,
-	//      agentserver-mcp-codex, agentserver-mcp-claude-desktop all
+	//      Hydra (mcp-claude-code,
+	//      mcp-codex, mcp-claude-desktop all
 	//      target mcp.<host>/mcp). A token from our consent flow can
 	//      only have been meant for here.
 	//   2. DCR is OFF (#258, hydra.yaml comment): nobody can

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -457,9 +457,9 @@ func (s *Server) Router() http.Handler {
 		// NOTE: /oauth2/register is intentionally NOT reverse-proxied.
 		// DCR is off chart-wide (see hydra.yaml comment); the static-
 		// public-client replacement is three shared OAuth clients:
-		//   - agentserver-mcp-claude-code (Claude Code CLI)
-		//   - agentserver-mcp-codex (Codex CLI + Desktop)
-		//   - agentserver-mcp-claude-desktop (Claude Desktop via
+		//   - mcp-claude-code (Claude Code CLI)
+		//   - mcp-codex (Codex CLI + Desktop)
+		//   - mcp-claude-desktop (Claude Desktop via
 		//     mcp-remote — uses /oauth/callback path)
 		// All provisioned by the hydra-client-setup helm job (see
 		// hydra.yaml). Users paste the right fixed client_id into
@@ -673,9 +673,9 @@ func (s *Server) Router() http.Handler {
 		r.Delete("/api/workspaces/{wid}/mcp/pats/{id}", s.handleRevokeMCPPAT)
 
 		// MCP OAuth clients — envmcp public gateway uses three shared
-		// public OAuth2 clients (`agentserver-mcp-claude-code` for
-		// Claude Code CLI, `agentserver-mcp-codex` for Codex CLI +
-		// Desktop, `agentserver-mcp-claude-desktop` for Claude Desktop
+		// public OAuth2 clients (`mcp-claude-code` for
+		// Claude Code CLI, `mcp-codex` for Codex CLI +
+		// Desktop, `mcp-claude-desktop` for Claude Desktop
 		// via mcp-remote) baked into the chart's hydra-client-setup job.
 		// Same shape as gh CLI / GitHub Desktop: client_id is published
 		// in the docs, users paste it into their config. The OAuth


### PR DESCRIPTION
Cosmetic rename: mcp-claude-code / mcp-codex / mcp-claude-desktop. agentserver-agent-cli (device flow) untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)