### PR TITLE
feat(cc-app-gateway): Phase 4 — IM intake (WeChat → claude end-to-end)

### DIFF
--- a/deploy/helm/agentserver/templates/deployment.yaml
+++ b/deploy/helm/agentserver/templates/deployment.yaml
@@ -194,6 +194,10 @@ spec:
                   name: {{ .Release.Name }}-codex-gateway
                   key: inbound-hmac-secret
             {{- end }}
+            {{- if .Values.ccAppGateway.enabled }}
+            - name: CC_APP_GATEWAY_REST_URL
+              value: "http://{{ .Release.Name }}-cc-app-gateway.{{ .Release.Namespace }}.svc:{{ .Values.ccAppGateway.port }}"
+            {{- end }}
             {{- if .Values.sandbox.claudecode.image }}
             - name: AGENTSERVER_INTERNAL_URL
               value: {{ printf "http://%s.%s.svc:%v" .Release.Name .Release.Namespace (int .Values.service.port) | quote }}

--- a/docs/superpowers/plans/2026-06-22-cc-app-gateway-phase4.md
+++ b/docs/superpowers/plans/2026-06-22-cc-app-gateway-phase4.md
@@ -1,0 +1,1330 @@
+# cc-app-gateway Phase 4 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add IM intake on the agentserver side so a WeChat message with `routing_mode=managed_cc` reaches claude via cc-app-gateway and the reply round-trips back to WeChat. This is the "I can talk to claude from my phone" milestone.
+
+**Architecture:** New `cc_im_inbound.go` handler on agentserver mirrors `codex_im_inbound.go`. Adds `claude_session_id` column to `agent_sessions` (pure UUID for cc-app-gateway's strict uuidRe). ccDispatcher is a copy of codexDispatcher (~100 LOC, intentional per spec Open Risk #7). imbridge gains `forwardToManagedCC()`. cc-app-gateway's `CcTurnResponse` amends to include `ErrorMessage`. All inter-service hops use synchronous HTTP with `X-Internal-Secret` (codex pattern, no async/callback).
+
+**Tech Stack:** Go 1.26, stdlib + already-present deps. No new libraries. Touches BOTH cc-app-gateway code (turn_api.go ErrorMessage field) AND agentserver code (~7 new/modified files).
+
+**Spec:** `docs/superpowers/specs/2026-06-22-cc-app-gateway-phase4-design.md` (read § Architecture diagram, § The session ID complication, § Audit revisions before starting).
+
+**Working directory:** `/root/agentserver/.claude/worktrees/cc-app-gateway-phase4` (worktree on `feat/cc-app-gateway-phase4`, stacked on Phase 1+2).
+
+**Module path:** `github.com/agentserver/agentserver`.
+
+## Global Constraints
+
+- Go 1.26, stdlib + already-present deps only — no new direct deps.
+- Phase 4 amends BOTH cc-app-gateway (Phase 1 contract) AND agentserver (new code). Treat as one PR.
+- `agent_sessions.claude_session_id` is **immutable per session** but **must be settable retroactively** when migrating an existing codex/nanoclaw session to managed_cc (NULL → minted UUID; once set, stays).
+- ccDispatcher = literal copy of codexDispatcher; do NOT extract generic package (spec Open Risk #7).
+- `Bridge.forwardMessage()` (NOT `routeMessage()`) is the actual function name at imbridge/bridge.go:414.
+- `X-Internal-Secret` header is explicit code, not implied by "mirrors codex".
+- agentserver pod helm template: wrap entire `- name: CC_APP_GATEWAY_REST_URL` block inside `{{- if .Values.ccAppGateway.enabled }}` (NOT just the value).
+- `Server.Close()` MUST wire `ccHandler.Close()` (mirrors codex at server.go:162).
+- `claude_session_id` format must satisfy cc-app-gateway's `uuidRe = ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`. `uuid.NewString()` from `github.com/google/uuid` produces this format (verified — package already in go.mod, used by codex).
+- Synchronous HTTP all the way (codex pattern); no callbackUrl async. 61-min HTTP client timeout.
+- `managed_cc` is the routing_mode wire string (spec § Naming).
+
+## File Structure
+
+| File | Status | Responsibility |
+|---|---|---|
+| `internal/db/migrations/036_agent_sessions_claude_session_id.sql` | NEW | Add nullable column + partial index |
+| `internal/db/agent_sessions.go` | MODIFY | Row struct + SELECT lists include `claude_session_id`; new `SetSessionClaudeSessionID(ctx, sessionID, claudeSessionID) error` setter |
+| `internal/server/codex_im_inbound.go` | MODIFY | `sessionView` struct gains `ClaudeSessionID string` field (shared between codex+cc; codex tests pass zero value) |
+| `internal/server/cc_im_inbound.go` | NEW | `ccInboundHandler` + `ccDbSessionStore` + `ccDispatcher` + processTurn + sendText/sendError + Close() |
+| `internal/server/cc_im_inbound_test.go` | NEW | Table-driven: new session create, existing session reuse, NULL claude_session_id migration path, error matrix, dispatcher serialization |
+| `internal/server/cc_client.go` | NEW | `CcClient.RunTurn(ctx, req) (*CcTurnResponse, error)` with 61-min timeout |
+| `internal/server/cc_client_test.go` | NEW | httptest server returns canned CcTurnResponse; assert URL/headers/body shape |
+| `internal/server/server.go` | MODIFY | Add `CcAppGatewayURL`, `ccHandler`; wire `/api/internal/imbridge/cc/turn` route conditionally; `ccHandler.Close()` in Server.Close() |
+| `internal/ccappgateway/turn_api.go` | MODIFY | Add `ErrorMessage string` to `CcTurnResponse`; populate from `Meta.ErrorMessage` |
+| `internal/ccappgateway/turn_api_test.go` | MODIFY | Update `TestServeHTTP_IsErrorReturned200` (or equivalent) to assert errorMessage |
+| `internal/imbridge/bridge.go` | MODIFY | `forwardMessage()` switch gains `case "managed_cc":`; new `forwardToManagedCC()`; `BridgeBinding.RoutingMode` doc comment updated |
+| `internal/imbridgesvc/handlers.go` | MODIFY | Validator at L977 accepts `managed_cc` |
+| `internal/imbridgesvc/handlers_test.go` | MODIFY | Test the validator change |
+| `deploy/helm/agentserver/templates/deployment.yaml` (agentserver) | MODIFY | Add `CC_APP_GATEWAY_REST_URL` env var, ENTIRE block inside `{{- if .Values.ccAppGateway.enabled }}` |
+| `internal/server/cc_im_integration_test.go` | NEW | `//go:build integration` — extends Phase 2 docker-compose with a mock imbridge listener; sends two IM messages, asserts reply text from claude lands on the imbridge mock |
+
+Total: 7 new + 8 modified files. Estimated LOC: ~1500 (~700 production + ~800 tests).
+
+---
+
+## Task 1: migration 036 + DB layer (agent_sessions.go)
+
+**Files:**
+- Create: `internal/db/migrations/036_agent_sessions_claude_session_id.sql`
+- Modify: `internal/db/agent_sessions.go`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces (later tasks use):
+  - `agent_sessions.claude_session_id TEXT` (nullable)
+  - Partial index `idx_agent_sessions_claude_session_id` (WHERE NOT NULL)
+  - `(*DB).SetSessionClaudeSessionID(ctx context.Context, sessionID, claudeSessionID string) error` — UPDATE row; error if no row matches.
+  - `Session` row struct (or equivalent) gains `ClaudeSessionID sql.NullString` field; existing SELECT statements include the column.
+
+- [ ] **Step 1: Write the failing test for the setter**
+
+Create or append `internal/db/agent_sessions_test.go`:
+
+```go
+func TestSetSessionClaudeSessionID(t *testing.T) {
+    db := newTestDB(t)  // existing helper (or t.Skip if not available, prefer integration-style)
+    ctx := context.Background()
+
+    // Set up a row.
+    err := db.CreateAgentSession(ctx, db.CreateAgentSessionInput{
+        ID:          "cse_test_abc",
+        SandboxID:   sql.NullString{},
+        WorkspaceID: "ws_test",
+        Title:       "test",
+    })
+    if err != nil { t.Fatal(err) }
+
+    // SetSessionClaudeSessionID populates the new column.
+    cid := "11111111-1111-4111-8111-111111111111"
+    if err := db.SetSessionClaudeSessionID(ctx, "cse_test_abc", cid); err != nil {
+        t.Fatalf("SetSessionClaudeSessionID: %v", err)
+    }
+
+    // Read it back via existing query path.
+    sess, err := db.GetAgentSession(ctx, "cse_test_abc")
+    if err != nil { t.Fatal(err) }
+    if !sess.ClaudeSessionID.Valid || sess.ClaudeSessionID.String != cid {
+        t.Errorf("ClaudeSessionID: got %v, want %q", sess.ClaudeSessionID, cid)
+    }
+
+    // Updating an existing claude_session_id (e.g. drift) overwrites.
+    cid2 := "22222222-2222-4222-8222-222222222222"
+    if err := db.SetSessionClaudeSessionID(ctx, "cse_test_abc", cid2); err != nil { t.Fatal(err) }
+    sess, _ = db.GetAgentSession(ctx, "cse_test_abc")
+    if sess.ClaudeSessionID.String != cid2 {
+        t.Errorf("update didn't take: %q", sess.ClaudeSessionID.String)
+    }
+
+    // Setting on nonexistent session returns an error.
+    if err := db.SetSessionClaudeSessionID(ctx, "cse_does_not_exist", "33333333-3333-4333-8333-333333333333"); err == nil {
+        t.Error("SetSessionClaudeSessionID on missing row should error")
+    }
+}
+```
+
+(If the existing test infrastructure doesn't have `newTestDB(t)` ready, look at how other `agent_sessions_test.go` tests work — there should be a pattern in the existing codex_thread_id setter test.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```
+go test -v -run TestSetSessionClaudeSessionID ./internal/db/
+```
+Expected: build error (`SetSessionClaudeSessionID` undefined) OR migration error (column doesn't exist).
+
+- [ ] **Step 3: Write the migration**
+
+`internal/db/migrations/036_agent_sessions_claude_session_id.sql`:
+
+```sql
+-- 036_agent_sessions_claude_session_id.sql
+-- Phase 4 (cc-app-gateway IM intake): cc-app-gateway requires pure-UUID
+-- sessionId per Phase 1's turn_api.go uuidRe validation. agent_sessions.id
+-- uses "cse_<uuid>" format which doesn't satisfy that regex; this column
+-- holds the cc-app-gateway-compatible session identifier. Nullable; only
+-- populated for rows that use the managed_cc routing mode.
+ALTER TABLE agent_sessions ADD COLUMN IF NOT EXISTS claude_session_id TEXT;
+
+-- Reverse-lookup index for Phase 5+ (NOT used in Phase 4).
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_claude_session_id
+    ON agent_sessions (claude_session_id)
+    WHERE claude_session_id IS NOT NULL;
+```
+
+- [ ] **Step 4: Update `agent_sessions.go`**
+
+a) Add field to row struct:
+
+```go
+type Session struct {
+    // ... existing fields ...
+    ClaudeSessionID sql.NullString
+}
+```
+
+b) Update existing SELECT statements (find every place that loads a `Session` row — `GetAgentSession`, `GetSessionByExternalID`, listers, etc.) to include `claude_session_id` in the column list and scan it into the new field.
+
+c) Add `SetSessionClaudeSessionID`:
+
+```go
+// SetSessionClaudeSessionID writes the cc-app-gateway-compatible session
+// identifier (pure UUID) for the given agent_sessions row. Used by the
+// managed_cc IM handler to record the session ID it minted, and to
+// upgrade existing codex/nanoclaw sessions when their channel migrates
+// to managed_cc (see spec § Audit Revision #2).
+func (db *DB) SetSessionClaudeSessionID(ctx context.Context, sessionID, claudeSessionID string) error {
+    res, err := db.pool.ExecContext(ctx,
+        `UPDATE agent_sessions SET claude_session_id = $1, updated_at = NOW() WHERE id = $2`,
+        claudeSessionID, sessionID,
+    )
+    if err != nil {
+        return fmt.Errorf("SetSessionClaudeSessionID: %w", err)
+    }
+    n, _ := res.RowsAffected()
+    if n == 0 {
+        return fmt.Errorf("SetSessionClaudeSessionID: no row with id=%s", sessionID)
+    }
+    return nil
+}
+```
+
+(Match the existing style of `SetSessionCodexThreadID` — same package, same pattern.)
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```
+go test -v -run TestSetSessionClaudeSessionID ./internal/db/
+```
+
+- [ ] **Step 6: Sanity build the full module**
+
+```
+go build ./...
+```
+
+(Catches any other SELECT * stragglers that need updating.)
+
+- [ ] **Step 7: Commit**
+
+```
+git add internal/db/migrations/036_agent_sessions_claude_session_id.sql internal/db/agent_sessions.go internal/db/agent_sessions_test.go
+git commit -m "feat(db): add claude_session_id column + SetSessionClaudeSessionID setter (Phase 4)"
+```
+
+---
+
+## Task 2: amend `CcTurnResponse` with ErrorMessage (cc-app-gateway side)
+
+**Files:**
+- Modify: `internal/ccappgateway/turn_api.go`
+- Modify: `internal/ccappgateway/turn_api_test.go`
+
+**Interfaces:**
+- Consumes: `runner.ResultMeta.ErrorMessage string` (Phase 1, runner/events.go).
+- Produces (Task 5 consumes):
+  - `CcTurnResponse.ErrorMessage string` JSON-tagged `errorMessage,omitempty`.
+
+This is a tiny additive change to Phase 1's contract. Lands on the same branch as Phase 4 (PR #281).
+
+- [ ] **Step 1: Write a failing test**
+
+Find the existing `TestServeHTTP_IsErrorReturned200` (or equivalent — search turn_api_test.go for `IsError`). Append to it OR add a new test:
+
+```go
+func TestServeHTTP_IsErrorPopulatesErrorMessage(t *testing.T) {
+    fakeRunner := func(_ context.Context, _ runner.RunInput) (*runner.RunResult, error) {
+        return &runner.RunResult{
+            AssistantText: "",
+            Meta: &runner.ResultMeta{
+                Subtype:      "error",
+                IsError:      true,
+                ErrorMessage: "context window exceeded",
+            },
+        }, nil
+    }
+    srv, _ := newTestServerWithStoreAndRunner(t, newFakeStore(), fakeRunner)
+    rr := postTurn(t, srv, `{"workspaceId":"ws_test","sessionId":"00000000-0000-4000-8000-000000000001","userMessage":"hi"}`)
+    if rr.Code != http.StatusOK {
+        t.Fatalf("status: %d body: %s", rr.Code, rr.Body.String())
+    }
+    var resp struct {
+        IsError      bool   `json:"isError"`
+        ErrorMessage string `json:"errorMessage"`
+    }
+    if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil { t.Fatal(err) }
+    if !resp.IsError {
+        t.Error("isError should be true")
+    }
+    if resp.ErrorMessage != "context window exceeded" {
+        t.Errorf("errorMessage: got %q, want %q", resp.ErrorMessage, "context window exceeded")
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+```
+go test -v -run TestServeHTTP_IsErrorPopulatesErrorMessage ./internal/ccappgateway/
+```
+Expected: assertion fails because `errorMessage` JSON field is empty (struct missing the field).
+
+- [ ] **Step 3: Add `ErrorMessage` field to `CcTurnResponse`**
+
+```go
+type CcTurnResponse struct {
+    SessionID     string                       `json:"sessionId"`
+    AssistantText string                       `json:"assistantText"`
+    IsError       bool                         `json:"isError"`
+    ErrorMessage  string                       `json:"errorMessage,omitempty"` // NEW (Phase 4)
+    DurationMs    int64                        `json:"durationMs"`
+    TotalCostUSD  float64                      `json:"totalCostUsd"`
+    ModelUsage    map[string]runner.ModelUsage `json:"modelUsage,omitempty"`
+}
+```
+
+In the response-builder section of `ServeHTTP`, populate it:
+
+```go
+if result.Meta != nil {
+    resp.IsError = result.Meta.IsError
+    resp.ErrorMessage = result.Meta.ErrorMessage  // NEW line
+    resp.TotalCostUSD = result.Meta.TotalCostUSD
+    resp.ModelUsage = result.Meta.ModelUsage
+}
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+```
+go test -v ./internal/ccappgateway/
+```
+All ccappgateway tests must still pass (the new field is additive, won't break Phase 2 tests).
+
+- [ ] **Step 5: Commit**
+
+```
+git commit -am "feat(cc-app-gateway): amend CcTurnResponse with ErrorMessage for Phase 4 error matrix"
+```
+
+---
+
+## Task 3: `internal/server/cc_client.go` + tests
+
+**Files:**
+- Create: `internal/server/cc_client.go`
+- Create: `internal/server/cc_client_test.go`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces (Task 4 uses):
+  - `type CcClient struct { ... }`; `NewCcClient(baseURL, secret string) *CcClient`
+  - `type CcTurnRequest struct { WorkspaceID, SessionID, UserMessage, Model string; TimeoutMs int }`
+  - `type CcTurnResponse struct { SessionID, AssistantText, ErrorMessage string; IsError bool; DurationMs int64; TotalCostUSD float64; ModelUsage map[string]any }`
+  - `func (c *CcClient) RunTurn(ctx context.Context, req CcTurnRequest) (*CcTurnResponse, error)`
+  - `func resolveCCAppGatewayRESTURL() string` — reads `CC_APP_GATEWAY_REST_URL`, trims trailing slash, returns "" if unset.
+
+Mirror `codex_client.go` exactly in shape — 61-minute HTTP timeout, X-Internal-Secret header, JSON encode/decode.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `internal/server/cc_client_test.go`:
+
+```go
+package server_test
+
+import (
+    "context"
+    "encoding/json"
+    "io"
+    "net/http"
+    "net/http/httptest"
+    "strings"
+    "testing"
+
+    "github.com/agentserver/agentserver/internal/server"
+)
+
+func TestCcClient_RunTurn_HappyPath(t *testing.T) {
+    var gotBody string
+    var gotPath string
+    var gotSecret string
+    ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        gotPath = r.URL.Path
+        gotSecret = r.Header.Get("X-Internal-Secret")
+        b, _ := io.ReadAll(r.Body)
+        gotBody = string(b)
+        w.Header().Set("Content-Type", "application/json")
+        json.NewEncoder(w).Encode(map[string]any{
+            "sessionId":     "abc-123",
+            "assistantText": "pong",
+            "isError":       false,
+            "durationMs":    int64(42),
+            "totalCostUsd":  0.0001,
+        })
+    }))
+    defer ts.Close()
+
+    c := server.NewCcClient(ts.URL, "secret123")
+    resp, err := c.RunTurn(context.Background(), server.CcTurnRequest{
+        WorkspaceID: "ws_test",
+        SessionID:   "00000000-0000-4000-8000-000000000001",
+        UserMessage: "hi",
+    })
+    if err != nil { t.Fatalf("RunTurn: %v", err) }
+    if gotPath != "/api/turns" { t.Errorf("path: %q", gotPath) }
+    if gotSecret != "secret123" { t.Errorf("secret: %q", gotSecret) }
+    if !strings.Contains(gotBody, `"workspaceId":"ws_test"`) {
+        t.Errorf("body missing workspaceId: %q", gotBody)
+    }
+    if resp.AssistantText != "pong" {
+        t.Errorf("AssistantText: %q", resp.AssistantText)
+    }
+}
+
+func TestCcClient_RunTurn_HTTPError(t *testing.T) {
+    ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.WriteHeader(http.StatusInternalServerError)
+        w.Write([]byte(`{"error":"runner_failed","code":"runner_failed"}`))
+    }))
+    defer ts.Close()
+
+    c := server.NewCcClient(ts.URL, "secret123")
+    _, err := c.RunTurn(context.Background(), server.CcTurnRequest{
+        WorkspaceID: "ws", SessionID: "00000000-0000-4000-8000-000000000001", UserMessage: "hi",
+    })
+    if err == nil {
+        t.Fatal("expected error on 500")
+    }
+    if !strings.Contains(err.Error(), "500") {
+        t.Errorf("error should mention status: %v", err)
+    }
+}
+
+func TestCcClient_RunTurn_DecodesErrorMessage(t *testing.T) {
+    ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        json.NewEncoder(w).Encode(map[string]any{
+            "sessionId":     "abc",
+            "assistantText": "",
+            "isError":       true,
+            "errorMessage":  "context window exceeded",
+            "durationMs":    int64(1000),
+        })
+    }))
+    defer ts.Close()
+
+    c := server.NewCcClient(ts.URL, "")
+    resp, err := c.RunTurn(context.Background(), server.CcTurnRequest{
+        WorkspaceID: "ws", SessionID: "00000000-0000-4000-8000-000000000001", UserMessage: "hi",
+    })
+    if err != nil { t.Fatal(err) }
+    if !resp.IsError {
+        t.Error("IsError should be true")
+    }
+    if resp.ErrorMessage != "context window exceeded" {
+        t.Errorf("ErrorMessage: got %q", resp.ErrorMessage)
+    }
+}
+
+func TestResolveCCAppGatewayRESTURL_Trim(t *testing.T) {
+    t.Setenv("CC_APP_GATEWAY_REST_URL", "http://cc-app-gateway.svc:8087/")
+    got := server.ResolveCCAppGatewayRESTURL()
+    if got != "http://cc-app-gateway.svc:8087" {
+        t.Errorf("trailing slash not trimmed: %q", got)
+    }
+}
+
+func TestResolveCCAppGatewayRESTURL_Empty(t *testing.T) {
+    t.Setenv("CC_APP_GATEWAY_REST_URL", "")
+    if server.ResolveCCAppGatewayRESTURL() != "" {
+        t.Errorf("empty env should return empty string")
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+```
+go test -v ./internal/server/ -run TestCcClient
+```
+Expected: build error (CcClient/CcTurnRequest/CcTurnResponse/ResolveCCAppGatewayRESTURL undefined).
+
+- [ ] **Step 3: Implement `cc_client.go`**
+
+```go
+package server
+
+import (
+    "bytes"
+    "context"
+    "encoding/json"
+    "fmt"
+    "io"
+    "net/http"
+    "os"
+    "strings"
+    "time"
+)
+
+// CcClient calls cc-app-gateway's POST /api/turns from agentserver.
+// Mirrors CodexClient (codex_client.go) — synchronous HTTP with 61-minute
+// timeout (well above cc-app-gateway's 10-minute runner cap).
+type CcClient struct {
+    baseURL string
+    secret  string
+    http    *http.Client
+}
+
+// CcTurnRequest is the JSON body POSTed to cc-app-gateway /api/turns.
+type CcTurnRequest struct {
+    WorkspaceID string `json:"workspaceId"`
+    SessionID   string `json:"sessionId"`
+    UserMessage string `json:"userMessage"`
+    Model       string `json:"model,omitempty"`
+    TimeoutMs   int    `json:"timeoutMs,omitempty"`
+}
+
+// CcTurnResponse is the JSON body returned by cc-app-gateway on 200.
+type CcTurnResponse struct {
+    SessionID     string         `json:"sessionId"`
+    AssistantText string         `json:"assistantText"`
+    IsError       bool           `json:"isError"`
+    ErrorMessage  string         `json:"errorMessage,omitempty"`
+    DurationMs    int64          `json:"durationMs"`
+    TotalCostUSD  float64        `json:"totalCostUsd"`
+    ModelUsage    map[string]any `json:"modelUsage,omitempty"`
+}
+
+func NewCcClient(baseURL, secret string) *CcClient {
+    return &CcClient{
+        baseURL: strings.TrimRight(baseURL, "/"),
+        secret:  secret,
+        http:    &http.Client{Timeout: 61 * time.Minute},
+    }
+}
+
+// RunTurn POSTs the request to cc-app-gateway's /api/turns and decodes
+// the response. Non-2xx responses are returned as errors with the body
+// preview attached.
+func (c *CcClient) RunTurn(ctx context.Context, req CcTurnRequest) (*CcTurnResponse, error) {
+    body, err := json.Marshal(req)
+    if err != nil {
+        return nil, fmt.Errorf("CcClient.RunTurn marshal: %w", err)
+    }
+    hreq, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/api/turns", bytes.NewReader(body))
+    if err != nil {
+        return nil, fmt.Errorf("CcClient.RunTurn build request: %w", err)
+    }
+    hreq.Header.Set("Content-Type", "application/json")
+    if c.secret != "" {
+        hreq.Header.Set("X-Internal-Secret", c.secret)
+    }
+    hresp, err := c.http.Do(hreq)
+    if err != nil {
+        return nil, fmt.Errorf("CcClient.RunTurn do: %w", err)
+    }
+    defer hresp.Body.Close()
+    if hresp.StatusCode/100 != 2 {
+        b, _ := io.ReadAll(io.LimitReader(hresp.Body, 1024))
+        return nil, fmt.Errorf("CcClient.RunTurn: status=%d body=%q", hresp.StatusCode, b)
+    }
+    var out CcTurnResponse
+    if err := json.NewDecoder(hresp.Body).Decode(&out); err != nil {
+        return nil, fmt.Errorf("CcClient.RunTurn decode: %w", err)
+    }
+    return &out, nil
+}
+
+// ResolveCCAppGatewayRESTURL reads CC_APP_GATEWAY_REST_URL from env,
+// trims trailing slash. Returns "" if unset (caller treats as disabled).
+func ResolveCCAppGatewayRESTURL() string {
+    return strings.TrimRight(strings.TrimSpace(os.Getenv("CC_APP_GATEWAY_REST_URL")), "/")
+}
+```
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```
+go test -v ./internal/server/ -run TestCcClient
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git commit -am "feat(server): CcClient for agentserver→cc-app-gateway POST /api/turns"
+```
+
+---
+
+## Task 4: `sessionView` ClaudeSessionID extension (codex_im_inbound.go)
+
+**Files:**
+- Modify: `internal/server/codex_im_inbound.go`
+
+**Interfaces:**
+- Consumes: Task 1's `Session.ClaudeSessionID sql.NullString`.
+- Produces (Task 5 uses):
+  - `sessionView` struct (declared in codex_im_inbound.go) gains `ClaudeSessionID string` field.
+  - `dbSessionStore.GetSessionByExternalID` populates the new field from the DB row.
+
+This is a minimal codex_im_inbound.go change — JUST extending the shared struct. Codex doesn't read the field; cc handler will.
+
+- [ ] **Step 1: Identify the existing sessionView struct + GetSessionByExternalID method**
+
+Open `internal/server/codex_im_inbound.go`, find:
+
+```go
+type sessionView struct {
+    ID            string
+    CodexThreadID string
+}
+```
+
+And in `dbSessionStore.GetSessionByExternalID`:
+
+```go
+return sessionView{ID: row.ID, CodexThreadID: row.CodexThreadID.String}, nil
+```
+
+(Exact line numbers may vary — search for `sessionView` and `GetSessionByExternalID`.)
+
+- [ ] **Step 2: Add field + populate from DB**
+
+```go
+type sessionView struct {
+    ID              string
+    CodexThreadID   string
+    ClaudeSessionID string  // NEW (Phase 4): cc-app-gateway-compatible session ID; "" for non-managed_cc sessions
+}
+```
+
+In `GetSessionByExternalID` (and any other call site that constructs sessionView from a DB row):
+
+```go
+return sessionView{
+    ID:              row.ID,
+    CodexThreadID:   row.CodexThreadID.String,
+    ClaudeSessionID: row.ClaudeSessionID.String,  // NEW
+}, nil
+```
+
+- [ ] **Step 3: Run codex tests to verify no regression**
+
+```
+go test ./internal/server/ -run TestCodex
+```
+All codex tests must still pass — they constructed `sessionView{}` with zero-value `ClaudeSessionID`, which compiles fine and codex doesn't read it.
+
+Also run `go build ./...` to catch any other sessionView construction site.
+
+- [ ] **Step 4: Commit**
+
+```
+git commit -am "refactor(server): extend sessionView with ClaudeSessionID (used by Phase 4 cc handler)"
+```
+
+---
+
+## Task 5: `cc_im_inbound.go` handler + ccDispatcher + processTurn
+
+**Files:**
+- Create: `internal/server/cc_im_inbound.go`
+- Create: `internal/server/cc_im_inbound_test.go`
+
+**Interfaces:**
+- Consumes (from Tasks 1-4): DB setter, CcClient, sessionView with ClaudeSessionID.
+- Produces (Task 6 wires):
+  - `type ccInboundHandler struct { ... }`
+  - `NewCcInboundHandler(cc *CcClient, sessions sessionStore, imbridgeSendURL, internalSecret string) *ccInboundHandler`
+  - `(*ccInboundHandler).ServeHTTP(w, r)` — auth + Enqueue + 202.
+  - `(*ccInboundHandler).Close()` — stops dispatcher; drains in-flight workers.
+- Internal:
+  - `type ccInboundRequest struct { ... }` (same fields as codex's)
+  - `type ccDispatcher struct { ... }` — copy of codexDispatcher
+  - `(*ccInboundHandler).processTurn(req ccInboundRequest)` — main flow
+  - `sendText` / `sendError` — POST back to imbridge /send
+
+The whole file is a near-copy of codex_im_inbound.go with these differences:
+- Request struct name: `ccInboundRequest` (same fields).
+- Handler type: `ccInboundHandler`.
+- Dispatcher type: `ccDispatcher` (cap=5, drop-oldest, key = channel_id + ":" + wechat_user_id — same as codex).
+- ccDbSessionStore (alongside the handler) has `CreateSession(ctx, workspaceID, externalID, title, imChannelID string) (sessionView, error)` that mints BOTH agent_sessions.id ("cse_" + uuid) AND claude_session_id (uuid.NewString()).
+- processTurn flow:
+  1. `sess := sessions.GetSessionByExternalID(workspaceID, wechat_user_id)`
+  2. If miss: `sess = sessions.CreateSession(...)` — creates row with both IDs.
+  3. If hit AND `sess.ClaudeSessionID == ""`: existing codex/nanoclaw session migrating to managed_cc. Mint fresh UUID, `db.SetSessionClaudeSessionID(sess.ID, newUUID)`, update sess.ClaudeSessionID. Codex history is NOT migrated.
+  4. Drop media + quoted fields with a log line (Prometheus counter `cc_im_inbound_dropped_media_total` per dropped field — IF Prometheus is already wired; else just log).
+  5. `ccClient.RunTurn(ctx, CcTurnRequest{ WorkspaceID, SessionID: sess.ClaudeSessionID, UserMessage: req.Text })`
+  6. Error matrix dispatch (see spec § Error handling matrix).
+  7. `sendText(channel_id, wechat_user_id, response.AssistantText)`.
+- No `ThreadID` concept; no thread-not-found retry (cc-app-gateway handles resume internally).
+
+This is the largest task. Plan ~400 LOC production + ~400 LOC tests.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `internal/server/cc_im_inbound_test.go` with these table-driven cases (use the pattern from `codex_im_inbound_test.go` if it exists; if not, follow this structure):
+
+```go
+package server_test
+
+// ... imports ...
+
+// fakeCcClient records calls + returns canned responses.
+type fakeCcClient struct {
+    calls    []server.CcTurnRequest
+    response *server.CcTurnResponse
+    err      error
+}
+
+func (f *fakeCcClient) RunTurn(ctx context.Context, req server.CcTurnRequest) (*server.CcTurnResponse, error) {
+    f.calls = append(f.calls, req)
+    return f.response, f.err
+}
+
+// fakeSessionStore is a map-backed session store.
+type fakeSessionStore struct {
+    sessions map[string]server.SessionView  // key: workspace_id+":"+external_id
+    created  []server.SessionView
+}
+// ... GetSessionByExternalID, CreateSession, etc.
+
+func TestCcInbound_NewSession(t *testing.T) {
+    // empty store → CreateSession path → assert both IDs minted + RunTurn called
+    // with the new claude_session_id.
+}
+
+func TestCcInbound_ExistingCcSessionReused(t *testing.T) {
+    // store seeded with a session that has claude_session_id → RunTurn called with that ID, no Create.
+}
+
+func TestCcInbound_MigrationFromCodex(t *testing.T) {
+    // store seeded with a session that has codex_thread_id but no claude_session_id →
+    // handler mints UUID, calls SetSessionClaudeSessionID, RunTurn uses new UUID.
+}
+
+func TestCcInbound_TransportError_SendsErrorMessage(t *testing.T) {
+    // fakeCcClient returns transport error → handler calls sendError with the right Chinese message.
+}
+
+func TestCcInbound_IsErrorContextWindow_SendsSpecificMessage(t *testing.T) {
+    // response has IsError=true, ErrorMessage contains "context" →
+    // user sees "上下文已满" message.
+}
+
+func TestCcInbound_EmptyAssistantText_SendsErrorMessage(t *testing.T) {
+    // response is 200 + isError=false + assistantText="" → handler treats as error.
+}
+
+func TestCcInbound_MediaFieldsDropped(t *testing.T) {
+    // request has media_data + quoted_text set → handler logs warning, ignores them,
+    // RunTurn receives only req.Text.
+}
+
+func TestCcInbound_DispatcherSerializesSameUser(t *testing.T) {
+    // submit 2 requests for same (channel_id, wechat_user_id) → first finishes before second runs.
+    // (Use a slow fakeCcClient that signals via a channel.)
+}
+
+func TestCcInbound_DispatcherParallelDifferentUsers(t *testing.T) {
+    // 2 requests for different (channel, user) keys → both run concurrently.
+}
+```
+
+(Exact test scaffolding depends on existing helpers in codex_im_inbound_test.go — adapt accordingly. If the codex tests use `httptest` for the imbridge-send endpoint, follow that pattern.)
+
+- [ ] **Step 2: Run tests to verify failure**
+
+```
+go test -v -run TestCcInbound ./internal/server/
+```
+Expected: build error.
+
+- [ ] **Step 3: Implement `cc_im_inbound.go`**
+
+Start by copying `codex_im_inbound.go` and renaming:
+- `codexInboundHandler` → `ccInboundHandler`
+- `codexInboundRequest` → `ccInboundRequest`
+- `codexDispatcher` → `ccDispatcher`
+- `codex_im` log prefix → `cc_im`
+- `dbSessionStore` → `ccDbSessionStore` (separate; doesn't share codex's instance)
+
+Then apply the Phase 4 differences from the spec § cc_im_inbound.go section:
+- Remove `ThreadID` concept; remove thread-not-found retry.
+- processTurn step 3: NULL claude_session_id handling.
+- buildCodexInput → buildCcInput, but for Phase 4 just returns `req.Text` (text only — media/quoted dropped with log).
+- error matrix per spec (different from codex's).
+
+The dispatcher is verbatim except for the request type. Don't extract it.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```
+go test -v ./internal/server/ -run TestCcInbound
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git commit -am "feat(server): ccInboundHandler + ccDispatcher for IM intake (Phase 4)"
+```
+
+---
+
+## Task 6: agentserver server.go wiring
+
+**Files:**
+- Modify: `internal/server/server.go`
+
+**Interfaces:**
+- Consumes (from Tasks 3, 5): `NewCcClient`, `NewCcInboundHandler`, `ResolveCCAppGatewayRESTURL`.
+- Produces:
+  - `Server.CcAppGatewayURL string` field.
+  - `Server.cc *CcClient` field.
+  - `Server.ccHandler *ccInboundHandler` field.
+  - Route `/api/internal/imbridge/cc/turn` registered conditionally.
+  - `Server.Close()` calls `ccHandler.Close()`.
+
+- [ ] **Step 1: Write failing test for the route registration**
+
+Append to `internal/server/server_test.go`:
+
+```go
+func TestServer_CcInboundRouteRegistered(t *testing.T) {
+    t.Setenv("CC_APP_GATEWAY_REST_URL", "http://cc-app-gateway:8087")
+    srv := newTestServer(t)
+    defer srv.Close()
+
+    // The route is registered; an unauthenticated POST should return 401 (auth middleware fires),
+    // NOT 404 (route not found).
+    req := httptest.NewRequest("POST", "/api/internal/imbridge/cc/turn", bytes.NewReader([]byte(`{}`)))
+    rr := httptest.NewRecorder()
+    srv.Routes().ServeHTTP(rr, req)
+    if rr.Code == http.StatusNotFound {
+        t.Error("cc inbound route should be registered when CC_APP_GATEWAY_REST_URL is set")
+    }
+}
+
+func TestServer_CcInboundRouteSkippedWhenURLEmpty(t *testing.T) {
+    t.Setenv("CC_APP_GATEWAY_REST_URL", "")
+    srv := newTestServer(t)
+    defer srv.Close()
+
+    req := httptest.NewRequest("POST", "/api/internal/imbridge/cc/turn", bytes.NewReader([]byte(`{}`)))
+    rr := httptest.NewRecorder()
+    srv.Routes().ServeHTTP(rr, req)
+    if rr.Code != http.StatusNotFound {
+        t.Errorf("cc inbound route should NOT be registered when CC_APP_GATEWAY_REST_URL is empty; got %d", rr.Code)
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+- [ ] **Step 3: Wire it in `server.go`**
+
+Find the codex route registration (`r.Post("/api/internal/imbridge/codex/turn", ...)` near server.go:381). Add the analogous cc block:
+
+```go
+ccURL := ResolveCCAppGatewayRESTURL()
+if ccURL != "" {
+    cc := NewCcClient(ccURL, internalSecret)
+    sessions := newCcDbSessionStore(s.db)
+    s.ccHandler = NewCcInboundHandler(cc, sessions, imbridgeSendURL, internalSecret)
+    r.Post("/api/internal/imbridge/cc/turn", func(w http.ResponseWriter, r *http.Request) {
+        secret := os.Getenv("INTERNAL_API_SECRET")
+        if secret != "" && r.Header.Get("X-Internal-Secret") != secret {
+            http.Error(w, "unauthorized", http.StatusUnauthorized)
+            return
+        }
+        s.ccHandler.ServeHTTP(w, r)
+    })
+}
+```
+
+In `Server.Close()` (find existing `codexHandler.Close()` call):
+
+```go
+if s.ccHandler != nil {
+    s.ccHandler.Close()
+}
+```
+
+Add startup-time misconfiguration warning per spec § Misconfiguration safeguard:
+
+```go
+if ccURL == "" {
+    // Check DB for any managed_cc channels — log warning if found.
+    n, _ := s.db.CountIMChannelsByRoutingMode(ctx, "managed_cc")
+    if n > 0 {
+        log.Printf("[server] WARNING: %d IM channels have routing_mode=managed_cc but CC_APP_GATEWAY_REST_URL is unset — those channels will fail until cc-app-gateway is enabled", n)
+    }
+}
+```
+
+(The `CountIMChannelsByRoutingMode` helper may need to be added to `internal/db/im_channels.go`. Trivial — one SELECT COUNT.)
+
+- [ ] **Step 4: Run tests to verify pass**
+
+```
+go test ./internal/server/
+```
+
+- [ ] **Step 5: Commit**
+
+```
+git commit -am "feat(server): wire cc inbound route + Close() lifecycle (Phase 4)"
+```
+
+---
+
+## Task 7: imbridge `forwardToManagedCC` + bridge.go switch
+
+**Files:**
+- Modify: `internal/imbridge/bridge.go`
+
+**Interfaces:**
+- Consumes: nothing new (HTTP call to agentserver).
+- Produces: `Bridge.forwardMessage()` recognizes `managed_cc`.
+
+- [ ] **Step 1: Write failing test for routing-mode switch**
+
+If `internal/imbridge/bridge_test.go` exists with a routing test, append. Else create:
+
+```go
+func TestForwardMessage_RoutesManagedCC(t *testing.T) {
+    var called bool
+    ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        if r.URL.Path == "/api/internal/imbridge/cc/turn" {
+            called = true
+            w.WriteHeader(http.StatusAccepted)
+            w.Write([]byte(`{"queued":true}`))
+        } else {
+            t.Errorf("unexpected path: %s", r.URL.Path)
+        }
+    }))
+    defer ts.Close()
+
+    b := &imbridge.Bridge{AgentserverURL: ts.URL}
+    binding := imbridge.BridgeBinding{RoutingMode: "managed_cc", WorkspaceID: "ws_test"}
+    msg := imbridge.IncomingMessage{ChannelID: "ch_test", FromUserID: "wxid_test", Text: "hi"}
+    b.ForwardMessage(context.Background(), msg, binding)  // assumes exported test helper, or use package internal test
+
+    if !called {
+        t.Error("expected POST to /api/internal/imbridge/cc/turn")
+    }
+}
+```
+
+(Exact pattern depends on how `forwardMessage` is structured. If it's unexported, this lives in `package imbridge` rather than `imbridge_test`.)
+
+- [ ] **Step 2: Run test to verify failure**
+
+- [ ] **Step 3: Add `managed_cc` case + `forwardToManagedCC` method**
+
+In `forwardMessage()` at bridge.go:414, add the case before `default`:
+
+```go
+case "managed_cc":
+    return b.forwardToManagedCC(ctx, msg, binding)
+```
+
+Add `forwardToManagedCC()` mirroring `forwardToCodex()` exactly — same payload, different URL:
+
+```go
+func (b *Bridge) forwardToManagedCC(ctx context.Context, msg IncomingMessage, binding BridgeBinding) (bool, error) {
+    payload := map[string]any{
+        "channel_id":         msg.ChannelID,
+        "workspace_id":       binding.WorkspaceID,
+        "wechat_user_id":     msg.FromUserID,
+        "wechat_sender":      msg.SenderName,
+        "text":               msg.Text,
+        "quoted_text":        msg.QuotedText,
+        "quoted_sender":      msg.QuotedSender,
+        "media_type":         msg.MediaType,
+        "media_data":         msg.MediaData,
+        "quoted_media_type":  msg.QuotedMediaType,
+        "quoted_media_data":  msg.QuotedMediaData,
+    }
+    body, _ := json.Marshal(payload)
+    req, err := http.NewRequestWithContext(ctx, "POST",
+        b.AgentserverURL+"/api/internal/imbridge/cc/turn",
+        bytes.NewReader(body))
+    if err != nil {
+        return false, fmt.Errorf("forwardToManagedCC: build request: %w", err)
+    }
+    req.Header.Set("Content-Type", "application/json")
+    if secret := os.Getenv("INTERNAL_API_SECRET"); secret != "" {
+        req.Header.Set("X-Internal-Secret", secret)
+    }
+    resp, err := b.http.Do(req)
+    if err != nil {
+        return false, fmt.Errorf("forwardToManagedCC: %w", err)
+    }
+    defer resp.Body.Close()
+    if resp.StatusCode != http.StatusAccepted {
+        b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+        return false, fmt.Errorf("forwardToManagedCC: status=%d body=%q", resp.StatusCode, b)
+    }
+    return true, nil
+}
+```
+
+Update doc comment on `BridgeBinding.RoutingMode` (bridge.go:51) to include `managed_cc`:
+
+```go
+// RoutingMode controls which agent backend the channel's messages route to:
+// "nanoclaw" (default), "codex", or "managed_cc" (Phase 4 cc-app-gateway).
+RoutingMode string
+```
+
+- [ ] **Step 4: Run test to verify pass**
+
+- [ ] **Step 5: Commit**
+
+```
+git commit -am "feat(imbridge): forwardToManagedCC + bridge switch case (Phase 4)"
+```
+
+---
+
+## Task 8: `imbridgesvc/handlers.go` validator accepts managed_cc
+
+**Files:**
+- Modify: `internal/imbridgesvc/handlers.go`
+- Modify: `internal/imbridgesvc/handlers_test.go`
+
+**Interfaces:**
+- Trivial validator extension.
+
+- [ ] **Step 1: Find existing test or add one**
+
+Search for tests around routing_mode validation — likely in `handlers_test.go`. If a test exists asserting the validator REJECTS "managed_cc", that needs flipping. If none exists, add:
+
+```go
+func TestPatchIMChannelRoutingMode_AcceptsManagedCC(t *testing.T) {
+    h := newTestHandlers(t)
+    req := httptest.NewRequest("PATCH", "/api/workspaces/ws/im-channels/ch?field=routing_mode",
+        strings.NewReader(`{"value":"managed_cc"}`))
+    rr := httptest.NewRecorder()
+    h.PatchIMChannel(rr, req)
+    if rr.Code != http.StatusOK {
+        t.Errorf("managed_cc should be accepted; got %d", rr.Code)
+    }
+}
+```
+
+- [ ] **Step 2: Update validator at handlers.go:977**
+
+```go
+if mode != "nanoclaw" && mode != "codex" && mode != "managed_cc" {
+    http.Error(w, `invalid routing_mode: must be nanoclaw, codex, or managed_cc`, http.StatusBadRequest)
+    return
+}
+```
+
+- [ ] **Step 3: Test passes; existing tests don't regress**
+
+```
+go test ./internal/imbridgesvc/
+```
+
+- [ ] **Step 4: Commit**
+
+```
+git commit -am "feat(imbridgesvc): accept managed_cc routing_mode value (Phase 4)"
+```
+
+---
+
+## Task 9: helm chart agentserver pod env var
+
+**Files:**
+- Modify: `deploy/helm/agentserver/templates/deployment.yaml` (or wherever the agentserver Deployment lives — check existing path)
+
+**Interfaces:**
+- No code interfaces; YAML only.
+
+- [ ] **Step 1: Find the existing codex env var pattern**
+
+```
+grep -n "CODEX_APP_GATEWAY_REST_URL" deploy/helm/agentserver/templates/*.yaml
+```
+
+It should already be in `deployment.yaml` (agentserver pod template). Look at the pattern — should be entirely wrapped in `{{- if .Values.codexAppGateway.enabled }}`.
+
+- [ ] **Step 2: Add the analogous block for cc-app-gateway**
+
+Below the CODEX_APP_GATEWAY_REST_URL block, add:
+
+```yaml
+{{- if .Values.ccAppGateway.enabled }}
+- name: CC_APP_GATEWAY_REST_URL
+  value: "http://{{ .Release.Name }}-cc-app-gateway.{{ .Release.Namespace }}.svc:{{ .Values.ccAppGateway.port }}"
+{{- end }}
+```
+
+- [ ] **Step 3: Smoke-test helm template**
+
+```bash
+cd deploy/helm/agentserver
+helm template . --set ccAppGateway.enabled=true \
+                --set ccAppGateway.s3.region=us-east-1 \
+                --set ccAppGateway.s3.bucket=test \
+       | grep -A1 "CC_APP_GATEWAY_REST_URL"
+# Expected: env var present with cluster service URL.
+
+helm template . | grep -c "CC_APP_GATEWAY_REST_URL"
+# Expected: 0 (default ccAppGateway.enabled=false → env var absent).
+```
+
+- [ ] **Step 4: Commit**
+
+```
+git commit -am "feat(helm): expose CC_APP_GATEWAY_REST_URL on agentserver pod when ccAppGateway enabled"
+```
+
+---
+
+## Task 10: integration test — IM → cc-app-gateway → claude → reply
+
+**Files:**
+- Create: `internal/server/cc_im_integration_test.go`
+
+**Interfaces:**
+- Reuses Phase 2's docker-compose harness; ADDS a mock imbridge listener service.
+
+This test proves end-to-end: a fake imbridge POSTs an IM message → agentserver routes to cc-app-gateway → claude responds → reply posted back to the fake imbridge listener within timeout.
+
+- [ ] **Step 1: Extend the docker-compose with agentserver + fake-imbridge**
+
+`internal/ccappgateway/testdata/integration/docker-compose.yml` already has minio + fake-agentserver + fake-llmproxy + cc-app-gateway. Phase 4 ADDS:
+- A real agentserver instance (or wrap the test's own `httptest.NewServer` running the agentserver chi router).
+- A fake-imbridge service that exposes `/api/internal/imbridge/send` and records calls.
+
+OR (simpler): run the integration test as a Go test with `httptest.NewServer` for both agentserver and fake-imbridge, and only docker-compose cc-app-gateway+minio+fake-llmproxy. The test wires:
+- Real agentserver (in-process) connects to docker-compose cc-app-gateway via host port 8087.
+- Real agentserver's IMBridgeURL points to the test's own httptest server.
+
+Pick the simpler option. The test runner orchestrates.
+
+- [ ] **Step 2: Write the test**
+
+```go
+//go:build integration
+
+package server_test
+
+import (
+    "bytes"
+    "context"
+    "encoding/json"
+    "io"
+    "net/http"
+    "net/http/httptest"
+    "os"
+    "os/exec"
+    "path/filepath"
+    "strings"
+    "sync"
+    "testing"
+    "time"
+
+    "github.com/agentserver/agentserver/internal/server"
+)
+
+func TestIntegration_IMToCcEndToEnd(t *testing.T) {
+    if testing.Short() {
+        t.Skip("integration test")
+    }
+
+    // 1. Bring up the Phase 2 docker-compose (cc-app-gateway + minio + fakes).
+    composeDir, _ := filepath.Abs("../ccappgateway/testdata/integration")
+    runMake := func(target string) {
+        cmd := exec.Command("make", "-C", composeDir, target)
+        out, err := cmd.CombinedOutput()
+        t.Logf("make %s: %s", target, out)
+        if err != nil { t.Fatalf("make %s: %v", target, err) }
+    }
+    runMake("up")
+    t.Cleanup(func() {
+        cmd := exec.Command("make", "-C", composeDir, "down")
+        out, _ := cmd.CombinedOutput()
+        t.Logf("make down: %s", out)
+    })
+
+    // Wait for cc-app-gateway readyz.
+    waitURL := "http://localhost:8087/readyz"
+    deadline := time.Now().Add(90 * time.Second)
+    for time.Now().Before(deadline) {
+        if resp, err := http.Get(waitURL); err == nil && resp.StatusCode == 200 {
+            resp.Body.Close()
+            break
+        }
+        time.Sleep(2 * time.Second)
+    }
+
+    // 2. Spin up a fake imbridge listener that records calls.
+    var sendCalls []map[string]any
+    var mu sync.Mutex
+    fakeImbridge := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        if r.URL.Path == "/api/internal/imbridge/send" {
+            var payload map[string]any
+            json.NewDecoder(r.Body).Decode(&payload)
+            mu.Lock()
+            sendCalls = append(sendCalls, payload)
+            mu.Unlock()
+            w.WriteHeader(200)
+            w.Write([]byte(`{"status":"sent"}`))
+        } else {
+            w.WriteHeader(404)
+        }
+    }))
+    t.Cleanup(fakeImbridge.Close)
+
+    // 3. Spin up a real agentserver in-process.
+    t.Setenv("INTERNAL_API_SECRET", "secret123")
+    t.Setenv("CC_APP_GATEWAY_REST_URL", "http://localhost:8087")
+    t.Setenv("IMBRIDGE_URL", fakeImbridge.URL)
+    // Set up a test DB (use existing test DB harness or skip if missing).
+    // ...
+
+    srv := server.NewServer(...)  // exact constructor depends on what's available
+    agentserverTS := httptest.NewServer(srv.Routes())
+    t.Cleanup(agentserverTS.Close)
+
+    // 4. POST an IM message to /api/internal/imbridge/cc/turn (turn 1).
+    sessionID := "wxid_alice"
+    body1 := `{"channel_id":"ch_test","workspace_id":"ws_test","wechat_user_id":"` + sessionID + `","wechat_sender":"Alice","text":"Remember code DELTA-9."}`
+    req, _ := http.NewRequest("POST", agentserverTS.URL+"/api/internal/imbridge/cc/turn",
+        strings.NewReader(body1))
+    req.Header.Set("X-Internal-Secret", "secret123")
+    req.Header.Set("Content-Type", "application/json")
+    resp, err := http.DefaultClient.Do(req)
+    if err != nil { t.Fatal(err) }
+    if resp.StatusCode != 202 {
+        b, _ := io.ReadAll(resp.Body)
+        t.Fatalf("expected 202, got %d: %s", resp.StatusCode, b)
+    }
+
+    // 5. Wait for the fake-imbridge to receive the reply (up to 60s — claude is real).
+    deadline = time.Now().Add(60 * time.Second)
+    for time.Now().Before(deadline) {
+        mu.Lock()
+        n := len(sendCalls)
+        mu.Unlock()
+        if n >= 1 { break }
+        time.Sleep(500 * time.Millisecond)
+    }
+    mu.Lock()
+    if len(sendCalls) < 1 {
+        mu.Unlock()
+        t.Fatal("fake imbridge never received reply for turn 1")
+    }
+    reply1 := sendCalls[0]
+    mu.Unlock()
+    t.Logf("turn 1 reply: %v", reply1)
+
+    // 6. POST turn 2 same (channel, user). Assert reply mentions DELTA-9 (resume worked).
+    body2 := `{"channel_id":"ch_test","workspace_id":"ws_test","wechat_user_id":"` + sessionID + `","wechat_sender":"Alice","text":"What's the code I just gave you?"}`
+    req2, _ := http.NewRequest("POST", agentserverTS.URL+"/api/internal/imbridge/cc/turn",
+        strings.NewReader(body2))
+    req2.Header.Set("X-Internal-Secret", "secret123")
+    req2.Header.Set("Content-Type", "application/json")
+    resp2, err := http.DefaultClient.Do(req2)
+    if err != nil { t.Fatal(err) }
+    if resp2.StatusCode != 202 { t.Fatalf("turn 2: %d", resp2.StatusCode) }
+
+    deadline = time.Now().Add(60 * time.Second)
+    for time.Now().Before(deadline) {
+        mu.Lock()
+        n := len(sendCalls)
+        mu.Unlock()
+        if n >= 2 { break }
+        time.Sleep(500 * time.Millisecond)
+    }
+    mu.Lock()
+    defer mu.Unlock()
+    if len(sendCalls) < 2 {
+        t.Fatal("fake imbridge never received reply for turn 2")
+    }
+    reply2Text, _ := sendCalls[1]["text"].(string)
+    if !strings.Contains(reply2Text, "DELTA-9") {
+        t.Errorf("turn 2 reply should mention DELTA-9 (resume across turns); got: %q", reply2Text)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test**
+
+```
+go test -tags integration -v -timeout 10m -run TestIntegration_IMToCcEndToEnd ./internal/server/
+```
+
+Iterate if it fails — common causes:
+- DB not seeded (need a test DB or migration)
+- agentserver Server constructor needs more wiring
+- fake-imbridge call doesn't fire (port conflict, hostnames)
+
+- [ ] **Step 3: Commit**
+
+```
+git commit -am "test(server): integration test for IM → cc-app-gateway → claude end-to-end (Phase 4)"
+```
+
+---
+
+## Final pass
+
+- [ ] **Run full test suite**
+
+```
+go test ./...
+go test -tags integration -v -timeout 10m -run TestIntegration_IMToCcEndToEnd ./internal/server/
+go test -tags integration -v -timeout 10m ./internal/ccappgateway/...
+go vet ./...
+```
+
+- [ ] **Update memory**
+
+Add a `cc_app_gateway_phase4_landed.md` note cross-linking with Phase 1+2 memories, documenting Phase 4 scope and the user-visible "WeChat now works" milestone.
+
+- [ ] **Open PR (stacked on Phase 2's PR #280)**
+
+```
+gh pr create --base feat/cc-app-gateway-phase2 \
+             --head feat/cc-app-gateway-phase4 \
+             --title "feat(cc-app-gateway): Phase 4 — IM intake (agentserver routes managed_cc → cc-app-gateway)" \
+             --body "$(cat /tmp/p4-pr-body.md)"
+```
+
+PR body must:
+- Mention this is Phase 4 stacked on Phase 2 (PR #280) which is stacked on Phase 1 (PR #279)
+- Link spec + plan
+- Call out the user-visible milestone: "After this lands, setting `routing_mode=managed_cc` on a WeChat channel routes through claude end-to-end"
+- Show integration test output asserting DELTA-9 reply in turn 2 (resume works)
+- Document the migration risk: codex → managed_cc loses history (no migration of codex turns)
+- List the Phase 4 deferred items (vision via Phase 4.5, per-channel model in Phase 5+, etc.)
+
+- [ ] **Bump chart (post-merge of all three PRs)**
+
+Per `agentserver_release_flow` memory: bump Chart.yaml minor, push `v<version>` git tag.
+
+---
+
+## Out-of-band: confirm Phase 1/2 PRs are mergeable before Phase 4 review
+
+Phase 4 cannot merge until PR #279 + PR #280 land. Before opening Phase 4 PR, sanity-check:
+
+```bash
+gh pr view 279 --json mergeStateStatus,state
+gh pr view 280 --json mergeStateStatus,state
+```
+
+If either is blocked (rebase conflict, CI red, review changes requested), prioritize unblocking those before flooding reviewer's queue with a third PR. Phase 4 implementation can still proceed in the worktree; just don't open the PR until #279/#280 are visibly close to mergeable.
+
+---
+
+## Self-review (run after writing this plan)
+
+Done as part of writing. Checks performed:
+
+1. **Spec coverage:** Every § Component changes item in the spec has a task. Migration → Task 1. CcTurnResponse field → Task 2. cc_client.go → Task 3. sessionView extension → Task 4. cc_im_inbound.go → Task 5. server.go wiring + misconfiguration safeguard → Task 6. imbridge → Task 7. validator → Task 8. helm → Task 9. Integration test → Task 10. Audit revisions all addressed.
+
+2. **Placeholder scan:** No "TBD", "TODO", or "fill in details". Every step has either code or an exact command. A few "exact pattern depends on existing helpers — adapt" notes; those are honest acknowledgments that helpers may differ, not placeholders.
+
+3. **Type consistency:**
+   - `CcClient`/`CcTurnRequest`/`CcTurnResponse` field names match between Task 3 (definition) and Task 5 (consumer).
+   - `sessionView.ClaudeSessionID string` consistent between Task 4 (definition) and Task 5 (consumer).
+   - `SetSessionClaudeSessionID(ctx, sessionID, claudeSessionID string) error` signature consistent across Tasks 1, 5.
+   - `ResolveCCAppGatewayRESTURL()` exported in Task 3, used in Task 6.
+   - `managed_cc` literal string consistent across Tasks 5 (handler), 7 (imbridge), 8 (validator).
+   - HTTP path `/api/internal/imbridge/cc/turn` consistent across Tasks 6 (server route), 7 (imbridge POST target), 10 (integration test).

--- a/docs/superpowers/specs/2026-06-22-cc-app-gateway-phase4-design.md
+++ b/docs/superpowers/specs/2026-06-22-cc-app-gateway-phase4-design.md
@@ -1,0 +1,460 @@
+# cc-app-gateway Phase 4 — IM intake (agentserver side)
+
+**Status:** draft v2 (self-audit revisions applied 2026-06-22, see § Audit revisions)
+**Date:** 2026-06-22
+**Owner:** agentserver / cc integration
+**Builds on:** Phase 1 (PR #279) and Phase 2 (PR #280, stacked). Cannot ship until both merge first.
+**Resolves the user-visible question:** "Can I talk to claude from WeChat now?" — yes, after this lands.
+
+## Goal
+
+End-to-end IM → cc-app-gateway → claude → reply path: when a WeChat message routes through imbridge with `routing_mode=managed_cc`, agentserver allocates/looks-up a claude session, forwards the message to cc-app-gateway, waits for claude's reply, and posts the assistant text back to imbridge's `/send` endpoint.
+
+After this lands, `kubectl rollout` of agentserver + the IM channel's `routing_mode` set to `managed_cc` is the only operational step needed for production WeChat ↔ claude.
+
+## Non-goals (deferred)
+
+- In-process MCP tools (Phase 3 — independent track; cc-app-gateway runs without tools, claude only chats).
+- Multi-modal IM input (image / file) routing to claude via Anthropic's vision API. Phase 4 forwards `text` only; `media_*` fields are received but dropped with a log warning. Phase 5+ pivots to vision once we wire MCP tool `attach_image` or similar.
+- Quoted-message context (`quoted_text`, `quoted_sender`) — same: received, dropped, follow-up.
+- Backfill / migration of existing TUI sessions into IM sessions.
+- Per-workspace LLM model override beyond `CCAPPGW_DEFAULT_MODEL`. Phase 4 hardcodes the gateway default model for all IM turns; per-channel model selection is Phase 5+.
+- Bidirectional handoff between codex and managed_cc (a user switching their channel's routing_mode mid-conversation). Phase 4 isolates the two; switching = new session.
+
+## Architecture decision: synchronous, not callback
+
+Phase 2 spec speculated cc-app-gateway might need a `callbackUrl` async mode for IM turns. **The codex IM path (`codex_im_inbound.go`) is fully synchronous** — it calls `codex.RunTurn()` with a 61-minute HTTP client timeout and blocks the dispatcher worker until completion. cc-app-gateway in Phase 1 already returns the assistant text synchronously from `POST /api/turns`. Phase 4 calls it the same way codex does. The `callbackUrl` field on `CcTurnRequest` shipped in Phase 2 → 501 remains unused (Phase 5+ may revisit if streaming SSE arrives).
+
+**Why this works** even though IM turns can take 10+ seconds:
+- HTTP keepalive holds the connection during the long claude `--print` run.
+- The dispatcher serializes per-(channel, user), so concurrent users don't pile up on the same worker.
+- claude's wall-clock cap (`CCAPPGW_TURN_TIMEOUT`, default 10m) is well below the HTTP client's 61-min cap, so client never times out before runner does.
+- If cc-app-gateway is unreachable, the HTTP error fires immediately; we send a user-facing error via `sendError()` (matching codex's pattern).
+
+**Network-path assumption (documented; mirrors codex's production reality):**
+agentserver and cc-app-gateway communicate **pod-to-pod inside the K8s cluster** via Service DNS — no ingress controller, no LB, no Cloudflare tunnel in the middle. Cluster-internal Service IPs honor HTTP keepalive without idle-timeout-killing intermediate proxies. If a deployment ever exposes this path through an ingress / LB with a shorter idle timeout (typically 60s), the 10-minute HTTP hold will be killed mid-turn and a user will see "connection reset by peer." Codex's `codex-app-gateway` runs in the same posture and has been operationally stable; Phase 4 inherits that assumption. Document in the helm chart and operator runbook: do NOT route cc-app-gateway traffic through an ingress.
+
+**Concurrency ceiling:** with 50 simultaneous IM users hitting 5-minute turns, agentserver holds 50 open HTTP connections + 50 dispatcher worker goroutines. cc-app-gateway side spawns 50 concurrent `claude --print` subprocesses (Phase 1 has no semaphore). Each `claude` is ~300-400 MB RSS → 50 × 350 MB = ~17.5 GB on the cc-app-gateway pod. Phase 1 Open Risk #7 documented this; Phase 4 inherits the bound. Operators sizing for >10 concurrent active IM channels should raise pod memory limits or scale `ccAppGateway.replicaCount`.
+
+## Architecture diagram
+
+```
+WeChat user types "What's my favorite color?"
+       │
+       ▼
+imbridge polls/receives, calls Bridge.forwardToManagedCC()  ← NEW [P4]
+       │  POST http://agentserver:8080/api/internal/imbridge/cc/turn
+       │  Header: X-Internal-Secret
+       │  Body: {channel_id, workspace_id, wechat_user_id, wechat_sender,
+       │         text, media_*, quoted_*}
+       ▼
+agentserver: internal/server/cc_im_inbound.go ServeHTTP    ← NEW [P4]
+       ├─ Verify X-Internal-Secret
+       ├─ ccDispatcher.Enqueue(req)         (per (channel_id, wechat_user_id) FIFO, cap 5, drop-oldest)
+       └─ 202 + {"queued":true}
+              │
+              ▼ (background dispatcher worker)
+       processTurn(req):
+       ├─ sess := sessions.GetSessionByExternalID(workspace_id, wechat_user_id)
+       │     ├─ hit AND sess.ClaudeSessionID != "":  reuse both
+       │     ├─ hit AND sess.ClaudeSessionID == "":  EXISTING codex/nanoclaw session migrating to managed_cc
+       │     │                                       — mint fresh UUID, SetSessionClaudeSessionID(),
+       │     │                                       continue with new claude_session_id (codex history
+       │     │                                       is NOT migrated; claude starts fresh — documented
+       │     │                                       Open Risk #6 user-visible behavior on routing_mode switch)
+       │     └─ miss: sessions.CreateSession() mints "cse_" + uuid.NewString() as agent_sessions.id
+       │              + ALSO mints a fresh UUID for ClaudeSessionID (cc-app-gateway needs UUID-format
+       │              per Phase 1 turn_api.go uuidRe validation)
+       │              + stores external_id = wechat_user_id, im_channel_id, claude_session_id
+       ├─ ccClient.RunTurn(ctx, CcTurnRequest{
+       │     workspaceId:  req.WorkspaceID,
+       │     sessionId:    sess.ClaudeSessionID,
+       │     userMessage:  req.Text,
+       │     // model omitted → uses cc-app-gateway's CCAPPGW_DEFAULT_MODEL
+       │   })
+       │     POST http://cc-app-gateway:8087/api/turns         (61-min client timeout)
+       │     Header: X-Internal-Secret
+       │     Body: CcTurnRequest JSON
+       │     ← returns CcTurnResponse {sessionId, assistantText, isError, ...}
+       ▼
+       Reply path (same as codex's):
+       ├─ h.postSend(channel_id, wechat_user_id, response.assistantText)
+       │     POST http://agentserver:8080/api/internal/imbridge/send
+       │     Header: X-Internal-Secret
+       │     Body: {channel_id, to_user_id, text}
+       ▼
+imbridge.handleSend → provider.Send() → WeChat reply
+```
+
+## The session ID complication
+
+agentserver's existing `agent_sessions.id` is `"cse_" + uuid.NewString()` (codex pattern). cc-app-gateway's Phase 1 `turn_api.go` validates sessionId via `uuidRe = ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-...$` (pure UUID format).
+
+So `agent_sessions.id` ("cse_xxx") CANNOT be sent as cc-app-gateway's sessionId. Three options:
+
+| Option | Description | Trade-off |
+|---|---|---|
+| **A** | Strip the `"cse_"` prefix when sending to cc-app-gateway | Fragile — couples cc-app-gateway's sessionId format to agentserver's id format forever |
+| **B** | Add new `claude_session_id` column to `agent_sessions`; mint pure UUID at session-creation time; store both | Clean separation, Phase 4 sets the pattern for any future agent backend |
+| **C** | Change cc-app-gateway's uuidRe to accept "cse_xxx" too | Couples cc-app-gateway to agentserver's ID format; Phase 1 chose strict UUID for a reason (path safety, log readability, no fake prefixes) |
+
+**Choose B.** This was the Phase 4 prerequisite documented in spec Phase 2's § Migration. Add `claude_session_id TEXT` column in a new migration (036_agent_sessions_claude_session_id.sql); populate it in `CreateSession()` alongside `id`; read it in `processTurn`.
+
+## Component changes
+
+### `internal/db/migrations/036_agent_sessions_claude_session_id.sql` (NEW)
+
+```sql
+-- 036_agent_sessions_claude_session_id.sql
+-- Phase 4: cc-app-gateway requires pure-UUID sessionId per Phase 1's
+-- turn_api.go uuidRe validation. agent_sessions.id uses "cse_<uuid>"
+-- format; we need a separate column for the cc-app-gateway-compatible
+-- session identifier. Nullable; only populated for rows that use the
+-- managed_cc routing mode.
+ALTER TABLE agent_sessions ADD COLUMN IF NOT EXISTS claude_session_id TEXT;
+
+-- Index for lookup-by-claude-session-id, if Phase 5+ needs reverse lookup.
+-- (Not used in Phase 4; lookups go via id or (workspace_id, external_id).)
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_claude_session_id
+    ON agent_sessions (claude_session_id)
+    WHERE claude_session_id IS NOT NULL;
+```
+
+### `internal/db/agent_sessions.go` (MODIFY)
+
+Note: `sessionView` and `dbSessionStore.CreateSession` live in
+`internal/server/codex_im_inbound.go` (lines 604–619), NOT in
+`internal/db/agent_sessions.go`. The DB-layer changes are smaller than they look.
+
+Concrete changes:
+
+1. **`agent_sessions.go` row struct + SELECT lists** — add `ClaudeSessionID *string` (nullable pointer) to the row type so SELECT * queries pick up the new column. Add `CreateAgentSessionWithClaude(sessionID, sandboxID, workspaceID, title, externalID, claudeSessionID string)` if existing `CreateAgentSession` doesn't accept the column; or amend the existing function signature.
+2. **Add `SetSessionClaudeSessionID(ctx, sessionID, claudeSessionID string) error`** — mirrors `SetSessionCodexThreadID`. **NOT** dead code per Audit Revision #2 below: used by the codex→managed_cc migration path in `processTurn` when an existing session is found with NULL claude_session_id (mints + persists fresh UUID).
+
+Existing `dbSessionStore.GetSessionByExternalID` in `codex_im_inbound.go:560` returns a `sessionView{ID, CodexThreadID}` — extend to also include `ClaudeSessionID`. Update the SELECT in that function's underlying query to include the new column. Codex's tests pass `sessionView{}` with zero-value `ClaudeSessionID` — they continue to compile (zero value is `""`); they're unaffected functionally because codex doesn't read the field.
+
+### `internal/server/cc_im_inbound.go` ccDbSessionStore (NEW, alongside the handler)
+
+The cc handler needs its own `ccDbSessionStore` (mirroring codex's `dbSessionStore` at codex_im_inbound.go:578) with a `CreateSession(workspaceID, externalID, title, imChannelID string) (sessionView, error)` that mints BOTH `agent_sessions.id` ("cse_" + uuid) AND `claude_session_id` (pure uuid). This sits alongside the handler, not inside `internal/db/`.
+
+The shared `sessionView` struct (with `ClaudeSessionID string` field added) is in `codex_im_inbound.go` — cc handler uses the SAME struct type. (Adding a new struct would be over-engineering — the field is just `""` for codex sessions.)
+
+### `internal/server/cc_im_inbound.go` (NEW)
+
+Mirror of `codex_im_inbound.go` — 90% same shape. Key differences:
+- Request struct = `ccInboundRequest` (same fields as codex's, JSON keys identical)
+- Process function calls `ccClient.RunTurn` (not codex)
+- No `ThreadID` concept — cc-app-gateway is keyed on `sessionId` (Phase 2 resume); ID lives on `agent_sessions.claude_session_id`
+- ccDispatcher copy of codexDispatcher (~100 LOC, deliberately NOT extracted to generic package per spec Phase 1 § Audit revisions Rev #2)
+- No thread-not-found retry needed — cc-app-gateway's resume is automatic (workspace.Setup hits or misses S3 transparently)
+- Error handling: timeout, runner_failed, runner_timeout, isError=true (returned in 200 body, not as transport error)
+
+### `internal/ccappgateway/turn_api.go` (MODIFY, cc-app-gateway side, NOT agentserver)
+
+**Phase 4 amends Phase 1's `CcTurnResponse`** to include the error message string when `IsError==true`. Phase 1 only carried `IsError bool`, which makes the agentserver-side error matrix unable to distinguish context-window-exceeded from other Anthropic-side errors. Add one field:
+
+```go
+type CcTurnResponse struct {
+    SessionID     string                       `json:"sessionId"`
+    AssistantText string                       `json:"assistantText"`
+    IsError       bool                         `json:"isError"`
+    ErrorMessage  string                       `json:"errorMessage,omitempty"` // NEW (Phase 4)
+    DurationMs    int64                        `json:"durationMs"`
+    TotalCostUSD  float64                      `json:"totalCostUsd"`
+    ModelUsage    map[string]runner.ModelUsage `json:"modelUsage,omitempty"`
+}
+```
+
+Populate in `ServeHTTP` from the runner's `ResultMeta.ErrorMessage` (which Phase 1 already extracts from the claude `result/error` SDKMessage — see `runner/events.go`):
+
+```go
+if result.Meta != nil {
+    resp.IsError = result.Meta.IsError
+    resp.ErrorMessage = result.Meta.ErrorMessage  // NEW line
+    resp.TotalCostUSD = result.Meta.TotalCostUSD
+    resp.ModelUsage = result.Meta.ModelUsage
+}
+```
+
+Update existing `turn_api_test.go` Phase 2 test `TestServeHTTP_IsErrorReturned200` (the one that returns 200 with `isError=true`) to assert `errorMessage` field in the response body too.
+
+### `internal/server/cc_client.go` (NEW, agentserver side)
+
+Mirror of `codex_client.go`. Key shape:
+
+```go
+type CcClient struct {
+    baseURL string
+    secret  string
+    http    *http.Client  // 61-minute timeout, same as codex
+}
+
+type CcTurnRequest struct {
+    WorkspaceID string `json:"workspaceId"`
+    SessionID   string `json:"sessionId"`
+    UserMessage string `json:"userMessage"`
+    Model       string `json:"model,omitempty"`
+    TimeoutMs   int    `json:"timeoutMs,omitempty"`
+}
+
+type CcTurnResponse struct {
+    SessionID     string         `json:"sessionId"`
+    AssistantText string         `json:"assistantText"`
+    IsError       bool           `json:"isError"`
+    ErrorMessage  string         `json:"errorMessage,omitempty"` // Mirrors cc-app-gateway's response
+    DurationMs    int64          `json:"durationMs"`
+    TotalCostUSD  float64        `json:"totalCostUsd"`
+    ModelUsage    map[string]any `json:"modelUsage,omitempty"`
+}
+
+func (c *CcClient) RunTurn(ctx context.Context, req CcTurnRequest) (*CcTurnResponse, error)
+```
+
+`resolveCCAppGatewayRESTURL()` env-var resolution: `CC_APP_GATEWAY_REST_URL` (primary), no `_URL` fallback variant since cc-app-gateway has no notebook/ws history.
+
+### `internal/server/server.go` (MODIFY)
+
+- Add `CcAppGatewayURL string` field on `Server` struct (mirrors `CodexAppGatewayURL`).
+- Register `/api/internal/imbridge/cc/turn` route ONLY if `CC_APP_GATEWAY_REST_URL` is set (mirrors codex's gating at server.go:372-390).
+- Construct `ccInboundHandler` with `ccClient`, `sessions`, `imbridgeSendURL`, `internalSecret`.
+- **Add `ccHandler.Close()` call to `Server.Close()`** (mirrors codex's `codexHandler.Close()` wiring at server.go:162). Without this, in-flight cc dispatcher turns get orphaned on graceful shutdown.
+
+### `internal/imbridge/bridge.go` (MODIFY)
+
+The actual function is `Bridge.forwardMessage()` at `bridge.go:414` (NOT `routeMessage()` — spec v1 used the wrong name). The switch at lines 422-427 has `case "codex"` explicit and `default` for nanoclaw. Add `case "managed_cc": b.forwardToManagedCC(ctx, msg, binding)` before `default`.
+
+Add `forwardToManagedCC()` method that mirrors `forwardToCodex()` (bridge.go:435-483) — same payload shape (channel_id, workspace_id, wechat_user_id, text, media_*, quoted_*), POSTed to `/api/internal/imbridge/cc/turn` on agentserver. **MUST explicitly set `X-Internal-Secret` header from `os.Getenv("INTERNAL_API_SECRET")`** — matches codex bridge.go:470. (Not implied; explicit code line.)
+
+Also update the stale doc comment on `BridgeBinding.RoutingMode` (bridge.go:51, currently says `// "nanoclaw" (default) or "codex"`) to include `managed_cc`.
+
+### Misconfiguration safeguard: managed_cc set + ccAppGateway disabled
+
+When a channel has `routing_mode=managed_cc` but cc-app-gateway is disabled in helm (or `CC_APP_GATEWAY_REST_URL` is empty), agentserver never registers the inbound route → imbridge POST returns 404 → `forwardMessage` returns error → imbridge retries every 2s forever, flooding logs and blocking cursor advancement.
+
+Mitigation: **add startup-time validation** in agentserver. On boot, if `CC_APP_GATEWAY_REST_URL` is empty, log a warning AND query DB for any `workspace_im_channels` with `routing_mode='managed_cc'`. If any exist, log a HIGH-severity warning naming the affected channels. Operators see "cc-app-gateway disabled but N channels expect it" instead of a flood of 404s in logs.
+
+### `internal/imbridgesvc/handlers.go` (MODIFY)
+
+The `routing_mode` validator at L977 currently rejects anything that isn't `nanoclaw` or `codex`. Add `managed_cc` to the allow list:
+
+```go
+if mode != "nanoclaw" && mode != "codex" && mode != "managed_cc" {
+    http.Error(w, `invalid routing_mode: must be nanoclaw, codex, or managed_cc`, http.StatusBadRequest)
+    return
+}
+```
+
+### `deploy/helm/agentserver/templates/agentserver.yaml` (MODIFY)
+
+Add env var on agentserver pod. **Wrap the ENTIRE `- name:` block inside the conditional** (mirrors codex pattern at deployment.yaml:184-196). Rendering an empty-string env var (`CC_APP_GATEWAY_REST_URL=""`) instead of omitting it is silently equivalent but inconsistent with how codex does it and surprises operators inspecting pod env:
+
+```yaml
+{{- if .Values.ccAppGateway.enabled }}
+- name: CC_APP_GATEWAY_REST_URL
+  value: "http://{{ .Release.Name }}-cc-app-gateway.{{ .Release.Namespace }}.svc:{{ .Values.ccAppGateway.port }}"
+{{- end }}
+```
+
+The conditional ensures agentserver doesn't try to route to a non-existent cc-app-gateway when it's disabled (Phase 1 default). When disabled, the env var is ABSENT (not empty-string) — `os.Getenv` returns `""` in both cases, but absence is the clearer signal in `kubectl exec ... env | grep CC_APP_GATEWAY` output.
+
+### Tests
+
+- `cc_im_inbound_test.go` — table-driven test covering: new session creation, existing session reuse, ccClient call mocking, send-back happy path, transport error path, isError=true in response body, dispatcher serialization for same (channel, user), distinct (channel, user) parallelism.
+- `cc_client_test.go` — httptest server returning canned CcTurnResponse; verify RunTurn URL, headers, body shape, response decoding.
+- `imbridgesvc/handlers_test.go` — routing_mode validator accepts `managed_cc`.
+- Integration smoke (NEW `integration/cc_im_test.go` in agentserver): docker-compose with imbridge mock + agentserver + cc-app-gateway:dev + fakes from Phase 2; sends a fake IM message via the imbridge mock's `/api/internal/imbridge/cc/turn` endpoint, asserts the reply comes back via the imbridge mock's `/send` endpoint within timeout.
+
+## Concurrency
+
+The ccDispatcher (per (channel_id, wechat_user_id) FIFO) gives natural serialization. Combined with Phase 2's per-session mutex on cc-app-gateway side (which serializes by (workspace_id, session_id)), the same user's WeChat messages are processed strictly in order, with cross-pod safety still bounded by sessionAffinity (Phase 2 § Open Risks #2 unchanged).
+
+Dispatcher cap = 5 (mirrors codex). Drop-oldest semantics: if a user spams 6 messages while the dispatcher is busy, the oldest queued message is silently dropped to keep the latest. Phase 4 inherits this without modification — codex's reasoning (users care more about their latest message than their oldest queued one) applies equally here.
+
+## Error handling matrix
+
+Mirror codex's mapping verbatim:
+
+| Failure | User-facing message (中文, matches codex) |
+|---|---|
+| `ccClient.RunTurn` returns transport error (network) | `"cc-app-gateway 暂时无法访问，请稍后再试"` |
+| `RunTurn` returns timeout (61min exceeded — should be impossible since runner cap is 10min) | `"对话超时，请重新发送"` |
+| `response.IsError == true && Meta.ErrorMessage contains "context"` | `"上下文已满，请新开对话（管理员请清理 session）"` |
+| `response.IsError == true` generic | `"Claude 返回错误：{ErrorMessage}"` |
+| `response.AssistantText == ""` (no text in completed turn) | `"Claude 返回为空，请重新发送"` |
+| ccDispatcher.Enqueue dropped oldest (queue full) | NO user-visible message — codex doesn't notify either (intentional; user sees their newer message processed, doesn't notice the dropped one) |
+| Workspace IM channel not bound to a workspace | Should never reach this code path (imbridge already filters); if it does, log and 400 |
+
+## Phase 4 vs prior contracts
+
+**Wire-level breaking changes from Phase 1/2:** None. cc-app-gateway's `POST /api/turns` contract unchanged. `CcTurnRequest`/`CcTurnResponse` shapes from Phase 1 stay.
+
+**Behavioral changes:**
+- agentserver gains a new internal HTTP route `/api/internal/imbridge/cc/turn`.
+- agent_sessions table gains a new column `claude_session_id` (nullable; only populated by ccInboundHandler).
+- imbridge accepts new `routing_mode=managed_cc` value.
+
+**New required env vars:** `CC_APP_GATEWAY_REST_URL` on agentserver pod. Helm template adds this conditional on `ccAppGateway.enabled`.
+
+## Migration / rollout
+
+After both Phase 1+2+4 PRs merge:
+
+1. Bump Chart.yaml minor version, push `v<version>` git tag.
+2. (Operator) Set `ccAppGateway.enabled=true` + `s3.bucket` + `s3.region` in flux config.
+3. (Operator) Set the target IM channel's `routing_mode` from `nanoclaw` (or `codex`) to `managed_cc`:
+   ```sql
+   UPDATE workspace_im_channels SET routing_mode='managed_cc' WHERE id='<channel-id>';
+   ```
+   Or via the existing PATCH endpoint on imbridgesvc.
+4. (Operator) Next message in that channel routes via cc-app-gateway → claude → reply.
+
+**Rollback:** revert routing_mode to `nanoclaw` or `codex`. Conversation history (in S3) preserved — if the channel is later re-enabled to `managed_cc`, prior turns resume.
+
+## Open risks
+
+1. **`agent_sessions.id` vs `claude_session_id` confusion.** Two IDs for the same row. Future readers might wonder which one to use where. Mitigation: clear naming, doc comments on both columns, only `claude_session_id` ever leaves the agentserver process (cc-app-gateway only sees this one; UI/audit code uses `id`).
+
+2. **No idempotency on duplicate IM messages.** imbridge may redeliver a message (rare, but possible during reconnect). cc-app-gateway sees two requests for the same session, second one resumes from first's S3 state — claude sees the message twice in its jsonl and may produce two replies. Mitigation: imbridge already has dedupe at delivery layer; Phase 4 doesn't add a second layer. Document as known.
+
+3. **Quoted message + media fields silently dropped — REGRESSION vs codex.** Phase 4 forwards only `text` to claude. A user replying to an image with a question loses the image context entirely. This is a functional REGRESSION for any channel migrating from `codex` to `managed_cc` — codex's `buildCodexInput` builds an ordered `input[]` array with quoted text and base64 images. Mitigation: emit log line + Prometheus counter `cc_im_inbound_dropped_media_total` per dropped field; document in operator runbook that switching codex → managed_cc loses image / quote context.
+
+   Phase 4.5 (NOT Phase 5+) — claude supports vision NATIVELY via the Messages API; no MCP tool required. The block is at the `claude --print` interface (only takes text on the CLI), not at the model. Phase 4.5 is a small follow-up: extend `cc-app-gateway`'s `RunInput` to carry `[]InputBlock` instead of `UserMessage string`, then pass through to stream-json's `SDKUserMessage.message.content[]` array (already supports `{type:"image",source:{...}}` per the Anthropic Messages schema). ~200 LOC; worth doing before declaring Phase 4 production-ready for image-heavy channels.
+
+4. **Dispatcher cap = 5 / drop-oldest is silent.** A user spamming 10 messages would have 5 silently dropped. The user sees the latest reply but the dropped messages are lost. Codex accepts this; Phase 4 inherits. Mitigation: only relevant for high-frequency-spam scenarios, which IM users rarely hit.
+
+5. **No per-channel model override.** All `managed_cc` channels share `CCAPPGW_DEFAULT_MODEL`. Power users wanting opus per-channel get a Phase 5 follow-up.
+
+6. **Cross-channel session collision risk:** if two different IM channels are bound to the same `workspace_id` AND a user has the same `wechat_user_id` in both (e.g. same person in two groups in the same workspace), `GetSessionByExternalID(workspace_id, wechat_user_id)` returns the SAME session — so the conversation history bleeds across channels. Codex has the same behavior. Mitigation: document as known; if it's a problem in practice, the `external_id` formula needs to include channel_id (Phase 5+).
+
+7. **ccDispatcher is a copy of codexDispatcher, not a shared package.** Two ~100-LOC implementations with subtle differences (request struct type, dispatcher key composition). If codex fixes a bug (e.g. drop-oldest semantics, channel cap), cc needs a parallel fix. Mitigation deferred — Phase 5+ may extract a generic `internal/imdispatch/` if a third backend appears or if drift causes actual bugs. Until then, two copies are cheaper than one premature abstraction.
+
+8. **codex→managed_cc migration loses conversation history.** When operators switch a channel's routing_mode, claude starts fresh — codex's prior history is invisible. Documented in Migration § Rollback. Users see "new conversation" with no warning; consider adding a one-time admin notification mechanism in Phase 5+ if migrations become common.
+
+## Acceptance
+
+A developer can:
+
+1. (Setup) Spin up the docker-compose harness from Phase 2 (`internal/ccappgateway/testdata/integration/`), then ADDITIONALLY start an agentserver instance pointing at the running cc-app-gateway:
+   ```bash
+   # NOTE: AGENTSERVER_INTERNAL_URL is cc-app-gateway's env var (it calls
+   # agentserver for /internal/workspace-token). It must be set on the
+   # cc-app-gateway PROCESS, not on agentserver. Phase 2 docker-compose
+   # already sets it correctly inside the cc-app-gateway container.
+   INTERNAL_API_SECRET=secret123 \
+   CC_APP_GATEWAY_REST_URL=http://localhost:8087 \
+   IMBRIDGE_URL=http://localhost:8090 \  # mock imbridge listener for the test
+   go run ./cmd/agentserver-go
+   ```
+
+2. Simulate an IM bridge call:
+   ```bash
+   curl -sX POST http://localhost:8080/api/internal/imbridge/cc/turn \
+     -H "X-Internal-Secret: secret123" \
+     -H "Content-Type: application/json" \
+     -d '{
+       "channel_id":     "ch_test",
+       "workspace_id":   "ws_test",
+       "wechat_user_id": "wxid_alice",
+       "wechat_sender":  "Alice",
+       "text":           "Remember code DELTA-9."
+     }'
+   # Expected: 202 + {"queued":true}
+   ```
+
+3. Within ~5 seconds, the mock imbridge listener at port 8090 receives:
+   ```json
+   POST /api/internal/imbridge/send
+   {"channel_id":"ch_test","to_user_id":"wxid_alice","text":"<claude's reply containing DELTA-9 acknowledgement>"}
+   ```
+
+4. Send a second turn for the SAME (channel, user):
+   ```bash
+   curl ... -d '{... "text":"What's the code?"}'
+   # Mock imbridge receives reply containing "DELTA-9" — proving resume across IM turns works end-to-end
+   ```
+
+5. Verify minio (via Phase 2 harness) shows the session tarball:
+   ```bash
+   docker compose -f internal/ccappgateway/testdata/integration/docker-compose.yml exec minio \
+       mc ls local/cc-app-gateway-test/cc-app-gateway/ws_test/
+   # → <uuid>.tar.gz exists; same UUID as what agent_sessions.claude_session_id stores
+   ```
+
+Integration test `TestIntegration_IMToCcEndToEnd` automates steps 2-5; included in Phase 4.
+
+## Naming: why `managed_cc` not `cc`?
+
+routing_mode values are immutable wire-level strings (stored in DB rows, referenced by operators). The `managed_` prefix distinguishes this gateway's "we run claude on the server side" mode from a future possible "user runs cc TUI locally and we proxy" mode (see [[cc_v2_1_185_gateway_feasibility]] for why the local-TUI path is technically blocked today, but it's a real product surface we don't want to permanently foreclose). Bare `cc` would force a rename if that ever ships. The `managed_` prefix is one extra word per DB row and operator command in exchange for keeping the namespace open.
+
+## Audit revisions (2026-06-22, post-self-review)
+
+Spec v1 was self-audited adversarially. Three critical + three important bugs found and patched.
+
+### Revision 1 (Critical) — `CcTurnResponse` had no `ErrorMessage` field
+
+**v1 error matrix referenced `Meta.ErrorMessage` in cc-app-gateway's HTTP response body.** That field doesn't exist in the Phase 1 contract — `CcTurnResponse` carries only `IsError bool`. The context-window-exceeded detection branch was un-implementable as written.
+
+**Patched:** Spec now amends `CcTurnResponse` (Phase 1 turn_api.go) to add `ErrorMessage string` populated from `ResultMeta.ErrorMessage` (which runner/events.go already extracts from claude's result/error SDKMessage). Phase 4 PR touches cc-app-gateway code, not only agentserver code. Updated existing Phase 2 test `TestServeHTTP_IsErrorReturned200` to assert the new field.
+
+### Revision 2 (Critical) — codex→managed_cc routing switch silently failed
+
+**v1 said:** "Non-goal: switching = new session."
+
+**Reality:** When a channel migrates `codex` → `managed_cc`, `GetSessionByExternalID` returns the existing codex row WITH `claude_session_id IS NULL`. processTurn would pass NULL to cc-app-gateway, triggering uuidRe validation 400 → user sees generic error → no clean migration path.
+
+**Patched:** processTurn flow now has explicit hit-but-NULL branch: mint fresh UUID, call `SetSessionClaudeSessionID` to persist it, continue with new claude_session_id. Codex's conversation history does NOT carry over (different agent stack), but the user gets a clean start instead of a failure. `SetSessionClaudeSessionID` setter is consequently NOT dead code.
+
+### Revision 3 (Critical) — `CreateSession()` doesn't exist on `db.DB`
+
+**v1 said:** "Modify `CreateSession()` to also mint a UUID and write `claude_session_id`."
+
+**Reality:** `CreateSession` lives on `dbSessionStore` in `codex_im_inbound.go:604-619`, NOT in `internal/db/`. Modifying a method that doesn't exist would have stalled the implementer.
+
+**Patched:** spec now specifies cc handler gets its own `ccDbSessionStore` (alongside codex's), with its own `CreateSession` mints both id and claude_session_id. The shared `sessionView` struct (in codex_im_inbound.go) gains `ClaudeSessionID string` field — zero-value `""` is fine for codex's use (it never reads the field). DB-layer changes are smaller: just add the column to the row struct + SELECT lists + add a `SetSessionClaudeSessionID` setter.
+
+### Revision 4 (Important) — Helm env-var was empty-string instead of absent
+
+**v1 used:** `value: {{ if .Values.ccAppGateway.enabled -}} "url" {{- end }}` — when disabled, renders empty string env var.
+
+**Reality:** codex's pattern wraps the entire `- name: ... value: ...` block inside `{{- if -}}` so the var is ABSENT when disabled. Operators inspecting `kubectl exec ... env` see clearer signal. `os.Getenv` returns `""` for both, so functionally equivalent, but inconsistent with project convention.
+
+**Patched:** spec now wraps entire block in conditional, matching codex pattern.
+
+### Revision 5 (Important) — `Server.Close()` lifecycle for cc dispatcher was missing
+
+**v1 didn't mention:** wiring `ccHandler.Close()` into agentserver's `Server.Close()`.
+
+**Reality:** codex does this at server.go:162. Without the analogous wiring, in-flight cc dispatcher turns get orphaned on graceful shutdown — workers blocked in `processTurn` get killed mid-S3-upload (via cc-app-gateway's own Shutdown path) but never report back to imbridge.
+
+**Patched:** spec now explicitly lists `ccHandler.Close()` in `Server.Close()` wiring.
+
+### Revision 6 (Important) — acceptance step pointed env vars at wrong process
+
+**v1 acceptance step:** passed `AGENTSERVER_INTERNAL_URL` to `go run ./cmd/agentserver-go`.
+
+**Reality:** that env var is cc-app-gateway's (it's how cc-app-gateway finds agentserver for workspace-token fetch). Setting it on agentserver itself is a no-op. Phase 2's docker-compose already sets it correctly inside the cc-app-gateway container.
+
+**Patched:** acceptance step removes the misplaced env var with an explanatory note.
+
+### Minor doc fixes also applied
+
+- `Bridge.routeMessage()` → corrected to `Bridge.forwardMessage()` at bridge.go:414.
+- `BridgeBinding.RoutingMode` doc comment update is explicit.
+- `X-Internal-Secret` header on forwardToManagedCC is explicit (not implied by "mirrors forwardToCodex").
+- Network-path assumption (pod-to-pod, no ingress) documented.
+- Concurrency ceiling (50 users × 350 MB) documented as inheriting Phase 1 Open Risk #7.
+- Misconfiguration safeguard added: startup-time DB check for managed_cc channels when ccAppGateway is disabled.
+- Media/quote drop is now explicitly labeled REGRESSION (not just "drop") with Prometheus counter + runbook note + Phase 4.5 path forward.
+- `managed_cc` naming justified.
+- Vision support correctly framed as Phase 4.5 (Anthropic Messages API native, NOT requiring MCP).
+
+### Audit findings NOT applied (deliberate)
+
+- **ccDispatcher generic extraction:** still deferred. Audit argued Phase 4 is the right moment (second consumer added). Decision: extraction can come in Phase 5+ when (a) a third backend would clearly benefit, or (b) one of the two copies diverges in a way that costs us actual bugs. Until then, two ~100-LOC copies are cheaper than one shared abstraction with two callers. Documented as Open Risk #7.
+- **Cross-channel session collision (same user in two channels in same workspace):** acknowledged as Open Risk #6 (same behavior as codex; not Phase 4's job to fix).
+- **No idempotency on duplicate IM messages:** acknowledged as Open Risk #2 (codex has same).
+- **Per-channel model override:** Phase 5+ — Open Risk #5 (all managed_cc channels share `CCAPPGW_DEFAULT_MODEL`).
+
+## Plan files
+
+- `docs/superpowers/plans/2026-06-22-cc-app-gateway-phase4.md` (TDD task breakdown — to be written next).

--- a/internal/ccappgateway/turn_api.go
+++ b/internal/ccappgateway/turn_api.go
@@ -53,6 +53,7 @@ type CcTurnResponse struct {
 	SessionID     string                       `json:"sessionId"`
 	AssistantText string                       `json:"assistantText"`
 	IsError       bool                         `json:"isError"`
+	ErrorMessage  string                       `json:"errorMessage,omitempty"` // Phase 4 error matrix
 	DurationMs    int64                        `json:"durationMs"`
 	TotalCostUSD  float64                      `json:"totalCostUsd"`
 	ModelUsage    map[string]runner.ModelUsage `json:"modelUsage,omitempty"`
@@ -218,6 +219,7 @@ func (h *TurnHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	if result.Meta != nil {
 		resp.IsError = result.Meta.IsError
+		resp.ErrorMessage = result.Meta.ErrorMessage // Phase 4 error matrix
 		resp.TotalCostUSD = result.Meta.TotalCostUSD
 		resp.ModelUsage = result.Meta.ModelUsage
 	} else {

--- a/internal/ccappgateway/turn_api_test.go
+++ b/internal/ccappgateway/turn_api_test.go
@@ -576,3 +576,34 @@ func TestServeHTTP_WorkspaceIDValidFormatAccepted(t *testing.T) {
 		})
 	}
 }
+
+func TestServeHTTP_IsErrorPopulatesErrorMessage(t *testing.T) {
+	fakeRunner := func(_ context.Context, _ runner.RunInput) (*runner.RunResult, error) {
+		return &runner.RunResult{
+			AssistantText: "",
+			Meta: &runner.ResultMeta{
+				Subtype:      "error",
+				IsError:      true,
+				ErrorMessage: "context window exceeded",
+			},
+		}, nil
+	}
+	srv := newTestServerWithStoreAndRunner(t, newFakeStore(), fakeRunner)
+	rr := postTurn(t, srv, `{"workspaceId":"ws_test","sessionId":"00000000-0000-4000-8000-000000000001","userMessage":"hi"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: %d body: %s", rr.Code, rr.Body.String())
+	}
+	var resp struct {
+		IsError      bool   `json:"isError"`
+		ErrorMessage string `json:"errorMessage"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if !resp.IsError {
+		t.Error("isError should be true")
+	}
+	if resp.ErrorMessage != "context window exceeded" {
+		t.Errorf("errorMessage: got %q, want %q", resp.ErrorMessage, "context window exceeded")
+	}
+}

--- a/internal/db/agent_sessions.go
+++ b/internal/db/agent_sessions.go
@@ -34,6 +34,7 @@ type AgentSession struct {
 	ResponderAttachedAt *time.Time
 	ActiveTurnID        *string
 	CodexThreadID       *string `json:"codex_thread_id,omitempty"`
+	ClaudeSessionID     sql.NullString
 }
 
 // AgentSessionEvent is a single event in a session's event log.
@@ -82,12 +83,12 @@ func (db *DB) GetAgentSession(id string) (*AgentSession, error) {
 		`SELECT id, sandbox_id, workspace_id, title, status, epoch, tags, im_channel_id, created_at, updated_at, archived_at,
 		        channel_type, creator_user_id, preferred_model, permission_mode,
 		        preferred_executor_id, permission_responder, responder_attached_at, active_turn_id,
-		        codex_thread_id
+		        codex_thread_id, claude_session_id
 		 FROM agent_sessions WHERE id = $1`, id,
 	).Scan(&s.ID, &sandboxID, &s.WorkspaceID, &s.Title, &s.Status, &s.Epoch, &tags, &imChannelID, &s.CreatedAt, &s.UpdatedAt, &s.ArchivedAt,
 		&s.ChannelType, &creatorUserID, &preferredModel, &s.PermissionMode,
 		&preferredExecutorID, &permissionResponder, &responderAttachedAt, &activeTurnID,
-		&codexThreadID)
+		&codexThreadID, &s.ClaudeSessionID)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -397,13 +398,13 @@ func (db *DB) GetSessionByExternalID(ctx context.Context, workspaceID, externalI
 		`SELECT id, sandbox_id, workspace_id, title, status, epoch, tags, im_channel_id, created_at, updated_at, archived_at,
 		        channel_type, creator_user_id, preferred_model, permission_mode,
 		        preferred_executor_id, permission_responder, responder_attached_at, active_turn_id,
-		        codex_thread_id
+		        codex_thread_id, claude_session_id
 		 FROM agent_sessions WHERE workspace_id = $1 AND external_id = $2`,
 		workspaceID, externalID,
 	).Scan(&s.ID, &sandboxID, &s.WorkspaceID, &s.Title, &s.Status, &s.Epoch, &tags, &imChannelID, &s.CreatedAt, &s.UpdatedAt, &s.ArchivedAt,
 		&s.ChannelType, &creatorUserID, &preferredModel, &s.PermissionMode,
 		&preferredExecutorID, &permissionResponder, &responderAttachedAt, &activeTurnID,
-		&codexThreadID)
+		&codexThreadID, &s.ClaudeSessionID)
 	if err == sql.ErrNoRows {
 		return nil, nil
 	}
@@ -688,6 +689,26 @@ func (db *DB) SetSessionCodexThreadID(ctx context.Context, sessionID string, thr
 	)
 	if err != nil {
 		return fmt.Errorf("update codex_thread_id: %w", err)
+	}
+	return nil
+}
+
+// SetSessionClaudeSessionID writes the cc-app-gateway-compatible session
+// identifier (pure UUID) for the given agent_sessions row. Used by the
+// managed_cc IM handler to record the session ID it minted, and to
+// upgrade existing codex/nanoclaw sessions when their channel migrates
+// to managed_cc (see spec § Audit Revision #2).
+func (db *DB) SetSessionClaudeSessionID(ctx context.Context, sessionID, claudeSessionID string) error {
+	res, err := db.ExecContext(ctx,
+		`UPDATE agent_sessions SET claude_session_id = $1, updated_at = NOW() WHERE id = $2`,
+		claudeSessionID, sessionID,
+	)
+	if err != nil {
+		return fmt.Errorf("SetSessionClaudeSessionID: %w", err)
+	}
+	n, _ := res.RowsAffected()
+	if n == 0 {
+		return fmt.Errorf("SetSessionClaudeSessionID: no row with id=%s", sessionID)
 	}
 	return nil
 }

--- a/internal/db/agent_sessions_test.go
+++ b/internal/db/agent_sessions_test.go
@@ -182,3 +182,57 @@ func TestListSessionsByChannel(t *testing.T) {
 		t.Errorf("first of our sessions should be cse_lbc2 (most recent), got %q", ours[0].ID)
 	}
 }
+
+func TestSetSessionClaudeSessionID(t *testing.T) {
+	db := newTestDB(t)
+	ctx := context.Background()
+
+	// Set up a row.
+	sid := "cse_cc_" + t.Name()
+	err := db.CreateAgentSessionTUI(ctx, CreateTUISessionParams{
+		ID:              sid,
+		WorkspaceID:     "ws_test",
+		ExternalID:      "tui:exe:1",
+		Title:           "test",
+		CreatorUserID:   "u_test",
+		PermissionMode:  "ask",
+		PreferredModel:  "",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { db.Exec(`DELETE FROM agent_sessions WHERE id = $1`, sid) })
+
+	// SetSessionClaudeSessionID populates the new column.
+	cid := "11111111-1111-4111-8111-111111111111"
+	if err := db.SetSessionClaudeSessionID(ctx, sid, cid); err != nil {
+		t.Fatalf("SetSessionClaudeSessionID: %v", err)
+	}
+
+	// Read it back via existing query path.
+	sess, err := db.GetAgentSession(sid)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if sess == nil {
+		t.Fatal("GetAgentSession returned nil")
+	}
+	if !sess.ClaudeSessionID.Valid || sess.ClaudeSessionID.String != cid {
+		t.Errorf("ClaudeSessionID: got %v, want %q", sess.ClaudeSessionID, cid)
+	}
+
+	// Updating an existing claude_session_id (e.g. drift) overwrites.
+	cid2 := "22222222-2222-4222-8222-222222222222"
+	if err := db.SetSessionClaudeSessionID(ctx, sid, cid2); err != nil {
+		t.Fatal(err)
+	}
+	sess, _ = db.GetAgentSession(sid)
+	if sess.ClaudeSessionID.String != cid2 {
+		t.Errorf("update didn't take: %q", sess.ClaudeSessionID.String)
+	}
+
+	// Setting on nonexistent session returns an error.
+	if err := db.SetSessionClaudeSessionID(ctx, "cse_does_not_exist", "33333333-3333-4333-8333-333333333333"); err == nil {
+		t.Error("SetSessionClaudeSessionID on missing row should error")
+	}
+}

--- a/internal/db/im_channels.go
+++ b/internal/db/im_channels.go
@@ -1,6 +1,7 @@
 package db
 
 import (
+	"context"
 	"encoding/json"
 	"time"
 )
@@ -284,6 +285,15 @@ func (db *DB) GetSandboxForChannel(channelID string) (sandboxID, podIP, bridgeSe
 		}
 	}
 	return
+}
+
+// CountIMChannelsByRoutingMode returns the number of workspace_im_channels
+// rows with the given routing_mode value. Used at startup to detect
+// misconfiguration (e.g. channels set to "managed_cc" but CC_APP_GATEWAY_REST_URL unset).
+func (db *DB) CountIMChannelsByRoutingMode(ctx context.Context, mode string) (int, error) {
+	var n int
+	err := db.QueryRowContext(ctx, `SELECT COUNT(*) FROM workspace_im_channels WHERE routing_mode = $1`, mode).Scan(&n)
+	return n, err
 }
 
 // GetIMChannelForSandbox returns the IM channel bound to a sandbox, if any.

--- a/internal/db/migrations/036_agent_sessions_claude_session_id.sql
+++ b/internal/db/migrations/036_agent_sessions_claude_session_id.sql
@@ -1,0 +1,12 @@
+-- 036_agent_sessions_claude_session_id.sql
+-- Phase 4 (cc-app-gateway IM intake): cc-app-gateway requires pure-UUID
+-- sessionId per Phase 1's turn_api.go uuidRe validation. agent_sessions.id
+-- uses "cse_<uuid>" format which doesn't satisfy that regex; this column
+-- holds the cc-app-gateway-compatible session identifier. Nullable; only
+-- populated for rows that use the managed_cc routing mode.
+ALTER TABLE agent_sessions ADD COLUMN IF NOT EXISTS claude_session_id TEXT;
+
+-- Reverse-lookup index for Phase 5+ (NOT used in Phase 4).
+CREATE INDEX IF NOT EXISTS idx_agent_sessions_claude_session_id
+    ON agent_sessions (claude_session_id)
+    WHERE claude_session_id IS NOT NULL;

--- a/internal/imbridge/bridge.go
+++ b/internal/imbridge/bridge.go
@@ -6,6 +6,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -48,7 +49,7 @@ type BridgeBinding struct {
 	ChannelID   string // workspace_im_channels.id
 	Cursor      string
 	WorkspaceID string // workspace that owns this channel
-	RoutingMode string // "nanoclaw" (default) or "codex"
+	RoutingMode string // "nanoclaw" (default), "codex", or "managed_cc" (Phase 4 cc-app-gateway)
 }
 
 // pollerEntry tracks an active poller so the bridge can both cancel it and
@@ -405,12 +406,12 @@ func (b *Bridge) pollLoop(ctx context.Context, binding BridgeBinding) {
 }
 
 // forwardMessage routes an inbound message based on the binding's RoutingMode.
-// "codex" forwards to agentserver's codex-app-gateway path; all other
-// values (including empty, for backward compatibility) forward to
-// NanoClaw. "stateless_cc" used to route to a since-removed agentserver
-// /api/workspaces/{id}/im/inbound handler (purged in #135); that route
-// is no longer accepted by the API and any DB row still carrying it
-// falls through to NanoClaw here.
+// "codex" forwards to agentserver's codex-app-gateway path; "managed_cc" (Phase 4)
+// forwards to the cc-app-gateway path; all other values (including empty, for
+// backward compatibility) forward to NanoClaw. "stateless_cc" used to route to
+// a since-removed agentserver /api/workspaces/{id}/im/inbound handler (purged
+// in #135); that route is no longer accepted by the API and any DB row still
+// carrying it falls through to NanoClaw here.
 func (b *Bridge) forwardMessage(ctx context.Context, binding BridgeBinding, msg InboundMessage) (bool, error) {
 	// In-memory routing mode (set via SetChannelRoutingMode) wins over
 	// the routing_mode captured at StartPoller time. Empty map value
@@ -422,6 +423,8 @@ func (b *Bridge) forwardMessage(ctx context.Context, binding BridgeBinding, msg 
 	switch mode {
 	case "codex":
 		return b.forwardToCodex(ctx, binding, msg)
+	case "managed_cc":
+		return b.forwardToManagedCC(ctx, binding, msg)
 	default: // "nanoclaw", "stateless_cc" (legacy), or empty
 		return b.forwardToNanoClaw(ctx, binding, msg)
 	}
@@ -479,6 +482,51 @@ func (b *Bridge) forwardToCodex(ctx context.Context, binding BridgeBinding, msg 
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusAccepted {
 		return false, fmt.Errorf("codex inbound: status %d", resp.StatusCode)
+	}
+	return true, nil
+}
+
+// forwardToManagedCC POSTs the inbound message to agentserver's
+// /api/internal/imbridge/cc/turn endpoint (Phase 4 cc-app-gateway).
+// Mirrors forwardToCodex's shape — HTTP-based, fire-and-forget
+// for the reply — that comes back via /api/internal/imbridge/send.
+func (b *Bridge) forwardToManagedCC(ctx context.Context, binding BridgeBinding, msg InboundMessage) (bool, error) {
+	payload := map[string]any{
+		"channel_id":         binding.ChannelID,
+		"workspace_id":       binding.WorkspaceID,
+		"wechat_user_id":     msg.FromUserID,
+		"wechat_sender":      msg.SenderName,
+		"text":               msg.Text,
+		"quoted_text":        msg.QuotedText,
+		"quoted_sender":      msg.QuotedSender,
+		"media_type":         msg.MediaType,
+		"media_data":         msg.MediaData,
+		"quoted_media_type":  msg.QuotedMediaType,
+		"quoted_media_data":  msg.QuotedMediaData,
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return false, fmt.Errorf("marshal managed_cc inbound: %w", err)
+	}
+	url := b.agentserverURL + "/api/internal/imbridge/cc/turn"
+	req, err := http.NewRequestWithContext(ctx, "POST", url, bytes.NewReader(body))
+	if err != nil {
+		return false, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if secret := os.Getenv("INTERNAL_API_SECRET"); secret != "" {
+		req.Header.Set("X-Internal-Secret", secret)
+	}
+	hctx, cancel := context.WithTimeout(ctx, forwardTimeout)
+	defer cancel()
+	resp, err := http.DefaultClient.Do(req.WithContext(hctx))
+	if err != nil {
+		return false, fmt.Errorf("forward managed_cc: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return false, fmt.Errorf("managed_cc inbound: status=%d body=%q", resp.StatusCode, respBody)
 	}
 	return true, nil
 }

--- a/internal/imbridge/bridge.go
+++ b/internal/imbridge/bridge.go
@@ -495,14 +495,20 @@ func (b *Bridge) forwardToManagedCC(ctx context.Context, binding BridgeBinding, 
 		"channel_id":         binding.ChannelID,
 		"workspace_id":       binding.WorkspaceID,
 		"wechat_user_id":     msg.FromUserID,
-		"wechat_sender":      msg.SenderName,
+		"wechat_sender_name": msg.SenderName,
 		"text":               msg.Text,
 		"quoted_text":        msg.QuotedText,
 		"quoted_sender":      msg.QuotedSender,
-		"media_type":         msg.MediaType,
-		"media_data":         msg.MediaData,
-		"quoted_media_type":  msg.QuotedMediaType,
-		"quoted_media_data":  msg.QuotedMediaData,
+	}
+	// Forward image bytes so cc-app-gateway turn input can carry them.
+	// Mirrors forwardToCodex's media payload shape (only include if present).
+	if len(msg.MediaData) > 0 {
+		payload["media_data"] = base64.StdEncoding.EncodeToString(msg.MediaData)
+		payload["media_type"] = msg.MediaType
+	}
+	if len(msg.QuotedMediaData) > 0 {
+		payload["quoted_media_data"] = base64.StdEncoding.EncodeToString(msg.QuotedMediaData)
+		payload["quoted_media_type"] = msg.QuotedMediaType
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {

--- a/internal/imbridge/bridge_routing_test.go
+++ b/internal/imbridge/bridge_routing_test.go
@@ -2,6 +2,9 @@ package imbridge
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -111,5 +114,171 @@ func TestForwardMessage_RoutesManagedCC(t *testing.T) {
 	}
 	if !called {
 		t.Errorf("expected POST to /api/internal/imbridge/cc/turn, got %q", receivedPath)
+	}
+}
+
+// TestForwardMessage_RoutesManagedCC_PayloadShape verifies that forwardToManagedCC
+// sends the correct JSON field names and base64-encodes media, mirroring forwardToCodex.
+func TestForwardMessage_RoutesManagedCC_PayloadShape(t *testing.T) {
+	var capturedBody []byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		capturedBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read body: %v", err)
+		}
+		w.WriteHeader(http.StatusAccepted)
+		w.Write([]byte(`{"queued":true}`))
+	}))
+	defer ts.Close()
+
+	b := &Bridge{
+		agentserverURL:   ts.URL,
+		providers:        map[string]Provider{},
+		pollers:          map[string]pollerEntry{},
+		registeredGroups: map[string]string{},
+		channelMention:   map[string]bool{},
+		channelRouting:   map[string]string{},
+		typingSessions:   map[string]func(){},
+	}
+	binding := BridgeBinding{RoutingMode: "managed_cc", WorkspaceID: "ws_test", ChannelID: "ch_test"}
+	pngMagic := []byte{0x89, 0x50, 0x4e, 0x47} // PNG magic bytes
+	msg := InboundMessage{
+		FromUserID:    "wxid_alice",
+		SenderName:    "Alice",
+		Text:          "hello world",
+		MediaType:     "image",
+		MediaData:     pngMagic,
+		QuotedText:    "previous message",
+		QuotedSender:  "Bob",
+		QuotedMediaData: []byte{0xff, 0xd8, 0xff, 0xe0}, // JPEG magic
+		QuotedMediaType: "image",
+	}
+	success, err := b.forwardMessage(context.Background(), binding, msg)
+
+	if err != nil {
+		t.Fatalf("forwardMessage returned error: %v", err)
+	}
+	if !success {
+		t.Fatalf("forwardMessage returned false, expected true")
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(capturedBody, &payload); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+
+	// Check wechat_sender_name (correct field name)
+	if got, ok := payload["wechat_sender_name"]; !ok || got != "Alice" {
+		t.Errorf("wechat_sender_name: got %q, want %q", got, "Alice")
+	}
+
+	// Ensure wechat_sender (wrong field name) is NOT present
+	if _, ok := payload["wechat_sender"]; ok {
+		t.Error("payload should not have wechat_sender field (use wechat_sender_name)")
+	}
+
+	// Check media_data is base64-encoded
+	expectedMediaData := base64.StdEncoding.EncodeToString(pngMagic)
+	if got, ok := payload["media_data"]; !ok || got != expectedMediaData {
+		t.Errorf("media_data: got %q, want %q (base64)", got, expectedMediaData)
+	}
+
+	// Check media_type is present
+	if got, ok := payload["media_type"]; !ok || got != "image" {
+		t.Errorf("media_type: got %q, want %q", got, "image")
+	}
+
+	// Check quoted fields
+	if got, ok := payload["quoted_text"]; !ok || got != "previous message" {
+		t.Errorf("quoted_text: got %q, want %q", got, "previous message")
+	}
+
+	if got, ok := payload["quoted_sender"]; !ok || got != "Bob" {
+		t.Errorf("quoted_sender: got %q, want %q", got, "Bob")
+	}
+
+	// Check quoted_media_data is base64-encoded
+	expectedQuotedMediaData := base64.StdEncoding.EncodeToString([]byte{0xff, 0xd8, 0xff, 0xe0})
+	if got, ok := payload["quoted_media_data"]; !ok || got != expectedQuotedMediaData {
+		t.Errorf("quoted_media_data: got %q, want %q (base64)", got, expectedQuotedMediaData)
+	}
+
+	// Check quoted_media_type is present
+	if got, ok := payload["quoted_media_type"]; !ok || got != "image" {
+		t.Errorf("quoted_media_type: got %q, want %q", got, "image")
+	}
+}
+
+// TestForwardMessage_RoutesManagedCC_NoMediaWhenEmpty verifies that media fields
+// are only included in the payload when present (mirrors forwardToCodex behavior).
+func TestForwardMessage_RoutesManagedCC_NoMediaWhenEmpty(t *testing.T) {
+	var capturedBody []byte
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		capturedBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read body: %v", err)
+		}
+		w.WriteHeader(http.StatusAccepted)
+		w.Write([]byte(`{"queued":true}`))
+	}))
+	defer ts.Close()
+
+	b := &Bridge{
+		agentserverURL:   ts.URL,
+		providers:        map[string]Provider{},
+		pollers:          map[string]pollerEntry{},
+		registeredGroups: map[string]string{},
+		channelMention:   map[string]bool{},
+		channelRouting:   map[string]string{},
+		typingSessions:   map[string]func(){},
+	}
+	binding := BridgeBinding{RoutingMode: "managed_cc", WorkspaceID: "ws_test", ChannelID: "ch_test"}
+	msg := InboundMessage{
+		FromUserID: "wxid_alice",
+		SenderName: "Alice",
+		Text:       "text only, no media",
+	}
+	success, err := b.forwardMessage(context.Background(), binding, msg)
+
+	if err != nil {
+		t.Fatalf("forwardMessage returned error: %v", err)
+	}
+	if !success {
+		t.Fatalf("forwardMessage returned false, expected true")
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(capturedBody, &payload); err != nil {
+		t.Fatalf("failed to unmarshal payload: %v", err)
+	}
+
+	// media_data should NOT be present when empty
+	if _, ok := payload["media_data"]; ok {
+		t.Error("payload should not have media_data field when message has no media")
+	}
+
+	// media_type should NOT be present when empty
+	if _, ok := payload["media_type"]; ok {
+		t.Error("payload should not have media_type field when message has no media")
+	}
+
+	// quoted_media_data should NOT be present when empty
+	if _, ok := payload["quoted_media_data"]; ok {
+		t.Error("payload should not have quoted_media_data field when message has no quoted media")
+	}
+
+	// quoted_media_type should NOT be present when empty
+	if _, ok := payload["quoted_media_type"]; ok {
+		t.Error("payload should not have quoted_media_type field when message has no quoted media")
+	}
+
+	// Required fields should still be present
+	if got, ok := payload["wechat_sender_name"]; !ok || got != "Alice" {
+		t.Errorf("wechat_sender_name: got %q, want %q", got, "Alice")
+	}
+	if got, ok := payload["text"]; !ok || got != "text only, no media" {
+		t.Errorf("text: got %q, want %q", got, "text only, no media")
 	}
 }

--- a/internal/imbridge/bridge_routing_test.go
+++ b/internal/imbridge/bridge_routing_test.go
@@ -1,6 +1,9 @@
 package imbridge
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
 	"sync"
 	"testing"
 )
@@ -67,5 +70,46 @@ func TestSetChannelRoutingModeConcurrent(t *testing.T) {
 
 	if b.getChannelRoutingMode("ch1") != "codex" {
 		t.Fatalf("expected codex after concurrent writes")
+	}
+}
+
+// TestForwardMessage_RoutesManagedCC verifies that forwardMessage routes
+// "managed_cc" mode to the /api/internal/imbridge/cc/turn endpoint.
+func TestForwardMessage_RoutesManagedCC(t *testing.T) {
+	var called bool
+	var receivedPath string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		if r.URL.Path == "/api/internal/imbridge/cc/turn" {
+			called = true
+			w.WriteHeader(http.StatusAccepted)
+			w.Write([]byte(`{"queued":true}`))
+		} else {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+	}))
+	defer ts.Close()
+
+	b := &Bridge{
+		agentserverURL:   ts.URL,
+		providers:        map[string]Provider{},
+		pollers:          map[string]pollerEntry{},
+		registeredGroups: map[string]string{},
+		channelMention:   map[string]bool{},
+		channelRouting:   map[string]string{},
+		typingSessions:   map[string]func(){},
+	}
+	binding := BridgeBinding{RoutingMode: "managed_cc", WorkspaceID: "ws_test", ChannelID: "ch_test"}
+	msg := InboundMessage{FromUserID: "wxid_test", Text: "hi"}
+	success, err := b.forwardMessage(context.Background(), binding, msg)
+
+	if err != nil {
+		t.Fatalf("forwardMessage returned error: %v", err)
+	}
+	if !success {
+		t.Fatalf("forwardMessage returned false, expected true")
+	}
+	if !called {
+		t.Errorf("expected POST to /api/internal/imbridge/cc/turn, got %q", receivedPath)
 	}
 }

--- a/internal/imbridgesvc/handlers.go
+++ b/internal/imbridgesvc/handlers.go
@@ -974,8 +974,8 @@ func (s *Server) handleUpdateWorkspaceIMChannel(w http.ResponseWriter, r *http.R
 		// stateless_cc is no longer accepted — the agentserver endpoint
 		// it pointed to (POST /api/workspaces/{id}/im/inbound) was
 		// removed in the #135 purge.
-		if mode != "nanoclaw" && mode != "codex" {
-			http.Error(w, "invalid routing_mode: must be nanoclaw or codex", http.StatusBadRequest)
+		if mode != "nanoclaw" && mode != "codex" && mode != "managed_cc" {
+			http.Error(w, "invalid routing_mode: must be nanoclaw, codex, or managed_cc", http.StatusBadRequest)
 			return
 		}
 		if err := s.db.UpdateIMChannelRoutingMode(channelID, mode); err != nil {

--- a/internal/imbridgesvc/handlers.go
+++ b/internal/imbridgesvc/handlers.go
@@ -971,10 +971,7 @@ func (s *Server) handleUpdateWorkspaceIMChannel(w http.ResponseWriter, r *http.R
 
 	if req.RoutingMode != nil {
 		mode := *req.RoutingMode
-		// stateless_cc is no longer accepted — the agentserver endpoint
-		// it pointed to (POST /api/workspaces/{id}/im/inbound) was
-		// removed in the #135 purge.
-		if mode != "nanoclaw" && mode != "codex" && mode != "managed_cc" {
+		if !isValidRoutingMode(mode) {
 			http.Error(w, "invalid routing_mode: must be nanoclaw, codex, or managed_cc", http.StatusBadRequest)
 			return
 		}
@@ -1260,4 +1257,10 @@ func (s *Server) handleWorkspaceMatrixConfigure(w http.ResponseWriter, r *http.R
 
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]interface{}{"connected": true, "bot_id": botID})
+}
+
+// isValidRoutingMode reports whether mode is an allowed IM channel routing
+// mode. stateless_cc was removed in the #135 purge.
+func isValidRoutingMode(mode string) bool {
+	return mode == "nanoclaw" || mode == "codex" || mode == "managed_cc"
 }

--- a/internal/imbridgesvc/handlers_test.go
+++ b/internal/imbridgesvc/handlers_test.go
@@ -1,28 +1,23 @@
 package imbridgesvc
 
-import (
-	"bytes"
-	"encoding/json"
-	"testing"
-)
+import "testing"
 
-func TestPatchIMChannel_AcceptsManagedCCRoutingMode(t *testing.T) {
-	payload := map[string]interface{}{
-		"routing_mode": "managed_cc",
+func TestIsValidRoutingMode(t *testing.T) {
+	cases := []struct {
+		mode string
+		want bool
+	}{
+		{"nanoclaw", true},
+		{"codex", true},
+		{"managed_cc", true},
+		{"stateless_cc", false}, // removed in #135 purge
+		{"", false},
+		{"unknown", false},
+		{"MANAGED_CC", false}, // case-sensitive
 	}
-	body, _ := json.Marshal(payload)
-
-	// Verify the validator logic accepts "managed_cc"
-	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&payload); err != nil {
-		t.Fatalf("failed to decode payload: %v", err)
+	for _, tc := range cases {
+		if got := isValidRoutingMode(tc.mode); got != tc.want {
+			t.Errorf("isValidRoutingMode(%q) = %v, want %v", tc.mode, got, tc.want)
+		}
 	}
-
-	mode := payload["routing_mode"].(string)
-	// This is the same condition as in handlers.go:977
-	if mode != "nanoclaw" && mode != "codex" && mode != "managed_cc" {
-		t.Errorf("managed_cc should be accepted by validator, but validator rejected it")
-		return
-	}
-
-	t.Logf("managed_cc validator check passed")
 }

--- a/internal/imbridgesvc/handlers_test.go
+++ b/internal/imbridgesvc/handlers_test.go
@@ -1,0 +1,28 @@
+package imbridgesvc
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+func TestPatchIMChannel_AcceptsManagedCCRoutingMode(t *testing.T) {
+	payload := map[string]interface{}{
+		"routing_mode": "managed_cc",
+	}
+	body, _ := json.Marshal(payload)
+
+	// Verify the validator logic accepts "managed_cc"
+	if err := json.NewDecoder(bytes.NewReader(body)).Decode(&payload); err != nil {
+		t.Fatalf("failed to decode payload: %v", err)
+	}
+
+	mode := payload["routing_mode"].(string)
+	// This is the same condition as in handlers.go:977
+	if mode != "nanoclaw" && mode != "codex" && mode != "managed_cc" {
+		t.Errorf("managed_cc should be accepted by validator, but validator rejected it")
+		return
+	}
+
+	t.Logf("managed_cc validator check passed")
+}

--- a/internal/server/cc_client.go
+++ b/internal/server/cc_client.go
@@ -1,0 +1,90 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// CcClient calls cc-app-gateway's POST /api/turns from agentserver.
+// Mirrors CodexClient (codex_client.go) — synchronous HTTP with 61-minute
+// timeout (well above cc-app-gateway's 10-minute runner cap).
+type CcClient struct {
+	baseURL string
+	secret  string
+	http    *http.Client
+}
+
+// CcTurnRequest is the JSON body POSTed to cc-app-gateway /api/turns.
+type CcTurnRequest struct {
+	WorkspaceID string `json:"workspaceId"`
+	SessionID   string `json:"sessionId"`
+	UserMessage string `json:"userMessage"`
+	Model       string `json:"model,omitempty"`
+	TimeoutMs   int    `json:"timeoutMs,omitempty"`
+}
+
+// CcTurnResponse is the JSON body returned by cc-app-gateway on 200.
+type CcTurnResponse struct {
+	SessionID     string         `json:"sessionId"`
+	AssistantText string         `json:"assistantText"`
+	IsError       bool           `json:"isError"`
+	ErrorMessage  string         `json:"errorMessage,omitempty"`
+	DurationMs    int64          `json:"durationMs"`
+	TotalCostUSD  float64        `json:"totalCostUsd"`
+	ModelUsage    map[string]any `json:"modelUsage,omitempty"`
+}
+
+// NewCcClient constructs a CcClient with the given baseURL and internal secret.
+// It trims trailing slashes from baseURL and uses a 61-minute HTTP timeout.
+func NewCcClient(baseURL, secret string) *CcClient {
+	return &CcClient{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		secret:  secret,
+		http:    &http.Client{Timeout: 61 * time.Minute},
+	}
+}
+
+// RunTurn POSTs the request to cc-app-gateway's /api/turns and decodes
+// the response. Non-2xx responses are returned as errors with the body
+// preview attached.
+func (c *CcClient) RunTurn(ctx context.Context, req CcTurnRequest) (*CcTurnResponse, error) {
+	body, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("CcClient.RunTurn marshal: %w", err)
+	}
+	hreq, err := http.NewRequestWithContext(ctx, "POST", c.baseURL+"/api/turns", bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("CcClient.RunTurn build request: %w", err)
+	}
+	hreq.Header.Set("Content-Type", "application/json")
+	if c.secret != "" {
+		hreq.Header.Set("X-Internal-Secret", c.secret)
+	}
+	hresp, err := c.http.Do(hreq)
+	if err != nil {
+		return nil, fmt.Errorf("CcClient.RunTurn do: %w", err)
+	}
+	defer hresp.Body.Close()
+	if hresp.StatusCode/100 != 2 {
+		b, _ := io.ReadAll(io.LimitReader(hresp.Body, 1024))
+		return nil, fmt.Errorf("CcClient.RunTurn: status=%d body=%q", hresp.StatusCode, b)
+	}
+	var out CcTurnResponse
+	if err := json.NewDecoder(hresp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("CcClient.RunTurn decode: %w", err)
+	}
+	return &out, nil
+}
+
+// ResolveCCAppGatewayRESTURL reads CC_APP_GATEWAY_REST_URL from env,
+// trims trailing slash. Returns "" if unset (caller treats as disabled).
+func ResolveCCAppGatewayRESTURL() string {
+	return strings.TrimRight(strings.TrimSpace(os.Getenv("CC_APP_GATEWAY_REST_URL")), "/")
+}

--- a/internal/server/cc_client_test.go
+++ b/internal/server/cc_client_test.go
@@ -1,0 +1,117 @@
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/agentserver/agentserver/internal/server"
+)
+
+func TestCcClient_RunTurn_HappyPath(t *testing.T) {
+	var gotBody string
+	var gotPath string
+	var gotSecret string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotSecret = r.Header.Get("X-Internal-Secret")
+		b, _ := io.ReadAll(r.Body)
+		gotBody = string(b)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"sessionId":     "abc-123",
+			"assistantText": "pong",
+			"isError":       false,
+			"durationMs":    int64(42),
+			"totalCostUsd":  0.0001,
+		})
+	}))
+	defer ts.Close()
+
+	c := server.NewCcClient(ts.URL, "secret123")
+	resp, err := c.RunTurn(context.Background(), server.CcTurnRequest{
+		WorkspaceID: "ws_test",
+		SessionID:   "00000000-0000-4000-8000-000000000001",
+		UserMessage: "hi",
+	})
+	if err != nil {
+		t.Fatalf("RunTurn: %v", err)
+	}
+	if gotPath != "/api/turns" {
+		t.Errorf("path: %q", gotPath)
+	}
+	if gotSecret != "secret123" {
+		t.Errorf("secret: %q", gotSecret)
+	}
+	if !strings.Contains(gotBody, `"workspaceId":"ws_test"`) {
+		t.Errorf("body missing workspaceId: %q", gotBody)
+	}
+	if resp.AssistantText != "pong" {
+		t.Errorf("AssistantText: %q", resp.AssistantText)
+	}
+}
+
+func TestCcClient_RunTurn_HTTPError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte(`{"error":"runner_failed","code":"runner_failed"}`))
+	}))
+	defer ts.Close()
+
+	c := server.NewCcClient(ts.URL, "secret123")
+	_, err := c.RunTurn(context.Background(), server.CcTurnRequest{
+		WorkspaceID: "ws", SessionID: "00000000-0000-4000-8000-000000000001", UserMessage: "hi",
+	})
+	if err == nil {
+		t.Fatal("expected error on 500")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("error should mention status: %v", err)
+	}
+}
+
+func TestCcClient_RunTurn_DecodesErrorMessage(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"sessionId":     "abc",
+			"assistantText": "",
+			"isError":       true,
+			"errorMessage":  "context window exceeded",
+			"durationMs":    int64(1000),
+		})
+	}))
+	defer ts.Close()
+
+	c := server.NewCcClient(ts.URL, "")
+	resp, err := c.RunTurn(context.Background(), server.CcTurnRequest{
+		WorkspaceID: "ws", SessionID: "00000000-0000-4000-8000-000000000001", UserMessage: "hi",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !resp.IsError {
+		t.Error("IsError should be true")
+	}
+	if resp.ErrorMessage != "context window exceeded" {
+		t.Errorf("ErrorMessage: got %q", resp.ErrorMessage)
+	}
+}
+
+func TestResolveCCAppGatewayRESTURL_Trim(t *testing.T) {
+	t.Setenv("CC_APP_GATEWAY_REST_URL", "http://cc-app-gateway.svc:8087/")
+	got := server.ResolveCCAppGatewayRESTURL()
+	if got != "http://cc-app-gateway.svc:8087" {
+		t.Errorf("trailing slash not trimmed: %q", got)
+	}
+}
+
+func TestResolveCCAppGatewayRESTURL_Empty(t *testing.T) {
+	t.Setenv("CC_APP_GATEWAY_REST_URL", "")
+	if server.ResolveCCAppGatewayRESTURL() != "" {
+		t.Errorf("empty env should return empty string")
+	}
+}

--- a/internal/server/cc_im_inbound.go
+++ b/internal/server/cc_im_inbound.go
@@ -1,0 +1,377 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/google/uuid"
+
+	"github.com/agentserver/agentserver/internal/db"
+)
+
+// ccInboundHandler routes inbound WeChat messages destined for the
+// cc-app-gateway routing path. POST /api/internal/imbridge/cc/turn body is:
+//
+//	{
+//	  "channel_id": "ch-xxx",
+//	  "workspace_id": "ws-xxx",
+//	  "wechat_user_id": "wxid_xxx",
+//	  "text": "..."
+//	}
+//
+// Returns 202 immediately and processes the turn in a goroutine.
+// A per-(channel,user) FIFO dispatcher serializes concurrent requests
+// from the same user so cc-app-gateway always sees a single in-flight
+// turn per conversation. Media and quoted fields are accepted in the
+// request body but dropped with a log warning (Phase 5+ adds vision).
+type ccInboundHandler struct {
+	cc              ccCaller
+	sessions        ccSessionStore
+	imbridgeSendURL string
+	internalSecret  string
+	dispatcher      *ccDispatcher
+}
+
+// ccCaller is the interface the cc handler needs from CcClient.
+// Defined as a local interface so tests can inject fakes without
+// depending on the concrete *CcClient type.
+type ccCaller interface {
+	RunTurn(ctx context.Context, req CcTurnRequest) (*CcTurnResponse, error)
+}
+
+// ccSessionStore is what the cc handler needs from the DB. It is a
+// separate interface from codex's sessionStore so the two handlers
+// remain independent per spec Open Risk #7.
+type ccSessionStore interface {
+	GetSessionByExternalID(ctx context.Context, workspaceID, externalID string) (sessionView, error)
+	CreateSession(ctx context.Context, workspaceID, externalID, title, imChannelID string) (sessionView, error)
+	// SetClaudeSessionID persists a newly-minted claude_session_id for
+	// an existing session (migration from codex/nanoclaw → managed_cc).
+	SetClaudeSessionID(ctx context.Context, sessionID, claudeSessionID string) error
+}
+
+// ccInboundRequest is the JSON body POSTed by imbridge to the cc turn endpoint.
+// Media and quoted fields mirror codex's request shape so imbridge can use the
+// same payload constructor — but for Phase 4 only the text field is forwarded
+// to cc-app-gateway. The rest is dropped with a log warning.
+type ccInboundRequest struct {
+	ChannelID    string `json:"channel_id"`
+	WorkspaceID  string `json:"workspace_id"`
+	WechatUserID string `json:"wechat_user_id"`
+	WechatSender string `json:"wechat_sender_name,omitempty"`
+	Text         string `json:"text"`
+	QuotedText   string `json:"quoted_text,omitempty"`
+	QuotedSender string `json:"quoted_sender,omitempty"`
+	// Media fields — accepted but dropped in Phase 4 (Phase 5+ adds vision).
+	MediaType       string `json:"media_type,omitempty"`
+	MediaData       string `json:"media_data,omitempty"` // base64
+	QuotedMediaType string `json:"quoted_media_type,omitempty"`
+	QuotedMediaData string `json:"quoted_media_data,omitempty"` // base64
+}
+
+func (h *ccInboundHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	var req ccInboundRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid json", http.StatusBadRequest)
+		return
+	}
+	if req.ChannelID == "" || req.WorkspaceID == "" || req.WechatUserID == "" {
+		http.Error(w, "channel_id, workspace_id, wechat_user_id required", http.StatusBadRequest)
+		return
+	}
+	w.WriteHeader(http.StatusAccepted)
+	_, _ = w.Write([]byte(`{"queued":true}`))
+	h.dispatcher.Enqueue(req)
+}
+
+func (h *ccInboundHandler) processTurn(ctx context.Context, req ccInboundRequest) {
+	externalID := req.WechatUserID
+
+	// Step 1: look up existing session.
+	sess, err := h.sessions.GetSessionByExternalID(ctx, req.WorkspaceID, externalID)
+	if err != nil {
+		log.Printf("cc_im: resolve session channel=%s user=%s: %v", req.ChannelID, externalID, err)
+		h.sendError(ctx, req, "⚠️ 内部错误，请重试")
+		return
+	}
+
+	// Step 2: create session on first contact.
+	if sess.ID == "" {
+		title := "IM: " + req.WechatSender
+		if title == "IM: " {
+			title = "IM: " + req.WechatUserID
+		}
+		sess, err = h.sessions.CreateSession(ctx, req.WorkspaceID, externalID, title, req.ChannelID)
+		if err != nil {
+			log.Printf("cc_im: create session channel=%s user=%s: %v", req.ChannelID, externalID, err)
+			h.sendError(ctx, req, "⚠️ 内部错误，请重试")
+			return
+		}
+	}
+
+	// Step 3: migration — existing codex/nanoclaw session has no ClaudeSessionID.
+	// Mint a fresh UUID and persist it. Codex history is NOT carried over.
+	if sess.ClaudeSessionID == "" {
+		newUUID := uuid.NewString()
+		log.Printf("cc_im: session migrating from codex/nanoclaw to managed_cc channel=%s user=%s session=%s new_claude_session_id=%s",
+			req.ChannelID, externalID, sess.ID, newUUID)
+		if err := h.sessions.SetClaudeSessionID(ctx, sess.ID, newUUID); err != nil {
+			log.Printf("cc_im: set claude_session_id channel=%s user=%s: %v", req.ChannelID, externalID, err)
+			h.sendError(ctx, req, "⚠️ 内部错误，请重试")
+			return
+		}
+		sess.ClaudeSessionID = newUUID
+	}
+
+	// Step 4: drop media + quoted fields with a log warning (Phase 5+ adds vision).
+	if req.MediaType != "" || req.QuotedText != "" || req.MediaData != "" || req.QuotedMediaType != "" || req.QuotedMediaData != "" {
+		log.Printf("cc_im: Phase 4 drops media/quoted fields channel=%s user=%s media_type=%q quoted_text_len=%d",
+			req.ChannelID, externalID, req.MediaType, len(req.QuotedText))
+	}
+
+	// Step 5: call cc-app-gateway.
+	resp, err := h.cc.RunTurn(ctx, CcTurnRequest{
+		WorkspaceID: req.WorkspaceID,
+		SessionID:   sess.ClaudeSessionID,
+		UserMessage: req.Text,
+	})
+
+	// Step 6: error matrix dispatch.
+	if err != nil {
+		log.Printf("cc_im: RunTurn channel=%s user=%s: %v", req.ChannelID, externalID, err)
+		h.sendError(ctx, req, "cc-app-gateway 暂时无法访问，请稍后再试")
+		return
+	}
+
+	if resp.IsError {
+		if strings.Contains(resp.ErrorMessage, "context") {
+			h.sendError(ctx, req, "上下文已满，请新开对话（管理员请清理 session）")
+			return
+		}
+		h.sendError(ctx, req, "Claude 返回错误："+resp.ErrorMessage)
+		return
+	}
+
+	if resp.AssistantText == "" {
+		h.sendError(ctx, req, "Claude 返回为空，请重新发送")
+		return
+	}
+
+	// Step 7: happy path — send the assistant's reply.
+	h.sendText(ctx, req, resp.AssistantText)
+}
+
+// sendText / sendError both POST /api/internal/imbridge/send.
+
+func (h *ccInboundHandler) sendText(ctx context.Context, req ccInboundRequest, text string) {
+	h.postSend(ctx, map[string]any{
+		"channel_id": req.ChannelID,
+		"to_user_id": req.WechatUserID,
+		"text":       text,
+	})
+}
+
+func (h *ccInboundHandler) sendError(ctx context.Context, req ccInboundRequest, text string) {
+	h.postSend(ctx, map[string]any{
+		"channel_id": req.ChannelID,
+		"to_user_id": req.WechatUserID,
+		"text":       text,
+	})
+}
+
+func (h *ccInboundHandler) postSend(ctx context.Context, body map[string]any) {
+	b, _ := json.Marshal(body)
+	r, err := http.NewRequestWithContext(ctx, "POST", h.imbridgeSendURL+"/api/internal/imbridge/send", bytes.NewReader(b))
+	if err != nil {
+		log.Printf("cc_im: build send req: %v", err)
+		return
+	}
+	r.Header.Set("Content-Type", "application/json")
+	if h.internalSecret != "" {
+		r.Header.Set("X-Internal-Secret", h.internalSecret)
+	}
+	resp, err := http.DefaultClient.Do(r)
+	if err != nil {
+		log.Printf("cc_im: send POST: %v", err)
+		return
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		b, _ := io.ReadAll(resp.Body)
+		log.Printf("cc_im: send status=%d body=%s", resp.StatusCode, b)
+	}
+}
+
+// newCcInboundHandler wires up the handler with its dispatcher already running.
+// Cap is the per-(channel,user) queue depth — past cap, drop-oldest applies.
+func newCcInboundHandler(cc ccCaller, sessions ccSessionStore, imbridgeSendURL, internalSecret string) *ccInboundHandler {
+	h := &ccInboundHandler{
+		cc:              cc,
+		sessions:        sessions,
+		imbridgeSendURL: imbridgeSendURL,
+		internalSecret:  internalSecret,
+	}
+	h.dispatcher = newCcDispatcher(func(req ccInboundRequest) {
+		h.processTurn(context.Background(), req)
+	}, 5)
+	return h
+}
+
+// Close stops the FIFO dispatcher. Safe to call multiple times.
+// In-flight worker goroutines complete their current task then exit.
+func (h *ccInboundHandler) Close() {
+	h.dispatcher.Stop()
+}
+
+// --- per-(channel,user) FIFO dispatcher ---
+// Verbatim copy of codexDispatcher with ccInboundRequest substituted for
+// codexInboundRequest. NOT extracted to a generic package per spec Open Risk #7.
+
+type ccDispatcher struct {
+	processFn func(ccInboundRequest)
+	cap       int
+
+	mu      sync.Mutex
+	workers map[string]*ccDispatcherSlot
+	stopped bool
+}
+
+type ccDispatcherSlot struct {
+	ch    chan ccInboundRequest
+	ready chan struct{}
+}
+
+func newCcDispatcher(processFn func(ccInboundRequest), cap int) *ccDispatcher {
+	return &ccDispatcher{
+		processFn: processFn,
+		cap:       cap,
+		workers:   make(map[string]*ccDispatcherSlot),
+	}
+}
+
+func ccDispatcherKey(req ccInboundRequest) string {
+	return req.ChannelID + ":" + req.WechatUserID
+}
+
+// Enqueue adds req to the per-key channel. If the channel is full,
+// drains the oldest queued item to make room (drop-oldest policy).
+// Starts a worker for this key if none is running.
+func (d *ccDispatcher) Enqueue(req ccInboundRequest) {
+	key := ccDispatcherKey(req)
+	d.mu.Lock()
+	if d.stopped {
+		d.mu.Unlock()
+		return
+	}
+	slot, ok := d.workers[key]
+	if !ok {
+		slot = &ccDispatcherSlot{
+			ch:    make(chan ccInboundRequest, d.cap),
+			ready: make(chan struct{}),
+		}
+		d.workers[key] = slot
+		slot.ch <- req // buffered, never blocks (fresh channel, cap >= 1)
+		go d.runWorker(key, slot)
+		d.mu.Unlock()
+		<-slot.ready
+		return
+	}
+	d.mu.Unlock()
+
+	for {
+		select {
+		case slot.ch <- req:
+			return
+		default:
+			// Full — drop oldest then retry.
+			select {
+			case <-slot.ch:
+			default:
+			}
+		}
+	}
+}
+
+func (d *ccDispatcher) runWorker(key string, slot *ccDispatcherSlot) {
+	first, ok := <-slot.ch
+	close(slot.ready) // unblock the spawning Enqueue
+	if !ok {
+		return
+	}
+	d.processFn(first)
+	for req := range slot.ch {
+		d.processFn(req)
+	}
+	_ = key
+}
+
+func (d *ccDispatcher) Stop() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.stopped {
+		return
+	}
+	d.stopped = true
+	for _, slot := range d.workers {
+		close(slot.ch)
+	}
+	d.workers = nil
+}
+
+// --- ccDbSessionStore: production ccSessionStore ---
+
+// ccDbSessionStore is the production ccSessionStore that reads/writes
+// the real agent_sessions table. Separate from codex's dbSessionStore —
+// the two handlers remain independent.
+type ccDbSessionStore struct {
+	db *db.DB
+}
+
+func (s *ccDbSessionStore) GetSessionByExternalID(ctx context.Context, workspaceID, externalID string) (sessionView, error) {
+	sess, err := s.db.GetSessionByExternalID(ctx, workspaceID, externalID)
+	if err != nil {
+		return sessionView{}, err
+	}
+	if sess == nil {
+		return sessionView{}, nil
+	}
+	return sessionView{
+		ID:              sess.ID,
+		CodexThreadID:   sess.CodexThreadID,
+		ClaudeSessionID: sess.ClaudeSessionID.String,
+	}, nil
+}
+
+func (s *ccDbSessionStore) CreateSession(ctx context.Context, workspaceID, externalID, title, imChannelID string) (sessionView, error) {
+	sessionID := "cse_" + uuid.NewString()
+	claudeSessionID := uuid.NewString() // pure UUID, no prefix — cc-app-gateway's session ID
+	if err := s.db.CreateAgentSession(sessionID, nil, workspaceID, title, nil); err != nil {
+		return sessionView{}, fmt.Errorf("create session: %w", err)
+	}
+	if err := s.db.SetSessionExternalID(ctx, sessionID, externalID); err != nil {
+		return sessionView{}, fmt.Errorf("set external_id: %w", err)
+	}
+	if err := s.db.SetSessionClaudeSessionID(ctx, sessionID, claudeSessionID); err != nil {
+		return sessionView{}, fmt.Errorf("set claude_session_id: %w", err)
+	}
+	if imChannelID != "" {
+		if err := s.db.SetSessionIMChannel(ctx, sessionID, imChannelID); err != nil {
+			log.Printf("cc_im: failed to set im_channel_id for session %s: %v", sessionID, err)
+		}
+	}
+	return sessionView{
+		ID:              sessionID,
+		ClaudeSessionID: claudeSessionID,
+	}, nil
+}
+
+func (s *ccDbSessionStore) SetClaudeSessionID(ctx context.Context, sessionID, claudeSessionID string) error {
+	return s.db.SetSessionClaudeSessionID(ctx, sessionID, claudeSessionID)
+}

--- a/internal/server/cc_im_inbound_route_test.go
+++ b/internal/server/cc_im_inbound_route_test.go
@@ -1,0 +1,48 @@
+package server
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newTestServer creates a minimal *Server suitable for route-registration tests.
+// It does NOT open a database connection (DB is nil); the misconfiguration
+// safeguard in Router() guards against nil DB, so this is safe.
+func newTestServer(t *testing.T) *Server {
+	t.Helper()
+	return &Server{}
+}
+
+// TestServer_CcInboundRouteRegistered verifies that the cc inbound route is
+// registered (i.e. NOT 404) when CC_APP_GATEWAY_REST_URL is set.
+func TestServer_CcInboundRouteRegistered(t *testing.T) {
+	t.Setenv("CC_APP_GATEWAY_REST_URL", "http://cc-app-gateway:8087")
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	// The route is registered; an unauthenticated POST should return 401 (auth
+	// middleware fires), NOT 404 (route not found).
+	req := httptest.NewRequest("POST", "/api/internal/imbridge/cc/turn", bytes.NewReader([]byte(`{}`)))
+	rr := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rr, req)
+	if rr.Code == http.StatusNotFound {
+		t.Errorf("cc inbound route should be registered when CC_APP_GATEWAY_REST_URL is set; got 404")
+	}
+}
+
+// TestServer_CcInboundRouteSkippedWhenURLEmpty verifies that the cc inbound
+// route is absent (404) when CC_APP_GATEWAY_REST_URL is empty.
+func TestServer_CcInboundRouteSkippedWhenURLEmpty(t *testing.T) {
+	t.Setenv("CC_APP_GATEWAY_REST_URL", "")
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	req := httptest.NewRequest("POST", "/api/internal/imbridge/cc/turn", bytes.NewReader([]byte(`{}`)))
+	rr := httptest.NewRecorder()
+	srv.Router().ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("cc inbound route should NOT be registered when CC_APP_GATEWAY_REST_URL is empty; got %d", rr.Code)
+	}
+}

--- a/internal/server/cc_im_inbound_test.go
+++ b/internal/server/cc_im_inbound_test.go
@@ -1,0 +1,670 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// fakeCcSessionStore implements ccSessionStore for tests.
+type fakeCcSessionStore struct {
+	mu       sync.Mutex
+	sessions map[string]sessionView // key: workspaceID+":"+externalID
+	created  []sessionView
+
+	// onSetClaudeSessionID is called when SetClaudeSessionID is invoked (optional).
+	onSetClaudeSessionID func(sessionID, claudeSessionID string) error
+}
+
+func newFakeCcSessionStore() *fakeCcSessionStore {
+	return &fakeCcSessionStore{
+		sessions: make(map[string]sessionView),
+	}
+}
+
+func (f *fakeCcSessionStore) GetSessionByExternalID(_ context.Context, workspaceID, externalID string) (sessionView, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	key := workspaceID + ":" + externalID
+	sess, ok := f.sessions[key]
+	if !ok {
+		return sessionView{}, nil
+	}
+	return sess, nil
+}
+
+func (f *fakeCcSessionStore) CreateSession(_ context.Context, workspaceID, externalID, title, imChannelID string) (sessionView, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	sess := sessionView{
+		ID:              "cse_created-" + externalID,
+		ClaudeSessionID: "claude-created-" + externalID,
+	}
+	key := workspaceID + ":" + externalID
+	f.sessions[key] = sess
+	f.created = append(f.created, sess)
+	_ = title
+	_ = imChannelID
+	return sess, nil
+}
+
+func (f *fakeCcSessionStore) SetClaudeSessionID(_ context.Context, sessionID, claudeSessionID string) error {
+	if f.onSetClaudeSessionID != nil {
+		return f.onSetClaudeSessionID(sessionID, claudeSessionID)
+	}
+	return nil
+}
+
+// fakeCcClient records RunTurn calls and returns canned responses.
+type fakeCcClient struct {
+	mu     sync.Mutex
+	calls  []CcTurnRequest
+	resp   *CcTurnResponse
+	err    error
+	turnFn func(req CcTurnRequest) (*CcTurnResponse, error)
+}
+
+func (f *fakeCcClient) RunTurn(_ context.Context, req CcTurnRequest) (*CcTurnResponse, error) {
+	f.mu.Lock()
+	f.calls = append(f.calls, req)
+	fn := f.turnFn
+	f.mu.Unlock()
+	if fn != nil {
+		return fn(req)
+	}
+	return f.resp, f.err
+}
+
+func (f *fakeCcClient) lastCall() (CcTurnRequest, bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.calls) == 0 {
+		return CcTurnRequest{}, false
+	}
+	return f.calls[len(f.calls)-1], true
+}
+
+func (f *fakeCcClient) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.calls)
+}
+
+// newCcInboundTestRequest creates an HTTP request for the cc inbound handler.
+func newCcInboundTestRequest(body map[string]any) *http.Request {
+	b, _ := json.Marshal(body)
+	return httptest.NewRequest("POST", "/api/internal/imbridge/cc/turn", bytes.NewReader(b))
+}
+
+// happyCcResponse is a CcTurnResponse for the happy path.
+func happyCcResponse(text string) *CcTurnResponse {
+	return &CcTurnResponse{AssistantText: text, IsError: false}
+}
+
+// waitForCc blocks until cond returns true or 2s elapses.
+func waitForCc(t *testing.T, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("waitForCc: condition never satisfied")
+}
+
+// --- Test 1: NewSession path ---
+
+func TestCcInbound_NewSession(t *testing.T) {
+	sendURL, sends, stop := newCapturingImbridge(t)
+	defer stop()
+
+	store := newFakeCcSessionStore()
+	client := &fakeCcClient{resp: happyCcResponse("session created response")}
+
+	h := newCcInboundHandler(client, store, sendURL, "")
+	defer h.Close()
+
+	r := newCcInboundTestRequest(map[string]any{
+		"channel_id":     "ch-1",
+		"workspace_id":   "ws-1",
+		"wechat_user_id": "wxid_new",
+		"text":           "hello",
+	})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("status=%d want 202", w.Code)
+	}
+
+	waitForCc(t, func() bool { return len(sends.Load().([]*capturedSend)) == 1 })
+
+	// CreateSession should have been called.
+	store.mu.Lock()
+	createdCount := len(store.created)
+	store.mu.Unlock()
+	if createdCount != 1 {
+		t.Errorf("CreateSession called %d times, want 1", createdCount)
+	}
+
+	// RunTurn should have been called with the new claude_session_id.
+	req, ok := client.lastCall()
+	if !ok {
+		t.Fatal("RunTurn not called")
+	}
+	if req.SessionID == "" {
+		t.Error("RunTurn called with empty SessionID — want the newly minted claude_session_id")
+	}
+	if req.WorkspaceID != "ws-1" {
+		t.Errorf("RunTurn WorkspaceID=%q want ws-1", req.WorkspaceID)
+	}
+
+	got := sends.Load().([]*capturedSend)[0]
+	if got.text != "session created response" {
+		t.Errorf("reply text=%q want 'session created response'", got.text)
+	}
+}
+
+// --- Test 2: ExistingCcSession reused ---
+
+func TestCcInbound_ExistingCcSessionReused(t *testing.T) {
+	sendURL, sends, stop := newCapturingImbridge(t)
+	defer stop()
+
+	store := newFakeCcSessionStore()
+	store.sessions["ws-1:wxid_existing"] = sessionView{
+		ID:              "cse_existing",
+		ClaudeSessionID: "existing-claude-id",
+	}
+
+	var setCalled int32
+	store.onSetClaudeSessionID = func(_, _ string) error {
+		atomic.AddInt32(&setCalled, 1)
+		return nil
+	}
+
+	client := &fakeCcClient{resp: happyCcResponse("existing session reply")}
+	h := newCcInboundHandler(client, store, sendURL, "")
+	defer h.Close()
+
+	r := newCcInboundTestRequest(map[string]any{
+		"channel_id":     "ch-1",
+		"workspace_id":   "ws-1",
+		"wechat_user_id": "wxid_existing",
+		"text":           "second message",
+	})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	waitForCc(t, func() bool { return len(sends.Load().([]*capturedSend)) == 1 })
+
+	// No CreateSession — session already existed.
+	store.mu.Lock()
+	createdCount := len(store.created)
+	store.mu.Unlock()
+	if createdCount != 0 {
+		t.Errorf("CreateSession called %d times, want 0 (session already exists)", createdCount)
+	}
+
+	// SetClaudeSessionID must NOT be called — session already had a claude_session_id.
+	if atomic.LoadInt32(&setCalled) != 0 {
+		t.Error("SetClaudeSessionID called unexpectedly — session already had ClaudeSessionID")
+	}
+
+	// RunTurn called with the existing claude session id.
+	req, ok := client.lastCall()
+	if !ok {
+		t.Fatal("RunTurn not called")
+	}
+	if req.SessionID != "existing-claude-id" {
+		t.Errorf("RunTurn SessionID=%q want 'existing-claude-id'", req.SessionID)
+	}
+}
+
+// --- Test 3: Migration from codex/nanoclaw (has ID but no ClaudeSessionID) ---
+
+func TestCcInbound_MigrationFromCodex(t *testing.T) {
+	sendURL, sends, stop := newCapturingImbridge(t)
+	defer stop()
+
+	store := newFakeCcSessionStore()
+	codexThreadID := "thr-legacy"
+	store.sessions["ws-1:wxid_legacy"] = sessionView{
+		ID:            "cse_legacy",
+		CodexThreadID: &codexThreadID,
+		// ClaudeSessionID is empty — simulates a codex/nanoclaw session
+	}
+
+	var setCalledWith struct {
+		sessionID       string
+		claudeSessionID string
+	}
+	var setCalled int32
+	store.onSetClaudeSessionID = func(sessionID, claudeSessionID string) error {
+		atomic.AddInt32(&setCalled, 1)
+		setCalledWith.sessionID = sessionID
+		setCalledWith.claudeSessionID = claudeSessionID
+		// Also update the in-memory session so subsequent gets work.
+		store.mu.Lock()
+		sess := store.sessions["ws-1:wxid_legacy"]
+		sess.ClaudeSessionID = claudeSessionID
+		store.sessions["ws-1:wxid_legacy"] = sess
+		store.mu.Unlock()
+		return nil
+	}
+
+	client := &fakeCcClient{resp: happyCcResponse("migrated reply")}
+	h := newCcInboundHandler(client, store, sendURL, "")
+	defer h.Close()
+
+	r := newCcInboundTestRequest(map[string]any{
+		"channel_id":     "ch-1",
+		"workspace_id":   "ws-1",
+		"wechat_user_id": "wxid_legacy",
+		"text":           "first cc message",
+	})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	waitForCc(t, func() bool { return len(sends.Load().([]*capturedSend)) == 1 })
+
+	if atomic.LoadInt32(&setCalled) != 1 {
+		t.Fatalf("SetClaudeSessionID called %d times, want 1", atomic.LoadInt32(&setCalled))
+	}
+	if setCalledWith.sessionID != "cse_legacy" {
+		t.Errorf("SetClaudeSessionID sessionID=%q want 'cse_legacy'", setCalledWith.sessionID)
+	}
+	if setCalledWith.claudeSessionID == "" {
+		t.Error("SetClaudeSessionID claudeSessionID is empty — should be a new UUID")
+	}
+
+	// RunTurn should use the newly minted UUID, not the old codex thread ID.
+	req, ok := client.lastCall()
+	if !ok {
+		t.Fatal("RunTurn not called")
+	}
+	if req.SessionID != setCalledWith.claudeSessionID {
+		t.Errorf("RunTurn SessionID=%q want %q (newly minted)", req.SessionID, setCalledWith.claudeSessionID)
+	}
+
+	got := sends.Load().([]*capturedSend)[0]
+	if got.text != "migrated reply" {
+		t.Errorf("reply=%q want 'migrated reply'", got.text)
+	}
+}
+
+// --- Test 4: Transport error sends Chinese error message ---
+
+func TestCcInbound_TransportError_SendsErrorMessage(t *testing.T) {
+	sendURL, sends, stop := newCapturingImbridge(t)
+	defer stop()
+
+	store := newFakeCcSessionStore()
+	store.sessions["ws-1:wxid_err"] = sessionView{
+		ID:              "cse_err",
+		ClaudeSessionID: "claude-err",
+	}
+
+	client := &fakeCcClient{
+		err: &testTransportError{msg: "connection refused"},
+	}
+	h := newCcInboundHandler(client, store, sendURL, "")
+	defer h.Close()
+
+	r := newCcInboundTestRequest(map[string]any{
+		"channel_id":     "ch-1",
+		"workspace_id":   "ws-1",
+		"wechat_user_id": "wxid_err",
+		"text":           "test",
+	})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	waitForCc(t, func() bool { return len(sends.Load().([]*capturedSend)) == 1 })
+
+	got := sends.Load().([]*capturedSend)[0]
+	if !strings.Contains(got.text, "cc-app-gateway") || !strings.Contains(got.text, "暂时无法访问") {
+		t.Errorf("error text=%q — want message containing 'cc-app-gateway' and '暂时无法访问'", got.text)
+	}
+}
+
+// testTransportError is a simple error type for testing transport failures.
+type testTransportError struct{ msg string }
+
+func (e *testTransportError) Error() string { return e.msg }
+
+// --- Test 5: Context window error ---
+
+func TestCcInbound_IsErrorContextWindow_SendsSpecificMessage(t *testing.T) {
+	sendURL, sends, stop := newCapturingImbridge(t)
+	defer stop()
+
+	store := newFakeCcSessionStore()
+	store.sessions["ws-1:wxid_ctx"] = sessionView{
+		ID:              "cse_ctx",
+		ClaudeSessionID: "claude-ctx",
+	}
+
+	client := &fakeCcClient{resp: &CcTurnResponse{
+		IsError:      true,
+		ErrorMessage: "context length exceeded — too many tokens in context window",
+	}}
+	h := newCcInboundHandler(client, store, sendURL, "")
+	defer h.Close()
+
+	r := newCcInboundTestRequest(map[string]any{
+		"channel_id":     "ch-1",
+		"workspace_id":   "ws-1",
+		"wechat_user_id": "wxid_ctx",
+		"text":           "test",
+	})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	waitForCc(t, func() bool { return len(sends.Load().([]*capturedSend)) == 1 })
+
+	got := sends.Load().([]*capturedSend)[0]
+	if !strings.Contains(got.text, "上下文已满") {
+		t.Errorf("error text=%q — want message containing '上下文已满'", got.text)
+	}
+}
+
+// --- Test 6: Empty assistant text treated as error ---
+
+func TestCcInbound_EmptyAssistantText_SendsErrorMessage(t *testing.T) {
+	sendURL, sends, stop := newCapturingImbridge(t)
+	defer stop()
+
+	store := newFakeCcSessionStore()
+	store.sessions["ws-1:wxid_empty"] = sessionView{
+		ID:              "cse_empty",
+		ClaudeSessionID: "claude-empty",
+	}
+
+	client := &fakeCcClient{resp: &CcTurnResponse{
+		IsError:       false,
+		AssistantText: "", // empty — should be treated as error
+	}}
+	h := newCcInboundHandler(client, store, sendURL, "")
+	defer h.Close()
+
+	r := newCcInboundTestRequest(map[string]any{
+		"channel_id":     "ch-1",
+		"workspace_id":   "ws-1",
+		"wechat_user_id": "wxid_empty",
+		"text":           "test",
+	})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	waitForCc(t, func() bool { return len(sends.Load().([]*capturedSend)) == 1 })
+
+	got := sends.Load().([]*capturedSend)[0]
+	if !strings.Contains(got.text, "返回为空") {
+		t.Errorf("error text=%q — want message containing '返回为空'", got.text)
+	}
+}
+
+// --- Test 7: Media fields dropped ---
+
+func TestCcInbound_MediaFieldsDropped(t *testing.T) {
+	sendURL, sends, stop := newCapturingImbridge(t)
+	defer stop()
+
+	store := newFakeCcSessionStore()
+	store.sessions["ws-1:wxid_media"] = sessionView{
+		ID:              "cse_media",
+		ClaudeSessionID: "claude-media",
+	}
+
+	client := &fakeCcClient{resp: happyCcResponse("text only reply")}
+	h := newCcInboundHandler(client, store, sendURL, "")
+	defer h.Close()
+
+	r := newCcInboundTestRequest(map[string]any{
+		"channel_id":     "ch-1",
+		"workspace_id":   "ws-1",
+		"wechat_user_id": "wxid_media",
+		"text":           "caption only",
+		"media_type":     "image",
+		"media_data":     "aGVsbG8=", // base64("hello") — won't be read
+		"quoted_text":    "earlier quote",
+	})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	waitForCc(t, func() bool { return len(sends.Load().([]*capturedSend)) == 1 })
+
+	// RunTurn must receive only the text, not media.
+	req, ok := client.lastCall()
+	if !ok {
+		t.Fatal("RunTurn not called")
+	}
+	if req.UserMessage != "caption only" {
+		t.Errorf("RunTurn UserMessage=%q want 'caption only'", req.UserMessage)
+	}
+	// Response should be the happy path text (media was silently dropped).
+	got := sends.Load().([]*capturedSend)[0]
+	if got.text != "text only reply" {
+		t.Errorf("reply=%q want 'text only reply'", got.text)
+	}
+}
+
+// --- Test 8: Dispatcher serializes same user ---
+
+func TestCcInbound_DispatcherSerializesSameUser(t *testing.T) {
+	sendURL, sends, stop := newCapturingImbridge(t)
+	defer stop()
+
+	store := newFakeCcSessionStore()
+	store.sessions["ws-1:wxid_serial"] = sessionView{
+		ID:              "cse_serial",
+		ClaudeSessionID: "claude-serial",
+	}
+
+	// Slow client: first call blocks until signaled, second call returns immediately.
+	firstStarted := make(chan struct{})
+	firstUnblock := make(chan struct{})
+	var callOrder []int
+	var mu sync.Mutex
+
+	client := &fakeCcClient{
+		turnFn: func(req CcTurnRequest) (*CcTurnResponse, error) {
+			mu.Lock()
+			n := len(callOrder) + 1
+			callOrder = append(callOrder, n)
+			mu.Unlock()
+			if n == 1 {
+				close(firstStarted)
+				<-firstUnblock // block until test unblocks
+			}
+			return happyCcResponse("reply " + req.UserMessage), nil
+		},
+	}
+
+	h := newCcInboundHandler(client, store, sendURL, "")
+	defer h.Close()
+
+	// Send first request.
+	r1 := newCcInboundTestRequest(map[string]any{
+		"channel_id":     "ch-1",
+		"workspace_id":   "ws-1",
+		"wechat_user_id": "wxid_serial",
+		"text":           "first",
+	})
+	h.ServeHTTP(httptest.NewRecorder(), r1)
+
+	// Wait until first call has started.
+	select {
+	case <-firstStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first call never started")
+	}
+
+	// Now enqueue second request — same (channel, user).
+	r2 := newCcInboundTestRequest(map[string]any{
+		"channel_id":     "ch-1",
+		"workspace_id":   "ws-1",
+		"wechat_user_id": "wxid_serial",
+		"text":           "second",
+	})
+	h.ServeHTTP(httptest.NewRecorder(), r2)
+
+	// Verify second hasn't started yet (first is still blocked).
+	time.Sleep(50 * time.Millisecond)
+	mu.Lock()
+	countSoFar := len(callOrder)
+	mu.Unlock()
+	if countSoFar != 1 {
+		t.Errorf("second call started before first finished: callOrder=%v", callOrder)
+	}
+
+	// Unblock first, both should complete.
+	close(firstUnblock)
+
+	waitForCc(t, func() bool { return len(sends.Load().([]*capturedSend)) == 2 })
+
+	mu.Lock()
+	order := make([]int, len(callOrder))
+	copy(order, callOrder)
+	mu.Unlock()
+	if len(order) != 2 || order[0] != 1 || order[1] != 2 {
+		t.Errorf("call order=%v want [1 2]", order)
+	}
+}
+
+// --- Test 9: Dispatcher runs different users in parallel ---
+
+func TestCcInbound_DispatcherParallelDifferentUsers(t *testing.T) {
+	sendURL, sends, stop := newCapturingImbridge(t)
+	defer stop()
+
+	store := newFakeCcSessionStore()
+	store.sessions["ws-1:wxid_para1"] = sessionView{ID: "cse_p1", ClaudeSessionID: "claude-p1"}
+	store.sessions["ws-1:wxid_para2"] = sessionView{ID: "cse_p2", ClaudeSessionID: "claude-p2"}
+
+	// Both calls block until both have started — proves parallelism.
+	bothStarted := make(chan struct{})
+	var startCount int32
+	unblock := make(chan struct{})
+
+	client := &fakeCcClient{
+		turnFn: func(req CcTurnRequest) (*CcTurnResponse, error) {
+			n := atomic.AddInt32(&startCount, 1)
+			if n == 2 {
+				close(bothStarted)
+			}
+			<-unblock
+			return happyCcResponse("parallel reply"), nil
+		},
+	}
+
+	h := newCcInboundHandler(client, store, sendURL, "")
+	defer h.Close()
+
+	r1 := newCcInboundTestRequest(map[string]any{
+		"channel_id":     "ch-1",
+		"workspace_id":   "ws-1",
+		"wechat_user_id": "wxid_para1",
+		"text":           "user1 msg",
+	})
+	r2 := newCcInboundTestRequest(map[string]any{
+		"channel_id":     "ch-1",
+		"workspace_id":   "ws-1",
+		"wechat_user_id": "wxid_para2",
+		"text":           "user2 msg",
+	})
+
+	h.ServeHTTP(httptest.NewRecorder(), r1)
+	h.ServeHTTP(httptest.NewRecorder(), r2)
+
+	// Both calls should start concurrently within 2s.
+	select {
+	case <-bothStarted:
+		// success — both ran in parallel
+	case <-time.After(2 * time.Second):
+		t.Fatalf("parallel calls did not both start; startCount=%d", atomic.LoadInt32(&startCount))
+	}
+
+	close(unblock)
+	waitForCc(t, func() bool { return len(sends.Load().([]*capturedSend)) == 2 })
+}
+
+// --- Test: 202 response shape ---
+
+func TestCcInbound_Returns202WithQueuedTrue(t *testing.T) {
+	sendURL, _, stop := newCapturingImbridge(t)
+	defer stop()
+
+	store := newFakeCcSessionStore()
+	store.sessions["ws-1:wxid_q"] = sessionView{ID: "cse_q", ClaudeSessionID: "claude-q"}
+	client := &fakeCcClient{resp: happyCcResponse("ok")}
+
+	h := newCcInboundHandler(client, store, sendURL, "")
+	defer h.Close()
+
+	r := newCcInboundTestRequest(map[string]any{
+		"channel_id":     "ch-1",
+		"workspace_id":   "ws-1",
+		"wechat_user_id": "wxid_q",
+		"text":           "hi",
+	})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	if w.Code != 202 {
+		t.Fatalf("status=%d want 202", w.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("body not JSON: %v", err)
+	}
+	if body["queued"] != true {
+		t.Errorf("body=%v — want {queued:true}", body)
+	}
+}
+
+// --- Test: Generic IsError ---
+
+func TestCcInbound_GenericIsError_SendsErrorMessage(t *testing.T) {
+	sendURL, sends, stop := newCapturingImbridge(t)
+	defer stop()
+
+	store := newFakeCcSessionStore()
+	store.sessions["ws-1:wxid_gerr"] = sessionView{ID: "cse_gerr", ClaudeSessionID: "claude-gerr"}
+	client := &fakeCcClient{resp: &CcTurnResponse{
+		IsError:      true,
+		ErrorMessage: "some backend failure detail",
+	}}
+
+	h := newCcInboundHandler(client, store, sendURL, "")
+	defer h.Close()
+
+	r := newCcInboundTestRequest(map[string]any{
+		"channel_id":     "ch-1",
+		"workspace_id":   "ws-1",
+		"wechat_user_id": "wxid_gerr",
+		"text":           "hi",
+	})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, r)
+
+	waitForCc(t, func() bool { return len(sends.Load().([]*capturedSend)) == 1 })
+
+	got := sends.Load().([]*capturedSend)[0]
+	if !strings.Contains(got.text, "Claude 返回错误") {
+		t.Errorf("error text=%q — want message containing 'Claude 返回错误'", got.text)
+	}
+	if !strings.Contains(got.text, "some backend failure detail") {
+		t.Errorf("error text=%q — want ErrorMessage included", got.text)
+	}
+}

--- a/internal/server/cc_im_integration_test.go
+++ b/internal/server/cc_im_integration_test.go
@@ -1,0 +1,298 @@
+//go:build integration
+
+// Package server_test provides an end-to-end integration test that proves the
+// IM → cc-app-gateway → claude → reply round-trip works.
+//
+// Requirements:
+//   - docker (29+) and docker compose (5+) must be available.
+//   - TEST_DATABASE_URL must be set to a live PostgreSQL database with all
+//     migrations applied (used to store agent_sessions for turn continuity).
+//   - The test brings up the Phase 2 docker-compose stack (cc-app-gateway +
+//     minio + fake-llmproxy + fake-agentserver) on host port 8087, then runs
+//     an in-process agentserver that routes to it.
+//
+// Run:
+//
+//	go test -tags integration -v -timeout 10m -run TestIntegration_IMToCcEndToEnd ./internal/server/
+package server_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/agentserver/agentserver/internal/db"
+	"github.com/agentserver/agentserver/internal/server"
+)
+
+// TestIntegration_IMToCcEndToEnd proves the full IM → agentserver →
+// cc-app-gateway → fake-llmproxy → imbridge reply round-trip, including
+// session resume across two consecutive turns.
+//
+// Architecture:
+//
+//	[test] POST /api/internal/imbridge/cc/turn
+//	  → in-process agentserver (httptest.Server)
+//	  → cc-app-gateway:8087 (docker-compose)
+//	  → fake-llmproxy (docker-compose)
+//	  → reply via POST /api/internal/imbridge/send
+//	  → fake-imbridge (httptest.Server in this test)
+//
+// Resume is verified by checking the fake-llmproxy request log: turn 2's
+// request MUST include "DELTA-9" from turn 1's conversation history.
+func TestIntegration_IMToCcEndToEnd(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test: skipped in short mode")
+	}
+	if os.Getenv("TEST_DATABASE_URL") == "" {
+		t.Skip("TEST_DATABASE_URL unset — skipping IM end-to-end integration test")
+	}
+
+	// ── Step 1: Bring up Phase 2 docker-compose ────────────────────────────────
+	// Resolve the absolute path from this test file's package directory.
+	composeDir, err := filepath.Abs("../ccappgateway/testdata/integration")
+	if err != nil {
+		t.Fatalf("resolve compose dir: %v", err)
+	}
+
+	// build + up (idempotent; uses cached docker layers on repeat runs).
+	runMakeIM(t, composeDir, "build")
+	runMakeIM(t, composeDir, "up")
+	t.Cleanup(func() { runMakeIMBestEffort(t, composeDir, "down") })
+
+	// ── Step 2: Wait for cc-app-gateway readyz ─────────────────────────────────
+	waitForReadyzIM(t, "http://localhost:8087/readyz", 90*time.Second)
+
+	// ── Step 3: Spin up a fake-imbridge that records /api/internal/imbridge/send
+	var mu sync.Mutex
+	var sendCalls []map[string]any
+	fakeImbridge := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/internal/imbridge/send" {
+			var payload map[string]any
+			if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+				t.Logf("fake-imbridge: decode body: %v", err)
+			}
+			mu.Lock()
+			sendCalls = append(sendCalls, payload)
+			mu.Unlock()
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"status":"sent"}`))
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(fakeImbridge.Close)
+
+	// ── Step 4: Open test DB ───────────────────────────────────────────────────
+	dbURL := os.Getenv("TEST_DATABASE_URL")
+	d, err := db.Open(dbURL)
+	if err != nil {
+		t.Fatalf("open test DB: %v", err)
+	}
+	t.Cleanup(func() { d.Close() })
+
+	// ── Step 5: Ensure workspace exists in DB ─────────────────────────────────
+	// agent_sessions has a FK to workspaces; create the row if absent.
+	wsID := "ws_cc_im_integration_test"
+	if err := d.CreateWorkspace(wsID, "CC IM Integration Test Workspace"); err != nil {
+		// Ignore "already exists" errors — the workspace may persist across test runs.
+		t.Logf("CreateWorkspace (may already exist): %v", err)
+	}
+	t.Cleanup(func() {
+		d.DeleteWorkspace(wsID) //nolint:errcheck — best-effort cleanup
+	})
+
+	// ── Step 6: Build in-process agentserver ──────────────────────────────────
+	// Env vars must be set before Router() reads them.
+	t.Setenv("INTERNAL_API_SECRET", "secret123")
+	t.Setenv("CC_APP_GATEWAY_REST_URL", "http://localhost:8087")
+	// CC route uses s.IMBridgeURL as the send-back URL; set it on the struct.
+
+	srv := &server.Server{
+		DB:          d,
+		IMBridgeURL: fakeImbridge.URL,
+	}
+	t.Cleanup(srv.Close)
+	agentserverTS := httptest.NewServer(srv.Router())
+	t.Cleanup(agentserverTS.Close)
+
+	// ── Step 7: Turns — post IM messages through agentserver ──────────────────
+	turnBody := func(text string) string {
+		return `{"channel_id":"ch_cc_im_test","workspace_id":"` + wsID + `","wechat_user_id":"wxid_alice","wechat_sender_name":"Alice","text":"` + text + `"}`
+	}
+	body1 := turnBody("Remember code DELTA-9.")
+	postIMRequest(t, agentserverTS.URL, "secret123", body1)
+
+	// Wait for fake-imbridge to receive the reply (fake-llmproxy replies "pong").
+	waitForSendCallsIM(t, &mu, &sendCalls, 1, 90*time.Second)
+	mu.Lock()
+	t.Logf("turn 1 reply from fake-imbridge: %v", sendCalls[0])
+	mu.Unlock()
+
+	// ── Step 8: Turn 2 — ask claude to recall the marker ─────────────────────
+	body2 := turnBody("What was the code I just gave you?")
+	postIMRequest(t, agentserverTS.URL, "secret123", body2)
+
+	waitForSendCallsIM(t, &mu, &sendCalls, 2, 90*time.Second)
+	mu.Lock()
+	t.Logf("turn 2 reply from fake-imbridge: %v", sendCalls[1])
+	mu.Unlock()
+
+	// ── Step 8: Verify resume — DELTA-9 must appear in fake-llmproxy log ──────
+	// fake-llmproxy always returns "pong" as the reply text, so we cannot
+	// check the reply itself. Instead, we verify that turn 2's Anthropic API
+	// request body (logged by fake-llmproxy) contains "DELTA-9" from turn 1's
+	// conversation history. This proves claude resumed the session and sent
+	// the full history rather than starting fresh.
+	logContent := readFakeLLMProxyLogIM(t, composeDir)
+	t.Logf("fake-llmproxy request log:\n%s", logContent)
+	if !strings.Contains(logContent, "DELTA-9") {
+		runMakeIMBestEffort(t, composeDir, "logs")
+		t.Errorf("fake-llmproxy request log should contain 'DELTA-9' from turn 1 history (proves session resume); log:\n%s", logContent)
+	}
+
+	// Both turns must have produced replies.
+	mu.Lock()
+	defer mu.Unlock()
+	if len(sendCalls) < 2 {
+		t.Fatalf("expected 2 replies from fake-imbridge, got %d", len(sendCalls))
+	}
+	// Sanity: each reply has a channel_id and text.
+	for i, call := range sendCalls[:2] {
+		if call["channel_id"] == nil {
+			t.Errorf("sendCalls[%d] missing channel_id: %v", i, call)
+		}
+		if call["text"] == nil {
+			t.Errorf("sendCalls[%d] missing text: %v", i, call)
+		}
+	}
+	t.Logf("PASS: turn 1 reply=%q turn 2 reply=%q DELTA-9 in llmproxy log=%v",
+		sendCalls[0]["text"], sendCalls[1]["text"],
+		strings.Contains(logContent, "DELTA-9"))
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+// runMakeIM calls `make <target>` in dir; fails the test on non-zero exit.
+func runMakeIM(t *testing.T, dir, target string) {
+	t.Helper()
+	cmd := exec.Command("make", "-C", dir, target)
+	var buf strings.Builder
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	out := buf.String()
+	if out != "" {
+		t.Logf("make %s output:\n%s", target, out)
+	}
+	if err != nil {
+		t.Fatalf("make %s in %s: %v", target, dir, err)
+	}
+}
+
+// runMakeIMBestEffort runs make <target> but logs rather than fatals on error.
+// Use for diagnostic calls (e.g., "logs") and cleanup callbacks.
+func runMakeIMBestEffort(t *testing.T, dir, target string) {
+	t.Helper()
+	cmd := exec.Command("make", "-C", dir, target)
+	var buf strings.Builder
+	cmd.Stdout = &buf
+	cmd.Stderr = &buf
+	err := cmd.Run()
+	out := buf.String()
+	if out != "" {
+		t.Logf("make %s output:\n%s", target, out)
+	}
+	if err != nil {
+		t.Logf("make %s (best-effort): %v", target, err)
+	}
+}
+
+// waitForReadyzIM polls url every second until it returns 200 or deadline passes.
+func waitForReadyzIM(t *testing.T, url string, timeout time.Duration) {
+	t.Helper()
+	start := time.Now()
+	client := &http.Client{Timeout: 2 * time.Second}
+	var lastErr string
+	for {
+		if time.Since(start) > timeout {
+			t.Fatalf("readyz %s never became healthy after %v; last: %s", url, timeout, lastErr)
+		}
+		resp, err := client.Get(url)
+		if err == nil {
+			raw, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
+			if resp.StatusCode == http.StatusOK {
+				t.Logf("readyz OK after %v", time.Since(start).Round(time.Millisecond))
+				return
+			}
+			lastErr = fmt.Sprintf("status=%d body=%s", resp.StatusCode, raw)
+		} else {
+			lastErr = err.Error()
+		}
+		time.Sleep(1 * time.Second)
+	}
+}
+
+// waitForSendCallsIM blocks until len(sendCalls) >= n or the timeout elapses.
+func waitForSendCallsIM(t *testing.T, mu *sync.Mutex, sendCalls *[]map[string]any, n int, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		mu.Lock()
+		cur := len(*sendCalls)
+		mu.Unlock()
+		if cur >= n {
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	mu.Lock()
+	cur := len(*sendCalls)
+	mu.Unlock()
+	t.Fatalf("fake-imbridge: timed out waiting for %d send call(s); got %d after %v", n, cur, timeout)
+}
+
+// postIMRequest POSTs body to the agentserver's /api/internal/imbridge/cc/turn
+// and asserts 202 Accepted.
+func postIMRequest(t *testing.T, baseURL, secret, body string) {
+	t.Helper()
+	req, err := http.NewRequest("POST", baseURL+"/api/internal/imbridge/cc/turn", bytes.NewReader([]byte(body)))
+	if err != nil {
+		t.Fatalf("build IM request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Internal-Secret", secret)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /api/internal/imbridge/cc/turn: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		raw, _ := io.ReadAll(resp.Body)
+		t.Fatalf("POST /api/internal/imbridge/cc/turn: expected 202, got %d: %s", resp.StatusCode, raw)
+	}
+}
+
+// readFakeLLMProxyLogIM reads the fake-llmproxy request log from inside its container.
+func readFakeLLMProxyLogIM(t *testing.T, testdataAbs string) string {
+	t.Helper()
+	cmd := exec.Command("docker", "compose", "-f", filepath.Join(testdataAbs, "docker-compose.yml"),
+		"exec", "-T", "fake-llmproxy", "cat", "/tmp/llmproxy-requests.log")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Logf("readFakeLLMProxyLogIM: %v (output: %s)", err, out)
+		return ""
+	}
+	return string(out)
+}

--- a/internal/server/codex_im_inbound.go
+++ b/internal/server/codex_im_inbound.go
@@ -55,8 +55,9 @@ type sessionStore interface {
 // sessionView is the subset of agent_sessions fields the codex handler
 // needs. Decoupled from db.AgentSession to keep test fakes small.
 type sessionView struct {
-	ID            string
-	CodexThreadID *string
+	ID              string
+	CodexThreadID   *string
+	ClaudeSessionID string  // Phase 4: cc-app-gateway-compatible session ID; "" for non-managed_cc sessions
 }
 
 type codexInboundRequest struct {
@@ -594,7 +595,11 @@ func (s *dbSessionStore) GetSessionByExternalID(ctx context.Context, workspaceID
 		// Not found — return empty sessionView so caller can create.
 		return sessionView{}, nil
 	}
-	return sessionView{ID: sess.ID, CodexThreadID: sess.CodexThreadID}, nil
+	return sessionView{
+		ID:              sess.ID,
+		CodexThreadID:   sess.CodexThreadID,
+		ClaudeSessionID: sess.ClaudeSessionID.String,
+	}, nil
 }
 
 func (s *dbSessionStore) SetSessionCodexThreadID(ctx context.Context, sessionID string, threadID *string) error {
@@ -615,5 +620,9 @@ func (s *dbSessionStore) CreateSession(ctx context.Context, workspaceID, externa
 			log.Printf("codex_im: failed to set im_channel_id for session %s: %v", sessionID, err)
 		}
 	}
-	return sessionView{ID: sessionID, CodexThreadID: nil}, nil
+	return sessionView{
+		ID:              sessionID,
+		CodexThreadID:   nil,
+		ClaudeSessionID: "", // newly created session has no Claude session ID
+	}, nil
 }

--- a/internal/server/e2e_tui_stubs_test.go
+++ b/internal/server/e2e_tui_stubs_test.go
@@ -1,0 +1,49 @@
+//go:build integration
+
+// Package server provides stubs for the e2e_tui_test.go test which references
+// the old TUI API (removed with the stateless-cc stack). The stubs make the
+// file compile but always skip the test.
+package server
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// newTestServerForEvents returns nil to signal that the TUI E2E test should be
+// skipped. The TUI API (handleTUIEventStream, handleTUIInbound,
+// handlePermissionDecision) was removed with the stateless-cc stack.
+func newTestServerForEvents(t *testing.T, _ string) (*Server, func()) {
+	t.Helper()
+	t.Skip("TUI API removed — e2e_tui_test.go is a relic; skipping")
+	return nil, nil
+}
+
+// mustAuthRequest constructs a fake authenticated HTTP request for TUI tests.
+// Only reached if newTestServerForEvents returns non-nil (it never does).
+func mustAuthRequest(t *testing.T, method, path, body string) *http.Request {
+	t.Helper()
+	var r *http.Request
+	if body != "" {
+		r = httptest.NewRequest(method, path, nil)
+	} else {
+		r = httptest.NewRequest(method, path, nil)
+	}
+	return r
+}
+
+// handleTUIEventStream is a stub for the removed TUI event-stream handler.
+func (s *Server) handleTUIEventStream(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "TUI API removed", http.StatusGone)
+}
+
+// handleTUIInbound is a stub for the removed TUI inbound handler.
+func (s *Server) handleTUIInbound(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "TUI API removed", http.StatusGone)
+}
+
+// handlePermissionDecision is a stub for the removed TUI permission handler.
+func (s *Server) handlePermissionDecision(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "TUI API removed", http.StatusGone)
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -95,6 +95,10 @@ type Server struct {
 	// configured. Kept here so Close() can stop its dispatcher.
 	codexHandler *codexInboundHandler
 
+	// ccHandler is set by Router() when CC_APP_GATEWAY_REST_URL is
+	// configured. Kept here so Close() can stop its dispatcher.
+	ccHandler *ccInboundHandler
+
 	// imBridgeProxy is set by Router() when IMBridgeURL is non-empty.
 	// Stored here so per-route wrapper methods (im_routes.go) can call it.
 	imBridgeProxy http.HandlerFunc
@@ -156,11 +160,14 @@ func New(a *auth.Auth, oidcMgr *auth.OIDCManager, database *db.DB, sandboxStore 
 }
 
 // Close releases resources owned by the Server. Safe to call after
-// Router() returns; a no-op if called before Router() or if the codex
-// routing path was not configured.
+// Router() returns; a no-op if called before Router() or if the routing
+// paths were not configured.
 func (s *Server) Close() {
 	if s.codexHandler != nil {
 		s.codexHandler.Close()
+	}
+	if s.ccHandler != nil {
+		s.ccHandler.Close()
 	}
 }
 
@@ -390,6 +397,40 @@ func (s *Server) Router() http.Handler {
 		})
 	} else {
 		log.Printf("server: codex routing endpoint disabled (set CODEX_APP_GATEWAY_REST_URL to enable)")
+	}
+
+	// CC routing path: WeChat (and other channels) with routing_mode="managed_cc"
+	// land here. Skipped when CC_APP_GATEWAY_REST_URL is unset, so dev envs
+	// without cc-app-gateway silently disable the endpoint.
+	ccURL := ResolveCCAppGatewayRESTURL()
+	if ccURL != "" {
+		log.Printf("server: cc routing endpoint enabled, cc=%s", ccURL)
+		ccClient := NewCcClient(ccURL, os.Getenv("INTERNAL_API_SECRET"))
+		imbridgeSendURL := s.IMBridgeURL
+		if imbridgeSendURL == "" {
+			imbridgeSendURL = "http://127.0.0.1:8080"
+		}
+		s.ccHandler = newCcInboundHandler(ccClient, &ccDbSessionStore{db: s.DB}, imbridgeSendURL, os.Getenv("INTERNAL_API_SECRET"))
+		ccHandler := s.ccHandler
+		r.Post("/api/internal/imbridge/cc/turn", func(w http.ResponseWriter, r *http.Request) {
+			secret := os.Getenv("INTERNAL_API_SECRET")
+			if secret != "" {
+				if r.Header.Get("X-Internal-Secret") != secret {
+					http.Error(w, "unauthorized", http.StatusUnauthorized)
+					return
+				}
+			}
+			ccHandler.ServeHTTP(w, r)
+		})
+	} else {
+		log.Printf("server: cc routing endpoint disabled (set CC_APP_GATEWAY_REST_URL to enable)")
+		// Misconfiguration safeguard: warn if any channels are set to managed_cc
+		// but the gateway URL is not configured — those channels will fail.
+		if s.DB != nil {
+			if n, err := s.DB.CountIMChannelsByRoutingMode(context.Background(), "managed_cc"); err == nil && n > 0 {
+				log.Printf("[server] WARNING: %d IM channel(s) have routing_mode=managed_cc but CC_APP_GATEWAY_REST_URL is unset — those channels will fail until cc-app-gateway is enabled", n)
+			}
+		}
 	}
 
 	// Agent registration (auth via OAuth Bearer token).


### PR DESCRIPTION
## Summary

Phase 4 of cc-app-gateway: **IM intake on the agentserver side**. With this PR merged, a WeChat message routed through imbridge with \`routing_mode=managed_cc\` reaches claude via cc-app-gateway and the reply round-trips back to WeChat. This is the user-visible *\"I can talk to claude from my phone\"* milestone.

## Stacking order ⚠️

This PR is the **third in a three-PR stack**. Base branch is \`feat/cc-app-gateway-phase2\`, NOT \`main\`.

\`\`\`
main
 └── feat/cc-app-gateway-phase1  (PR #279) ← must merge first
      └── feat/cc-app-gateway-phase2  (PR #280) ← must merge second
           └── feat/cc-app-gateway-phase4  (this PR) ← merge last
\`\`\`

Reviewers: view diff against \`feat/cc-app-gateway-phase2\` (22 files / +3937 / -19 LOC for the Phase 4 delta only).

## What's in this PR

**Database**
- Migration #036 adds \`agent_sessions.claude_session_id\` (TEXT NULL, indexed WHERE NOT NULL). Additive + nullable — safe to apply under live traffic.
- New setter \`SetSessionClaudeSessionID\`. Existing sessions get the column populated on first managed_cc turn.

**cc-app-gateway**
- \`CcTurnResponse.ErrorMessage\` field added so Phase 4 can construct user-facing error strings from the gateway's structured error.

**agentserver intake**
- \`cc_client.go\`: HTTP client agentserver→cc-app-gateway, 61-min timeout, mirrors codex_client.
- \`cc_im_inbound.go\` + \`ccInboundHandler\` + \`ccDispatcher\` (per-(channel, user) FIFO, cap=5, drop-oldest — copy of codexDispatcher; generic extraction deferred to Phase 5+).
- Session migration path: existing codex sessions reused on first managed_cc turn with NULL→UUID claude_session_id mint. Codex history is **not** carried over (announce before flipping a busy channel).
- Error matrix: transport / IsError+context / IsError generic / empty / happy — each path tested and sends back to imbridge /send.

**imbridge**
- \`forwardToManagedCC()\` mirrors forwardToCodex (\`wechat_sender_name\` field + conditional base64 media).
- Switch case \`\"managed_cc\"\` added to routing dispatch.
- \`imbridgesvc\` validator accepts \`managed_cc\`.

**Server lifecycle**
- Conditional route registration (only when \`CC_APP_GATEWAY_REST_URL\` is set).
- \`Server.Close()\` drains the cc dispatcher.
- Startup misconfiguration safeguard: WARN if managed_cc channels exist but the gateway URL is unset.

**Helm**
- \`CC_APP_GATEWAY_REST_URL\` env var on the agentserver pod, gated on \`ccAppGateway.enabled\`.

**Tests**
- Per-component unit tests for handler, dispatcher, store, error matrix, migration path.
- Real \`isValidRoutingMode\` helper extracted + table-driven test (replaces a tautological test the final reviewer flagged).
- Integration test (\`cc_im_integration_test.go\`, \`//go:build integration\`): docker-compose brings up cc-app-gateway + minio + fake-llmproxy + Postgres; in-process agentserver + httptest fake-imbridge. Two turns same (channel, user): turn 1 *\"Remember code DELTA-9.\"*, turn 2 *\"What was the code I just gave you?\"*. Asserts \"DELTA-9\" appears in fake-llmproxy's turn-2 request body — proves resume worked end-to-end.

## Audit revisions applied (spec v1 → v2)

The spec ran an adversarial self-audit before any code was written; 6 revisions landed:

| # | Issue | Fix |
|---|---|---|
| 1 | CcTurnResponse missing structured error → can't build error matrix | Added ErrorMessage field |
| 2 | Hit-but-NULL claude_session_id branch missing → first managed_cc turn after codex would crash | Mint UUID + persist via SetSessionClaudeSessionID |
| 3 | ccDbSessionStore in internal/db/ would create cyclic import | Lives in cc_im_inbound.go |
| 4 | Helm env var only had value gated, not whole \`- name:\` block → broken YAML when disabled | Whole block in conditional |
| 5 | Server.Close() didn't drain cc dispatcher → goroutine leak on shutdown | Nil-safe Close() added |
| 6 | Acceptance step had wrong process for env var | Doc fix |

## Functional regression to announce

On routing_mode switch \`codex → managed_cc\` for an existing channel, the existing conversation history is NOT carried over to claude. Documented in spec § Open Risk #8, tested in \`TestCcInbound_MigrationFromCodex\`. Operators flipping a busy channel should announce a session reset.

## Cross-cutting cleanup callouts

- \`internal/server/e2e_tui_stubs_test.go\` (new) — pre-existing \`e2e_tui_test.go\` referenced symbols removed in #135 but only compiled when nothing else under \`//go:build integration\` forced it. Phase 4's new integration test forces it; stubbing the 3 missing methods was the minimal compile-fix. NOT a TUI regression.
- \`internal/ccappgateway/turn_api.go\`: response shape extension is backward compatible (omitempty).

## Test plan

- [ ] CI green
- [ ] \`go test ./...\` — unit suite
- [ ] \`go test -tags integration ./internal/ccappgateway/... ./internal/server/...\` — integration suite (requires docker)
- [ ] Helm lint / template render with \`ccAppGateway.enabled=true/false\`
- [ ] Manual smoke after stack merges: flip a workspace's IM channel routing_mode to managed_cc, send a WeChat message, get a claude reply
- [ ] After all 3 PRs merge: bump \`deploy/helm/agentserver/Chart.yaml\` minor + push \`v<version>\` tag