### PR TITLE
chore(chart): bump 0.69.4 → 0.69.5 to ship #277

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.69.4
-appVersion: "0.69.4"
+version: 0.69.5
+appVersion: "0.69.5"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
## Summary

Carries the codex-exec-gateway noise relay protocol (#277) — feature off by default.

## Test plan

- [x] Helm template renders cleanly
- [ ] Post-merge: confirm CI image build picks up the v0.69.5 tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)