### PR TITLE
chore(chart): bump 0.69.5 → 0.69.6 to ship #279/#280/#281

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.69.5
-appVersion: "0.69.5"
+version: 0.69.6
+appVersion: "0.69.6"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
Bumps Chart.yaml from 0.69.5 to 0.69.6 so the next \`pulumi up\` picks up cc-app-gateway Phase 1+2+4:

- #279 — Phase 1: cc-app-gateway service skeleton (per-turn claude --print subprocess)
- #280 — Phase 2: S3 workspace persistence + session resume
- #281 — Phase 4: IM intake (\`managed_cc\` routing_mode; WeChat → claude end-to-end)

Per [[agentserver_release_flow]]: after merge, push \`v0.69.6\` git tag so registry images get the version tag (otherwise pulumi ImagePullBackOff).