### PR TITLE
chore(chart): bump 0.69.7 → 0.69.8 to ship #284

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.69.7
-appVersion: "0.69.7"
+version: 0.69.8
+appVersion: "0.69.8"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
Ships #284 (IM channel UI gets 'claude code' option for managed_cc routing_mode). After merge, push v0.69.8 tag.