### PR TITLE
fix(chart): map cc-app-gateway s3 secret to AWS_ACCESS_KEY_ID/SECRET (bump 0.69.7)

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.69.6
-appVersion: "0.69.6"
+version: 0.69.7
+appVersion: "0.69.7"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/deploy/helm/agentserver/templates/cc-app-gateway.yaml
+++ b/deploy/helm/agentserver/templates/cc-app-gateway.yaml
@@ -60,9 +60,16 @@ spec:
             - name: CCAPPGW_S3_PATH_STYLE
               value: {{ .Values.ccAppGateway.s3.pathStyle | quote }}
 {{- if .Values.ccAppGateway.s3.existingSecret }}
-          envFrom:
-            - secretRef:
-                name: {{ .Values.ccAppGateway.s3.existingSecret }}
+            - name: AWS_ACCESS_KEY_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.ccAppGateway.s3.existingSecret }}
+                  key: access_key_id
+            - name: AWS_SECRET_ACCESS_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.ccAppGateway.s3.existingSecret }}
+                  key: secret_access_key
 {{- end }}
           volumeMounts:
             - name: cc-gateway-tmp


### PR DESCRIPTION
\`envFrom: secretRef\` was injecting the s3 secret keys verbatim as env vars \`access_key_id\` / \`secret_access_key\` (lowercase). aws-sdk-go-v2's default credential chain doesn't recognize those — it looks for \`AWS_ACCESS_KEY_ID\` / \`AWS_SECRET_ACCESS_KEY\`. Result: SDK fell through to EC2 IMDS lookup, hung waiting for \`169.254.169.254\`, the HTTP listener never started, pod stayed \`0/1 Ready\` forever, helm-agentserver timed out.

Reproduced live on nj-prod after #282 deploy. Pod's only TCP socket was an ESTABLISHED outbound to ~10.96.x.x — no LISTEN socket on port 8087.

Fix mirrors codex-app-gateway's pattern: explicit \`secretKeyRef\` for each key, mapped to the env var names AWS SDK reads natively.

Chart bumped to 0.69.7.

Post-merge: push \`v0.69.7\` git tag, then \`pulumi up\` again.