### PR TITLE
chore(chart): bump 0.69.8 → 0.69.9 to ship #286

### DIFF
--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.69.8
-appVersion: "0.69.8"
+version: 0.69.9
+appVersion: "0.69.9"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver


### PR DESCRIPTION
Ships #286 (cc-app-gateway Phase 3 env-MCP). After merge: push `v0.69.9` tag, update /root/k8s to set `ccAppGateway.envMcp.enabled=true`.