### PR TITLE
feat(web): add "claude code" option to IM channel routing_mode dropdown

### DIFF
--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -199,7 +199,7 @@ type IMChannelListResponse struct {
 
 // IMChannelPatchRequest is the body for PATCH /api/workspaces/{id}/im/channels/{channelId}.
 // Both fields are optional — only the supplied keys are applied.
-// routing_mode must be "nanoclaw" or "codex".
+// routing_mode must be "nanoclaw", "codex", or "managed_cc".
 type IMChannelPatchRequest struct {
 	RequireMention *bool   `json:"require_mention" extensions:"x-nullable=true"`
 	RoutingMode    *string `json:"routing_mode" extensions:"x-nullable=true" example:"codex"`

--- a/web/src/components/WorkspaceDetail.tsx
+++ b/web/src/components/WorkspaceDetail.tsx
@@ -1165,16 +1165,17 @@ function IMTab({ workspaceId }: { workspaceId: string }) {
                             onChange={async (e) => {
                               try {
                                 await updateWorkspaceIMChannel(workspaceId, ch.id, {
-                                  routing_mode: e.target.value as 'nanoclaw' | 'codex',
+                                  routing_mode: e.target.value as 'nanoclaw' | 'codex' | 'managed_cc',
                                 })
                                 loadChannels()
                               } catch {}
                             }}
                             className="w-full rounded border border-[var(--border)] bg-[var(--background)] px-1.5 py-0.5 text-[11px] text-[var(--foreground)]"
-                            title="Routing mode: nanoclaw = legacy NanoClaw sandbox; codex = Codex via codex-app-gateway"
+                            title="Routing mode: nanoclaw = legacy NanoClaw sandbox; codex = Codex via codex-app-gateway; managed_cc = Claude Code via cc-app-gateway"
                           >
                             <option value="nanoclaw">nanoclaw</option>
                             <option value="codex">codex</option>
+                            <option value="managed_cc">claude code</option>
                           </select>
                         </td>
                         <td className="px-3 py-2">


### PR DESCRIPTION
Backend (#281) accepts \`managed_cc\` but the UI dropdown only listed nanoclaw + codex, so users had no way to switch a channel to it without curling the PATCH endpoint by hand.

Adds `<option value="managed_cc">claude code</option>` to the IM channels table in `WorkspaceDetail.tsx`. Display label is "claude code" (matches the column convention).

Test plan:
- [ ] Open a workspace IM tab, switch a channel to "claude code", verify backend persists `routing_mode=managed_cc`
- [ ] Send a WeChat message to that channel, verify it routes through cc-app-gateway