### PR TITLE
feat(cc-app-gateway): Phase 3 — env-MCP wiring (claude gets env tools via cc-app-gateway)

### DIFF
--- a/Dockerfile.cc-app-gateway
+++ b/Dockerfile.cc-app-gateway
@@ -28,7 +28,11 @@ ARG SHA=unknown
 RUN CGO_ENABLED=0 go build \
     -trimpath \
     -ldflags "-s -w -X main.BuildVersion=${VERSION} -X main.BuildSHA=${SHA}" \
-    -o /out/cc-app-gateway ./cmd/cc-app-gateway
+    -o /out/cc-app-gateway ./cmd/cc-app-gateway && \
+    CGO_ENABLED=0 go build \
+    -trimpath \
+    -ldflags "-s -w -X main.BuildVersion=${VERSION} -X main.BuildSHA=${SHA}" \
+    -o /out/codex-app-gateway ./cmd/codex-app-gateway
 
 # --- runtime stage -----------------------------------------------------------
 FROM debian:bookworm-slim
@@ -53,6 +57,7 @@ RUN apt-get update && \
 RUN claude --version
 
 COPY --from=build /out/cc-app-gateway /usr/local/bin/cc-app-gateway
+COPY --from=build /out/codex-app-gateway /usr/local/bin/codex-app-gateway
 
 # IS_SANDBOX=1 allows claude --dangerously-skip-permissions to run as root
 # inside the container.  Required for managed-harness mode in a pod

--- a/deploy/helm/agentserver/templates/cc-app-gateway.yaml
+++ b/deploy/helm/agentserver/templates/cc-app-gateway.yaml
@@ -71,6 +71,25 @@ spec:
                   name: {{ .Values.ccAppGateway.s3.existingSecret }}
                   key: secret_access_key
 {{- end }}
+{{- if .Values.ccAppGateway.envMcp.enabled }}
+{{- if not .Values.codexExecGateway.enabled }}{{- fail "ccAppGateway.envMcp.enabled=true requires codexExecGateway.enabled=true (env-mcp dials codex-exec-gateway)" }}{{- end }}
+            - name: CCAPPGW_ENV_MCP_BINARY
+              value: "/usr/local/bin/codex-app-gateway"
+            - name: CCAPPGW_EXEC_GATEWAY_WS_URL
+              value: "ws://{{ .Release.Name }}-codex-exec-gateway.{{ .Release.Namespace }}.svc:{{ .Values.codexExecGateway.port }}"
+            - name: CCAPPGW_EXEC_GATEWAY_INTERNAL_URL
+              value: "http://{{ .Release.Name }}-codex-exec-gateway.{{ .Release.Namespace }}.svc:{{ .Values.codexExecGateway.port }}"
+            - name: CCAPPGW_CAPTOKEN_HMAC_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-codex-gateway
+                  key: cap-token-hmac-secret
+            - name: CCAPPGW_EXEC_GATEWAY_INTERNAL_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-codex-gateway
+                  key: internal-shared-secret
+{{- end }}
           volumeMounts:
             - name: cc-gateway-tmp
               mountPath: {{ .Values.ccAppGateway.tmpRoot }}

--- a/deploy/helm/agentserver/templates/codex-gateway-secret.yaml
+++ b/deploy/helm/agentserver/templates/codex-gateway-secret.yaml
@@ -1,4 +1,4 @@
-{{- if or .Values.codexAppGateway.enabled .Values.codexExecGateway.enabled }}
+{{- if or .Values.codexAppGateway.enabled .Values.codexExecGateway.enabled (and .Values.ccAppGateway.enabled .Values.ccAppGateway.envMcp.enabled) }}
 {{- /*
 Shared secret used by codex-app-gateway AND codex-exec-gateway.
 

--- a/deploy/helm/agentserver/values.yaml
+++ b/deploy/helm/agentserver/values.yaml
@@ -273,6 +273,8 @@ ccAppGateway:
     limits:
       memory: "2Gi"
       cpu: "2000m"
+  envMcp:
+    enabled: false  # opt-in; requires codexExecGateway.enabled=true
 
 # codexGateway: shared secrets for the codex-app-gateway / codex-exec-gateway
 # pair. Both pods read from the same auto-generated k8s Secret so the cap

--- a/docs/superpowers/plans/2026-06-22-cc-app-gateway-phase3.md
+++ b/docs/superpowers/plans/2026-06-22-cc-app-gateway-phase3.md
@@ -1,0 +1,540 @@
+# cc-app-gateway Phase 3 plan: env-MCP wiring
+
+**Spec:** `docs/superpowers/specs/2026-06-22-cc-app-gateway-phase3-design.md` (v3 — audited + Phase 0 v2 verified)
+**Branch:** `feat/cc-app-gateway-phase3` (worktree at `/root/agentserver/.claude/worktrees/cc-app-gateway-phase3`)
+**Base:** main @ `41cee9b` (chart 0.69.8)
+**Date:** 2026-06-22
+
+## Global constraints
+
+- Each task TDD: RED first (failing test) → GREEN (minimal impl) → commit
+- Each commit message includes Co-Authored-By trailer
+- Reviews: sonnet for non-trivial tasks, haiku for transcription tasks
+- Final whole-branch review with opus before PR
+- After all tasks: bump chart 0.69.8 → 0.69.9, tag `v0.69.9`, update /root/k8s pulumi
+
+## Files added/modified
+
+| Task | File | Op | Notes |
+|---|---|---|---|
+| 1 | `internal/ccappgateway/mcp/config.go` | NEW | Pure WriteConfig + tests |
+| 2 | `internal/ccappgateway/config.go` | MOD | New env vars + struct fields + tests |
+| 3 | `internal/ccappgateway/runner/options.go` | MOD | RunInput.MCPConfigPath + BuildArgs |
+| 4 | `internal/ccappgateway/server.go` | MOD | NewServer validation + plumbing Cfg fields |
+| 4 | `internal/ccappgateway/turn_api.go` | MOD | Mint cap-token + WriteConfig + pass to runner |
+| 5 | `Dockerfile.cc-app-gateway` | MOD | Also build codex-app-gateway binary; COPY into final image |
+| 6 | `deploy/helm/agentserver/templates/cc-app-gateway.yaml` | MOD | Conditional env block + fail gate |
+| 6 | `deploy/helm/agentserver/templates/codex-gateway-secret.yaml` | MOD | Widen `if` to include cc env-mcp consumer |
+| 6 | `deploy/helm/agentserver/values.yaml` | MOD | `ccAppGateway.envMcp.enabled: false` default |
+| 7 | `internal/ccappgateway/integration_phase3_test.go` | NEW | End-to-end: cc-app-gateway → claude → env-mcp child → mock codex-exec-gateway returns env list |
+
+7 tasks total. Task 7 = integration test (largest).
+
+## Tasks
+
+### Task 1: `mcp.WriteConfig` (pure function)
+
+**Subject:** New `internal/ccappgateway/mcp/config.go` with `WriteConfig(dir string, in ConfigInput) (string, error)` returning the path of the written mcp.json.
+
+**RED test** (`internal/ccappgateway/mcp/config_test.go`):
+```go
+func TestWriteConfig_HappyPath(t *testing.T) {
+    tmp := t.TempDir()
+    path, err := WriteConfig(tmp, ConfigInput{
+        EnvMcpBinary:           "/usr/local/bin/codex-app-gateway",
+        WorkspaceID:            "wsp_abc",
+        ExecGatewayBridgeURL:   "ws://codex-exec-gateway:6060/bridge",
+        ExecGatewayInternalURL: "http://codex-exec-gateway:6060",
+        AgentserverInternalURL: "http://agentserver:8080",
+        WorkspaceCapToken:      "cap-token-abc.def.ghi",
+        LogFile:                "/dev/stderr",
+    })
+    if err != nil {
+        t.Fatalf("WriteConfig: %v", err)
+    }
+    if path != filepath.Join(tmp, "mcp.json") {
+        t.Errorf("path = %q, want %q", path, filepath.Join(tmp, "mcp.json"))
+    }
+    info, err := os.Stat(path)
+    if err != nil { t.Fatal(err) }
+    if info.Mode().Perm() != 0o600 {
+        t.Errorf("mode = %v, want 0600 (secret in env block)", info.Mode().Perm())
+    }
+    raw, _ := os.ReadFile(path)
+    var got map[string]any
+    if err := json.Unmarshal(raw, &got); err != nil { t.Fatal(err) }
+    servers := got["mcpServers"].(map[string]any)
+    srv := servers["agentserver"].(map[string]any)  // key MUST be "agentserver" — env-mcp's self-name
+    if srv["command"] != "/usr/local/bin/codex-app-gateway" {
+        t.Errorf("command = %v", srv["command"])
+    }
+    args := srv["args"].([]any)
+    wantSubstrs := []string{"env-mcp", "--workspace-id", "wsp_abc",
+        "--exec-gateway-url", "ws://codex-exec-gateway:6060/bridge",
+        "--exec-gateway-internal-url", "http://codex-exec-gateway:6060",
+        "--agentserver-internal-url", "http://agentserver:8080",
+        "--workspace-token-env", "CXG_WORKSPACE_TOKEN",
+        "--log-file", "/dev/stderr"}
+    var got_args []string
+    for _, a := range args { got_args = append(got_args, a.(string)) }
+    for _, want := range wantSubstrs {
+        if !contains(got_args, want) {
+            t.Errorf("args missing %q; got %v", want, got_args)
+        }
+    }
+    env := srv["env"].(map[string]any)
+    if env["CXG_WORKSPACE_TOKEN"] != "cap-token-abc.def.ghi" {
+        t.Errorf("env CXG_WORKSPACE_TOKEN = %v", env["CXG_WORKSPACE_TOKEN"])
+    }
+}
+
+func TestWriteConfig_OptionalExecGatewayInternalSecret(t *testing.T) {
+    tmp := t.TempDir()
+    _, err := WriteConfig(tmp, ConfigInput{
+        EnvMcpBinary: "/x", WorkspaceID: "w", WorkspaceCapToken: "t",
+        ExecGatewayInternalSecret: "secret-xxx",
+    })
+    if err != nil { t.Fatal(err) }
+    raw, _ := os.ReadFile(filepath.Join(tmp, "mcp.json"))
+    if !bytes.Contains(raw, []byte("CXG_EXEC_GATEWAY_INTERNAL_SECRET")) {
+        t.Errorf("expected --exec-gateway-internal-secret-env flag + env var")
+    }
+    if !bytes.Contains(raw, []byte("secret-xxx")) {
+        t.Errorf("expected secret value in env block")
+    }
+}
+
+func TestWriteConfig_ValidatesRequired(t *testing.T) {
+    cases := []struct{ name string; in ConfigInput }{
+        {"empty binary",    ConfigInput{WorkspaceID: "w", WorkspaceCapToken: "t"}},
+        {"empty workspace", ConfigInput{EnvMcpBinary: "/x", WorkspaceCapToken: "t"}},
+        {"empty captoken",  ConfigInput{EnvMcpBinary: "/x", WorkspaceID: "w"}},
+    }
+    for _, tc := range cases {
+        t.Run(tc.name, func(t *testing.T) {
+            _, err := WriteConfig(t.TempDir(), tc.in)
+            if err == nil { t.Errorf("want error, got nil") }
+        })
+    }
+}
+```
+
+**Commit:** `feat(ccappgateway/mcp): WriteConfig writes per-turn mcp.json for env-mcp stdio child`
+
+**Test command:** `go test ./internal/ccappgateway/mcp/...`
+
+**Review:** sonnet — verify JSON structure matches Phase 0 v2 findings (key="agentserver", env block honored).
+
+---
+
+### Task 2: config.go env vars + struct fields
+
+**Subject:** Add Phase 3 fields to `Config` struct and `Load()`.
+
+New struct fields + env loading (in `internal/ccappgateway/config.go`):
+
+```go
+type Config struct {
+    // ... existing Phase 1/2 fields ...
+
+    // Phase 3: env-MCP wiring. All required when EnvMcpBinary != "".
+    EnvMcpBinary              string
+    ExecGatewayWSURL          string // ws://...; cc-app-gateway appends /bridge
+    ExecGatewayInternalURL    string
+    ExecGatewayInternalSecret string // optional
+    AgentserverInternalURL    string
+    CapTokenHMACSecret        []byte
+    CapTokenTTL               time.Duration // default time.Hour
+}
+```
+
+Load() additions:
+```go
+cfg.EnvMcpBinary = os.Getenv("CCAPPGW_ENV_MCP_BINARY")
+cfg.ExecGatewayWSURL = os.Getenv("CCAPPGW_EXEC_GATEWAY_WS_URL")
+cfg.ExecGatewayInternalURL = os.Getenv("CCAPPGW_EXEC_GATEWAY_INTERNAL_URL")
+cfg.ExecGatewayInternalSecret = os.Getenv("CCAPPGW_EXEC_GATEWAY_INTERNAL_SECRET")
+cfg.AgentserverInternalURL = os.Getenv("CCAPPGW_AGENTSERVER_INTERNAL_URL")
+cfg.CapTokenHMACSecret = []byte(os.Getenv("CCAPPGW_CAPTOKEN_HMAC_SECRET"))
+if v := os.Getenv("CCAPPGW_CAPTOKEN_TTL"); v != "" {
+    d, err := time.ParseDuration(v)
+    if err != nil { return Config{}, fmt.Errorf("CCAPPGW_CAPTOKEN_TTL: %w", err) }
+    cfg.CapTokenTTL = d
+} else {
+    cfg.CapTokenTTL = time.Hour
+}
+```
+
+**RED tests** (in `internal/ccappgateway/config_test.go`):
+- All Phase 3 env vars empty → Phase 1/2 behavior, no MCP fields populated.
+- Each env var set → corresponding field populated.
+- `CCAPPGW_CAPTOKEN_TTL=invalid` → Load returns error.
+- `CCAPPGW_CAPTOKEN_TTL` empty → field = `time.Hour`.
+
+**Commit:** `feat(ccappgateway): add env-MCP config env vars (Phase 3)`
+
+**Review:** haiku — straightforward env parsing.
+
+---
+
+### Task 3: runner BuildArgs with --mcp-config
+
+**Subject:** Append MCP flags to BuildArgs when MCPConfigPath != "".
+
+`internal/ccappgateway/runner/options.go`:
+
+```go
+type RunInput struct {
+    // ... existing fields ...
+    MCPConfigPath string  // when set: --mcp-config + --strict-mcp-config + --tools
+}
+
+// BuildArgs ...
+func BuildArgs(in RunInput) []string {
+    args := []string{
+        "--print",
+        "--input-format", "stream-json",
+        "--output-format", "stream-json",
+        "--verbose",
+        "--permission-mode", "bypassPermissions",
+        "--dangerously-skip-permissions",
+        "--model", in.Model,
+    }
+    if in.MCPConfigPath != "" {
+        args = append(args, "--mcp-config", in.MCPConfigPath, "--strict-mcp-config", "--tools", "mcp__agentserver__*")
+    }
+    switch in.SessionMode {
+    case "resume":
+        args = append(args, "--resume", in.SessionID)
+    default:
+        args = append(args, "--session-id", in.SessionID)
+    }
+    return args
+}
+```
+
+**RED tests:**
+- MCPConfigPath empty → BuildArgs returns Phase 1/2 args (no `--mcp-config`).
+- MCPConfigPath set → BuildArgs contains `--mcp-config /path/mcp.json`, `--strict-mcp-config`, `--tools mcp__agentserver__*`.
+- Phase 0 v2 finding: glob `*` is correct (don't enumerate tools).
+
+**Commit:** `feat(ccappgateway/runner): pass --mcp-config + --tools when MCPConfigPath set (Phase 3)`
+
+**Review:** haiku — single conditional append.
+
+---
+
+### Task 4: turn_api.go integration + server.go startup validation
+
+**Subject:** TurnHandler mints cap-token, writes mcp.json, passes to runner. NewServer validates Phase 3 config consistency.
+
+`internal/ccappgateway/server.go` — in `NewServer` after existing checks:
+
+```go
+if cfg.EnvMcpBinary != "" {
+    if cfg.ExecGatewayWSURL == "" { return nil, fmt.Errorf("CCAPPGW_EXEC_GATEWAY_WS_URL required when CCAPPGW_ENV_MCP_BINARY set") }
+    if cfg.ExecGatewayInternalURL == "" { return nil, fmt.Errorf("CCAPPGW_EXEC_GATEWAY_INTERNAL_URL required when CCAPPGW_ENV_MCP_BINARY set") }
+    if cfg.AgentserverInternalURL == "" { return nil, fmt.Errorf("CCAPPGW_AGENTSERVER_INTERNAL_URL required when CCAPPGW_ENV_MCP_BINARY set") }
+    if len(cfg.CapTokenHMACSecret) == 0 { return nil, fmt.Errorf("CCAPPGW_CAPTOKEN_HMAC_SECRET required when CCAPPGW_ENV_MCP_BINARY set") }
+    if cfg.CapTokenTTL <= cfg.TurnTimeout {
+        return nil, fmt.Errorf("CapTokenTTL (%v) must exceed TurnTimeout (%v)", cfg.CapTokenTTL, cfg.TurnTimeout)
+    }
+}
+```
+
+`internal/ccappgateway/turn_api.go` — between `workspace.Setup` and `runner.Run`:
+
+```go
+var mcpConfigPath string
+if h.Cfg.EnvMcpBinary != "" {
+    capTok, err := captoken.Mint(h.Cfg.CapTokenHMACSecret, captoken.Payload{
+        TurnID:      "trn_" + shortid.Generate(),
+        WorkspaceID: req.WorkspaceID,
+        UserID:      "",
+    }, h.Cfg.CapTokenTTL)
+    if err != nil {
+        log.Printf("[cc-app-gateway] mint_captoken_failed (session=%s workspace=%s): %v", req.SessionID, req.WorkspaceID, err)
+        writeError(w, http.StatusInternalServerError, "captoken_failed", "internal authorization failure")
+        return
+    }
+    bridgeURL := strings.TrimRight(h.Cfg.ExecGatewayWSURL, "/") + "/bridge"
+    p, err := mcp.WriteConfig(ws.TempDir, mcp.ConfigInput{
+        EnvMcpBinary:              h.Cfg.EnvMcpBinary,
+        WorkspaceID:               req.WorkspaceID,
+        ExecGatewayBridgeURL:      bridgeURL,
+        ExecGatewayInternalURL:    h.Cfg.ExecGatewayInternalURL,
+        ExecGatewayInternalSecret: h.Cfg.ExecGatewayInternalSecret,
+        AgentserverInternalURL:    h.Cfg.AgentserverInternalURL,
+        WorkspaceCapToken:         capTok,
+        LogFile:                   "/dev/stderr",
+    })
+    if err != nil {
+        log.Printf("[cc-app-gateway] mcp_config_write_failed (session=%s): %v", req.SessionID, err)
+        writeError(w, http.StatusInternalServerError, "mcp_config_failed", "internal MCP config failure")
+        return
+    }
+    mcpConfigPath = p
+}
+
+result, err := h.Runner(runCtx, runner.RunInput{
+    // ... existing fields ...
+    MCPConfigPath: mcpConfigPath,
+})
+```
+
+Imports added: `"github.com/agentserver/agentserver/internal/captoken"`, `"github.com/agentserver/agentserver/internal/shortid"`, `"github.com/agentserver/agentserver/internal/ccappgateway/mcp"`, `"strings"`.
+
+**RED tests** (`turn_api_test.go`):
+- With `Cfg.EnvMcpBinary != ""` + valid config: ServeHTTP calls runner with non-empty `MCPConfigPath`, and the file at that path is a valid mcp.json with the cap-token in env block.
+- With `Cfg.EnvMcpBinary == ""`: ServeHTTP calls runner with empty `MCPConfigPath` (Phase 2 behavior unchanged).
+- Empty `CapTokenHMACSecret` at runtime (despite startup check) → captoken_failed response (defense in depth).
+
+Plus (`server_test.go`):
+- `NewServer` with `EnvMcpBinary` set but missing `ExecGatewayWSURL` → returns error.
+- `NewServer` with `CapTokenTTL <= TurnTimeout` → returns error.
+
+**Commit:** `feat(ccappgateway): mint cap-token + write mcp.json per turn (Phase 3)`
+
+**Review:** sonnet — main integration point, multiple failure paths.
+
+---
+
+### Task 5: Dockerfile.cc-app-gateway adds codex-app-gateway binary
+
+**Subject:** Build stage compiles both `cmd/cc-app-gateway` and `cmd/codex-app-gateway`; runtime stage COPYs both into final image.
+
+Edit `Dockerfile.cc-app-gateway`:
+
+```dockerfile
+# --- build stage -------------------------------------------------------------
+FROM golang:1.26-trixie AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+ARG VERSION=dev
+ARG SHA=unknown
+RUN CGO_ENABLED=0 go build \
+    -trimpath \
+    -ldflags "-s -w -X main.BuildVersion=${VERSION} -X main.BuildSHA=${SHA}" \
+    -o /out/cc-app-gateway ./cmd/cc-app-gateway && \
+    CGO_ENABLED=0 go build \
+    -trimpath \
+    -ldflags "-s -w -X main.BuildVersion=${VERSION} -X main.BuildSHA=${SHA}" \
+    -o /out/codex-app-gateway ./cmd/codex-app-gateway
+```
+
+And in runtime stage:
+
+```dockerfile
+COPY --from=build /out/cc-app-gateway      /usr/local/bin/cc-app-gateway
+COPY --from=build /out/codex-app-gateway   /usr/local/bin/codex-app-gateway
+```
+
+**Verification:**
+- `docker build -f Dockerfile.cc-app-gateway .` succeeds locally
+- Final image has both binaries: `docker run --rm <image> ls /usr/local/bin/ | grep gateway`
+- `docker run --rm --entrypoint /usr/local/bin/codex-app-gateway <image> env-mcp --help` returns usage (sanity check the codex binary is runnable)
+
+**Commit:** `feat(Dockerfile.cc-app-gateway): embed codex-app-gateway binary for env-mcp child`
+
+**Review:** haiku — Dockerfile change only, no logic.
+
+**Risk:** image size grows ~30 MB (one extra Go binary). Acceptable.
+
+---
+
+### Task 6: Helm chart + values.yaml
+
+**Subject:** Conditional env block, fail-fast gate, widen secret consumer if.
+
+`deploy/helm/agentserver/templates/cc-app-gateway.yaml` — append to existing env list:
+
+```yaml
+{{- if .Values.ccAppGateway.envMcp.enabled }}
+{{- if not .Values.codexExecGateway.enabled }}{{- fail "ccAppGateway.envMcp.enabled=true requires codexExecGateway.enabled=true (env-mcp dials codex-exec-gateway)" }}{{- end }}
+            - name: CCAPPGW_ENV_MCP_BINARY
+              value: "/usr/local/bin/codex-app-gateway"
+            - name: CCAPPGW_EXEC_GATEWAY_WS_URL
+              value: "ws://{{ .Release.Name }}-codex-exec-gateway.{{ .Release.Namespace }}.svc:{{ .Values.codexExecGateway.port }}"
+            - name: CCAPPGW_EXEC_GATEWAY_INTERNAL_URL
+              value: "http://{{ .Release.Name }}-codex-exec-gateway.{{ .Release.Namespace }}.svc:{{ .Values.codexExecGateway.port }}"
+            - name: CCAPPGW_AGENTSERVER_INTERNAL_URL
+              value: "http://{{ .Release.Name }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}"
+            - name: CCAPPGW_CAPTOKEN_HMAC_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-codex-gateway
+                  key: cap-token-hmac-secret
+            - name: CCAPPGW_EXEC_GATEWAY_INTERNAL_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-codex-gateway
+                  key: internal-shared-secret
+{{- end }}
+```
+
+`deploy/helm/agentserver/values.yaml`:
+
+```yaml
+ccAppGateway:
+  # ... existing fields ...
+  envMcp:
+    enabled: false  # opt-in; requires codexExecGateway.enabled=true
+```
+
+`deploy/helm/agentserver/templates/codex-gateway-secret.yaml` — widen the gate:
+
+```yaml
+{{- if or .Values.codexAppGateway.enabled .Values.codexExecGateway.enabled (and .Values.ccAppGateway.enabled .Values.ccAppGateway.envMcp.enabled) }}
+```
+
+**Verification:**
+- `helm template deploy/helm/agentserver --set ccAppGateway.enabled=true --set ccAppGateway.envMcp.enabled=true --set codexExecGateway.enabled=true` renders without errors and shows the env block.
+- `helm template ... --set ccAppGateway.envMcp.enabled=true --set codexExecGateway.enabled=false` fails with the explicit message.
+- `helm template ... --set ccAppGateway.envMcp.enabled=false` renders without the env block (Phase 2 behavior preserved).
+- `helm template ... --set ccAppGateway.envMcp.enabled=true --set codexExecGateway.enabled=true --set codexAppGateway.enabled=false` STILL includes the `codex-gateway` Secret (verifying the widened gate).
+
+**Commit:** `feat(helm/cc-app-gateway): conditional env-MCP env block + codex-gateway-secret consumer widen`
+
+**Review:** sonnet — fail-gate logic + secret-consumer wiring.
+
+---
+
+### Task 7: Integration test — end-to-end env tool call
+
+**Subject:** Real cc-app-gateway server in a sub-test; real claude --print subprocess; real env-mcp child; mock codex-exec-gateway returns an env list. Asserts the model called `list_environments` and saw the mock's response.
+
+`//go:build integration` (NOT default test pass — opt-in like Phase 2 + Phase 4).
+
+`internal/ccappgateway/integration_phase3_test.go`:
+
+```go
+//go:build integration
+// +build integration
+
+package ccappgateway_test
+
+import (
+    "context"
+    "encoding/json"
+    "net/http"
+    "net/http/httptest"
+    "os"
+    "os/exec"
+    "path/filepath"
+    "strings"
+    "testing"
+    "time"
+    // ...
+)
+
+func TestIntegration_EnvMcp_ListEnvironments(t *testing.T) {
+    // 1. Build codex-app-gateway binary into testdata/.
+    binDir := t.TempDir()
+    out := filepath.Join(binDir, "codex-app-gateway")
+    cmd := exec.Command("go", "build", "-o", out, "./cmd/codex-app-gateway")
+    cmd.Dir = repoRoot(t)
+    if b, err := cmd.CombinedOutput(); err != nil { t.Fatalf("build codex-app-gateway: %v: %s", err, b) }
+
+    // 2. Mock codex-exec-gateway: GET /api/exec-gateway/connected returns a fake env.
+    mockExecGw := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        if r.URL.Path == "/api/exec-gateway/connected" {
+            json.NewEncoder(w).Encode(map[string]any{
+                "environments": []map[string]any{
+                    {"env_id": "env_test123", "name": "test-env", "status": "connected"},
+                },
+            })
+            return
+        }
+        http.NotFound(w, r)
+    }))
+    defer mockExecGw.Close()
+
+    // 3. Mock agentserver-main for /internal/workspace-token (returns dummy WS token).
+    mockAgsv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        if r.URL.Path == "/internal/workspace-token" {
+            json.NewEncoder(w).Encode(map[string]string{"token": "fake-ws-token"})
+            return
+        }
+        http.NotFound(w, r)
+    }))
+    defer mockAgsv.Close()
+
+    // 4. Compute a valid HMAC secret + matching helm-style env.
+    hmacSecret := []byte("integration-test-hmac-secret-32b!")
+    t.Setenv("CCAPPGW_ENV_MCP_BINARY", out)
+    t.Setenv("CCAPPGW_EXEC_GATEWAY_WS_URL", strings.Replace(mockExecGw.URL, "http://", "ws://", 1))
+    t.Setenv("CCAPPGW_EXEC_GATEWAY_INTERNAL_URL", mockExecGw.URL)
+    t.Setenv("CCAPPGW_AGENTSERVER_INTERNAL_URL", mockAgsv.URL)
+    t.Setenv("CCAPPGW_CAPTOKEN_HMAC_SECRET", string(hmacSecret))
+    t.Setenv("CCAPPGW_CAPTOKEN_TTL", "1h")
+    t.Setenv("AGENTSERVER_INTERNAL_URL", mockAgsv.URL)
+    t.Setenv("INTERNAL_API_SECRET", "test-secret")
+    // Plus all the Phase 1/2 base env vars (claude bin, llmproxy URL, etc.).
+
+    cfg, err := ccappgateway.Load()
+    if err != nil { t.Fatalf("config load: %v", err) }
+    srv, err := ccappgateway.NewServer(cfg)  // validates Phase 3 config
+    if err != nil { t.Fatalf("server init: %v", err) }
+    defer srv.Shutdown(context.Background())
+
+    // 5. POST /api/turns asking claude to call list_environments.
+    body := `{
+        "workspaceId":"wsp_test",
+        "sessionId":"00000000-0000-0000-0000-000000000001",
+        "userMessage":"Please call the list_environments tool and tell me what envs exist.",
+        "model":"claude-haiku-4-5"
+    }`
+    req := httptest.NewRequest(http.MethodPost, "/api/turns", strings.NewReader(body))
+    req.Header.Set("X-Internal-Secret", "test-secret")
+    req.Header.Set("Content-Type", "application/json")
+    rec := httptest.NewRecorder()
+    srv.Routes().ServeHTTP(rec, req)
+
+    // 6. Assertions:
+    if rec.Code != http.StatusOK { t.Fatalf("status %d: %s", rec.Code, rec.Body.String()) }
+    var resp struct{
+        AssistantText string `json:"assistantText"`
+        IsError       bool   `json:"isError"`
+    }
+    json.Unmarshal(rec.Body.Bytes(), &resp)
+    if resp.IsError { t.Errorf("turn returned IsError; assistant text: %s", resp.AssistantText) }
+    if !strings.Contains(strings.ToLower(resp.AssistantText), "test-env") &&
+       !strings.Contains(resp.AssistantText, "env_test123") {
+        t.Errorf("expected env name or id in response; got: %q", resp.AssistantText)
+    }
+}
+```
+
+**Required prerequisites for the test to pass:**
+- `claude` binary in PATH (cc-app-gateway image has it; CI/dev must too)
+- `ANTHROPIC_BASE_URL` + `ANTHROPIC_AUTH_TOKEN` set (test reads from env; CI env or skipped)
+- The codex-app-gateway binary builds clean (test builds it)
+
+**Test command:** `go test -tags integration -timeout 90s ./internal/ccappgateway/... -run TestIntegration_EnvMcp_ListEnvironments`
+
+**Commit:** `test(ccappgateway): integration test asserts env-mcp child returns list_environments through claude (Phase 3)`
+
+**Review:** sonnet — complex test scaffolding; verify mocks faithfully represent codex-exec-gateway's contract.
+
+**Skip-if-no-claude-binary**: integration tests already gate on `claude` in PATH (Phase 2 pattern); reuse.
+
+---
+
+## After all tasks pass
+
+1. Final whole-branch review (opus model, code-reviewer agent) over `.superpowers/sdd/review-41cee9b..HEAD.diff`.
+2. Open PR (this is `feat/cc-app-gateway-phase3` against `main`; not stacked).
+3. After PR merges + CI green: bump `Chart.yaml` 0.69.8 → 0.69.9, push `v0.69.9` tag.
+4. Update `/root/k8s/stacks/agentserver.ts`:
+   - All `"0.69.8"` → `"0.69.9"`
+   - Add `envMcp: { enabled: true }` to the `ccAppGateway` block
+5. `pulumi up` and smoke test: send WeChat message asking claude to list executors.
+
+## Out of scope
+
+- HTTP/SSE MCP (Phase 5+)
+- Per-workspace user-defined MCP servers (Phase 5+)
+- MCP server health probes at startup (Phase 5+)
+- Streaming long-running tool output (Phase 5+)

--- a/docs/superpowers/specs/2026-06-22-cc-app-gateway-phase3-design.md
+++ b/docs/superpowers/specs/2026-06-22-cc-app-gateway-phase3-design.md
@@ -1,0 +1,413 @@
+# cc-app-gateway Phase 3: env-MCP wiring
+
+**Status:** Audited + Phase 0 verified (v3)
+**Date:** 2026-06-22
+**Author:** SDD-built
+**Builds on:** Phase 1 (#279), Phase 2 (#280), Phase 4 (#281), chart fixes (#283, #285)
+**Self-audit:** 7 critical + 7 important + 5 minor; v2 below incorporates all critical + important fixes.
+
+## Goal
+
+Wire env-MCP into cc-app-gateway so claude (via the managed_cc IM path) can call workspace env tools (shell, exec_command, read_file, apply_patch, copy_path, list_environments, scheduled tasks) — feature parity with the codex path for the same workspace.
+
+After this lands, WeChat users on `routing_mode=managed_cc` channels can ask claude to do real work in their workspace executors, not just chat / write temp files in the ephemeral pod-local dir.
+
+## Non-goals
+
+- New env tools beyond what env-mcp already exposes (`apply_patch`, `read_file`, `shell`, etc.).
+- A cc-specific env-mcp variant — Phase 3 reuses the existing `codex-app-gateway env-mcp` binary as-is.
+- Bidirectional handoff between codex and managed_cc for an in-progress conversation (Phase 4 Open Risk #8 stands: switching routing_mode = new session).
+- HTTP/SSE MCP (Phase 3 sticks with stdio per Phase 0 probe).
+
+## Phase 0 probe results (v2, completed before code)
+
+3 unknowns verified at `/tmp/cc-probe-v2/`:
+
+| Probe | Result | Spec impact |
+|---|---|---|
+| P0-A: `--tools mcp__<server>__*` glob | ✅ Works | Use `--tools mcp__agentserver__*` — no enumeration needed |
+| P0-B: mcp.json `env` block honored by claude | ✅ Yes; child ALSO inherits claude's parent env | Use env block for cap-token (explicit, auditable). NB: claude's full env passes through too |
+| P0-C: `bypassPermissions` blanket-covers MCP tools | ✅ Yes | NO `--allowedTools`, NO per-tool list, NO readOnlyHint needed |
+
+**Pinned claude flags for Phase 3**:
+```
+--permission-mode bypassPermissions
+--dangerously-skip-permissions
+--mcp-config <path>
+--strict-mcp-config
+--tools mcp__agentserver__*
+```
+
+**P0-B security note**: env-mcp child inherits claude's full parent env (in addition to mcp.json `env` block). cc-app-gateway's `envAllowlist` (runner/options.go:83) only lets PATH/HOME/USER/LANG/etc. + the 6 explicitly-set `ANTHROPIC_*` / `CLAUDE_*` / `IS_SANDBOX` vars through — `CXG_*` are NOT in the allowlist, so they won't leak into env-mcp accidentally. The mcp.json `env` block remains the SOLE intended path for `CXG_WORKSPACE_TOKEN` and `CXG_EXEC_GATEWAY_INTERNAL_SECRET`.
+
+Env-mcp tool inventory (for reference; not used as allowlist since glob suffices):
+- `list_environments`, `shell`, `unified_exec`, `write_stdin`, `read_output`, `terminate`, `read_file`, `apply_patch`, `copy_path`
+- Scheduling: `schedule_task`, `list_tasks`, `update_task`, `cancel_task`, `pause_task`, `resume_task`
+
+## Architecture
+
+```
+WeChat msg
+   │
+   ▼
+imbridge ──POST──▶ agentserver /api/internal/imbridge/cc/turn
+                       │
+                       ▼ ccDispatcher → ccInboundHandler
+                       │
+                       ▼ POST cc-app-gateway /api/turns
+                            │
+                            ▼ TurnHandler.ServeHTTP
+                              │
+                              ├─ AcquireSessionLock
+                              ├─ workspace.Setup (S3 download)
+                              ├─ mint cap-token (HMAC, per-turn) ────────┐  NEW (Phase 3)
+                              ├─ mcp.WriteConfig(<TempDir>/mcp.json)   │  NEW
+                              ├─ runner.Run(claude --print --mcp-config) │
+                              │                                          │
+                              │  ┌──── claude subprocess ──────────┐    │
+                              │  │                                 │    │
+                              │  │ reads mcp.json                  │    │
+                              │  │ forks env-mcp stdio child       │    │
+                              │  │   │                             │    │
+                              │  │   └─ codex-app-gateway env-mcp  │    │
+                              │  │      WorkspaceID, ExecGwURL,    │◀───┘
+                              │  │      CXG_WORKSPACE_TOKEN env    │
+                              │  │      → ws://codex-exec-gateway  │
+                              │  │      → http://agentserver-main  │
+                              │  └─────────────────────────────────┘
+                              │
+                              └─ Teardown (goroutine, S3 upload + mutex release)
+```
+
+Key insight: env-mcp is **codex-agnostic** — it talks to `codex-exec-gateway` and `agentserver-main` over standard internal APIs. The "codex" in `codex-app-gateway env-mcp` is just where the binary lives, not who can use it. Phase 3 ships the binary into the cc-app-gateway container and invokes its `env-mcp` subcommand directly.
+
+## Code shape
+
+### New: `internal/ccappgateway/mcp/config.go`
+
+```go
+package mcp
+
+import (
+    "encoding/json"
+    "fmt"
+    "os"
+    "path/filepath"
+)
+
+// ConfigInput carries everything mcp.WriteConfig needs to render
+// the per-turn mcp.json file claude reads via --mcp-config.
+type ConfigInput struct {
+    EnvMcpBinary              string // absolute path to codex-app-gateway binary
+    WorkspaceID               string
+    ExecGatewayBridgeURL      string // ws:// URL with "/bridge" suffix already appended
+    ExecGatewayInternalURL    string // http:// base URL
+    ExecGatewayInternalSecret string // optional; HTTP relay shared key
+    AgentserverInternalURL    string // http:// base URL
+    WorkspaceCapToken         string // per-turn HMAC cap-token (NOT the proxy token)
+    LogFile                   string // optional; env-mcp --log-file (use "/dev/stderr" for kubectl-logs-visible)
+}
+
+// WriteConfig renders mcp.json into dir and returns the absolute path.
+// Mode 0600 — the cap-token in env block is sensitive.
+//
+// JSON server key is "agentserver" (matches the env-mcp MCPServer self-name
+// at internal/codexappgateway/envmcp/envmcp.go around `NewMCPServer("agentserver", ...)`).
+// claude's --tools / --allowedTools allowlist uses prefix mcp__agentserver__<tool>;
+// mismatching the JSON key would cause every tool call to be rejected.
+func WriteConfig(dir string, in ConfigInput) (string, error) {
+    if in.EnvMcpBinary == "" {
+        return "", fmt.Errorf("mcp.WriteConfig: EnvMcpBinary required")
+    }
+    if in.WorkspaceID == "" {
+        return "", fmt.Errorf("mcp.WriteConfig: WorkspaceID required")
+    }
+    if in.WorkspaceCapToken == "" {
+        return "", fmt.Errorf("mcp.WriteConfig: WorkspaceCapToken required")
+    }
+    args := []string{
+        "env-mcp",
+        "--workspace-id", in.WorkspaceID,
+        "--exec-gateway-url", in.ExecGatewayBridgeURL,  // must end with /bridge — caller's responsibility
+        "--exec-gateway-internal-url", in.ExecGatewayInternalURL,
+        "--agentserver-internal-url", in.AgentserverInternalURL,
+        "--workspace-token-env", "CXG_WORKSPACE_TOKEN",
+    }
+    env := map[string]string{"CXG_WORKSPACE_TOKEN": in.WorkspaceCapToken}
+    if in.ExecGatewayInternalSecret != "" {
+        args = append(args, "--exec-gateway-internal-secret-env", "CXG_EXEC_GATEWAY_INTERNAL_SECRET")
+        env["CXG_EXEC_GATEWAY_INTERNAL_SECRET"] = in.ExecGatewayInternalSecret
+    }
+    if in.LogFile != "" {
+        args = append(args, "--log-file", in.LogFile)
+    }
+    payload := map[string]any{
+        "mcpServers": map[string]any{
+            "agentserver": map[string]any{
+                "command": in.EnvMcpBinary,
+                "args":    args,
+                "env":     env,
+            },
+        },
+    }
+    b, err := json.Marshal(payload)
+    if err != nil {
+        return "", fmt.Errorf("marshal: %w", err)
+    }
+    path := filepath.Join(dir, "mcp.json")
+    if err := os.WriteFile(path, b, 0o600); err != nil {
+        return "", fmt.Errorf("write %s: %w", path, err)
+    }
+    return path, nil
+}
+```
+
+### Cap-token: direct import from `internal/captoken`
+
+cc-app-gateway imports `github.com/agentserver/agentserver/internal/captoken` directly (the package lives at top-level `internal/captoken`, NOT under `internal/codexappgateway/captoken`). codex-app-gateway already imports it from the same path (see `internal/codexappgateway/server.go` around `captoken.Mint(...)`). No wrapper needed.
+
+`shortid` package: import path `github.com/agentserver/agentserver/internal/shortid` (matches codex's `cmd/codex-app-gateway/main.go`).
+
+### Modify: `internal/ccappgateway/runner/options.go`
+
+Append `RunInput` field:
+
+```go
+// MCPConfigPath, when non-empty, adds --mcp-config <path>, --strict-mcp-config,
+// and --tools mcp__agentserver__* to the claude args. Phase 3.
+// (Per Phase 0 v2: glob works, --allowedTools redundant, no per-tool list needed.)
+MCPConfigPath string
+```
+
+`BuildArgs` appends `--mcp-config <path>`, `--strict-mcp-config`, `--tools mcp__agentserver__*` when `MCPConfigPath != ""`. Backward-compat: Phase 1/2 callers leave it empty → no change.
+
+The MCP server name `agentserver` is hardcoded because env-mcp's `NewMCPServer("agentserver", ...)` self-name is hardcoded; the allowlist prefix MUST match.
+
+### Modify: `internal/ccappgateway/config.go`
+
+Add fields (env var → struct):
+
+| env var | field | required |
+|---|---|---|
+| `CCAPPGW_ENV_MCP_BINARY` | `EnvMcpBinary` | Phase 3 only |
+| `CCAPPGW_EXEC_GATEWAY_WS_URL` | `ExecGatewayWSURL` (ws:// **without** /bridge suffix; cc-app-gateway appends) | Phase 3 only |
+| `CCAPPGW_EXEC_GATEWAY_INTERNAL_URL` | `ExecGatewayInternalURL` (http://) | Phase 3 only |
+| `CCAPPGW_EXEC_GATEWAY_INTERNAL_SECRET` | `ExecGatewayInternalSecret` | optional |
+| `CCAPPGW_AGENTSERVER_INTERNAL_URL` | `AgentserverInternalURL` | Phase 3 only |
+| `CCAPPGW_CAPTOKEN_HMAC_SECRET` | `CapTokenHMACSecret` ([]byte) | Phase 3 only |
+| `CCAPPGW_CAPTOKEN_TTL` | `CapTokenTTL` (time.Duration; default `time.Hour`, matching codex `server.go` cap default) | optional |
+
+"Phase 3 only" = required when `Cfg.EnvMcpBinary != ""`. If all are empty, behavior is identical to Phase 2 (no MCP, no cap-token mint). Lets us ship the chart with env-mcp opt-in.
+
+URL construction note: cc-app-gateway's `NewServer` (or `TurnHandler.ServeHTTP` per turn) computes `bridgeURL := strings.TrimRight(cfg.ExecGatewayWSURL, "/") + "/bridge"` and passes that to `mcp.WriteConfig`. Mirrors codex's `internal/codexappgateway/server.go` line ~187. Keeps the chart value matching codex's `codexAppGateway.execGatewayWsUrl` shape exactly so operators don't have to set two different URLs.
+
+### Modify: `internal/ccappgateway/turn_api.go`
+
+Between `workspace.Setup` and `runner.Run`:
+
+```go
+var (
+    mcpConfigPath    string
+    mcpToolAllowlist string
+    mcpToolFlag      string
+)
+if h.Cfg.EnvMcpBinary != "" {
+    // Mint per-turn cap-token from the SAME HMAC secret codex shares.
+    capTok, err := captoken.Mint(h.Cfg.CapTokenHMACSecret, captoken.Payload{
+        TurnID:      "trn_" + shortid.Generate(),
+        WorkspaceID: req.WorkspaceID,
+        UserID:      "", // cc-app-gateway is internal-secret authed; no enduser context.
+                         // captoken.Mint accepts UserID=""; codex-exec-gateway's
+                         // VerifyCapabilityToken does NOT require non-empty UserID
+                         // (see codexexecgateway auth_test.go
+                         // TestVerifyCapabilityToken_OldTokenHasNoUserID).
+    }, h.Cfg.CapTokenTTL)
+    if err != nil {
+        log.Printf("[cc-app-gateway] mint_captoken_failed (session=%s workspace=%s): %v", req.SessionID, req.WorkspaceID, err)
+        writeError(w, http.StatusInternalServerError, "captoken_failed", "internal authorization failure")
+        return
+    }
+    bridgeURL := strings.TrimRight(h.Cfg.ExecGatewayWSURL, "/") + "/bridge"
+    p, err := mcp.WriteConfig(ws.TempDir, mcp.ConfigInput{
+        EnvMcpBinary:              h.Cfg.EnvMcpBinary,
+        WorkspaceID:               req.WorkspaceID,
+        ExecGatewayBridgeURL:      bridgeURL,
+        ExecGatewayInternalURL:    h.Cfg.ExecGatewayInternalURL,
+        ExecGatewayInternalSecret: h.Cfg.ExecGatewayInternalSecret,
+        AgentserverInternalURL:    h.Cfg.AgentserverInternalURL,
+        WorkspaceCapToken:         capTok,
+        LogFile:                   "/dev/stderr", // pod-stderr → kubectl logs; survives Teardown
+    })
+    if err != nil {
+        log.Printf("[cc-app-gateway] mcp_config_write_failed (session=%s): %v", req.SessionID, err)
+        writeError(w, http.StatusInternalServerError, "mcp_config_failed", "internal MCP config failure")
+        return
+    }
+    mcpConfigPath = p
+}
+```
+
+Pass `MCPConfigPath: mcpConfigPath` to `runner.RunInput`. Tool allowlist hardcoded in `BuildArgs` per Phase 0 v2.
+
+### Modify: `internal/ccappgateway/server.go` (NewServer)
+
+Validate config when env-mcp is enabled. If `EnvMcpBinary != ""` AND any of `ExecGatewayWSURL` / `ExecGatewayInternalURL` / `AgentserverInternalURL` / `CapTokenHMACSecret` is empty → return error at startup (CrashLoopBackOff). Also validate `CapTokenTTL > TurnTimeout` (TTL=1h, TurnTimeout=10m by default — wide margin). Misconfig fails fast, not silently disabled.
+
+### Modify: `Dockerfile.cc-app-gateway`
+
+The repo currently builds the cc-app-gateway image from a Dockerfile under `Dockerfile.cc-app-gateway` (or similar — IMPLEMENTATION TASK: locate by `grep -l "cc-app-gateway" Dockerfile* deploy/`). To embed the env-mcp binary:
+
+1. Add a build stage that compiles codex-app-gateway: `go build -o /out/codex-app-gateway ./cmd/codex-app-gateway`
+2. In the final stage: `COPY --from=<codex-builder> /out/codex-app-gateway /usr/local/bin/codex-app-gateway`
+
+Verify the cc-app-gateway image size delta (~30 MB for the codex binary; acceptable).
+
+**Decision**: ship the existing codex-app-gateway binary as-is (no fork, no shim). Zero new build artifact. cc and codex must build from the same Git commit (already true: `.github/workflows/build.yml` runs all builds in one workflow run per push), so binary version drift is impossible within a release.
+
+### Modify: `deploy/helm/agentserver/templates/cc-app-gateway.yaml`
+
+Two changes: (1) hard-gate that codex-exec-gateway is enabled (since env-mcp's whole reason for existing is to dial it); (2) the env block itself.
+
+```yaml
+{{- if .Values.ccAppGateway.envMcp.enabled }}
+{{- if not .Values.codexExecGateway.enabled }}{{- fail "ccAppGateway.envMcp.enabled=true requires codexExecGateway.enabled=true (env-mcp dials codex-exec-gateway)" }}{{- end }}
+- name: CCAPPGW_ENV_MCP_BINARY
+  value: "/usr/local/bin/codex-app-gateway"
+- name: CCAPPGW_EXEC_GATEWAY_WS_URL
+  value: "ws://{{ .Release.Name }}-codex-exec-gateway.{{ .Release.Namespace }}.svc:{{ .Values.codexExecGateway.port }}"
+- name: CCAPPGW_EXEC_GATEWAY_INTERNAL_URL
+  value: "http://{{ .Release.Name }}-codex-exec-gateway.{{ .Release.Namespace }}.svc:{{ .Values.codexExecGateway.port }}"
+- name: CCAPPGW_AGENTSERVER_INTERNAL_URL
+  value: "http://{{ .Release.Name }}.{{ .Release.Namespace }}.svc:{{ .Values.service.port }}"
+- name: CCAPPGW_CAPTOKEN_HMAC_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-codex-gateway
+      key: cap-token-hmac-secret
+- name: CCAPPGW_EXEC_GATEWAY_INTERNAL_SECRET
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Release.Name }}-codex-gateway
+      key: internal-shared-secret
+{{- end }}
+```
+
+values.yaml default:
+
+```yaml
+ccAppGateway:
+  envMcp:
+    enabled: false  # opt-in; requires codexExecGateway.enabled=true
+```
+
+(No `toolFlag` / `toolAllowlist` — `BuildArgs` hardcodes `--tools mcp__agentserver__*` per Phase 0 v2.)
+
+### Modify: `deploy/helm/agentserver/templates/codex-gateway-secret.yaml`
+
+The current secret template wraps the entire resource in `{{- if or .Values.codexAppGateway.enabled .Values.codexExecGateway.enabled }}`. Widen to include the cc env-mcp case:
+
+```yaml
+{{- if or .Values.codexAppGateway.enabled .Values.codexExecGateway.enabled (and .Values.ccAppGateway.enabled .Values.ccAppGateway.envMcp.enabled) }}
+```
+
+Otherwise an operator running cc-app-gateway env-mcp WITHOUT codex pods would have the secret missing and the pod would CrashLoopBackOff on missing `secretKeyRef`. The helm `fail` gate above prevents the typical misconfig, but defense in depth keeps the secret resource consistent with consumers.
+
+## Security model
+
+- **Cap-token = same HMAC secret as codex.** cc-app-gateway shares the `cap-token-hmac-secret` k8s secret with codex-app-gateway and codex-exec-gateway. env-mcp's Authorization: Bearer to codex-exec-gateway verifies cap-token; same workspace_id payload semantics. No new HMAC, no new trust boundary.
+- **Token TTL = 1h default.** Same as codex. Turn timeout is 10m; one cap-token per turn so token outlives all in-flight env-mcp work even if claude stalls.
+- **Token persistence bounded by Teardown.** mcp.json (mode 0600) is written under per-session TempDir (`<tmpRoot>/<wid>/<sid>/`); Phase 2's `workspace.Teardown` does `os.RemoveAll(TempDir)` at end of turn (workspace.go ~L146). If Teardown fails (Phase 2 logs and continues), the cap-token sits on local pod disk until the next turn's Setup overwrites the layout. Worst-case stale-file exposure window = `CapTokenTTL` (1h default). NOT written into ClaudeDir (which gets tarred to S3 — would be a leak).
+- **env-mcp subprocess inherits ONLY the env we set in mcp.json's `env` block.** Phase 0 probe P0-B validates this assumption before coding. Fallback if claude DOES pass parent env: cc-app-gateway's `envAllowlist` in runner/options.go already strips `CXG_*` from the parent env claude inherits, so even an unintended passthrough would deliver nothing. The `env` block in mcp.json is the SOLE intended source of `CXG_WORKSPACE_TOKEN`.
+- **No new attack surface.** cc-app-gateway already trusts the workspace via WSToken; cap-token is a narrower authorization (per-turn TTL) over the same trust relationship.
+
+## Concurrency
+
+No new locks. Per-(workspace, session) mutex from Phase 2 already serializes turns within a pod. mcp.WriteConfig writes a different `mcp.json` under each turn's TempDir, so no contention.
+
+## Teardown
+
+mcp.json lives at `<TempDir>/mcp.json` where TempDir = `<tmpRoot>/<wid>/<sid>/` (per-session, NOT per-turn — but Phase 2's Teardown wipes it at end of every turn, restoring per-turn ephemerality). env-mcp.log goes to `/dev/stderr` so it's visible via `kubectl logs <pod>` (NOT in TempDir, so survives Teardown — which is what we want operationally). No teardown code changes needed.
+
+## Failure modes
+
+| Failure | User sees | Logs |
+|---|---|---|
+| cap-token mint fails (HMAC empty / clock skew) | "Claude 返回错误：internal authorization failure" | mint_captoken_failed |
+| mcp.WriteConfig fails (disk full, perms) | "Claude 返回错误：internal MCP config failure" | mcp_config_write_failed |
+| codex-exec-gateway unreachable from env-mcp | claude sees `tools/call` error; replies with text mentioning tool failure | env-mcp logs in pod stderr (via `--log-file /dev/stderr`); persist across Teardown |
+| claude doesn't call any tools (LLM choice) | normal reply | no MCP activity |
+| upstream agentserver `/internal/workspaces/<wid>/scheduled-tasks/*` returns 5xx | claude sees `tools/call` error | env-mcp logs |
+
+**Operational mitigation**: when env-mcp fails consistently, operators flip `ccAppGateway.envMcp.enabled=false` and roll → falls back to Phase 1 behavior (no tools, but still chats).
+
+## Open risks
+
+1. **Cap-token TTL vs turn timeout**: TTL=1h is plenty for turnTimeout=10m. But if turnTimeout is bumped past 1h, expired token mid-turn → 401 from codex-exec-gateway → tools start failing. Mitigation: validate `CapTokenTTL >= TurnTimeout * 2` at startup, fail-fast otherwise.
+
+2. **HMAC secret sharing across pods**: cc-app-gateway and codex-app-gateway must read the SAME `cap-token-hmac-secret`. Chart-side enforcement: both pods mount `{{ .Release.Name }}-codex-gateway` secret; values.yaml's `codexGateway.capTokenHmacSecret` is set ONCE and consumed by both. Operator must NOT override per-pod.
+
+3. **env-mcp binary version drift**: cc-app-gateway image and codex-app-gateway image both ship the same `codex-app-gateway` binary. If they're built at different times from different commits, env-mcp behavior could differ. Mitigation: both images built in the same workflow run (`build.yml`), tagged identically (e.g., 0.69.9). No new build-time check needed since they share the same Git commit.
+
+4. **No HTTP/SSE MCP fallback**: stdio-only. If claude's stdio MCP layer has a bug discovered post-deploy, no in-band workaround — must roll back to envMcp.enabled=false.
+
+5. **List_environments returns empty when workspace has no executors**: pre-existing condition (same for codex). claude sees an empty list and proceeds with text-only response. UX: user gets a chat reply explaining no executors found, which is correct but might confuse a first-time user who hasn't set up executors.
+
+6. **codex executor required**: `ccAppGateway.envMcp.enabled=true` requires `codexExecGateway.enabled=true` (helm `required` gate). If operator disables codex but leaves managed_cc env-mcp on, helm install/upgrade fails fast.
+
+7. **No per-tool allowlist override**: `--tools mcp__env-mcp__*` lets claude call any env tool. If we later add a tool we don't want exposed (e.g., privileged "execute-as-root"), we'd need explicit allowlist OR env-mcp side filtering. Acceptable for Phase 3.
+
+8. **MCP config has cap-token in plaintext inside the pod**: mcp.json mode 0600, lives in TempDir which is pod-local emptyDir. Other containers in the same pod could read it if compromised. cc-app-gateway has no sidecars by design; if that changes, revisit.
+
+## Acceptance criteria
+
+1. Build & ship a 0.69.9 chart with `ccAppGateway.envMcp.enabled=true` deployable on nj-prod.
+2. WeChat user on managed_cc channel: "请帮我看下我 workspace 里有哪些 executor" → claude calls `list_environments` → reply naming connected executors.
+3. WeChat user: "帮我在 executor X 上跑 `pwd`" → claude calls `shell` → reply with cwd path.
+4. WeChat user: "读一下 executor 上 /etc/hostname 内容" → claude calls `read_file` → reply with file contents.
+5. Failure injection: stop codex-exec-gateway → next claude tool call fails → claude responds with a text explanation, NOT 500 to WeChat.
+6. `kubectl logs <cc-app-gateway-pod>` shows env-mcp tool invocations (because `LogFile=/dev/stderr` writes into pod stderr; survives Teardown).
+7. Existing managed_cc path (no tool calls): unchanged behavior — still works.
+
+## Out of scope / future phases
+
+- **Per-workspace MCP server overrides** (user-defined MCP servers in addition to env-mcp). Phase 5+.
+- **Streaming MCP server output to claude** for long-running shell commands (currently buffered; Phase 5+ or env-mcp-side enhancement).
+- **MCP server health probes** at cc-app-gateway startup (env-mcp can be unhealthy without us knowing until first tool call).
+- **HTTP/SSE MCP transport** (e.g., for cross-cluster MCP servers).
+
+## Audit revisions (v1 → v2)
+
+Self-audit (opus, fresh-eyes) found 7 critical + 7 important + 5 minor BEFORE any code was written. Critical + important resolved in v2:
+
+**Critical:**
+1. `captoken` package path was wrong (`internal/codexappgateway/captoken` → actual is `internal/captoken`). Fixed throughout.
+2. ExecGatewayURL needs `/bridge` suffix appended; helm passes bare WS URL; cc-app-gateway appends in code. Mirrors codex's `internal/codexappgateway/server.go` pattern. Renamed env var to `CCAPPGW_EXEC_GATEWAY_WS_URL` to match codex's `ExecGatewayWSURL` field naming.
+3. mcp.json server key changed from `"env-mcp"` to `"agentserver"` to match env-mcp's hardcoded MCPServer self-name. Tool allowlist becomes `mcp__agentserver__*` (NOT `mcp__env-mcp__*`).
+4. `--tools` glob (`*`) is unverified by Phase 0 — added Phase 0 probe P0-A. If glob unsupported, fall back to enumerated list. `--allowedTools` vs `--tools` flag choice deferred to probe P0-C result.
+5. Helm `required` doesn't error on bool `false`. Replaced with explicit `{{- if not .Values.codexExecGateway.enabled }}{{- fail "..." }}{{- end }}`.
+6. claude env block passthrough for MCP child unverified — added Phase 0 probe P0-B. Fallback noted (envAllowlist already strips CXG_*).
+7. Dockerfile change hand-waved — named the actual file (Dockerfile.cc-app-gateway) and the exact `COPY --from=...` line. Build atomicity (same Git commit) addressed via existing workflow design.
+
+**Important:**
+8. `codex-gateway-secret.yaml` `if` widened to include cc env-mcp case (otherwise pod CrashLoopBackOff on missing secret if codex pods are disabled).
+9. shortid import path explicitly named (`internal/shortid`).
+10. TempDir lifecycle wording fixed (per-session, NOT per-turn; ephemerality via Teardown).
+11. CapTokenTTL > TurnTimeout validation pinned in NewServer.
+12. Acceptance criterion #6 changed to `kubectl logs` (LogFile=/dev/stderr) since `kubectl exec` post-turn finds TempDir gone.
+13. ProjectTrustedPaths not needed (env tools execute remotely on executor, not on cc-app-gateway local filesystem).
+14. cap-token TTL default = `time.Hour` (codex's default).
+
+**Minor (deferred):**
+15. Stale PR reference (#285 vs #283/#284) — non-functional.
+16. JSON map ordering nondeterminism — test design concern; addressed at test-writing time.
+17. MCP handshake noise in jsonl — known Phase 2 issue; noted in Open Risks.
+18. (this section).
+19. (this section).
+
+## Spec strengths (validated by audit)
+
+1. `captoken.Mint` signature exactly matches (`Mint(secret []byte, p Payload, ttl time.Duration) (string, error)`); Payload fields TurnID/WorkspaceID/UserID match the struct; UserID empty is fine (covered by codexexecgateway's auth_test `TestVerifyCapabilityToken_OldTokenHasNoUserID`).
+2. env-mcp arg flag names verified letter-for-letter against `cmd/codex-app-gateway/main.go` (`--workspace-id`, `--exec-gateway-url`, `--exec-gateway-internal-url`, `--agentserver-internal-url`, `--workspace-token-env`, `--exec-gateway-internal-secret-env`, `--log-file`).
+3. Cap-token shared-secret strategy correct: `cap-token-hmac-secret` from auto-generated + `lookup()`-preserved `codex-gateway-secret.yaml`.
+4. Concurrency: Phase 2's per-(workspace, session) mutex sufficient; mcp.json per-turn write has no contention.
+5. Fail-fast posture: validate env-mcp config at NewServer, not first turn.

--- a/internal/ccappgateway/config.go
+++ b/internal/ccappgateway/config.go
@@ -22,6 +22,14 @@ type ServeConfig struct {
 	S3Region               string
 	S3Bucket               string
 	S3PathStyle            bool
+
+	// Phase 3: env-MCP wiring. All required when EnvMcpBinary != "".
+	EnvMcpBinary              string
+	ExecGatewayWSURL          string // ws://...; cc-app-gateway appends /bridge per-turn
+	ExecGatewayInternalURL    string
+	ExecGatewayInternalSecret string // optional
+	CapTokenHMACSecret        []byte
+	CapTokenTTL               time.Duration // default time.Hour
 }
 
 // ServeFlags represents parsed command-line flags for the serve subcommand.
@@ -101,6 +109,22 @@ func LoadServeConfigFromEnv(flags ServeFlags) (ServeConfig, error) {
 			return ServeConfig{}, fmt.Errorf("CCAPPGW_S3_PATH_STYLE: %w", err)
 		}
 		cfg.S3PathStyle = b
+	}
+
+	// Load Phase 3 env-MCP vars
+	cfg.EnvMcpBinary = os.Getenv("CCAPPGW_ENV_MCP_BINARY")
+	cfg.ExecGatewayWSURL = os.Getenv("CCAPPGW_EXEC_GATEWAY_WS_URL")
+	cfg.ExecGatewayInternalURL = os.Getenv("CCAPPGW_EXEC_GATEWAY_INTERNAL_URL")
+	cfg.ExecGatewayInternalSecret = os.Getenv("CCAPPGW_EXEC_GATEWAY_INTERNAL_SECRET")
+	cfg.CapTokenHMACSecret = []byte(os.Getenv("CCAPPGW_CAPTOKEN_HMAC_SECRET"))
+	if v := os.Getenv("CCAPPGW_CAPTOKEN_TTL"); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return ServeConfig{}, fmt.Errorf("CCAPPGW_CAPTOKEN_TTL: %w", err)
+		}
+		cfg.CapTokenTTL = d
+	} else {
+		cfg.CapTokenTTL = time.Hour
 	}
 
 	return cfg, nil

--- a/internal/ccappgateway/config_test.go
+++ b/internal/ccappgateway/config_test.go
@@ -325,3 +325,108 @@ func TestLoadServeConfigFromEnv_S3Vars(t *testing.T) {
 		}
 	})
 }
+
+// Phase 3 tests for env-MCP config fields
+func TestLoad_Phase3FieldsEmpty_BackwardCompat(t *testing.T) {
+	// Set only required Phase 1/2 vars, leave Phase 3 vars empty
+	t.Setenv("INTERNAL_API_SECRET", "secret")
+	t.Setenv("AGENTSERVER_INTERNAL_URL", "http://a:8080")
+	t.Setenv("CCAPPGW_LLMPROXY_URL", "http://l:8081")
+	t.Setenv("CCAPPGW_S3_REGION", "us-east-1")
+	t.Setenv("CCAPPGW_S3_BUCKET", "bucket")
+
+	// Explicitly clear Phase 3 env vars
+	t.Setenv("CCAPPGW_ENV_MCP_BINARY", "")
+	t.Setenv("CCAPPGW_EXEC_GATEWAY_WS_URL", "")
+	t.Setenv("CCAPPGW_EXEC_GATEWAY_INTERNAL_URL", "")
+	t.Setenv("CCAPPGW_EXEC_GATEWAY_INTERNAL_SECRET", "")
+	t.Setenv("CCAPPGW_CAPTOKEN_HMAC_SECRET", "")
+	t.Setenv("CCAPPGW_CAPTOKEN_TTL", "")
+
+	cfg, err := LoadServeConfigFromEnv(ServeFlags{})
+	if err != nil {
+		t.Fatalf("LoadServeConfigFromEnv: %v", err)
+	}
+
+	// All Phase 3 fields should be zero-valued
+	if cfg.EnvMcpBinary != "" {
+		t.Errorf("EnvMcpBinary should be empty, got %q", cfg.EnvMcpBinary)
+	}
+	if cfg.ExecGatewayWSURL != "" {
+		t.Errorf("ExecGatewayWSURL should be empty, got %q", cfg.ExecGatewayWSURL)
+	}
+	if cfg.ExecGatewayInternalURL != "" {
+		t.Errorf("ExecGatewayInternalURL should be empty, got %q", cfg.ExecGatewayInternalURL)
+	}
+	if cfg.ExecGatewayInternalSecret != "" {
+		t.Errorf("ExecGatewayInternalSecret should be empty, got %q", cfg.ExecGatewayInternalSecret)
+	}
+	if len(cfg.CapTokenHMACSecret) != 0 {
+		t.Errorf("CapTokenHMACSecret should be empty, got %d bytes", len(cfg.CapTokenHMACSecret))
+	}
+	if cfg.CapTokenTTL != time.Hour {
+		t.Errorf("CapTokenTTL should be time.Hour, got %v", cfg.CapTokenTTL)
+	}
+}
+
+func TestLoad_Phase3FieldsSet(t *testing.T) {
+	// Set all required Phase 1/2 vars
+	t.Setenv("INTERNAL_API_SECRET", "secret")
+	t.Setenv("AGENTSERVER_INTERNAL_URL", "http://a:8080")
+	t.Setenv("CCAPPGW_LLMPROXY_URL", "http://l:8081")
+	t.Setenv("CCAPPGW_S3_REGION", "us-east-1")
+	t.Setenv("CCAPPGW_S3_BUCKET", "bucket")
+
+	// Set all Phase 3 vars
+	t.Setenv("CCAPPGW_ENV_MCP_BINARY", "/usr/local/bin/codex-app-gateway")
+	t.Setenv("CCAPPGW_EXEC_GATEWAY_WS_URL", "ws://codex-exec-gateway:6060")
+	t.Setenv("CCAPPGW_EXEC_GATEWAY_INTERNAL_URL", "http://codex-exec-gateway:6060")
+	t.Setenv("CCAPPGW_EXEC_GATEWAY_INTERNAL_SECRET", "secret-internal")
+	t.Setenv("CCAPPGW_CAPTOKEN_HMAC_SECRET", "fake-secret-123")
+	t.Setenv("CCAPPGW_CAPTOKEN_TTL", "2h")
+
+	cfg, err := LoadServeConfigFromEnv(ServeFlags{})
+	if err != nil {
+		t.Fatalf("LoadServeConfigFromEnv: %v", err)
+	}
+
+	// Verify all Phase 3 fields are populated correctly
+	if cfg.EnvMcpBinary != "/usr/local/bin/codex-app-gateway" {
+		t.Errorf("EnvMcpBinary = %q, want /usr/local/bin/codex-app-gateway", cfg.EnvMcpBinary)
+	}
+	if cfg.ExecGatewayWSURL != "ws://codex-exec-gateway:6060" {
+		t.Errorf("ExecGatewayWSURL = %q, want ws://codex-exec-gateway:6060", cfg.ExecGatewayWSURL)
+	}
+	if cfg.ExecGatewayInternalURL != "http://codex-exec-gateway:6060" {
+		t.Errorf("ExecGatewayInternalURL = %q, want http://codex-exec-gateway:6060", cfg.ExecGatewayInternalURL)
+	}
+	if cfg.ExecGatewayInternalSecret != "secret-internal" {
+		t.Errorf("ExecGatewayInternalSecret = %q, want secret-internal", cfg.ExecGatewayInternalSecret)
+	}
+	if string(cfg.CapTokenHMACSecret) != "fake-secret-123" {
+		t.Errorf("CapTokenHMACSecret = %q, want fake-secret-123", string(cfg.CapTokenHMACSecret))
+	}
+	if cfg.CapTokenTTL != 2*time.Hour {
+		t.Errorf("CapTokenTTL = %v, want 2h", cfg.CapTokenTTL)
+	}
+}
+
+func TestLoad_CapTokenTTL_Invalid(t *testing.T) {
+	// Set all required Phase 1/2 vars
+	t.Setenv("INTERNAL_API_SECRET", "secret")
+	t.Setenv("AGENTSERVER_INTERNAL_URL", "http://a:8080")
+	t.Setenv("CCAPPGW_LLMPROXY_URL", "http://l:8081")
+	t.Setenv("CCAPPGW_S3_REGION", "us-east-1")
+	t.Setenv("CCAPPGW_S3_BUCKET", "bucket")
+
+	// Set invalid TTL
+	t.Setenv("CCAPPGW_CAPTOKEN_TTL", "not-a-duration")
+
+	_, err := LoadServeConfigFromEnv(ServeFlags{})
+	if err == nil {
+		t.Errorf("LoadServeConfigFromEnv should return error for invalid CCAPPGW_CAPTOKEN_TTL, got nil")
+	}
+	if !strings.Contains(err.Error(), "CCAPPGW_CAPTOKEN_TTL") {
+		t.Errorf("error should mention CCAPPGW_CAPTOKEN_TTL, got: %v", err)
+	}
+}

--- a/internal/ccappgateway/integration_phase3_test.go
+++ b/internal/ccappgateway/integration_phase3_test.go
@@ -1,0 +1,182 @@
+//go:build integration
+// +build integration
+
+package ccappgateway_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agentserver/agentserver/internal/ccappgateway"
+	"github.com/agentserver/agentserver/internal/ccappgateway/runner"
+)
+
+// TestIntegration_EnvMcp_ListEnvironments tests the full Phase 3 env-MCP path:
+//
+//	cc-app-gateway server
+//	  → real claude binary (with MCP config pointing at codex-app-gateway env-mcp)
+//	  → codex-app-gateway env-mcp child
+//	  → mock codex-exec-gateway (serves /api/exec-gateway/connected)
+//
+// The test asks claude to call list_environments and asserts the response
+// contains the mock env's name or id.
+//
+// Prerequisites (t.Skip if missing):
+//   - claude binary in PATH
+//   - ANTHROPIC_BASE_URL and ANTHROPIC_AUTH_TOKEN set
+func TestIntegration_EnvMcp_ListEnvironments(t *testing.T) {
+	anthropicBaseURL := os.Getenv("ANTHROPIC_BASE_URL")
+	anthropicAuthToken := os.Getenv("ANTHROPIC_AUTH_TOKEN")
+	if anthropicBaseURL == "" || anthropicAuthToken == "" {
+		t.Skip("ANTHROPIC_BASE_URL + ANTHROPIC_AUTH_TOKEN required for Phase 3 integration test")
+	}
+	claudeBin, err := exec.LookPath("claude")
+	if err != nil {
+		t.Skip("claude binary not in PATH")
+	}
+
+	// 1. Build codex-app-gateway binary into a temp dir (provides the env-mcp subcommand).
+	binDir := t.TempDir()
+	envMcpBin := filepath.Join(binDir, "codex-app-gateway")
+	repoRoot := findRepoRootPhase3(t)
+	buildCmd := exec.Command("go", "build", "-o", envMcpBin, "./cmd/codex-app-gateway")
+	buildCmd.Dir = repoRoot
+	if out, err := buildCmd.CombinedOutput(); err != nil {
+		t.Fatalf("build codex-app-gateway: %v\n%s", err, out)
+	}
+
+	// 2. Mock codex-exec-gateway: serves GET /api/exec-gateway/connected
+	//    returning a fake environment list.
+	//
+	//    The nameresolver expects a bare JSON array of ConnectedEntry objects
+	//    (not a wrapper object): []{"exe_id","name","description","is_default"}.
+	mockExecGw := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Logf("mock-exec-gw: %s %s", r.Method, r.URL.Path)
+		if r.URL.Path == "/api/exec-gateway/connected" && r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "application/json")
+			// Bare array — matches nameresolver.ConnectedEntry JSON shape.
+			json.NewEncoder(w).Encode([]map[string]any{ //nolint:errcheck
+				{"exe_id": "env_test123", "name": "test-env", "description": "integration test env", "is_default": true},
+			})
+			return
+		}
+		t.Logf("mock-exec-gw: 404 for %s %s", r.Method, r.URL.Path)
+		http.NotFound(w, r)
+	}))
+	defer mockExecGw.Close()
+
+	// 3. Mock agentserver-main: serves POST /internal/workspace-token.
+	//    Returns the real ANTHROPIC_AUTH_TOKEN as the workspace token so that
+	//    the claude subprocess gets a valid credential for the real API.
+	mockAgsv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Logf("mock-agsv: %s %s", r.Method, r.URL.Path)
+		if r.URL.Path == "/internal/workspace-token" && r.Method == http.MethodPost {
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(map[string]string{"token": anthropicAuthToken}) //nolint:errcheck
+			return
+		}
+		t.Logf("mock-agsv: 404 for %s %s", r.Method, r.URL.Path)
+		http.NotFound(w, r)
+	}))
+	defer mockAgsv.Close()
+
+	// 4. Build ServeConfig directly (avoid S3 + LoadServeConfigFromEnv complexity).
+	//    Phase 3 requires CapTokenTTL > TurnTimeout.
+	turnTimeout := 90 * time.Second
+	capTokenTTL := 2 * time.Hour
+	cfg := ccappgateway.ServeConfig{
+		ListenAddr:             "127.0.0.1:0",
+		ClaudeBin:              claudeBin,
+		InternalSecret:         "test-internal-secret",
+		AgentserverInternalURL: mockAgsv.URL,
+		LLMProxyURL:            anthropicBaseURL,
+		DefaultModel:           "claude-haiku-4-5",
+		TurnTimeout:            turnTimeout,
+		TmpRoot:                t.TempDir(),
+		// Phase 3 fields
+		EnvMcpBinary:           envMcpBin,
+		ExecGatewayWSURL:       strings.Replace(mockExecGw.URL, "http://", "ws://", 1),
+		ExecGatewayInternalURL: mockExecGw.URL,
+		CapTokenHMACSecret:     []byte("integration-test-hmac-secret-32b!"),
+		CapTokenTTL:            capTokenTTL,
+	}
+
+	// 5. Wire up the server with a real runner.Run and no-op store (no S3 needed).
+	srv, err := ccappgateway.NewServerWithRunnerAndStore(cfg, runner.Run, newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServerWithRunnerAndStore: %v", err)
+	}
+
+	// 6. POST /api/turns: ask claude to call list_environments.
+	reqBody := `{
+		"workspaceId": "wsp_phase3test",
+		"sessionId":   "00000000-0000-0000-0000-000000000003",
+		"userMessage": "Please call the list_environments tool and tell me what environments exist. Include each environment name and id in your reply.",
+		"model":       "claude-haiku-4-5"
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/api/turns", strings.NewReader(reqBody))
+	req.Header.Set("X-Internal-Secret", "test-internal-secret")
+	req.Header.Set("Content-Type", "application/json")
+
+	// Apply a generous timeout so the test doesn't hang forever.
+	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	defer cancel()
+	req = req.WithContext(ctx)
+
+	rec := httptest.NewRecorder()
+	srv.Routes().ServeHTTP(rec, req)
+
+	// 7. Assertions.
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected HTTP 200, got %d: %s", rec.Code, rec.Body.String())
+	}
+
+	var resp struct {
+		AssistantText string `json:"assistantText"`
+		IsError       bool   `json:"isError"`
+		ErrorMessage  string `json:"errorMessage,omitempty"`
+		SessionID     string `json:"sessionId"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode response body: %v\nraw: %s", err, rec.Body.String())
+	}
+
+	t.Logf("assistantText: %q", resp.AssistantText)
+	t.Logf("isError: %v errorMessage: %q", resp.IsError, resp.ErrorMessage)
+
+	if resp.IsError {
+		t.Errorf("turn returned isError=true; errorMessage=%q; assistantText=%q",
+			resp.ErrorMessage, resp.AssistantText)
+	}
+
+	// Check that the response mentions the mock env's name or id.
+	lower := strings.ToLower(resp.AssistantText)
+	if !strings.Contains(lower, "test-env") && !strings.Contains(resp.AssistantText, "env_test123") {
+		t.Errorf("expected mock env name %q or id %q in response; got: %q",
+			"test-env", "env_test123", resp.AssistantText)
+	}
+}
+
+// findRepoRootPhase3 walks up from cwd until it finds a go.mod file.
+func findRepoRootPhase3(t *testing.T) string {
+	t.Helper()
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	for d := cwd; d != "/"; d = filepath.Dir(d) {
+		if _, err := os.Stat(filepath.Join(d, "go.mod")); err == nil {
+			return d
+		}
+	}
+	t.Fatal("could not find repo root (no go.mod found)")
+	return ""
+}

--- a/internal/ccappgateway/mcp/config.go
+++ b/internal/ccappgateway/mcp/config.go
@@ -1,0 +1,105 @@
+package mcp
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// ConfigInput carries everything WriteConfig needs to render the per-turn
+// mcp.json file that claude reads via --mcp-config.
+type ConfigInput struct {
+	// EnvMcpBinary is the absolute path to the codex-app-gateway binary.
+	EnvMcpBinary string
+
+	// WorkspaceID identifies the workspace for env-mcp.
+	WorkspaceID string
+
+	// ExecGatewayBridgeURL is the WebSocket URL with "/bridge" already appended.
+	// Caller is responsible for appending /bridge to the base WS URL before passing in.
+	ExecGatewayBridgeURL string
+
+	// ExecGatewayInternalURL is the http:// base URL for the exec-gateway internal API.
+	ExecGatewayInternalURL string
+
+	// ExecGatewayInternalSecret is an optional shared key for HTTP relay authentication.
+	// When non-empty, it is passed via the CXG_EXEC_GATEWAY_INTERNAL_SECRET env var.
+	ExecGatewayInternalSecret string
+
+	// AgentserverInternalURL is the http:// base URL for agentserver's internal API.
+	AgentserverInternalURL string
+
+	// WorkspaceCapToken is the per-turn HMAC cap-token (NOT the proxy token).
+	// It is placed in the env block as CXG_WORKSPACE_TOKEN.
+	WorkspaceCapToken string
+
+	// LogFile is the optional path passed to env-mcp's --log-file.
+	// Use "/dev/stderr" to make env-mcp output visible in kubectl logs.
+	LogFile string
+}
+
+// WriteConfig renders mcp.json into dir and returns the absolute path.
+//
+// The file is written with mode 0600 because the env block carries a
+// cap-token (WorkspaceCapToken), which is sensitive.
+//
+// The JSON server key is "agentserver". This MUST match env-mcp's hardcoded
+// MCPServer self-name (see internal/codexappgateway/envmcp/envmcp.go around
+// NewMCPServer("agentserver", ...)). Claude's --tools allowlist uses the prefix
+// mcp__agentserver__<tool>; a mismatched JSON key causes every tool call to fail.
+func WriteConfig(dir string, in ConfigInput) (string, error) {
+	if in.EnvMcpBinary == "" {
+		return "", fmt.Errorf("mcp.WriteConfig: EnvMcpBinary required")
+	}
+	if in.WorkspaceID == "" {
+		return "", fmt.Errorf("mcp.WriteConfig: WorkspaceID required")
+	}
+	if in.WorkspaceCapToken == "" {
+		return "", fmt.Errorf("mcp.WriteConfig: WorkspaceCapToken required")
+	}
+
+	args := []string{
+		"env-mcp",
+		"--workspace-id", in.WorkspaceID,
+		"--exec-gateway-url", in.ExecGatewayBridgeURL, // /bridge suffix is caller's responsibility
+		"--exec-gateway-internal-url", in.ExecGatewayInternalURL,
+		"--agentserver-internal-url", in.AgentserverInternalURL,
+		"--workspace-token-env", "CXG_WORKSPACE_TOKEN",
+	}
+
+	env := map[string]string{
+		"CXG_WORKSPACE_TOKEN": in.WorkspaceCapToken,
+	}
+
+	if in.ExecGatewayInternalSecret != "" {
+		args = append(args, "--exec-gateway-internal-secret-env", "CXG_EXEC_GATEWAY_INTERNAL_SECRET")
+		env["CXG_EXEC_GATEWAY_INTERNAL_SECRET"] = in.ExecGatewayInternalSecret
+	}
+
+	if in.LogFile != "" {
+		args = append(args, "--log-file", in.LogFile)
+	}
+
+	payload := map[string]any{
+		"mcpServers": map[string]any{
+			"agentserver": map[string]any{
+				"command": in.EnvMcpBinary,
+				"args":    args,
+				"env":     env,
+			},
+		},
+	}
+
+	b, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal: %w", err)
+	}
+
+	path := filepath.Join(dir, "mcp.json")
+	if err := os.WriteFile(path, b, 0o600); err != nil {
+		return "", fmt.Errorf("write %s: %w", path, err)
+	}
+
+	return path, nil
+}

--- a/internal/ccappgateway/mcp/config_test.go
+++ b/internal/ccappgateway/mcp/config_test.go
@@ -1,0 +1,111 @@
+package mcp
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func contains(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+func TestWriteConfig_HappyPath(t *testing.T) {
+	tmp := t.TempDir()
+	path, err := WriteConfig(tmp, ConfigInput{
+		EnvMcpBinary:           "/usr/local/bin/codex-app-gateway",
+		WorkspaceID:            "wsp_abc",
+		ExecGatewayBridgeURL:   "ws://codex-exec-gateway:6060/bridge",
+		ExecGatewayInternalURL: "http://codex-exec-gateway:6060",
+		AgentserverInternalURL: "http://agentserver:8080",
+		WorkspaceCapToken:      "cap-token-abc.def.ghi",
+		LogFile:                "/dev/stderr",
+	})
+	if err != nil {
+		t.Fatalf("WriteConfig: %v", err)
+	}
+	if path != filepath.Join(tmp, "mcp.json") {
+		t.Errorf("path = %q, want %q", path, filepath.Join(tmp, "mcp.json"))
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("mode = %v, want 0600 (secret in env block)", info.Mode().Perm())
+	}
+	raw, _ := os.ReadFile(path)
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatal(err)
+	}
+	servers := got["mcpServers"].(map[string]any)
+	srv := servers["agentserver"].(map[string]any) // key MUST be "agentserver" — env-mcp's self-name
+	if srv["command"] != "/usr/local/bin/codex-app-gateway" {
+		t.Errorf("command = %v", srv["command"])
+	}
+	args := srv["args"].([]any)
+	wantSubstrs := []string{"env-mcp", "--workspace-id", "wsp_abc",
+		"--exec-gateway-url", "ws://codex-exec-gateway:6060/bridge",
+		"--exec-gateway-internal-url", "http://codex-exec-gateway:6060",
+		"--agentserver-internal-url", "http://agentserver:8080",
+		"--workspace-token-env", "CXG_WORKSPACE_TOKEN",
+		"--log-file", "/dev/stderr"}
+	var got_args []string
+	for _, a := range args {
+		got_args = append(got_args, a.(string))
+	}
+	for _, want := range wantSubstrs {
+		if !contains(got_args, want) {
+			t.Errorf("args missing %q; got %v", want, got_args)
+		}
+	}
+	env := srv["env"].(map[string]any)
+	if env["CXG_WORKSPACE_TOKEN"] != "cap-token-abc.def.ghi" {
+		t.Errorf("env CXG_WORKSPACE_TOKEN = %v", env["CXG_WORKSPACE_TOKEN"])
+	}
+}
+
+func TestWriteConfig_OptionalExecGatewayInternalSecret(t *testing.T) {
+	tmp := t.TempDir()
+	_, err := WriteConfig(tmp, ConfigInput{
+		EnvMcpBinary: "/x", WorkspaceID: "w", WorkspaceCapToken: "t",
+		ExecGatewayInternalSecret: "secret-xxx",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	raw, _ := os.ReadFile(filepath.Join(tmp, "mcp.json"))
+	if !bytes.Contains(raw, []byte("CXG_EXEC_GATEWAY_INTERNAL_SECRET")) {
+		t.Errorf("expected --exec-gateway-internal-secret-env flag + env var")
+	}
+	if !bytes.Contains(raw, []byte("secret-xxx")) {
+		t.Errorf("expected secret value in env block")
+	}
+}
+
+func TestWriteConfig_ValidatesRequired(t *testing.T) {
+	cases := []struct {
+		name string
+		in   ConfigInput
+	}{
+		{"empty binary", ConfigInput{WorkspaceID: "w", WorkspaceCapToken: "t"}},
+		{"empty workspace", ConfigInput{EnvMcpBinary: "/x", WorkspaceCapToken: "t"}},
+		{"empty captoken", ConfigInput{EnvMcpBinary: "/x", WorkspaceID: "w"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := WriteConfig(t.TempDir(), tc.in)
+			if err == nil {
+				t.Errorf("want error, got nil")
+			}
+		})
+	}
+}

--- a/internal/ccappgateway/runner/options.go
+++ b/internal/ccappgateway/runner/options.go
@@ -24,6 +24,11 @@ type RunInput struct {
 	// Default "" behaves as "fresh" (backward compat for Phase 1 callers).
 	SessionMode string
 
+	// MCPConfigPath is the path to the mcp.json config file (Phase 3+). When set,
+	// BuildArgs appends --mcp-config, --strict-mcp-config, and --tools flags.
+	// Empty string disables MCP (Phase 2 behavior).
+	MCPConfigPath string
+
 	// ExtraAllowedEnv is an optional set of env-var keys that should pass
 	// through to the subprocess in addition to envAllowlist. Production
 	// callers leave this empty; tests use it to inject helper vars (e.g.
@@ -42,10 +47,12 @@ type RunInput struct {
 //
 // Includes: --print, --input-format stream-json, --output-format stream-json,
 // --verbose, --permission-mode bypassPermissions, --dangerously-skip-permissions,
-// --model <Model>, followed by either --session-id <SessionID> (fresh) or
-// --resume <SessionID> (resume), depending on RunInput.SessionMode.
+// --model <Model>, followed by MCP flags (if MCPConfigPath != ""), followed by
+// either --session-id <SessionID> (fresh) or --resume <SessionID> (resume),
+// depending on RunInput.SessionMode.
 //
-// Phase 1 deliberately omits --mcp-config, --strict-mcp-config, --tools.
+// Phase 2 (MCPConfigPath empty) omits --mcp-config, --strict-mcp-config, --tools.
+// Phase 3+ (MCPConfigPath set) appends those flags in that order before session flags.
 // There is no --cwd flag on claude; use cmd.Dir instead.
 func BuildArgs(in RunInput) []string {
 	args := []string{
@@ -56,6 +63,9 @@ func BuildArgs(in RunInput) []string {
 		"--permission-mode", "bypassPermissions",
 		"--dangerously-skip-permissions",
 		"--model", in.Model,
+	}
+	if in.MCPConfigPath != "" {
+		args = append(args, "--mcp-config", in.MCPConfigPath, "--strict-mcp-config", "--tools", "mcp__agentserver__*")
 	}
 	switch in.SessionMode {
 	case "resume":

--- a/internal/ccappgateway/runner/options_test.go
+++ b/internal/ccappgateway/runner/options_test.go
@@ -99,13 +99,14 @@ func TestBuildArgs_RequiredFlags(t *testing.T) {
 
 func TestBuildArgs_ForbiddenFlags(t *testing.T) {
 	in := baseRunInput()
+	in.MCPConfigPath = "" // empty: Phase 2 behavior
 	args := BuildArgs(in)
 	joined := strings.Join(args, " ")
 
 	forbidden := []string{"--mcp-config", "--strict-mcp-config", "--tools", "--resume", "--cwd"}
 	for _, f := range forbidden {
 		if strings.Contains(joined, f) {
-			t.Errorf("BuildArgs: must not contain %q (Phase 1 restriction)", f)
+			t.Errorf("BuildArgs (empty MCPConfigPath): must not contain %q (Phase 2 restriction)", f)
 		}
 	}
 }
@@ -206,12 +207,12 @@ func TestBuildEnv_RequiredVarsPresent(t *testing.T) {
 	result := BuildEnv(in, nil)
 
 	required := map[string]string{
-		"CLAUDE_CONFIG_DIR":                  "/custom/claude/dir",
-		"IS_SANDBOX":                         "1",
-		"CLAUDE_CODE_AUTO_COMPACT_WINDOW":    "165000",
+		"CLAUDE_CONFIG_DIR":                      "/custom/claude/dir",
+		"IS_SANDBOX":                             "1",
+		"CLAUDE_CODE_AUTO_COMPACT_WINDOW":        "165000",
 		"CLAUDE_CODE_DISABLE_FILE_CHECKPOINTING": "1",
-		"ANTHROPIC_AUTH_TOKEN":               "my-ws-token",
-		"ANTHROPIC_BASE_URL":                 "http://llmproxy:9999",
+		"ANTHROPIC_AUTH_TOKEN":                   "my-ws-token",
+		"ANTHROPIC_BASE_URL":                     "http://llmproxy:9999",
 	}
 
 	for key, wantVal := range required {
@@ -329,4 +330,123 @@ func containsAdjacent(args []string, a, b string) bool {
 		}
 	}
 	return false
+}
+
+func TestBuildArgs_NoMCPConfig_Phase2Compat(t *testing.T) {
+	in := baseRunInput()
+	in.MCPConfigPath = "" // empty: Phase 2 behavior
+	args := BuildArgs(in)
+	joined := strings.Join(args, " ")
+
+	// Verify MCP flags are NOT present.
+	mcpForbidden := []string{"--mcp-config", "--strict-mcp-config", "--tools"}
+	for _, flag := range mcpForbidden {
+		if strings.Contains(joined, flag) {
+			t.Errorf("BuildArgs with empty MCPConfigPath: must not contain %q; args=%v", flag, args)
+		}
+	}
+
+	// Verify Phase 2 args are still present.
+	if !containsAdjacent(args, "--model", in.Model) {
+		t.Errorf("BuildArgs: --model flag missing or misplaced")
+	}
+	if !containsAdjacent(args, "--session-id", in.SessionID) {
+		t.Errorf("BuildArgs: --session-id flag missing or misplaced")
+	}
+}
+
+func TestBuildArgs_WithMCPConfig(t *testing.T) {
+	in := baseRunInput()
+	in.MCPConfigPath = "/tmp/mcp.json"
+	args := BuildArgs(in)
+
+	// Verify the exact sub-sequence exists.
+	if !containsSubsequence(args, []string{"--mcp-config", "/tmp/mcp.json", "--strict-mcp-config", "--tools", "mcp__agentserver__*"}) {
+		t.Errorf("BuildArgs: expected sub-sequence [--mcp-config /tmp/mcp.json --strict-mcp-config --tools mcp__agentserver__*]; args=%v", args)
+	}
+
+	// Verify it appears BEFORE --session-id.
+	mcp := indexOfSubsequence(args, []string{"--mcp-config", "/tmp/mcp.json"})
+	sid := indexOf(args, "--session-id")
+	if mcp == -1 {
+		t.Errorf("BuildArgs: --mcp-config sub-sequence not found")
+	}
+	if sid == -1 {
+		t.Errorf("BuildArgs: --session-id not found")
+	}
+	if mcp != -1 && sid != -1 && mcp >= sid {
+		t.Errorf("BuildArgs: --mcp-config must appear BEFORE --session-id; mcp index=%d, session-id index=%d", mcp, sid)
+	}
+}
+
+func TestBuildArgs_WithMCPConfig_Resume(t *testing.T) {
+	in := baseRunInput()
+	in.MCPConfigPath = "/tmp/mcp.json"
+	in.SessionMode = "resume"
+	args := BuildArgs(in)
+
+	// Verify both MCP flags AND --resume are present.
+	if !containsSubsequence(args, []string{"--mcp-config", "/tmp/mcp.json", "--strict-mcp-config", "--tools", "mcp__agentserver__*"}) {
+		t.Errorf("BuildArgs: expected MCP sub-sequence; args=%v", args)
+	}
+	if !containsAdjacent(args, "--resume", in.SessionID) {
+		t.Errorf("BuildArgs: expected --resume <SessionID>; args=%v", args)
+	}
+
+	// Verify MCP flags appear BEFORE --resume.
+	mcp := indexOfSubsequence(args, []string{"--mcp-config", "/tmp/mcp.json"})
+	resume := indexOf(args, "--resume")
+	if mcp != -1 && resume != -1 && mcp >= resume {
+		t.Errorf("BuildArgs: --mcp-config must appear BEFORE --resume; mcp index=%d, resume index=%d", mcp, resume)
+	}
+}
+
+// indexOf returns the index of flag in args, or -1 if not found.
+func indexOf(args []string, flag string) int {
+	for i, a := range args {
+		if a == flag {
+			return i
+		}
+	}
+	return -1
+}
+
+// containsSubsequence returns true if args contains the exact subsequence.
+func containsSubsequence(args []string, subseq []string) bool {
+	if len(subseq) == 0 {
+		return true
+	}
+	for i := 0; i <= len(args)-len(subseq); i++ {
+		match := true
+		for j, v := range subseq {
+			if args[i+j] != v {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+// indexOfSubsequence returns the starting index of subseq in args, or -1 if not found.
+func indexOfSubsequence(args []string, subseq []string) int {
+	if len(subseq) == 0 {
+		return 0
+	}
+	for i := 0; i <= len(args)-len(subseq); i++ {
+		match := true
+		for j, v := range subseq {
+			if args[i+j] != v {
+				match = false
+				break
+			}
+		}
+		if match {
+			return i
+		}
+	}
+	return -1
 }

--- a/internal/ccappgateway/server.go
+++ b/internal/ccappgateway/server.go
@@ -57,9 +57,37 @@ func (s *Server) AcquireSessionLock(workspaceID, sessionID string) *sync.Mutex {
 	return mu
 }
 
+// validatePhase3Config checks that all required Phase 3 env-MCP fields are
+// present when EnvMcpBinary is set. Called by all public constructors so that
+// misconfiguration causes a fast crash at startup rather than a silent no-op.
+func validatePhase3Config(cfg ServeConfig) error {
+	if cfg.EnvMcpBinary == "" {
+		return nil // Phase 3 disabled; no validation needed.
+	}
+	if cfg.ExecGatewayWSURL == "" {
+		return fmt.Errorf("CCAPPGW_EXEC_GATEWAY_WS_URL required when CCAPPGW_ENV_MCP_BINARY set")
+	}
+	if cfg.ExecGatewayInternalURL == "" {
+		return fmt.Errorf("CCAPPGW_EXEC_GATEWAY_INTERNAL_URL required when CCAPPGW_ENV_MCP_BINARY set")
+	}
+	if cfg.AgentserverInternalURL == "" {
+		return fmt.Errorf("AGENTSERVER_INTERNAL_URL required when CCAPPGW_ENV_MCP_BINARY set")
+	}
+	if len(cfg.CapTokenHMACSecret) == 0 {
+		return fmt.Errorf("CCAPPGW_CAPTOKEN_HMAC_SECRET required when CCAPPGW_ENV_MCP_BINARY set")
+	}
+	if cfg.CapTokenTTL <= cfg.TurnTimeout {
+		return fmt.Errorf("CapTokenTTL (%v) must exceed TurnTimeout (%v)", cfg.CapTokenTTL, cfg.TurnTimeout)
+	}
+	return nil
+}
+
 // NewServer wires config, wstoken client, turn handler, chi router with the
 // real runner and a real S3 client. Fails fast if S3 client init fails.
 func NewServer(cfg ServeConfig) (*Server, error) {
+	if err := validatePhase3Config(cfg); err != nil {
+		return nil, err
+	}
 	ctx := context.Background()
 	store, err := NewS3Client(ctx, S3Config{
 		Endpoint:  cfg.S3Endpoint,
@@ -83,6 +111,9 @@ func NewServerWithRunner(cfg ServeConfig, runFn RunnerFunc) (*Server, error) {
 // custom ObjectStore. Used by tests that exercise S3-dependent logic (readyz,
 // Setup/Teardown).
 func NewServerWithRunnerAndStore(cfg ServeConfig, runFn RunnerFunc, store workspace.ObjectStore) (*Server, error) {
+	if err := validatePhase3Config(cfg); err != nil {
+		return nil, err
+	}
 	return newServerInternal(cfg, runFn, store), nil
 }
 

--- a/internal/ccappgateway/server.go
+++ b/internal/ccappgateway/server.go
@@ -77,7 +77,7 @@ func validatePhase3Config(cfg ServeConfig) error {
 		return fmt.Errorf("CCAPPGW_CAPTOKEN_HMAC_SECRET required when CCAPPGW_ENV_MCP_BINARY set")
 	}
 	if cfg.CapTokenTTL <= cfg.TurnTimeout {
-		return fmt.Errorf("CapTokenTTL (%v) must exceed TurnTimeout (%v)", cfg.CapTokenTTL, cfg.TurnTimeout)
+		return fmt.Errorf("CCAPPGW_CAPTOKEN_TTL (%v) must exceed CCAPPGW_TURN_TIMEOUT (%v); set CCAPPGW_CAPTOKEN_TTL to at least 2× turn timeout", cfg.CapTokenTTL, cfg.TurnTimeout)
 	}
 	return nil
 }

--- a/internal/ccappgateway/server_test.go
+++ b/internal/ccappgateway/server_test.go
@@ -476,8 +476,8 @@ func TestNewServer_Phase3_RejectsIfTTLTooShort(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when CapTokenTTL <= TurnTimeout, got nil")
 	}
-	if !strings.Contains(err.Error(), "CapTokenTTL") {
-		t.Errorf("error should mention CapTokenTTL; got: %v", err)
+	if !strings.Contains(err.Error(), "CCAPPGW_CAPTOKEN_TTL") {
+		t.Errorf("error should mention CCAPPGW_CAPTOKEN_TTL; got: %v", err)
 	}
 }
 

--- a/internal/ccappgateway/server_test.go
+++ b/internal/ccappgateway/server_test.go
@@ -431,6 +431,66 @@ func TestShutdown_DrainsTeardownWG(t *testing.T) {
 	// would have returned via ctx-deadline exceeded — but here we expect clean drain.
 }
 
+// --- Phase 3 NewServer validation tests ---
+
+// buildPhase3Cfg returns a ServeConfig with all Phase 3 fields populated correctly.
+func buildPhase3Cfg(claudeBin, agentserverURL string) ccappgateway.ServeConfig {
+	cfg := buildTestCfg(claudeBin, agentserverURL, "")
+	cfg.EnvMcpBinary = "/usr/local/bin/codex-app-gateway"
+	cfg.ExecGatewayWSURL = "ws://exec-gw:8080"
+	cfg.ExecGatewayInternalURL = "http://exec-gw-internal:9090"
+	cfg.ExecGatewayInternalSecret = "secret"
+	cfg.CapTokenHMACSecret = []byte("hmac-secret-32-bytes-long-enough!")
+	cfg.CapTokenTTL = 2 * time.Hour // exceeds TurnTimeout=30s
+	return cfg
+}
+
+func TestNewServer_Phase3_RejectsIfWSURLMissing(t *testing.T) {
+	cfg := buildPhase3Cfg("/nonexistent/claude", "http://localhost:9999")
+	cfg.ExecGatewayWSURL = ""
+	_, err := ccappgateway.NewServerWithRunner(cfg, happyRunner)
+	if err == nil {
+		t.Fatal("expected error when ExecGatewayWSURL is empty, got nil")
+	}
+	if !strings.Contains(err.Error(), "CCAPPGW_EXEC_GATEWAY_WS_URL") {
+		t.Errorf("error should mention CCAPPGW_EXEC_GATEWAY_WS_URL; got: %v", err)
+	}
+}
+
+func TestNewServer_Phase3_RejectsIfHMACMissing(t *testing.T) {
+	cfg := buildPhase3Cfg("/nonexistent/claude", "http://localhost:9999")
+	cfg.CapTokenHMACSecret = nil
+	_, err := ccappgateway.NewServerWithRunner(cfg, happyRunner)
+	if err == nil {
+		t.Fatal("expected error when CapTokenHMACSecret is empty, got nil")
+	}
+	if !strings.Contains(err.Error(), "CCAPPGW_CAPTOKEN_HMAC_SECRET") {
+		t.Errorf("error should mention CCAPPGW_CAPTOKEN_HMAC_SECRET; got: %v", err)
+	}
+}
+
+func TestNewServer_Phase3_RejectsIfTTLTooShort(t *testing.T) {
+	cfg := buildPhase3Cfg("/nonexistent/claude", "http://localhost:9999")
+	cfg.CapTokenTTL = 5 * time.Second // less than TurnTimeout=30s
+	_, err := ccappgateway.NewServerWithRunner(cfg, happyRunner)
+	if err == nil {
+		t.Fatal("expected error when CapTokenTTL <= TurnTimeout, got nil")
+	}
+	if !strings.Contains(err.Error(), "CapTokenTTL") {
+		t.Errorf("error should mention CapTokenTTL; got: %v", err)
+	}
+}
+
+func TestNewServer_Phase3_Disabled_NoValidation(t *testing.T) {
+	// When EnvMcpBinary is empty, Phase 3 fields are ignored.
+	cfg := buildTestCfg("/nonexistent/claude", "http://localhost:9999", "")
+	// All Phase 3 fields empty — should succeed.
+	_, err := ccappgateway.NewServerWithRunner(cfg, happyRunner)
+	if err != nil {
+		t.Fatalf("expected no error when EnvMcpBinary is empty; got: %v", err)
+	}
+}
+
 func TestReadyz_S3Unreachable(t *testing.T) {
 	srv, cleanup := newTestServerWithStore(t, &errorStore{err: errors.New("s3 unreachable")})
 	defer cleanup()

--- a/internal/ccappgateway/turn_api.go
+++ b/internal/ccappgateway/turn_api.go
@@ -7,10 +7,14 @@ import (
 	"log"
 	"net/http"
 	"regexp"
+	"strings"
 	"time"
 
+	"github.com/agentserver/agentserver/internal/captoken"
+	"github.com/agentserver/agentserver/internal/ccappgateway/mcp"
 	"github.com/agentserver/agentserver/internal/ccappgateway/runner"
 	"github.com/agentserver/agentserver/internal/ccappgateway/workspace"
+	"github.com/agentserver/agentserver/internal/shortid"
 )
 
 // RunnerFunc abstracts runner.Run for testability. In production it's
@@ -184,21 +188,54 @@ func (h *TurnHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		sessionMode = "resume"
 	}
 
+	// Phase 3: mint cap-token and write mcp.json when env-MCP is configured.
+	var mcpConfigPath string
+	if h.Cfg.EnvMcpBinary != "" {
+		capTok, err := captoken.Mint(h.Cfg.CapTokenHMACSecret, captoken.Payload{
+			TurnID:      "trn_" + shortid.Generate(),
+			WorkspaceID: req.WorkspaceID,
+			UserID:      "", // cc-app-gateway is internal-secret authed; no enduser context
+		}, h.Cfg.CapTokenTTL)
+		if err != nil {
+			log.Printf("[cc-app-gateway] mint_captoken_failed (session=%s workspace=%s): %v", req.SessionID, req.WorkspaceID, err)
+			writeError(w, http.StatusInternalServerError, "captoken_failed", "internal authorization failure")
+			return
+		}
+		bridgeURL := strings.TrimRight(h.Cfg.ExecGatewayWSURL, "/") + "/bridge"
+		p, err := mcp.WriteConfig(ws.TempDir, mcp.ConfigInput{
+			EnvMcpBinary:              h.Cfg.EnvMcpBinary,
+			WorkspaceID:               req.WorkspaceID,
+			ExecGatewayBridgeURL:      bridgeURL,
+			ExecGatewayInternalURL:    h.Cfg.ExecGatewayInternalURL,
+			ExecGatewayInternalSecret: h.Cfg.ExecGatewayInternalSecret,
+			AgentserverInternalURL:    h.Cfg.AgentserverInternalURL,
+			WorkspaceCapToken:         capTok,
+			LogFile:                   "/dev/stderr",
+		})
+		if err != nil {
+			log.Printf("[cc-app-gateway] mcp_config_write_failed (session=%s): %v", req.SessionID, err)
+			writeError(w, http.StatusInternalServerError, "mcp_config_failed", "internal MCP config failure")
+			return
+		}
+		mcpConfigPath = p
+	}
+
 	// Run claude with per-turn timeout.
 	runCtx, rcancel := context.WithTimeout(r.Context(), turnTimeout)
 	defer rcancel()
 
 	result, err := h.Runner(runCtx, runner.RunInput{
-		ClaudeBin:   h.Cfg.ClaudeBin,
-		ClaudeDir:   ws.ClaudeDir,
-		ProjectDir:  ws.ProjectDir,
-		SessionID:   req.SessionID,
-		Model:       model,
-		UserMessage: req.UserMessage,
-		WSToken:     wsToken,
-		LLMProxyURL: h.Cfg.LLMProxyURL,
-		Timeout:     turnTimeout,
-		SessionMode: sessionMode,
+		ClaudeBin:     h.Cfg.ClaudeBin,
+		ClaudeDir:     ws.ClaudeDir,
+		ProjectDir:    ws.ProjectDir,
+		SessionID:     req.SessionID,
+		Model:         model,
+		UserMessage:   req.UserMessage,
+		WSToken:       wsToken,
+		LLMProxyURL:   h.Cfg.LLMProxyURL,
+		Timeout:       turnTimeout,
+		SessionMode:   sessionMode,
+		MCPConfigPath: mcpConfigPath,
 	})
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {

--- a/internal/ccappgateway/turn_api_test.go
+++ b/internal/ccappgateway/turn_api_test.go
@@ -559,8 +559,8 @@ func TestServeHTTP_WorkspaceIDValidFormatAccepted(t *testing.T) {
 		"ws_test",
 		"ws-prod-123",
 		"ABC_def_42",
-		"x",                       // 1 char
-		strings.Repeat("a", 64),   // max length
+		"x",                     // 1 char
+		strings.Repeat("a", 64), // max length
 	}
 	fakeRunner := func(_ context.Context, _ runner.RunInput) (*runner.RunResult, error) {
 		return &runner.RunResult{AssistantText: "ok", Meta: &runner.ResultMeta{Subtype: "success"}}, nil
@@ -605,5 +605,111 @@ func TestServeHTTP_IsErrorPopulatesErrorMessage(t *testing.T) {
 	}
 	if resp.ErrorMessage != "context window exceeded" {
 		t.Errorf("errorMessage: got %q, want %q", resp.ErrorMessage, "context window exceeded")
+	}
+}
+
+// --- Phase 3: cap-token + mcp.json per-turn tests ---
+
+// buildPhase3ServerCfg returns a ServeConfig with valid Phase 3 fields and
+// a real fake wstoken server. The caller must call cleanup() when done.
+func buildPhase3ServerCfg(t *testing.T) (ccappgateway.ServeConfig, func()) {
+	t.Helper()
+	wstokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"token":"deadbeef"}`)
+	}))
+	cfg := ccappgateway.ServeConfig{
+		DefaultModel:              "haiku",
+		TurnTimeout:               30 * time.Second,
+		TmpRoot:                   t.TempDir(),
+		AgentserverInternalURL:    wstokenSrv.URL,
+		InternalSecret:            "",
+		EnvMcpBinary:              "/usr/local/bin/codex-app-gateway",
+		ExecGatewayWSURL:          "ws://exec-gw:8080",
+		ExecGatewayInternalURL:    "http://exec-gw-internal:9090",
+		ExecGatewayInternalSecret: "exec-secret",
+		CapTokenHMACSecret:        []byte("hmac-secret-32-bytes-long-enough!"),
+		CapTokenTTL:               2 * time.Hour,
+	}
+	return cfg, wstokenSrv.Close
+}
+
+func TestServeHTTP_Phase3_WritesMCPConfigAndPassesPath(t *testing.T) {
+	cfg, cleanup := buildPhase3ServerCfg(t)
+	defer cleanup()
+
+	// Fake runner captures RunInput and reads the mcp.json while it still exists.
+	var capturedPath string
+	var capturedMCPContent []byte
+
+	fakeRunner := func(_ context.Context, in runner.RunInput) (*runner.RunResult, error) {
+		capturedPath = in.MCPConfigPath
+		if in.MCPConfigPath != "" {
+			var err error
+			capturedMCPContent, err = os.ReadFile(in.MCPConfigPath)
+			if err != nil {
+				return nil, fmt.Errorf("mcp file read in runner: %w", err)
+			}
+		}
+		return &runner.RunResult{
+			AssistantText: "ok",
+			Meta:          &runner.ResultMeta{Subtype: "success"},
+		}, nil
+	}
+
+	srv, err := ccappgateway.NewServerWithRunnerAndStore(cfg, fakeRunner, newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServerWithRunnerAndStore: %v", err)
+	}
+
+	rr := postTurn(t, srv, `{"workspaceId":"ws_test","sessionId":"00000000-0000-0000-0000-000000000001","userMessage":"hi"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: %d body: %s", rr.Code, rr.Body.String())
+	}
+
+	if capturedPath == "" {
+		t.Fatal("runner received empty MCPConfigPath; expected non-empty")
+	}
+
+	if len(capturedMCPContent) == 0 {
+		t.Fatal("mcp.json content was empty at runner call time")
+	}
+
+	// Parse the JSON and verify CXG_WORKSPACE_TOKEN is present.
+	var mcpJSON struct {
+		MCPServers map[string]struct {
+			Env map[string]string `json:"env"`
+		} `json:"mcpServers"`
+	}
+	if err := json.Unmarshal(capturedMCPContent, &mcpJSON); err != nil {
+		t.Fatalf("mcp.json is not valid JSON: %v; content: %s", err, capturedMCPContent)
+	}
+	agentserver, ok := mcpJSON.MCPServers["agentserver"]
+	if !ok {
+		t.Fatalf("mcp.json missing mcpServers.agentserver key; got: %s", capturedMCPContent)
+	}
+	tok := agentserver.Env["CXG_WORKSPACE_TOKEN"]
+	if tok == "" {
+		t.Errorf("CXG_WORKSPACE_TOKEN is empty in mcp.json env; got env: %+v", agentserver.Env)
+	}
+}
+
+func TestServeHTTP_Phase3_Disabled_EmptyMCPConfigPath(t *testing.T) {
+	// Phase 2 behavior: EnvMcpBinary="" → MCPConfigPath must be "" in RunInput.
+	var capturedPath string
+	fakeRunner := func(_ context.Context, in runner.RunInput) (*runner.RunResult, error) {
+		capturedPath = in.MCPConfigPath
+		return &runner.RunResult{
+			AssistantText: "ok",
+			Meta:          &runner.ResultMeta{Subtype: "success"},
+		}, nil
+	}
+	srv := newTestServerWithStoreAndRunner(t, newFakeStore(), fakeRunner)
+	rr := postTurn(t, srv, `{"workspaceId":"ws_test","sessionId":"00000000-0000-0000-0000-000000000001","userMessage":"hi"}`)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status: %d body: %s", rr.Code, rr.Body.String())
+	}
+	if capturedPath != "" {
+		t.Errorf("expected MCPConfigPath=\"\" when EnvMcpBinary is empty; got %q", capturedPath)
 	}
 }


### PR DESCRIPTION
## Summary

Phase 3 of cc-app-gateway: wires env-MCP into the managed_cc IM path so claude (over WeChat) can call workspace env tools (shell, exec_command, read_file, apply_patch, copy_path, list_environments, scheduled tasks) — feature parity with the codex routing path.

Before this PR: claude in WeChat had only built-in tools (bash/read/write on the ephemeral pod-local dir). After: claude calls real env tools on the workspace's connected executors.

## Design

When \`CCAPPGW_ENV_MCP_BINARY\` is set, every turn:
1. Mints a per-turn HMAC cap-token (same secret codex shares).
2. Writes \`<TempDir>/mcp.json\` (mode 0600) referencing the codex-app-gateway binary's \`env-mcp\` subcommand with the workspace ID + cap-token + exec-gateway URLs.
3. Passes \`--mcp-config <path> --strict-mcp-config --tools mcp__agentserver__*\` to claude.
4. claude forks env-mcp as a stdio child; env-mcp dials codex-exec-gateway (env tools) and agentserver-main (scheduling) using the cap-token.

env-mcp is reused as-is from \`cmd/codex-app-gateway\`. Same binary, embedded into the cc-app-gateway image at \`/usr/local/bin/codex-app-gateway\` so it's spawnable inside the pod. cc-app-gateway and codex-app-gateway share the cap-token HMAC secret (auto-generated by chart; same Git commit ⇒ no binary drift).

## Spec, plan, audit

- **Spec** (v3, audited + Phase 0 v2 verified): \`docs/superpowers/specs/2026-06-22-cc-app-gateway-phase3-design.md\`
- **Plan** (7 TDD tasks): \`docs/superpowers/plans/2026-06-22-cc-app-gateway-phase3.md\`
- **Spec self-audit** (opus, fresh-eyes): 7 critical + 7 important + 5 minor — all critical + important fixed in v2 before any code was written.
- **Phase 0 v2 probe**: validated 3 unknowns about claude \`--mcp-config\` (glob \`mcp__<server>__*\` works, mcp.json \`env\` block honored, \`bypassPermissions\` blankets MCP tools — no \`--allowedTools\` needed). Probes at \`/tmp/cc-probe-v2/FINDINGS-v2.md\`.

## Final review (opus, whole-branch)

**Verdict: Ready with 1 optional fix.** No Critical. 3 Important were all UX nits, not safety/correctness. Important #2 (error message env var name) addressed in commit \`b7286fc\`.

## Notable callouts

- **Spec divergence (intentional)**: Task 2 implementer correctly reused Phase 1's existing \`AGENTSERVER_INTERNAL_URL\` env var instead of introducing a new \`CCAPPGW_AGENTSERVER_INTERNAL_URL\` (spec proposed). Better outcome — no operator-visible duplicate vars.
- **Image size**: cc-app-gateway grows ~30 MB from embedding codex-app-gateway binary. Acceptable.
- **Cross-component coupling**: cc-app-gateway now imports \`internal/captoken\` and ships the codex-app-gateway binary. Both pinned to same Git commit via \`build.yml\` single workflow run; version drift impossible within a release.
- **Integration test (\`internal/ccappgateway/integration_phase3_test.go\`)**: spins up mock codex-exec-gateway + agentserver-main via httptest, builds codex-app-gateway binary fresh, asks REAL claude to call \`list_environments\`, asserts response mentions the mock env's name. PASSED with real claude correctly invoking the env-mcp tool chain.
- **Helm \`codex-gateway-secret.yaml\` widened**: gate now includes the cc env-mcp consumer so the shared Secret renders even if codex pods are disabled — prevents CrashLoopBackOff on missing secretKeyRef.

## Stats

8 commits / 17 files / +1893 / -23 LOC.

## Test plan

- [ ] CI green (unit tests)
- [ ] Local \`go test -tags integration -timeout 120s ./internal/ccappgateway/ -run TestIntegration_EnvMcp\` — integration test PASS (requires local \`claude\` + ANTHROPIC env)
- [ ] Helm template renders correctly:
  - \`--set ccAppGateway.envMcp.enabled=true --set codexExecGateway.enabled=true\` → env block rendered
  - \`--set ccAppGateway.envMcp.enabled=true --set codexExecGateway.enabled=false\` → fail with explicit message
  - \`--set ccAppGateway.envMcp.enabled=false\` → no Phase 3 env vars
- [ ] After merge: bump Chart 0.69.8 → 0.69.9, push \`v0.69.9\` tag
- [ ] After tag build: \`pulumi up\` with \`ccAppGateway.envMcp.enabled=true\` in pulumi values
- [ ] Smoke: WeChat user asks claude to "list executors" → claude calls list_environments → reply names connected executor

## Follow-ups (deferred)

- Cap-token mint / mcp-config-write failure branches lack test coverage (unreachable due to startup validation; defense-in-depth tests could be added)
- Integration test \`json.NewEncoder.Encode\` errcheck cosmetic