### PR TITLE
fix(server): #290 whoami returns identity + sandbox_status, no longer 403s on inactive sandbox

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1,8002 +1,6 @@
 {
-  "openapi": "3.0.0",
-  "info": {
-    "description": "Public REST API for agentserver. Generated from\nGo handler annotations via swaggo/swag; see\ndocs/api/README.md for regeneration instructions.",
-    "title": "agentserver API",
-    "contact": {},
-    "version": "0.1.0"
-  },
-  "paths": {
-    "/api/admin/quotas/defaults": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Admin"
-        ],
-        "summary": "Get system-wide quota defaults (admin)",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AdminQuotaDefaultsResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "admin role required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Admin"
-        ],
-        "summary": "Update system-wide quota defaults (admin)",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AdminQuotaDefaultsUpdateRequest"
-              }
-            }
-          },
-          "description": "Quota fields to update (all optional)",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "Updated defaults",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AdminQuotaDefaultsResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "admin role required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/admin/sandboxes": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Admin"
-        ],
-        "summary": "List all sandboxes (admin)",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AdminSandboxItem"
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "admin role required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/admin/users": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Admin"
-        ],
-        "summary": "List all users (admin)",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AdminUserItem"
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "admin role required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/admin/users/{id}/quota": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Admin"
-        ],
-        "summary": "Get per-user quota override (admin)",
-        "parameters": [
-          {
-            "description": "User ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AdminUserQuotaResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "admin role required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Admin"
-        ],
-        "summary": "Set per-user quota override (admin)",
-        "parameters": [
-          {
-            "description": "User ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AdminSetUserQuotaRequest"
-              }
-            }
-          },
-          "description": "Quota overrides",
-          "required": true
-        },
-        "responses": {
-          "204": {
-            "description": "saved"
-          },
-          "400": {
-            "description": "bad request",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "admin role required",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Admin"
-        ],
-        "summary": "Delete per-user quota override (admin)",
-        "parameters": [
-          {
-            "description": "User ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "deleted"
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "admin role required",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/admin/users/{id}/role": {
-      "put": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Admin"
-        ],
-        "summary": "Update a user's role (admin)",
-        "parameters": [
-          {
-            "description": "User ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AdminUpdateUserRoleRequest"
-              }
-            }
-          },
-          "description": "New role (user or admin)",
-          "required": true
-        },
-        "responses": {
-          "204": {
-            "description": "updated"
-          },
-          "400": {
-            "description": "bad request / invalid role",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "admin role required",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/admin/workspaces": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Admin"
-        ],
-        "summary": "List all workspaces (admin)",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AdminWorkspaceItem"
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "admin role required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/admin/workspaces/{id}/llm-quota": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Admin"
-        ],
-        "summary": "Get workspace LLM quota (admin, proxied to llmproxy)",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LLMQuotaResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "admin role required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "llmproxy unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "llmproxy not configured",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Admin"
-        ],
-        "summary": "Set workspace LLM quota override (admin, proxied to llmproxy)",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "saved"
-          },
-          "400": {
-            "description": "bad request",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "admin role required",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "llmproxy unavailable",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "llmproxy not configured",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Admin"
-        ],
-        "summary": "Delete workspace LLM quota override (admin, proxied to llmproxy)",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "deleted"
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "admin role required",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "llmproxy unavailable",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "llmproxy not configured",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/admin/workspaces/{id}/quota": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Admin"
-        ],
-        "summary": "Get workspace quota override (admin)",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AdminWorkspaceQuotaResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "admin role required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Admin"
-        ],
-        "summary": "Set workspace quota override (admin)",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AdminSetWorkspaceQuotaRequest"
-              }
-            }
-          },
-          "description": "Quota overrides (all optional, merged with existing)",
-          "required": true
-        },
-        "responses": {
-          "204": {
-            "description": "saved"
-          },
-          "400": {
-            "description": "bad request",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "admin role required",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Admin"
-        ],
-        "summary": "Delete workspace quota override (admin)",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "deleted"
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "admin role required",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/agent/discovery/agents": {
-      "get": {
-        "tags": [
-          "Agent"
-        ],
-        "summary": "Discover agents in the calling agent's workspace (proxy_token auth)",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AgentCardItem"
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/agent/discovery/cards": {
-      "post": {
-        "tags": [
-          "Agent"
-        ],
-        "summary": "Register or update an agent capability card",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AgentCardRegisterRequest"
-              }
-            }
-          },
-          "description": "Agent card info",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentCardRegisterResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/agent/mailbox/inbox": {
-      "get": {
-        "tags": [
-          "Agent"
-        ],
-        "summary": "Read messages from the calling agent's inbox",
-        "parameters": [
-          {
-            "description": "Max messages to return (default 10)",
-            "name": "limit",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AgentMailboxMessage"
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/agent/mailbox/send": {
-      "post": {
-        "tags": [
-          "Agent"
-        ],
-        "summary": "Send a message to another agent's mailbox",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AgentMailboxSendRequest"
-              }
-            }
-          },
-          "description": "Message payload",
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentMailboxSendResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "target not in same workspace",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "target agent not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/agent/register": {
-      "post": {
-        "tags": [
-          "Agent"
-        ],
-        "summary": "Register an agent (obtain sandbox credentials)",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AgentRegisterRequest"
-              }
-            }
-          },
-          "description": "Agent registration info",
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentRegisterResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "no permission",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/agent/tasks": {
-      "post": {
-        "tags": [
-          "Agent"
-        ],
-        "summary": "Create a delegated task (proxy_token auth)",
-        "requestBody": {
-          "$ref": "#/components/requestBodies/AgentTaskCreateRequest"
-        },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentTaskCreateResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "target agent not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/agent/tasks/poll": {
-      "get": {
-        "tags": [
-          "Agent"
-        ],
-        "summary": "Poll for pending tasks (proxy_token auth)",
-        "parameters": [
-          {
-            "description": "Sandbox ID (defaults to token's sandbox)",
-            "name": "sandbox_id",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AgentTaskPollItem"
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/agent/tasks/{id}": {
-      "get": {
-        "tags": [
-          "Agent"
-        ],
-        "summary": "Get a task by ID (proxy_token auth)",
-        "parameters": [
-          {
-            "description": "Task ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentTaskDetail"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/agent/tasks/{id}/status": {
-      "put": {
-        "tags": [
-          "Agent"
-        ],
-        "summary": "Update task status (proxy_token auth)",
-        "parameters": [
-          {
-            "description": "Task ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/AgentTaskStatusRequest"
-              }
-            }
-          },
-          "description": "Status update",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK"
-          },
-          "400": {
-            "description": "bad request",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/agent/whoami": {
-      "get": {
-        "tags": [
-          "Agent"
-        ],
-        "summary": "Inspect the calling agent identity (proxy_token auth)",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentWhoamiResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/agents/{sandboxId}": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Agent"
-        ],
-        "summary": "Get a single agent card by sandbox ID",
-        "parameters": [
-          {
-            "description": "Sandbox ID",
-            "name": "sandboxId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentCardItem"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/auth/check": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Auth"
-        ],
-        "summary": "Check session validity",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthStatusResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/auth/login": {
-      "post": {
-        "description": "Validates credentials; on success sets the session cookie and returns {\"status\":\"ok\"}.",
-        "tags": [
-          "Auth"
-        ],
-        "summary": "Log in with email + password",
-        "requestBody": {
-          "$ref": "#/components/requestBodies/AuthCredentials"
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthStatusResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "invalid credentials",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/auth/logout": {
-      "post": {
-        "tags": [
-          "Auth"
-        ],
-        "summary": "Log out (clear session cookie)",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthStatusResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/auth/me": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Auth"
-        ],
-        "summary": "Get current user profile",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthMeResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "user not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/auth/register": {
-      "post": {
-        "description": "On success returns the new user id. The first registered user becomes admin.",
-        "tags": [
-          "Auth"
-        ],
-        "summary": "Register a new user",
-        "requestBody": {
-          "$ref": "#/components/requestBodies/AuthCredentials"
-        },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuthRegisterResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad request / email and password required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "email already taken",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error / failed to create user",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/codex/tokens": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Codex Tokens"
-        ],
-        "summary": "List Codex tokens for a workspace",
-        "parameters": [
-          {
-            "description": "Workspace id",
-            "name": "workspace_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Include revoked tokens (default false)",
-            "name": "include_revoked",
-            "in": "query",
-            "schema": {
-              "type": "boolean"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/CodexTokenListItem"
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "workspace_id required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Codex Tokens"
-        ],
-        "summary": "Mint a Codex access token",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CodexTokenMintRequest"
-              }
-            }
-          },
-          "description": "Token parameters",
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CodexTokenMintResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "invalid JSON",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a member of this workspace",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "workspace_id and name are required / expires_at invalid",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/codex/tokens/{id}": {
-      "delete": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Codex Tokens"
-        ],
-        "summary": "Revoke a Codex token",
-        "parameters": [
-          {
-            "description": "Token id",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "forbidden",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/connectors/envs/list": {
-      "post": {
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "tags": [
-          "Connectors"
-        ],
-        "summary": "List connected executors for the calling workspace",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/sdk.ConnectorEnvsListResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "missing or invalid bearer token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "registry_error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/connectors/envs/{name}/tool/call": {
-      "post": {
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "tags": [
-          "Connectors"
-        ],
-        "summary": "Call an MCP tool on a connected executor",
-        "parameters": [
-          {
-            "description": "Connected environment name (from /envs/list)",
-            "name": "name",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/sdk.ConnectorToolCallRequest"
-              }
-            }
-          },
-          "description": "Tool name and arguments. The gateway injects environment_id from the path; callers can omit it.",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/tools.MCPCallToolResult"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad_request | unknown_tool | bad_arguments",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "missing or invalid bearer token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "workspace_init | tool_error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/connectors/processes/{sid}/output": {
-      "get": {
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "tags": [
-          "Connectors"
-        ],
-        "summary": "Poll a running process's stdout/stderr",
-        "parameters": [
-          {
-            "description": "Session id returned by exec_command",
-            "name": "sid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Highest seq already seen; only newer chunks are returned",
-            "name": "since",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/sdk.ConnectorOutputResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "missing or invalid bearer token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "session belongs to a different workspace",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "session_not_found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/connectors/processes/{sid}/stdin": {
-      "post": {
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "tags": [
-          "Connectors"
-        ],
-        "summary": "Write to a running process's stdin",
-        "parameters": [
-          {
-            "description": "Session id returned by exec_command",
-            "name": "sid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/sdk.ConnectorStdinRequest"
-              }
-            }
-          },
-          "description": "Base64-encoded stdin chunk",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/sdk.ConnectorOKResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad_request | bad_base64",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "missing or invalid bearer token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "session belongs to a different workspace",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "session_not_found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/connectors/processes/{sid}/terminate": {
-      "post": {
-        "security": [
-          {
-            "BearerAuth": []
-          }
-        ],
-        "tags": [
-          "Connectors"
-        ],
-        "summary": "Terminate a running process",
-        "parameters": [
-          {
-            "description": "Session id returned by exec_command",
-            "name": "sid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/sdk.ConnectorOKResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "missing or invalid bearer token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "session belongs to a different workspace",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "session_not_found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/sandboxes/{id}": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Sandboxes"
-        ],
-        "summary": "Get a sandbox by id",
-        "parameters": [
-          {
-            "description": "Sandbox id",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Sandbox"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "sandbox not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Sandboxes"
-        ],
-        "summary": "Delete a sandbox",
-        "parameters": [
-          {
-            "description": "Sandbox id",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "403": {
-            "description": "not a member",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "sandbox not found",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Sandboxes"
-        ],
-        "summary": "Rename a sandbox",
-        "parameters": [
-          {
-            "description": "Sandbox id",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SandboxRenameRequest"
-              }
-            }
-          },
-          "description": "New name",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Sandbox"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "name required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "sandbox not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/sandboxes/{id}/im/bind": {
-      "post": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "IM Channels"
-        ],
-        "summary": "Bind a sandbox to an IM channel",
-        "parameters": [
-          {
-            "description": "Sandbox id",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/IMSandboxBindRequest"
-              }
-            }
-          },
-          "description": "Channel id",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IMSandboxBindResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "sandbox or channel not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "IM Channels"
-        ],
-        "summary": "Unbind a sandbox from its IM channel",
-        "parameters": [
-          {
-            "description": "Sandbox id",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IMSandboxUnbindResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "sandbox not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/sandboxes/{id}/pause": {
-      "post": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "description": "Initiates pause transition; returns {\"status\":\"pausing\"}. Final state lands asynchronously.",
-        "tags": [
-          "Sandboxes"
-        ],
-        "summary": "Pause a sandbox (cloud sandboxes only)",
-        "parameters": [
-          {
-            "description": "Sandbox id",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SandboxLifecycleStatusResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "local sandbox cannot be paused",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "sandbox not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "invalid state for pause",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/sandboxes/{id}/resume": {
-      "post": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "description": "Initiates resume transition; returns {\"status\":\"resuming\"}. Final state lands asynchronously.",
-        "tags": [
-          "Sandboxes"
-        ],
-        "summary": "Resume a paused sandbox (cloud sandboxes only)",
-        "parameters": [
-          {
-            "description": "Sandbox id",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SandboxLifecycleStatusResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "local sandbox cannot be resumed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "sandbox not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "invalid state for resume",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/sandboxes/{id}/traces": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Misc"
-        ],
-        "summary": "List LLM traces for a sandbox",
-        "parameters": [
-          {
-            "description": "Sandbox ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Max entries to return",
-            "name": "limit",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Pagination offset",
-            "name": "offset",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TraceListResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a workspace member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "sandbox not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "llmproxy not configured",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/sandboxes/{id}/traces/{traceId}": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Misc"
-        ],
-        "summary": "Get a single LLM trace for a sandbox",
-        "parameters": [
-          {
-            "description": "Sandbox ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Trace ID",
-            "name": "traceId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TraceDetailResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a workspace member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "sandbox not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "llmproxy not configured",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/sandboxes/{id}/usage": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Sandboxes"
-        ],
-        "summary": "Get sandbox usage stats",
-        "parameters": [
-          {
-            "description": "Sandbox id",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SandboxUsage"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "sandbox not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/tasks/{id}": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Agent"
-        ],
-        "summary": "Get a task by ID",
-        "parameters": [
-          {
-            "description": "Task ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Include output events",
-            "name": "include_output",
-            "in": "query",
-            "schema": {
-              "type": "boolean"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentTaskDetail"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/tasks/{id}/cancel": {
-      "post": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Agent"
-        ],
-        "summary": "Cancel a task",
-        "parameters": [
-          {
-            "description": "Task ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentTaskCancelResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "task already finished",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "List workspaces for the current user",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Workspace"
-                  }
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "description": "Creator is auto-added as owner. May fail with 403 if the per-user workspace quota is exceeded.",
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "Create a new workspace",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WorkspaceCreateRequest"
-              }
-            }
-          },
-          "description": "Workspace name",
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Workspace"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad request / empty name",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "workspace quota exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/quota": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "Get per-user workspace quota",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkspaceQuotaResponse"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{id}": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "Get a workspace by id",
-        "parameters": [
-          {
-            "description": "Workspace id",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Workspace"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "workspace not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "Delete a workspace (owner only; cascades to sandboxes + namespace)",
-        "parameters": [
-          {
-            "description": "Workspace id",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "403": {
-            "description": "owner only",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "Rename a workspace",
-        "parameters": [
-          {
-            "description": "Workspace id",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WorkspaceRenameRequest"
-              }
-            }
-          },
-          "description": "New name",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Workspace"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "empty name",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "owner or maintainer required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{id}/credentials/{kind}": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Misc"
-        ],
-        "summary": "List credential bindings for a workspace",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Credential kind (e.g. kubernetes)",
-            "name": "kind",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/CredentialBindingItem"
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "description": "On success returns 201 with the new binding. When the provider requires OIDC device code authentication returns 202 with verification_uri and user_code; poll device-complete to finalize.",
-        "tags": [
-          "Misc"
-        ],
-        "summary": "Create a credential binding for a workspace",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Credential kind (e.g. kubernetes)",
-            "name": "kind",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CredentialBindingCreateRequest"
-              }
-            }
-          },
-          "description": "Credential config",
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Binding created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CredentialBindingCreateResponse"
-                }
-              }
-            }
-          },
-          "202": {
-            "description": "OIDC device code flow initiated",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CredentialBindingCreateResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "duplicate display_name",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{id}/credentials/{kind}/{bindingId}": {
-      "delete": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Misc"
-        ],
-        "summary": "Delete a credential binding",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Credential kind",
-            "name": "kind",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Binding ID",
-            "name": "bindingId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "deleted"
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "not found",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "cannot delete default binding while others exist",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Misc"
-        ],
-        "summary": "Patch a credential binding (rename)",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Credential kind",
-            "name": "kind",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Binding ID",
-            "name": "bindingId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/CredentialBindingPatchRequest"
-              }
-            }
-          },
-          "description": "Fields to update",
-          "required": true
-        },
-        "responses": {
-          "204": {
-            "description": "updated"
-          },
-          "400": {
-            "description": "bad request",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "not found",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{id}/credentials/{kind}/{bindingId}/device-complete": {
-      "post": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "description": "Long-polls until the user authorizes the device code. Returns 201 with the created binding on success.",
-        "tags": [
-          "Misc"
-        ],
-        "summary": "Complete an OIDC device code flow for a pending credential binding",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Credential kind",
-            "name": "kind",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Pending binding ID",
-            "name": "bindingId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "201": {
-            "description": "Binding created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CredentialBindingCreateResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "device code authorization failed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "no pending device code flow found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "duplicate display_name or flow already being completed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "410": {
-            "description": "device code flow expired",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{id}/credentials/{kind}/{bindingId}/set-default": {
-      "post": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Misc"
-        ],
-        "summary": "Set a credential binding as the default",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Credential kind",
-            "name": "kind",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Binding ID",
-            "name": "bindingId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "updated"
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{id}/exec-audit/calls": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Exec-Audit"
-        ],
-        "summary": "List exec-audit calls (workspace-scoped)",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Session ID filter",
-            "name": "session_id",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Executor ID filter",
-            "name": "exe_id",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "User ID filter",
-            "name": "user_id",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Source filter",
-            "name": "source",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "RPC method filter",
-            "name": "method",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "RFC3339 lower bound (started_at)",
-            "name": "since",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "RFC3339 upper bound (started_at)",
-            "name": "until",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Max rows (default 50)",
-            "name": "limit",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListAuditCallsResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{id}/exec-audit/calls/{call_id}": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Exec-Audit"
-        ],
-        "summary": "Get exec-audit call (workspace-scoped)",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Call ID",
-            "name": "call_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuditCallDetail"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{id}/exec-audit/calls/{call_id}/payload": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Exec-Audit"
-        ],
-        "summary": "Get exec-audit call request payload (workspace-scoped)",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Call ID",
-            "name": "call_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/octet-stream": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/octet-stream": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/octet-stream": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/octet-stream": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/octet-stream": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{id}/exec-audit/sessions": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Exec-Audit"
-        ],
-        "summary": "List exec-audit sessions (workspace-scoped)",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Executor ID filter",
-            "name": "exe_id",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "User ID filter",
-            "name": "user_id",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Turn ID filter",
-            "name": "turn_id",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "RFC3339 lower bound (opened_at)",
-            "name": "since",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "RFC3339 upper bound (opened_at)",
-            "name": "until",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Max rows (default 50)",
-            "name": "limit",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListAuditSessionsResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{id}/exec-audit/sessions/{session_id}": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Exec-Audit"
-        ],
-        "summary": "Get exec-audit session (workspace-scoped)",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Session ID",
-            "name": "session_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuditSessionDetail"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{id}/im/channels": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "IM Channels"
-        ],
-        "summary": "List IM channels in a workspace",
-        "parameters": [
-          {
-            "description": "Workspace id",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IMChannelListResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{id}/im/channels/{channelId}": {
-      "delete": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "IM Channels"
-        ],
-        "summary": "Delete an IM channel",
-        "parameters": [
-          {
-            "description": "Workspace id",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Channel id",
-            "name": "channelId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "403": {
-            "description": "not a member",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "channel not found",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "patch": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "IM Channels"
-        ],
-        "summary": "Update IM channel settings",
-        "parameters": [
-          {
-            "description": "Workspace id",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Channel id",
-            "name": "channelId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/IMChannelPatchRequest"
-              }
-            }
-          },
-          "description": "Settings patch",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IMChannelPatchResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "channel not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{id}/im/matrix/configure": {
-      "post": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "IM Channels"
-        ],
-        "summary": "Bind a Matrix account to a workspace",
-        "parameters": [
-          {
-            "description": "Workspace id",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/IMMatrixConfigureRequest"
-              }
-            }
-          },
-          "description": "Matrix credentials",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IMMatrixConfigureResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "invalid credentials",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{id}/im/telegram/configure": {
-      "post": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "IM Channels"
-        ],
-        "summary": "Bind a Telegram bot to a workspace",
-        "parameters": [
-          {
-            "description": "Workspace id",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/IMTelegramConfigureRequest"
-              }
-            }
-          },
-          "description": "Bot token",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IMTelegramConfigureResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "invalid bot token",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{id}/im/weixin/qr-start": {
-      "post": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "description": "Returns a QR code URL the user scans in WeChat. Client should then long-poll qr-wait until the channel is bound.",
-        "tags": [
-          "IM Channels"
-        ],
-        "summary": "Start WeChat QR-code bind for a workspace",
-        "parameters": [
-          {
-            "description": "Workspace id",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IMWeixinQRStartResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "upstream error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{id}/im/weixin/qr-wait": {
-      "post": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "description": "Polls for QR scan progress. Returns status \"wait\", \"scaned\", \"confirmed\", \"expired\", or other terminal states. On \"confirmed\", bot_id is set. On \"expired\", qrcode_url contains a refreshed code.",
-        "tags": [
-          "IM Channels"
-        ],
-        "summary": "Long-poll WeChat QR-code scan for a workspace",
-        "parameters": [
-          {
-            "description": "Workspace id",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/IMWeixinQRWaitResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "no active session",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "upstream error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{id}/llm-config": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "description": "The returned api_key is masked (first 3 + \"...\" + last 4). updated_at is null when no config is set.",
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "Get workspace LLM config (owner/maintainer)",
-        "parameters": [
-          {
-            "description": "Workspace id",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LLMConfigResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "insufficient role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "description": "On update, omitting api_key retains the existing key.",
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "Upsert workspace LLM config (owner/maintainer)",
-        "parameters": [
-          {
-            "description": "Workspace id",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/LLMConfigUpsertRequest"
-              }
-            }
-          },
-          "description": "Config payload",
-          "required": true
-        },
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LLMConfigUpsertResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "validation error (invalid URL / missing field / too many models)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "insufficient role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "Delete workspace LLM config (owner/maintainer)",
-        "parameters": [
-          {
-            "description": "Workspace id",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "403": {
-            "description": "insufficient role",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{id}/llm-quota": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "Get the workspace's daily LLM request quota usage",
-        "parameters": [
-          {
-            "description": "Workspace id",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LLMQuotaResponse"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "insufficient role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{id}/members": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "List members of a workspace",
-        "parameters": [
-          {
-            "description": "Workspace id",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/WorkspaceMember"
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "description": "Looks up the user by email. Default role is \"developer\" if omitted.",
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "Add a member to a workspace",
-        "parameters": [
-          {
-            "description": "Workspace id",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MemberAddRequest"
-              }
-            }
-          },
-          "description": "Email and optional role",
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkspaceMember"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "owner or maintainer required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "user not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{id}/members/{userId}": {
-      "put": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "Change a member's role (owner only)",
-        "parameters": [
-          {
-            "description": "Workspace id",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "User id",
-            "name": "userId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MemberRoleUpdateRequest"
-              }
-            }
-          },
-          "description": "New role",
-          "required": true
-        },
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "400": {
-            "description": "empty role",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "owner only",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "delete": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Workspaces"
-        ],
-        "summary": "Remove a member (owner only)",
-        "parameters": [
-          {
-            "description": "Workspace id",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "User id",
-            "name": "userId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "403": {
-            "description": "owner only",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{id}/modelserver/connect": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "description": "Redirects the browser to the ModelServer OAuth authorization URL. Returns 302.",
-        "tags": [
-          "Misc"
-        ],
-        "summary": "Initiate ModelServer OAuth connection for a workspace",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "302": {
-            "description": "redirect to ModelServer OAuth"
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "insufficient role (owner/maintainer required)",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "501": {
-            "description": "ModelServer OAuth not configured",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{id}/modelserver/disconnect": {
-      "delete": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Misc"
-        ],
-        "summary": "Disconnect ModelServer from a workspace",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "disconnected"
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "insufficient role (owner/maintainer required)",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{id}/modelserver/status": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Misc"
-        ],
-        "summary": "Get ModelServer connection status for a workspace",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ModelServerStatusResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a workspace member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{wid}/agent-interactions": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Misc"
-        ],
-        "summary": "List agent interaction audit trail for a workspace",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "wid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Max entries (1–200, default 50)",
-            "name": "limit",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Pagination offset",
-            "name": "offset",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AgentInteractionItem"
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a workspace member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{wid}/agents": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Agent"
-        ],
-        "summary": "List agent cards in a workspace",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "wid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AgentCardItem"
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{wid}/api-keys": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "description": "Returns prefix-only metadata. Secrets are never included.",
-        "tags": [
-          "Workspace API Keys"
-        ],
-        "summary": "List workspace API keys",
-        "parameters": [
-          {
-            "description": "Workspace id",
-            "name": "wid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/WorkspaceAPIKey"
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "description": "Returns the secret ONCE in the response body. At least one Available scope must be provided.",
-        "tags": [
-          "Workspace API Keys"
-        ],
-        "summary": "Mint a workspace API key",
-        "parameters": [
-          {
-            "description": "Workspace id",
-            "name": "wid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/WorkspaceAPIKeyMintRequest"
-              }
-            }
-          },
-          "description": "Key metadata",
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkspaceAPIKeyMintResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "name required / scope not available / at least one scope required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "owner or maintainer required",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "expires_at invalid (bad RFC3339 / in past / >365d in future)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{wid}/api-keys/scopes": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "description": "Returns the catalog of scope names + descriptions. Available=false entries are placeholders shown greyed-out in the UI.",
-        "tags": [
-          "Workspace API Keys"
-        ],
-        "summary": "List available API key scopes",
-        "parameters": [
-          {
-            "description": "Workspace id",
-            "name": "wid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/APIKeyScopeDescriptor"
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{wid}/api-keys/{id}": {
-      "delete": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Workspace API Keys"
-        ],
-        "summary": "Revoke a workspace API key",
-        "parameters": [
-          {
-            "description": "Workspace id",
-            "name": "wid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Key id (= prefix)",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "403": {
-            "description": "owner or maintainer required",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{wid}/browsers": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Codex Browser Sessions"
-        ],
-        "summary": "List Codex browser sessions for a workspace",
-        "parameters": [
-          {
-            "description": "Workspace id",
-            "name": "wid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/CodexBrowserItem"
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{wid}/defaults": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Misc"
-        ],
-        "summary": "Get workspace quota defaults and current sandbox count",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "wid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/WorkspaceDefaultsResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "insufficient role",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{wid}/executors": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Misc"
-        ],
-        "summary": "List codex remote executors for a workspace",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "wid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/ExecutorItem"
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a workspace member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "upstream gateway error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Misc"
-        ],
-        "summary": "Register a new codex remote executor for a workspace",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "wid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ExecutorRegisterRequest"
-              }
-            }
-          },
-          "description": "Executor registration payload",
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExecutorRegisterResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad request / invalid name",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "insufficient role (owner/maintainer required)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "upstream gateway error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "executors not configured",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{wid}/executors/{exe_id}": {
-      "delete": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Misc"
-        ],
-        "summary": "Remove a codex remote executor from a workspace",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "wid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Executor ID",
-            "name": "exe_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "removed"
-          },
-          "400": {
-            "description": "bad request",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "insufficient role (owner/maintainer required)",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "upstream gateway error",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "executors not configured",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{wid}/mcp/pats": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "MCP PATs"
-        ],
-        "summary": "List MCP Personal Access Tokens for a workspace",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "wid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/MCPPAT"
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "not authenticated",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "not found (or not a member)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "description": "Returns the secret ONCE in the response body. At least one scope must be provided. The PAT is bound to the URL's workspace; the body has no workspace field.",
-        "tags": [
-          "MCP PATs"
-        ],
-        "summary": "Mint an MCP Personal Access Token for a workspace",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "wid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/MCPPATMintRequest"
-              }
-            }
-          },
-          "description": "PAT metadata",
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MCPPATMintResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "name required / scope not available",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "not authenticated",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "not found (or not a member of the workspace)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "expires_at invalid",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{wid}/mcp/pats/scopes": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "description": "Static capability scopes (mcp:read, mcp:exec). No dynamic workspace scopes — workspace binding is implicit in the route's {wid}.",
-        "tags": [
-          "MCP PATs"
-        ],
-        "summary": "List MCP PAT scope catalog for a workspace",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "wid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/MCPPATScopesResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "not authenticated",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "not found (or not a member of the workspace)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{wid}/mcp/pats/{id}": {
-      "delete": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "MCP PATs"
-        ],
-        "summary": "Revoke an MCP Personal Access Token",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "wid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "PAT id (= prefix, e.g. agpat_a1b2...)",
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "204": {
-            "description": "No Content"
-          },
-          "401": {
-            "description": "not authenticated",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "not found (or not a member of the workspace)",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{wid}/sandboxes": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Sandboxes"
-        ],
-        "summary": "List sandboxes in a workspace",
-        "parameters": [
-          {
-            "description": "Workspace id",
-            "name": "wid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Sandbox"
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "description": "Validates type / CPU / memory / idle_timeout / quota / budget. Returns 201 immediately with status=\"provisioning\"; container starts asynchronously.",
-        "tags": [
-          "Sandboxes"
-        ],
-        "summary": "Create a sandbox in a workspace",
-        "parameters": [
-          {
-            "description": "Workspace id",
-            "name": "wid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/SandboxCreateRequest"
-              }
-            }
-          },
-          "description": "Create payload",
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Sandbox"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "validation error (type/cpu/memory/idle_timeout)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "insufficient role / quota / budget",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{wid}/tasks": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Agent"
-        ],
-        "summary": "List delegated tasks for a workspace",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "wid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/AgentTaskItem"
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "post": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Agent"
-        ],
-        "summary": "Create a delegated task in a workspace",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "wid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "$ref": "#/components/requestBodies/AgentTaskCreateRequest"
-        },
-        "responses": {
-          "201": {
-            "description": "Created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentTaskCreateResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "target agent not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{wid}/traces": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Misc"
-        ],
-        "summary": "List LLM traces for a workspace",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "wid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Max entries to return",
-            "name": "limit",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            }
-          },
-          {
-            "description": "Pagination offset",
-            "name": "offset",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TraceListResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a workspace member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "llmproxy not configured",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/workspaces/{wid}/traces/{traceId}": {
-      "get": {
-        "security": [
-          {
-            "CookieAuth": []
-          }
-        ],
-        "tags": [
-          "Misc"
-        ],
-        "summary": "Get a single LLM trace for a workspace",
-        "parameters": [
-          {
-            "description": "Workspace ID",
-            "name": "wid",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Trace ID",
-            "name": "traceId",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/TraceDetailResponse"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "not a workspace member",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "llmproxy not configured",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/internal/exec-audit/batch": {
-      "post": {
-        "tags": [
-          "Exec-Audit"
-        ],
-        "summary": "Ingest a batch of exec-gateway audit records (internal)",
-        "parameters": [
-          {
-            "description": "Shared secret",
-            "name": "X-Internal-Secret",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ExecAuditBatchAckResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/internal/exec-audit/calls": {
-      "get": {
-        "tags": [
-          "Exec-Audit"
-        ],
-        "summary": "List exec-audit calls (internal)",
-        "parameters": [
-          {
-            "description": "Shared secret",
-            "name": "X-Internal-Secret",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Workspace ID",
-            "name": "workspace_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Session ID filter",
-            "name": "session_id",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Executor ID filter",
-            "name": "exe_id",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "User ID filter",
-            "name": "user_id",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Source filter (e.g. mcp_rpc, sse_event)",
-            "name": "source",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "RPC method filter",
-            "name": "method",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "RFC3339 lower bound (started_at)",
-            "name": "since",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "RFC3339 upper bound (started_at)",
-            "name": "until",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Max rows (default 50)",
-            "name": "limit",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListAuditCallsResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/internal/exec-audit/calls/{call_id}": {
-      "get": {
-        "tags": [
-          "Exec-Audit"
-        ],
-        "summary": "Get an exec-audit call detail (internal)",
-        "parameters": [
-          {
-            "description": "Shared secret",
-            "name": "X-Internal-Secret",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Call ID",
-            "name": "call_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuditCallDetail"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/internal/exec-audit/sessions": {
-      "get": {
-        "tags": [
-          "Exec-Audit"
-        ],
-        "summary": "List exec-audit sessions (internal)",
-        "parameters": [
-          {
-            "description": "Shared secret",
-            "name": "X-Internal-Secret",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Workspace ID",
-            "name": "workspace_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Executor ID filter",
-            "name": "exe_id",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "User ID filter",
-            "name": "user_id",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Turn ID filter",
-            "name": "turn_id",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "RFC3339 lower bound (opened_at)",
-            "name": "since",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "RFC3339 upper bound (opened_at)",
-            "name": "until",
-            "in": "query",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Max rows (default 50)",
-            "name": "limit",
-            "in": "query",
-            "schema": {
-              "type": "integer"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ListAuditSessionsResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/internal/exec-audit/sessions/{session_id}": {
-      "get": {
-        "tags": [
-          "Exec-Audit"
-        ],
-        "summary": "Get an exec-audit session detail (internal)",
-        "parameters": [
-          {
-            "description": "Shared secret",
-            "name": "X-Internal-Secret",
-            "in": "header",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Session ID",
-            "name": "session_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AuditSessionDetail"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    }
-  },
-  "servers": [
-    {
-      "url": "/"
-    }
-  ],
   "components": {
     "requestBodies": {
-      "AuthCredentials": {
-        "content": {
-          "application/json": {
-            "schema": {
-              "$ref": "#/components/schemas/AuthCredentials"
-            }
-          }
-        },
-        "description": "Email and password",
-        "required": true
-      },
       "AgentTaskCreateRequest": {
         "content": {
           "application/json": {
@@ -8007,30 +11,21 @@
         },
         "description": "Task details",
         "required": true
-      }
-    },
-    "securitySchemes": {
-      "BearerAuth": {
-        "description": "`Authorization: Bearer <token>` with an OAuth access token, a `proxy_token` from POST /api/agent/register, or a workspace API key (`wak_*`).",
-        "type": "apiKey",
-        "name": "Authorization",
-        "in": "header"
       },
-      "CookieAuth": {
-        "description": "Session cookie set by POST /api/auth/login. All non-auth endpoints assume this cookie.",
-        "type": "apiKey",
-        "name": "agentserver-token",
-        "in": "cookie"
+      "AuthCredentials": {
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/AuthCredentials"
+            }
+          }
+        },
+        "description": "Email and password",
+        "required": true
       }
     },
     "schemas": {
       "APIKeyScopeDescriptor": {
-        "type": "object",
-        "required": [
-          "available",
-          "description",
-          "name"
-        ],
         "properties": {
           "available": {
             "type": "boolean"
@@ -8039,17 +34,18 @@
             "type": "string"
           },
           "name": {
-            "type": "string",
-            "example": "turns:submit"
+            "example": "turns:submit",
+            "type": "string"
           }
-        }
+        },
+        "required": [
+          "available",
+          "description",
+          "name"
+        ],
+        "type": "object"
       },
       "AdminOwnerInfo": {
-        "type": "object",
-        "required": [
-          "email",
-          "id"
-        ],
         "properties": {
           "email": {
             "type": "string"
@@ -8058,17 +54,50 @@
             "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           },
           "picture": {
-            "type": "string",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           }
-        }
+        },
+        "required": [
+          "email",
+          "id"
+        ],
+        "type": "object"
       },
       "AdminQuotaDefaultsResponse": {
-        "type": "object",
+        "properties": {
+          "max_idle_timeout": {
+            "type": "integer"
+          },
+          "max_sandbox_cpu": {
+            "type": "integer"
+          },
+          "max_sandbox_memory": {
+            "type": "integer"
+          },
+          "max_sandboxes_per_workspace": {
+            "type": "integer"
+          },
+          "max_workspace_drive_size": {
+            "type": "integer"
+          },
+          "max_workspaces_per_user": {
+            "type": "integer"
+          },
+          "ws_max_idle_timeout": {
+            "type": "integer"
+          },
+          "ws_max_total_cpu": {
+            "type": "integer"
+          },
+          "ws_max_total_memory": {
+            "type": "integer"
+          }
+        },
         "required": [
           "max_idle_timeout",
           "max_sandbox_cpu",
@@ -8080,38 +109,9 @@
           "ws_max_total_cpu",
           "ws_max_total_memory"
         ],
-        "properties": {
-          "max_idle_timeout": {
-            "type": "integer"
-          },
-          "max_sandbox_cpu": {
-            "type": "integer"
-          },
-          "max_sandbox_memory": {
-            "type": "integer"
-          },
-          "max_sandboxes_per_workspace": {
-            "type": "integer"
-          },
-          "max_workspace_drive_size": {
-            "type": "integer"
-          },
-          "max_workspaces_per_user": {
-            "type": "integer"
-          },
-          "ws_max_idle_timeout": {
-            "type": "integer"
-          },
-          "ws_max_total_cpu": {
-            "type": "integer"
-          },
-          "ws_max_total_memory": {
-            "type": "integer"
-          }
-        }
+        "type": "object"
       },
       "AdminQuotaDefaultsUpdateRequest": {
-        "type": "object",
         "properties": {
           "max_idle_timeout": {
             "type": "integer"
@@ -8140,18 +140,10 @@
           "ws_max_total_memory": {
             "type": "integer"
           }
-        }
+        },
+        "type": "object"
       },
       "AdminSandboxItem": {
-        "type": "object",
-        "required": [
-          "created_at",
-          "id",
-          "name",
-          "status",
-          "type",
-          "workspace_id"
-        ],
         "properties": {
           "created_at": {
             "type": "string"
@@ -8163,87 +155,89 @@
             "type": "boolean"
           },
           "last_activity_at": {
-            "type": "string",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           },
           "name": {
             "type": "string"
           },
           "status": {
-            "type": "string",
-            "example": "running"
+            "example": "running",
+            "type": "string"
           },
           "type": {
-            "type": "string",
-            "example": "opencode"
+            "example": "opencode",
+            "type": "string"
           },
           "workspace_id": {
             "type": "string"
           }
-        }
-      },
-      "AdminSetUserQuotaRequest": {
-        "type": "object",
-        "properties": {
-          "max_workspaces": {
-            "type": "integer",
-            "nullable": true
-          }
-        }
-      },
-      "AdminSetWorkspaceQuotaRequest": {
-        "type": "object",
-        "properties": {
-          "max_drive_size": {
-            "type": "integer",
-            "nullable": true
-          },
-          "max_idle_timeout": {
-            "type": "integer",
-            "nullable": true
-          },
-          "max_sandbox_cpu": {
-            "type": "integer",
-            "nullable": true
-          },
-          "max_sandbox_memory": {
-            "type": "integer",
-            "nullable": true
-          },
-          "max_sandboxes": {
-            "type": "integer",
-            "nullable": true
-          },
-          "max_total_cpu": {
-            "type": "integer",
-            "nullable": true
-          },
-          "max_total_memory": {
-            "type": "integer",
-            "nullable": true
-          }
-        }
-      },
-      "AdminUpdateUserRoleRequest": {
-        "type": "object",
-        "required": [
-          "role"
-        ],
-        "properties": {
-          "role": {
-            "type": "string",
-            "example": "admin"
-          }
-        }
-      },
-      "AdminUserItem": {
-        "type": "object",
+        },
         "required": [
           "created_at",
-          "email",
           "id",
+          "name",
+          "status",
+          "type",
+          "workspace_id"
+        ],
+        "type": "object"
+      },
+      "AdminSetUserQuotaRequest": {
+        "properties": {
+          "max_workspaces": {
+            "nullable": true,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "AdminSetWorkspaceQuotaRequest": {
+        "properties": {
+          "max_drive_size": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "max_idle_timeout": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "max_sandbox_cpu": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "max_sandbox_memory": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "max_sandboxes": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "max_total_cpu": {
+            "nullable": true,
+            "type": "integer"
+          },
+          "max_total_memory": {
+            "nullable": true,
+            "type": "integer"
+          }
+        },
+        "type": "object"
+      },
+      "AdminUpdateUserRoleRequest": {
+        "properties": {
+          "role": {
+            "example": "admin",
+            "type": "string"
+          }
+        },
+        "required": [
           "role"
         ],
+        "type": "object"
+      },
+      "AdminUserItem": {
         "properties": {
           "created_at": {
             "type": "string"
@@ -8255,46 +249,49 @@
             "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           },
           "role": {
-            "type": "string",
-            "example": "user"
+            "example": "user",
+            "type": "string"
           }
-        }
+        },
+        "required": [
+          "created_at",
+          "email",
+          "id",
+          "role"
+        ],
+        "type": "object"
       },
       "AdminUserQuotaDefaults": {
-        "type": "object",
-        "required": [
-          "max_workspaces_per_user"
-        ],
         "properties": {
           "max_workspaces_per_user": {
             "type": "integer"
           }
-        }
+        },
+        "required": [
+          "max_workspaces_per_user"
+        ],
+        "type": "object"
       },
       "AdminUserQuotaOverrides": {
-        "type": "object",
-        "required": [
-          "updated_at"
-        ],
         "properties": {
           "max_workspaces": {
-            "type": "integer",
-            "nullable": true
+            "nullable": true,
+            "type": "integer"
           },
           "updated_at": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "updated_at"
+        ],
+        "type": "object"
       },
       "AdminUserQuotaResponse": {
-        "type": "object",
-        "required": [
-          "defaults"
-        ],
         "properties": {
           "defaults": {
             "$ref": "#/components/schemas/AdminUserQuotaDefaults"
@@ -8307,16 +304,13 @@
             ],
             "nullable": true
           }
-        }
+        },
+        "required": [
+          "defaults"
+        ],
+        "type": "object"
       },
       "AdminWorkspaceItem": {
-        "type": "object",
-        "required": [
-          "created_at",
-          "id",
-          "name",
-          "updated_at"
-        ],
         "properties": {
           "created_at": {
             "type": "string"
@@ -8344,10 +338,39 @@
           "updated_at": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "created_at",
+          "id",
+          "name",
+          "updated_at"
+        ],
+        "type": "object"
       },
       "AdminWorkspaceQuotaDefaults": {
-        "type": "object",
+        "properties": {
+          "max_drive_size": {
+            "type": "integer"
+          },
+          "max_idle_timeout": {
+            "type": "integer"
+          },
+          "max_sandbox_cpu": {
+            "type": "integer"
+          },
+          "max_sandbox_memory": {
+            "type": "integer"
+          },
+          "max_sandboxes": {
+            "type": "integer"
+          },
+          "max_total_cpu": {
+            "type": "integer"
+          },
+          "max_total_memory": {
+            "type": "integer"
+          }
+        },
         "required": [
           "max_drive_size",
           "max_idle_timeout",
@@ -8357,74 +380,48 @@
           "max_total_cpu",
           "max_total_memory"
         ],
-        "properties": {
-          "max_drive_size": {
-            "type": "integer"
-          },
-          "max_idle_timeout": {
-            "type": "integer"
-          },
-          "max_sandbox_cpu": {
-            "type": "integer"
-          },
-          "max_sandbox_memory": {
-            "type": "integer"
-          },
-          "max_sandboxes": {
-            "type": "integer"
-          },
-          "max_total_cpu": {
-            "type": "integer"
-          },
-          "max_total_memory": {
-            "type": "integer"
-          }
-        }
+        "type": "object"
       },
       "AdminWorkspaceQuotaOverrides": {
-        "type": "object",
-        "required": [
-          "updated_at"
-        ],
         "properties": {
           "max_drive_size": {
-            "type": "integer",
-            "nullable": true
+            "nullable": true,
+            "type": "integer"
           },
           "max_idle_timeout": {
-            "type": "integer",
-            "nullable": true
+            "nullable": true,
+            "type": "integer"
           },
           "max_sandbox_cpu": {
-            "type": "integer",
-            "nullable": true
+            "nullable": true,
+            "type": "integer"
           },
           "max_sandbox_memory": {
-            "type": "integer",
-            "nullable": true
+            "nullable": true,
+            "type": "integer"
           },
           "max_sandboxes": {
-            "type": "integer",
-            "nullable": true
+            "nullable": true,
+            "type": "integer"
           },
           "max_total_cpu": {
-            "type": "integer",
-            "nullable": true
+            "nullable": true,
+            "type": "integer"
           },
           "max_total_memory": {
-            "type": "integer",
-            "nullable": true
+            "nullable": true,
+            "type": "integer"
           },
           "updated_at": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "updated_at"
+        ],
+        "type": "object"
       },
       "AdminWorkspaceQuotaResponse": {
-        "type": "object",
-        "required": [
-          "defaults"
-        ],
         "properties": {
           "defaults": {
             "$ref": "#/components/schemas/AdminWorkspaceQuotaDefaults"
@@ -8437,25 +434,20 @@
             ],
             "nullable": true
           }
-        }
+        },
+        "required": [
+          "defaults"
+        ],
+        "type": "object"
       },
       "AgentCardItem": {
-        "type": "object",
-        "required": [
-          "agent_id",
-          "agent_type",
-          "card",
-          "display_name",
-          "status",
-          "version"
-        ],
         "properties": {
           "agent_id": {
             "type": "string"
           },
           "agent_type": {
-            "type": "string",
-            "example": "claudecode"
+            "example": "claudecode",
+            "type": "string"
           },
           "card": {},
           "description": {
@@ -8465,65 +457,57 @@
             "type": "string"
           },
           "status": {
-            "type": "string",
-            "example": "available"
+            "example": "available",
+            "type": "string"
           },
           "version": {
             "type": "integer"
           }
-        }
+        },
+        "required": [
+          "agent_id",
+          "agent_type",
+          "card",
+          "display_name",
+          "status",
+          "version"
+        ],
+        "type": "object"
       },
       "AgentCardRegisterRequest": {
-        "type": "object",
         "properties": {
           "agent_type": {
             "description": "optional; defaults to \"claudecode\"",
-            "type": "string",
-            "example": "claudecode"
+            "example": "claudecode",
+            "type": "string"
           },
           "card": {
             "description": "optional; arbitrary JSON"
           },
           "description": {
-            "type": "string",
-            "example": "A helpful coding agent"
+            "example": "A helpful coding agent",
+            "type": "string"
           },
           "display_name": {
-            "type": "string",
-            "example": "My Agent"
+            "example": "My Agent",
+            "type": "string"
           }
-        }
+        },
+        "type": "object"
       },
       "AgentCardRegisterResponse": {
-        "type": "object",
+        "properties": {
+          "status": {
+            "example": "ok",
+            "type": "string"
+          }
+        },
         "required": [
           "status"
         ],
-        "properties": {
-          "status": {
-            "type": "string",
-            "example": "ok"
-          }
-        }
+        "type": "object"
       },
       "AgentInfo": {
-        "type": "object",
-        "required": [
-          "agent_version",
-          "cpu_count_logical",
-          "cpu_model_name",
-          "disk_free",
-          "disk_total",
-          "hostname",
-          "kernel_arch",
-          "memory_total",
-          "opencode_version",
-          "os",
-          "platform",
-          "platform_version",
-          "updated_at",
-          "workdir"
-        ],
         "properties": {
           "agent_version": {
             "type": "string"
@@ -8567,25 +551,34 @@
           "workdir": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "agent_version",
+          "cpu_count_logical",
+          "cpu_model_name",
+          "disk_free",
+          "disk_total",
+          "hostname",
+          "kernel_arch",
+          "memory_total",
+          "opencode_version",
+          "os",
+          "platform",
+          "platform_version",
+          "updated_at",
+          "workdir"
+        ],
+        "type": "object"
       },
       "AgentInteractionItem": {
-        "type": "object",
-        "required": [
-          "action",
-          "created_at",
-          "id",
-          "target_id",
-          "target_type"
-        ],
         "properties": {
           "action": {
-            "type": "string",
-            "example": "task.created"
+            "example": "task.created",
+            "type": "string"
           },
           "actor_id": {
-            "type": "string",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           },
           "created_at": {
             "type": "string"
@@ -8598,20 +591,20 @@
             "type": "string"
           },
           "target_type": {
-            "type": "string",
-            "example": "task"
+            "example": "task",
+            "type": "string"
           }
-        }
+        },
+        "required": [
+          "action",
+          "created_at",
+          "id",
+          "target_id",
+          "target_type"
+        ],
+        "type": "object"
       },
       "AgentMailboxMessage": {
-        "type": "object",
-        "required": [
-          "created_at",
-          "from",
-          "id",
-          "msg_type",
-          "text"
-        ],
         "properties": {
           "created_at": {
             "type": "string"
@@ -8623,74 +616,74 @@
             "type": "string"
           },
           "msg_type": {
-            "type": "string",
-            "example": "text"
+            "example": "text",
+            "type": "string"
           },
           "text": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "created_at",
+          "from",
+          "id",
+          "msg_type",
+          "text"
+        ],
+        "type": "object"
       },
       "AgentMailboxSendRequest": {
-        "type": "object",
+        "properties": {
+          "msg_type": {
+            "example": "text",
+            "type": "string"
+          },
+          "text": {
+            "example": "Hello from another agent",
+            "type": "string"
+          },
+          "to": {
+            "example": "sandbox-uuid-of-target",
+            "type": "string"
+          }
+        },
         "required": [
           "text",
           "to"
         ],
-        "properties": {
-          "msg_type": {
-            "type": "string",
-            "example": "text"
-          },
-          "text": {
-            "type": "string",
-            "example": "Hello from another agent"
-          },
-          "to": {
-            "type": "string",
-            "example": "sandbox-uuid-of-target"
-          }
-        }
+        "type": "object"
       },
       "AgentMailboxSendResponse": {
-        "type": "object",
-        "required": [
-          "message_id",
-          "status"
-        ],
         "properties": {
           "message_id": {
             "type": "string"
           },
           "status": {
-            "type": "string",
-            "example": "sent"
+            "example": "sent",
+            "type": "string"
           }
-        }
+        },
+        "required": [
+          "message_id",
+          "status"
+        ],
+        "type": "object"
       },
       "AgentRegisterRequest": {
-        "type": "object",
         "properties": {
           "name": {
-            "type": "string",
-            "example": "Local Agent"
+            "example": "Local Agent",
+            "type": "string"
           },
           "type": {
             "description": "optional; defaults to \"opencode\"",
-            "type": "string",
-            "example": "opencode"
+            "example": "opencode",
+            "type": "string"
           }
-        }
+        },
+        "type": "object"
       },
       "AgentRegisterResponse": {
-        "type": "object",
-        "required": [
-          "proxy_token",
-          "sandbox_id",
-          "short_id",
-          "tunnel_token",
-          "workspace_id"
-        ],
         "properties": {
           "proxy_token": {
             "type": "string"
@@ -8707,105 +700,104 @@
           "workspace_id": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "proxy_token",
+          "sandbox_id",
+          "short_id",
+          "tunnel_token",
+          "workspace_id"
+        ],
+        "type": "object"
       },
       "AgentTaskCancelResponse": {
-        "type": "object",
+        "properties": {
+          "status": {
+            "example": "cancelled",
+            "type": "string"
+          }
+        },
         "required": [
           "status"
         ],
-        "properties": {
-          "status": {
-            "type": "string",
-            "example": "cancelled"
-          }
-        }
+        "type": "object"
       },
       "AgentTaskCreateRequest": {
-        "type": "object",
-        "required": [
-          "prompt",
-          "target_id"
-        ],
         "properties": {
           "delegation_chain": {
-            "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "type": "array"
           },
           "max_budget_usd": {
-            "type": "number",
-            "example": 1
+            "example": 1,
+            "type": "number"
           },
           "max_turns": {
-            "type": "integer",
-            "example": 50
+            "example": 50,
+            "type": "integer"
           },
           "prompt": {
-            "type": "string",
-            "example": "Run the test suite"
+            "example": "Run the test suite",
+            "type": "string"
           },
           "requester_id": {
             "type": "string"
           },
           "skill": {
-            "type": "string",
-            "example": "testing"
+            "example": "testing",
+            "type": "string"
           },
           "system_context": {
             "type": "string"
           },
           "target_id": {
-            "type": "string",
-            "example": "sandbox-uuid"
+            "example": "sandbox-uuid",
+            "type": "string"
           },
           "timeout_seconds": {
-            "type": "integer",
-            "example": 300
+            "example": 300,
+            "type": "integer"
           }
-        }
+        },
+        "required": [
+          "prompt",
+          "target_id"
+        ],
+        "type": "object"
       },
       "AgentTaskCreateResponse": {
-        "type": "object",
-        "required": [
-          "status",
-          "task_id"
-        ],
         "properties": {
           "session_id": {
             "type": "string"
           },
           "status": {
-            "type": "string",
-            "example": "pending"
+            "example": "pending",
+            "type": "string"
           },
           "task_id": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "status",
+          "task_id"
+        ],
+        "type": "object"
       },
       "AgentTaskDetail": {
-        "type": "object",
-        "required": [
-          "created_at",
-          "prompt",
-          "status",
-          "target_id",
-          "task_id",
-          "workspace_id"
-        ],
         "properties": {
           "completed_at": {
-            "type": "string",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           },
           "created_at": {
             "type": "string"
           },
           "failure_reason": {
-            "type": "string",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           },
           "num_turns": {
             "type": "integer"
@@ -8820,16 +812,16 @@
             "nullable": true
           },
           "session_id": {
-            "type": "string",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           },
           "skill": {
-            "type": "string",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           },
           "status": {
-            "type": "string",
-            "example": "pending"
+            "example": "pending",
+            "type": "string"
           },
           "target_id": {
             "type": "string"
@@ -8838,27 +830,28 @@
             "type": "string"
           },
           "total_cost_usd": {
-            "type": "number",
-            "nullable": true
+            "nullable": true,
+            "type": "number"
           },
           "workspace_id": {
             "type": "string"
           }
-        }
-      },
-      "AgentTaskItem": {
-        "type": "object",
+        },
         "required": [
           "created_at",
           "prompt",
           "status",
           "target_id",
-          "task_id"
+          "task_id",
+          "workspace_id"
         ],
+        "type": "object"
+      },
+      "AgentTaskItem": {
         "properties": {
           "completed_at": {
-            "type": "string",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           },
           "created_at": {
             "type": "string"
@@ -8876,8 +869,8 @@
             "type": "string"
           },
           "status": {
-            "type": "string",
-            "example": "pending"
+            "example": "pending",
+            "type": "string"
           },
           "target_id": {
             "type": "string"
@@ -8886,17 +879,20 @@
             "type": "string"
           },
           "total_cost_usd": {
-            "type": "number",
-            "nullable": true
+            "nullable": true,
+            "type": "number"
           }
-        }
-      },
-      "AgentTaskPollItem": {
-        "type": "object",
+        },
         "required": [
+          "created_at",
           "prompt",
+          "status",
+          "target_id",
           "task_id"
         ],
+        "type": "object"
+      },
+      "AgentTaskPollItem": {
         "properties": {
           "max_budget_usd": {
             "type": "number"
@@ -8916,13 +912,14 @@
           "task_id": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "prompt",
+          "task_id"
+        ],
+        "type": "object"
       },
       "AgentTaskStatusRequest": {
-        "type": "object",
-        "required": [
-          "status"
-        ],
         "properties": {
           "failure_reason": {
             "type": "string"
@@ -8932,66 +929,68 @@
           },
           "result": {},
           "status": {
-            "type": "string",
-            "example": "completed"
+            "example": "completed",
+            "type": "string"
           },
           "total_cost_usd": {
-            "type": "number",
-            "nullable": true
+            "nullable": true,
+            "type": "number"
           }
-        }
+        },
+        "required": [
+          "status"
+        ],
+        "type": "object"
       },
       "AgentWhoamiResponse": {
-        "type": "object",
+        "properties": {
+          "display_name": {
+            "example": "Alice Driver",
+            "type": "string"
+          },
+          "role": {
+            "example": "developer",
+            "type": "string"
+          },
+          "sandbox_id": {
+            "example": "sbx_456",
+            "type": "string"
+          },
+          "sandbox_status": {
+            "description": "SandboxStatus is the current sandboxes.status column verbatim —\none of creating / running / pausing / paused / resuming / offline /\ndeleting (see internal/sbxstore/state.go), or \"\" for legacy rows\nwhere the field was never set. The server always populates this\nfield on 200 responses.",
+            "example": "running",
+            "type": "string"
+          },
+          "short_id": {
+            "example": "alice-driver-01",
+            "type": "string"
+          },
+          "user_id": {
+            "example": "u_abc123",
+            "type": "string"
+          },
+          "workspace_id": {
+            "example": "ws_xyz789",
+            "type": "string"
+          },
+          "workspace_name": {
+            "example": "Alice's Workspace",
+            "type": "string"
+          }
+        },
         "required": [
           "display_name",
           "role",
           "sandbox_id",
+          "sandbox_status",
           "short_id",
           "user_id",
           "workspace_id",
           "workspace_name"
         ],
-        "properties": {
-          "display_name": {
-            "type": "string",
-            "example": "Alice Driver"
-          },
-          "role": {
-            "type": "string",
-            "example": "developer"
-          },
-          "sandbox_id": {
-            "type": "string",
-            "example": "sbx_456"
-          },
-          "short_id": {
-            "type": "string",
-            "example": "alice-driver-01"
-          },
-          "user_id": {
-            "type": "string",
-            "example": "u_abc123"
-          },
-          "workspace_id": {
-            "type": "string",
-            "example": "ws_xyz789"
-          },
-          "workspace_name": {
-            "type": "string",
-            "example": "Alice's Workspace"
-          }
-        }
+        "type": "object"
       },
       "AuditCallDetail": {
-        "type": "object",
-        "required": [
-          "exe_id",
-          "id",
-          "source",
-          "started_at",
-          "workspace_id"
-        ],
         "properties": {
           "exe_id": {
             "type": "string"
@@ -9034,10 +1033,7 @@
           "workspace_id": {
             "type": "string"
           }
-        }
-      },
-      "AuditCallSummary": {
-        "type": "object",
+        },
         "required": [
           "exe_id",
           "id",
@@ -9045,6 +1041,9 @@
           "started_at",
           "workspace_id"
         ],
+        "type": "object"
+      },
+      "AuditCallSummary": {
         "properties": {
           "exe_id": {
             "type": "string"
@@ -9084,35 +1083,35 @@
           "workspace_id": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "exe_id",
+          "id",
+          "source",
+          "started_at",
+          "workspace_id"
+        ],
+        "type": "object"
       },
       "AuditSessionDetail": {
-        "type": "object",
-        "required": [
-          "first_calls",
-          "session"
-        ],
         "properties": {
           "first_calls": {
-            "type": "array",
             "items": {
               "$ref": "#/components/schemas/AuditCallSummary"
-            }
+            },
+            "type": "array"
           },
           "session": {
             "$ref": "#/components/schemas/AuditSessionSummary"
           }
-        }
+        },
+        "required": [
+          "first_calls",
+          "session"
+        ],
+        "type": "object"
       },
       "AuditSessionSummary": {
-        "type": "object",
-        "required": [
-          "exe_id",
-          "id",
-          "opened_at",
-          "stream_id",
-          "workspace_id"
-        ],
         "properties": {
           "bytes_to_backend": {
             "type": "integer"
@@ -9158,32 +1157,34 @@
           "workspace_id": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "exe_id",
+          "id",
+          "opened_at",
+          "stream_id",
+          "workspace_id"
+        ],
+        "type": "object"
       },
       "AuthCredentials": {
-        "type": "object",
+        "properties": {
+          "email": {
+            "example": "alice@example.com",
+            "type": "string"
+          },
+          "password": {
+            "example": "hunter2",
+            "type": "string"
+          }
+        },
         "required": [
           "email",
           "password"
         ],
-        "properties": {
-          "email": {
-            "type": "string",
-            "example": "alice@example.com"
-          },
-          "password": {
-            "type": "string",
-            "example": "hunter2"
-          }
-        }
+        "type": "object"
       },
       "AuthMeResponse": {
-        "type": "object",
-        "required": [
-          "email",
-          "id",
-          "role"
-        ],
         "properties": {
           "email": {
             "type": "string"
@@ -9192,58 +1193,55 @@
             "type": "string"
           },
           "name": {
-            "type": "string",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           },
           "picture": {
-            "type": "string",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           },
           "role": {
-            "type": "string",
-            "example": "developer"
+            "example": "developer",
+            "type": "string"
           }
-        }
+        },
+        "required": [
+          "email",
+          "id",
+          "role"
+        ],
+        "type": "object"
       },
       "AuthRegisterResponse": {
-        "type": "object",
+        "properties": {
+          "email": {
+            "example": "alice@example.com",
+            "type": "string"
+          },
+          "id": {
+            "example": "7e7a4f6c-...",
+            "type": "string"
+          }
+        },
         "required": [
           "email",
           "id"
         ],
-        "properties": {
-          "email": {
-            "type": "string",
-            "example": "alice@example.com"
-          },
-          "id": {
-            "type": "string",
-            "example": "7e7a4f6c-..."
-          }
-        }
+        "type": "object"
       },
       "AuthStatusResponse": {
-        "type": "object",
+        "properties": {
+          "status": {
+            "example": "ok",
+            "type": "string"
+          }
+        },
         "required": [
           "status"
         ],
-        "properties": {
-          "status": {
-            "type": "string",
-            "example": "ok"
-          }
-        }
+        "type": "object"
       },
       "CodexBrowserItem": {
-        "type": "object",
-        "required": [
-          "created_at",
-          "expires_at",
-          "id",
-          "is_online",
-          "name",
-          "workspace_id"
-        ],
         "properties": {
           "client_ip": {
             "type": "string"
@@ -9284,17 +1282,18 @@
           "workspace_id": {
             "type": "string"
           }
-        }
-      },
-      "CodexTokenListItem": {
-        "type": "object",
+        },
         "required": [
           "created_at",
           "expires_at",
           "id",
+          "is_online",
           "name",
           "workspace_id"
         ],
+        "type": "object"
+      },
+      "CodexTokenListItem": {
         "properties": {
           "created_at": {
             "type": "string"
@@ -9306,8 +1305,8 @@
             "type": "string"
           },
           "last_used_at": {
-            "type": "string",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           },
           "name": {
             "type": "string"
@@ -9316,44 +1315,43 @@
             "type": "boolean"
           },
           "revoked_at": {
-            "type": "string",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           },
           "workspace_id": {
             "type": "string"
           }
-        }
-      },
-      "CodexTokenMintRequest": {
-        "type": "object",
-        "required": [
-          "name",
-          "workspace_id"
-        ],
-        "properties": {
-          "expires_at": {
-            "type": "string",
-            "example": "2026-08-20T08:30:00Z"
-          },
-          "name": {
-            "type": "string",
-            "example": "my mac"
-          },
-          "workspace_id": {
-            "type": "string"
-          }
-        }
-      },
-      "CodexTokenMintResponse": {
-        "type": "object",
+        },
         "required": [
           "created_at",
           "expires_at",
           "id",
           "name",
-          "token",
           "workspace_id"
         ],
+        "type": "object"
+      },
+      "CodexTokenMintRequest": {
+        "properties": {
+          "expires_at": {
+            "example": "2026-08-20T08:30:00Z",
+            "type": "string"
+          },
+          "name": {
+            "example": "my mac",
+            "type": "string"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "workspace_id"
+        ],
+        "type": "object"
+      },
+      "CodexTokenMintResponse": {
         "properties": {
           "created_at": {
             "type": "string"
@@ -9373,30 +1371,35 @@
           "workspace_id": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "created_at",
+          "expires_at",
+          "id",
+          "name",
+          "token",
+          "workspace_id"
+        ],
+        "type": "object"
       },
       "CredentialBindingCreateRequest": {
-        "type": "object",
+        "properties": {
+          "config": {
+            "example": "{\"server\": \"https://...\"}",
+            "type": "string"
+          },
+          "display_name": {
+            "example": "My K8s Cluster",
+            "type": "string"
+          }
+        },
         "required": [
           "config",
           "display_name"
         ],
-        "properties": {
-          "config": {
-            "type": "string",
-            "example": "{\"server\": \"https://...\"}"
-          },
-          "display_name": {
-            "type": "string",
-            "example": "My K8s Cluster"
-          }
-        }
+        "type": "object"
       },
       "CredentialBindingCreateResponse": {
-        "type": "object",
-        "required": [
-          "id"
-        ],
         "properties": {
           "auth_type": {
             "type": "string"
@@ -9417,8 +1420,8 @@
             "type": "string"
           },
           "status": {
-            "type": "string",
-            "example": "pending_device_code"
+            "example": "pending_device_code",
+            "type": "string"
           },
           "user_code": {
             "type": "string"
@@ -9426,20 +1429,17 @@
           "verification_uri": {
             "type": "string"
           }
-        }
-      },
-      "CredentialBindingItem": {
-        "type": "object",
+        },
         "required": [
-          "auth_type",
-          "created_at",
-          "display_name",
           "id"
         ],
+        "type": "object"
+      },
+      "CredentialBindingItem": {
         "properties": {
           "auth_type": {
-            "type": "string",
-            "example": "static"
+            "example": "static",
+            "type": "string"
           },
           "created_at": {
             "type": "string"
@@ -9457,20 +1457,26 @@
           "server_url": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "auth_type",
+          "created_at",
+          "display_name",
+          "id"
+        ],
+        "type": "object"
       },
       "CredentialBindingPatchRequest": {
-        "type": "object",
         "properties": {
           "display_name": {
-            "type": "string",
             "example": "Renamed Cluster",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           }
-        }
+        },
+        "type": "object"
       },
       "ExecAuditBatchAckResponse": {
-        "type": "object",
         "properties": {
           "processed": {
             "type": "integer"
@@ -9478,25 +1484,21 @@
           "skipped": {
             "type": "integer"
           }
-        }
+        },
+        "type": "object"
       },
       "ExecutorConnectCommands": {
-        "type": "object",
-        "required": [
-          "agent_identity"
-        ],
         "properties": {
           "agent_identity": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "agent_identity"
+        ],
+        "type": "object"
       },
       "ExecutorItem": {
-        "type": "object",
-        "required": [
-          "exe_id",
-          "name"
-        ],
         "properties": {
           "client_ip": {
             "type": "string"
@@ -9508,15 +1510,15 @@
             "type": "string"
           },
           "connected_at": {
-            "type": "string",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           },
           "description": {
             "type": "string"
           },
           "disconnected_at": {
-            "type": "string",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           },
           "exe_id": {
             "type": "string"
@@ -9528,8 +1530,8 @@
             "type": "boolean"
           },
           "last_seen_at": {
-            "type": "string",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           },
           "name": {
             "type": "string"
@@ -9537,29 +1539,30 @@
           "os": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "exe_id",
+          "name"
+        ],
+        "type": "object"
       },
       "ExecutorRegisterRequest": {
-        "type": "object",
+        "properties": {
+          "description": {
+            "example": "Main development laptop",
+            "type": "string"
+          },
+          "name": {
+            "example": "my-dev-machine",
+            "type": "string"
+          }
+        },
         "required": [
           "name"
         ],
-        "properties": {
-          "description": {
-            "type": "string",
-            "example": "Main development laptop"
-          },
-          "name": {
-            "type": "string",
-            "example": "my-dev-machine"
-          }
-        }
+        "type": "object"
       },
       "ExecutorRegisterResponse": {
-        "type": "object",
-        "required": [
-          "exe_id"
-        ],
         "properties": {
           "agent_identity_jwt": {
             "type": "string"
@@ -9573,15 +1576,13 @@
           "exe_id": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "exe_id"
+        ],
+        "type": "object"
       },
       "IMBinding": {
-        "type": "object",
-        "required": [
-          "bot_id",
-          "bound_at",
-          "provider"
-        ],
         "properties": {
           "bot_id": {
             "type": "string"
@@ -9595,18 +1596,15 @@
           "user_id": {
             "type": "string"
           }
-        }
-      },
-      "IMChannel": {
-        "type": "object",
+        },
         "required": [
           "bot_id",
           "bound_at",
-          "id",
-          "provider",
-          "routing_mode",
-          "workspace_id"
+          "provider"
         ],
+        "type": "object"
+      },
+      "IMChannel": {
         "properties": {
           "bot_id": {
             "type": "string"
@@ -9618,15 +1616,15 @@
             "type": "string"
           },
           "provider": {
-            "type": "string",
-            "example": "weixin"
+            "example": "weixin",
+            "type": "string"
           },
           "require_mention": {
             "type": "boolean"
           },
           "routing_mode": {
-            "type": "string",
-            "example": "codex"
+            "example": "codex",
+            "type": "string"
           },
           "user_id": {
             "type": "string"
@@ -9634,74 +1632,78 @@
           "workspace_id": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "bot_id",
+          "bound_at",
+          "id",
+          "provider",
+          "routing_mode",
+          "workspace_id"
+        ],
+        "type": "object"
       },
       "IMChannelListResponse": {
-        "type": "object",
+        "properties": {
+          "channels": {
+            "items": {
+              "$ref": "#/components/schemas/IMChannel"
+            },
+            "type": "array"
+          }
+        },
         "required": [
           "channels"
         ],
-        "properties": {
-          "channels": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/IMChannel"
-            }
-          }
-        }
+        "type": "object"
       },
       "IMChannelPatchRequest": {
-        "type": "object",
         "properties": {
           "require_mention": {
-            "type": "boolean",
-            "nullable": true
+            "nullable": true,
+            "type": "boolean"
           },
           "routing_mode": {
-            "type": "string",
             "example": "codex",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           }
-        }
+        },
+        "type": "object"
       },
       "IMChannelPatchResponse": {
-        "type": "object",
+        "properties": {
+          "status": {
+            "example": "updated",
+            "type": "string"
+          }
+        },
         "required": [
           "status"
         ],
-        "properties": {
-          "status": {
-            "type": "string",
-            "example": "updated"
-          }
-        }
+        "type": "object"
       },
       "IMMatrixConfigureRequest": {
-        "type": "object",
-        "required": [
-          "access_token",
-          "homeserver_url"
-        ],
         "properties": {
           "access_token": {
             "type": "string"
           },
           "homeserver_url": {
-            "type": "string",
-            "example": "https://matrix.example.com"
+            "example": "https://matrix.example.com",
+            "type": "string"
           },
           "recovery_key": {
             "description": "optional, for E2EE",
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "access_token",
+          "homeserver_url"
+        ],
+        "type": "object"
       },
       "IMMatrixConfigureResponse": {
-        "type": "object",
-        "required": [
-          "bot_id",
-          "connected"
-        ],
         "properties": {
           "bot_id": {
             "type": "string"
@@ -9709,122 +1711,123 @@
           "connected": {
             "type": "boolean"
           }
-        }
+        },
+        "required": [
+          "bot_id",
+          "connected"
+        ],
+        "type": "object"
       },
       "IMSandboxBindRequest": {
-        "type": "object",
-        "required": [
-          "channel_id"
-        ],
         "properties": {
           "channel_id": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "channel_id"
+        ],
+        "type": "object"
       },
       "IMSandboxBindResponse": {
-        "type": "object",
+        "properties": {
+          "status": {
+            "example": "bound",
+            "type": "string"
+          }
+        },
         "required": [
           "status"
         ],
-        "properties": {
-          "status": {
-            "type": "string",
-            "example": "bound"
-          }
-        }
+        "type": "object"
       },
       "IMSandboxUnbindResponse": {
-        "type": "object",
+        "properties": {
+          "status": {
+            "example": "unbound",
+            "type": "string"
+          }
+        },
         "required": [
           "status"
         ],
-        "properties": {
-          "status": {
-            "type": "string",
-            "example": "unbound"
-          }
-        }
+        "type": "object"
       },
       "IMTelegramConfigureRequest": {
-        "type": "object",
+        "properties": {
+          "bot_token": {
+            "example": "123456:ABC-DEF...",
+            "type": "string"
+          }
+        },
         "required": [
           "bot_token"
         ],
-        "properties": {
-          "bot_token": {
-            "type": "string",
-            "example": "123456:ABC-DEF..."
-          }
-        }
+        "type": "object"
       },
       "IMTelegramConfigureResponse": {
-        "type": "object",
+        "properties": {
+          "bot_id": {
+            "type": "string"
+          },
+          "connected": {
+            "type": "boolean"
+          }
+        },
         "required": [
           "bot_id",
           "connected"
         ],
-        "properties": {
-          "bot_id": {
-            "type": "string"
-          },
-          "connected": {
-            "type": "boolean"
-          }
-        }
+        "type": "object"
       },
       "IMWeixinQRStartResponse": {
-        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "qrcode_url": {
+            "type": "string"
+          }
+        },
         "required": [
           "message",
           "qrcode_url"
         ],
-        "properties": {
-          "message": {
-            "type": "string"
-          },
-          "qrcode_url": {
-            "type": "string"
-          }
-        }
+        "type": "object"
       },
       "IMWeixinQRWaitResponse": {
-        "type": "object",
-        "required": [
-          "connected",
-          "status"
-        ],
         "properties": {
           "bot_id": {
-            "type": "string",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           },
           "connected": {
             "type": "boolean"
           },
           "message": {
-            "type": "string",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           },
           "qrcode_url": {
-            "type": "string",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           },
           "status": {
-            "type": "string",
-            "example": "wait"
+            "example": "wait",
+            "type": "string"
           },
           "user_id": {
-            "type": "string",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           }
-        }
+        },
+        "required": [
+          "connected",
+          "status"
+        ],
+        "type": "object"
       },
       "LLMConfigResponse": {
-        "type": "object",
-        "required": [
-          "configured"
-        ],
         "properties": {
           "api_key": {
             "type": "string"
@@ -9836,75 +1839,74 @@
             "type": "boolean"
           },
           "models": {
-            "type": "array",
             "items": {
               "$ref": "#/components/schemas/LLMModel"
-            }
+            },
+            "type": "array"
           },
           "updated_at": {
-            "type": "string",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           }
-        }
+        },
+        "required": [
+          "configured"
+        ],
+        "type": "object"
       },
       "LLMConfigUpsertRequest": {
-        "type": "object",
+        "properties": {
+          "api_key": {
+            "description": "optional on update",
+            "example": "sk-ant-...",
+            "type": "string"
+          },
+          "base_url": {
+            "example": "https://api.anthropic.com",
+            "type": "string"
+          },
+          "models": {
+            "items": {
+              "$ref": "#/components/schemas/LLMModel"
+            },
+            "type": "array"
+          }
+        },
         "required": [
           "base_url",
           "models"
         ],
-        "properties": {
-          "api_key": {
-            "description": "optional on update",
-            "type": "string",
-            "example": "sk-ant-..."
-          },
-          "base_url": {
-            "type": "string",
-            "example": "https://api.anthropic.com"
-          },
-          "models": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/LLMModel"
-            }
-          }
-        }
+        "type": "object"
       },
       "LLMConfigUpsertResponse": {
-        "type": "object",
-        "required": [
-          "ok"
-        ],
         "properties": {
           "ok": {
             "type": "boolean"
           }
-        }
+        },
+        "required": [
+          "ok"
+        ],
+        "type": "object"
       },
       "LLMModel": {
-        "type": "object",
+        "properties": {
+          "id": {
+            "example": "claude-opus-4-7",
+            "type": "string"
+          },
+          "name": {
+            "example": "Claude Opus 4.7",
+            "type": "string"
+          }
+        },
         "required": [
           "id",
           "name"
         ],
-        "properties": {
-          "id": {
-            "type": "string",
-            "example": "claude-opus-4-7"
-          },
-          "name": {
-            "type": "string",
-            "example": "Claude Opus 4.7"
-          }
-        }
+        "type": "object"
       },
       "LLMQuotaResponse": {
-        "type": "object",
-        "required": [
-          "default_max_rpd",
-          "today_request_count"
-        ],
         "properties": {
           "default_max_rpd": {
             "type": "integer"
@@ -9920,18 +1922,18 @@
             ],
             "nullable": true
           }
-        }
+        },
+        "required": [
+          "default_max_rpd",
+          "today_request_count"
+        ],
+        "type": "object"
       },
       "LLMWorkspaceQuotaPart": {
-        "type": "object",
-        "required": [
-          "updated_at",
-          "workspace_id"
-        ],
         "properties": {
           "max_rpd": {
-            "type": "integer",
-            "nullable": true
+            "nullable": true,
+            "type": "integer"
           },
           "updated_at": {
             "type": "string"
@@ -9939,44 +1941,83 @@
           "workspace_id": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "updated_at",
+          "workspace_id"
+        ],
+        "type": "object"
       },
       "ListAuditCallsResponse": {
-        "type": "object",
-        "required": [
-          "calls"
-        ],
         "properties": {
           "calls": {
-            "type": "array",
             "items": {
               "$ref": "#/components/schemas/AuditCallSummary"
-            }
+            },
+            "type": "array"
           },
           "next_cursor": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "calls"
+        ],
+        "type": "object"
       },
       "ListAuditSessionsResponse": {
-        "type": "object",
-        "required": [
-          "sessions"
-        ],
         "properties": {
           "next_cursor": {
             "type": "string"
           },
           "sessions": {
-            "type": "array",
             "items": {
               "$ref": "#/components/schemas/AuditSessionSummary"
-            }
+            },
+            "type": "array"
           }
-        }
+        },
+        "required": [
+          "sessions"
+        ],
+        "type": "object"
       },
       "MCPPAT": {
-        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "expires_at": {
+            "type": "string"
+          },
+          "id": {
+            "example": "agpat_a1b2c3d4e5f6g7h8",
+            "type": "string"
+          },
+          "last_used_at": {
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "prefix": {
+            "type": "string"
+          },
+          "revoked_at": {
+            "nullable": true,
+            "type": "string"
+          },
+          "scopes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "workspace_id": {
+            "type": "string"
+          }
+        },
         "required": [
           "created_at",
           "expires_at",
@@ -9986,71 +2027,68 @@
           "scopes",
           "workspace_id"
         ],
+        "type": "object"
+      },
+      "MCPPATMintRequest": {
+        "properties": {
+          "expires_at": {
+            "example": "2026-09-09T08:30:00Z",
+            "type": "string"
+          },
+          "name": {
+            "example": "claude-desktop-laptop",
+            "type": "string"
+          },
+          "scopes": {
+            "example": [
+              "[\"mcp:read\"",
+              "\"mcp:exec\"]"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "scopes"
+        ],
+        "type": "object"
+      },
+      "MCPPATMintResponse": {
         "properties": {
           "created_at": {
             "type": "string"
           },
           "expires_at": {
+            "example": "2026-09-09T08:30:00Z",
             "type": "string"
           },
           "id": {
-            "type": "string",
-            "example": "agpat_a1b2c3d4e5f6g7h8"
-          },
-          "last_used_at": {
-            "type": "string",
-            "nullable": true
+            "example": "agpat_a1b2c3d4e5f6g7h8",
+            "type": "string"
           },
           "name": {
             "type": "string"
           },
           "prefix": {
+            "example": "agpat_a1b2c3d4e5f6g7h8",
             "type": "string"
           },
-          "revoked_at": {
-            "type": "string",
-            "nullable": true
-          },
           "scopes": {
-            "type": "array",
             "items": {
               "type": "string"
-            }
+            },
+            "type": "array"
+          },
+          "secret": {
+            "type": "string"
           },
           "workspace_id": {
             "type": "string"
           }
-        }
-      },
-      "MCPPATMintRequest": {
-        "type": "object",
-        "required": [
-          "name",
-          "scopes"
-        ],
-        "properties": {
-          "expires_at": {
-            "type": "string",
-            "example": "2026-09-09T08:30:00Z"
-          },
-          "name": {
-            "type": "string",
-            "example": "claude-desktop-laptop"
-          },
-          "scopes": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            },
-            "example": [
-              "[\"mcp:read\"",
-              "\"mcp:exec\"]"
-            ]
-          }
-        }
-      },
-      "MCPPATMintResponse": {
-        "type": "object",
+        },
         "required": [
           "created_at",
           "expires_at",
@@ -10061,46 +2099,9 @@
           "secret",
           "workspace_id"
         ],
-        "properties": {
-          "created_at": {
-            "type": "string"
-          },
-          "expires_at": {
-            "type": "string",
-            "example": "2026-09-09T08:30:00Z"
-          },
-          "id": {
-            "type": "string",
-            "example": "agpat_a1b2c3d4e5f6g7h8"
-          },
-          "name": {
-            "type": "string"
-          },
-          "prefix": {
-            "type": "string",
-            "example": "agpat_a1b2c3d4e5f6g7h8"
-          },
-          "scopes": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "secret": {
-            "type": "string"
-          },
-          "workspace_id": {
-            "type": "string"
-          }
-        }
+        "type": "object"
       },
       "MCPPATScopeDescriptor": {
-        "type": "object",
-        "required": [
-          "available",
-          "description",
-          "name"
-        ],
         "properties": {
           "available": {
             "type": "boolean"
@@ -10109,59 +2110,61 @@
             "type": "string"
           },
           "name": {
-            "type": "string",
-            "example": "mcp:read"
+            "example": "mcp:read",
+            "type": "string"
           }
-        }
+        },
+        "required": [
+          "available",
+          "description",
+          "name"
+        ],
+        "type": "object"
       },
       "MCPPATScopesResponse": {
-        "type": "object",
+        "properties": {
+          "scopes": {
+            "items": {
+              "$ref": "#/components/schemas/MCPPATScopeDescriptor"
+            },
+            "type": "array"
+          }
+        },
         "required": [
           "scopes"
         ],
-        "properties": {
-          "scopes": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/MCPPATScopeDescriptor"
-            }
-          }
-        }
+        "type": "object"
       },
       "MemberAddRequest": {
-        "type": "object",
-        "required": [
-          "email"
-        ],
         "properties": {
           "email": {
-            "type": "string",
-            "example": "alice@example.com"
+            "example": "alice@example.com",
+            "type": "string"
           },
           "role": {
             "description": "optional; defaults to \"developer\"",
-            "type": "string",
-            "example": "developer"
+            "example": "developer",
+            "type": "string"
           }
-        }
+        },
+        "required": [
+          "email"
+        ],
+        "type": "object"
       },
       "MemberRoleUpdateRequest": {
-        "type": "object",
+        "properties": {
+          "role": {
+            "example": "maintainer",
+            "type": "string"
+          }
+        },
         "required": [
           "role"
         ],
-        "properties": {
-          "role": {
-            "type": "string",
-            "example": "maintainer"
-          }
-        }
+        "type": "object"
       },
       "ModelServerStatusResponse": {
-        "type": "object",
-        "required": [
-          "connected"
-        ],
         "properties": {
           "connected": {
             "type": "boolean"
@@ -10170,10 +2173,10 @@
             "type": "string"
           },
           "models": {
-            "type": "array",
             "items": {
               "$ref": "#/components/schemas/LLMModel"
-            }
+            },
+            "type": "array"
           },
           "project_id": {
             "type": "string"
@@ -10181,19 +2184,13 @@
           "project_name": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "connected"
+        ],
+        "type": "object"
       },
       "Sandbox": {
-        "type": "object",
-        "required": [
-          "created_at",
-          "id",
-          "is_local",
-          "name",
-          "status",
-          "type",
-          "workspace_id"
-        ],
         "properties": {
           "agent_info": {
             "$ref": "#/components/schemas/AgentInfo"
@@ -10217,10 +2214,10 @@
             "type": "integer"
           },
           "im_bindings": {
-            "type": "array",
             "items": {
               "$ref": "#/components/schemas/IMBinding"
-            }
+            },
+            "type": "array"
           },
           "is_local": {
             "type": "boolean"
@@ -10229,8 +2226,8 @@
             "type": "string"
           },
           "last_activity_at": {
-            "type": "string",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           },
           "last_heartbeat_at": {
             "type": "string"
@@ -10239,8 +2236,8 @@
             "type": "integer"
           },
           "metadata": {
-            "type": "object",
-            "additionalProperties": true
+            "additionalProperties": true,
+            "type": "object"
           },
           "name": {
             "type": "string"
@@ -10252,8 +2249,8 @@
             "type": "string"
           },
           "paused_at": {
-            "type": "string",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           },
           "short_id": {
             "type": "string"
@@ -10265,21 +2262,27 @@
             "type": "string"
           },
           "weixin_bindings": {
-            "type": "array",
             "items": {
               "$ref": "#/components/schemas/IMBinding"
-            }
+            },
+            "type": "array"
           },
           "workspace_id": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "created_at",
+          "id",
+          "is_local",
+          "name",
+          "status",
+          "type",
+          "workspace_id"
+        ],
+        "type": "object"
       },
       "SandboxCreateRequest": {
-        "type": "object",
-        "required": [
-          "name"
-        ],
         "properties": {
           "cpu": {
             "description": "optional; millicores, e.g. 500 or 2000",
@@ -10294,75 +2297,69 @@
             "type": "integer"
           },
           "metadata": {
+            "additionalProperties": true,
             "description": "optional; arbitrary key-value metadata",
-            "type": "object",
-            "additionalProperties": true
+            "type": "object"
           },
           "name": {
-            "type": "string",
-            "example": "my-sandbox"
+            "example": "my-sandbox",
+            "type": "string"
           },
           "type": {
             "description": "optional; default \"opencode\"",
-            "type": "string",
-            "example": "opencode"
+            "example": "opencode",
+            "type": "string"
           }
-        }
-      },
-      "SandboxLifecycleStatusResponse": {
-        "type": "object",
-        "required": [
-          "status"
-        ],
-        "properties": {
-          "status": {
-            "type": "string",
-            "example": "pausing"
-          }
-        }
-      },
-      "SandboxRenameRequest": {
-        "type": "object",
+        },
         "required": [
           "name"
         ],
+        "type": "object"
+      },
+      "SandboxLifecycleStatusResponse": {
+        "properties": {
+          "status": {
+            "example": "pausing",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "type": "object"
+      },
+      "SandboxRenameRequest": {
         "properties": {
           "name": {
-            "type": "string",
-            "example": "renamed-sandbox"
+            "example": "renamed-sandbox",
+            "type": "string"
           }
-        }
+        },
+        "required": [
+          "name"
+        ],
+        "type": "object"
       },
       "SandboxUsage": {
-        "type": "object",
+        "properties": {
+          "since": {
+            "example": "2026-01-01T00:00:00Z",
+            "nullable": true,
+            "type": "string"
+          },
+          "usage": {
+            "items": {
+              "$ref": "#/components/schemas/SandboxUsageSummary"
+            },
+            "type": "array"
+          }
+        },
         "required": [
           "usage"
         ],
-        "properties": {
-          "since": {
-            "type": "string",
-            "example": "2026-01-01T00:00:00Z",
-            "nullable": true
-          },
-          "usage": {
-            "type": "array",
-            "items": {
-              "$ref": "#/components/schemas/SandboxUsageSummary"
-            }
-          }
-        }
+        "type": "object"
       },
       "SandboxUsageSummary": {
-        "type": "object",
-        "required": [
-          "cache_creation_input_tokens",
-          "cache_read_input_tokens",
-          "input_tokens",
-          "model",
-          "output_tokens",
-          "provider",
-          "request_count"
-        ],
         "properties": {
           "cache_creation_input_tokens": {
             "type": "integer"
@@ -10374,71 +2371,67 @@
             "type": "integer"
           },
           "model": {
-            "type": "string",
-            "example": "claude-sonnet-4-6"
+            "example": "claude-sonnet-4-6",
+            "type": "string"
           },
           "output_tokens": {
             "type": "integer"
           },
           "provider": {
-            "type": "string",
-            "example": "anthropic"
+            "example": "anthropic",
+            "type": "string"
           },
           "request_count": {
             "type": "integer"
           }
-        }
+        },
+        "required": [
+          "cache_creation_input_tokens",
+          "cache_read_input_tokens",
+          "input_tokens",
+          "model",
+          "output_tokens",
+          "provider",
+          "request_count"
+        ],
+        "type": "object"
       },
       "TraceDetailResponse": {
-        "type": "object",
-        "required": [
-          "requests",
-          "trace"
-        ],
         "properties": {
           "requests": {
-            "type": "array",
             "items": {
               "$ref": "#/components/schemas/TraceRequest"
-            }
+            },
+            "type": "array"
           },
           "trace": {
             "$ref": "#/components/schemas/TraceRecord"
           }
-        }
+        },
+        "required": [
+          "requests",
+          "trace"
+        ],
+        "type": "object"
       },
       "TraceListResponse": {
-        "type": "object",
-        "required": [
-          "traces"
-        ],
         "properties": {
           "total": {
             "type": "integer"
           },
           "traces": {
-            "type": "array",
             "items": {
               "$ref": "#/components/schemas/TraceRecord"
-            }
+            },
+            "type": "array"
           }
-        }
+        },
+        "required": [
+          "traces"
+        ],
+        "type": "object"
       },
       "TraceRecord": {
-        "type": "object",
-        "required": [
-          "created_at",
-          "id",
-          "request_count",
-          "sandbox_id",
-          "source",
-          "total_cache_creation_tokens",
-          "total_cache_read_tokens",
-          "total_input_tokens",
-          "total_output_tokens",
-          "updated_at",
-          "workspace_id"
-        ],
         "properties": {
           "created_at": {
             "type": "string"
@@ -10456,8 +2449,8 @@
             "type": "string"
           },
           "source": {
-            "type": "string",
-            "example": "codex"
+            "example": "codex",
+            "type": "string"
           },
           "total_cache_creation_tokens": {
             "type": "integer"
@@ -10477,23 +2470,23 @@
           "workspace_id": {
             "type": "string"
           }
-        }
-      },
-      "TraceRequest": {
-        "type": "object",
+        },
         "required": [
-          "cache_creation_input_tokens",
-          "cache_read_input_tokens",
           "created_at",
-          "duration",
           "id",
-          "input_tokens",
-          "model",
-          "output_tokens",
-          "provider",
+          "request_count",
           "sandbox_id",
+          "source",
+          "total_cache_creation_tokens",
+          "total_cache_read_tokens",
+          "total_input_tokens",
+          "total_output_tokens",
+          "updated_at",
           "workspace_id"
         ],
+        "type": "object"
+      },
+      "TraceRequest": {
         "properties": {
           "cache_creation_input_tokens": {
             "type": "integer"
@@ -10540,16 +2533,23 @@
           "workspace_id": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "cache_creation_input_tokens",
+          "cache_read_input_tokens",
+          "created_at",
+          "duration",
+          "id",
+          "input_tokens",
+          "model",
+          "output_tokens",
+          "provider",
+          "sandbox_id",
+          "workspace_id"
+        ],
+        "type": "object"
       },
       "Workspace": {
-        "type": "object",
-        "required": [
-          "created_at",
-          "id",
-          "name",
-          "updated_at"
-        ],
         "properties": {
           "created_at": {
             "type": "string"
@@ -10563,10 +2563,50 @@
           "updated_at": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "created_at",
+          "id",
+          "name",
+          "updated_at"
+        ],
+        "type": "object"
       },
       "WorkspaceAPIKey": {
-        "type": "object",
+        "properties": {
+          "created_at": {
+            "type": "string"
+          },
+          "expires_at": {
+            "example": "2026-08-20T08:30:00Z",
+            "type": "string"
+          },
+          "id": {
+            "example": "ask_a1b2c3d4e5f6g7h8",
+            "type": "string"
+          },
+          "last_used_at": {
+            "nullable": true,
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "prefix": {
+            "example": "ask_a1b2c3d4e5f6g7h8",
+            "type": "string"
+          },
+          "revoked_at": {
+            "nullable": true,
+            "type": "string"
+          },
+          "scopes": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
         "required": [
           "created_at",
           "expires_at",
@@ -10575,69 +2615,65 @@
           "prefix",
           "scopes"
         ],
+        "type": "object"
+      },
+      "WorkspaceAPIKeyMintRequest": {
+        "properties": {
+          "expires_at": {
+            "example": "2026-08-20T08:30:00Z",
+            "type": "string"
+          },
+          "name": {
+            "example": "my-bot-integration",
+            "type": "string"
+          },
+          "scopes": {
+            "example": [
+              "[\"turns:submit\"]"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "scopes"
+        ],
+        "type": "object"
+      },
+      "WorkspaceAPIKeyMintResponse": {
         "properties": {
           "created_at": {
             "type": "string"
           },
           "expires_at": {
-            "type": "string",
-            "example": "2026-08-20T08:30:00Z"
+            "example": "2026-08-20T08:30:00Z",
+            "type": "string"
           },
           "id": {
-            "type": "string",
-            "example": "ask_a1b2c3d4e5f6g7h8"
-          },
-          "last_used_at": {
-            "type": "string",
-            "nullable": true
+            "example": "ask_a1b2c3d4e5f6g7h8",
+            "type": "string"
           },
           "name": {
             "type": "string"
           },
           "prefix": {
-            "type": "string",
-            "example": "ask_a1b2c3d4e5f6g7h8"
-          },
-          "revoked_at": {
-            "type": "string",
-            "nullable": true
+            "example": "ask_a1b2c3d4e5f6g7h8",
+            "type": "string"
           },
           "scopes": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          }
-        }
-      },
-      "WorkspaceAPIKeyMintRequest": {
-        "type": "object",
-        "required": [
-          "name",
-          "scopes"
-        ],
-        "properties": {
-          "expires_at": {
-            "type": "string",
-            "example": "2026-08-20T08:30:00Z"
-          },
-          "name": {
-            "type": "string",
-            "example": "my-bot-integration"
-          },
-          "scopes": {
-            "type": "array",
             "items": {
               "type": "string"
             },
-            "example": [
-              "[\"turns:submit\"]"
-            ]
+            "type": "array"
+          },
+          "secret": {
+            "example": "ask_a1b2c3d4e5f6g7h8_X9y8Z7w6V5u4T3s2R1q0P9o8N7m6L5k4J3i2H1g0F9e8D7c6B5a4AbCdEf",
+            "type": "string"
           }
-        }
-      },
-      "WorkspaceAPIKeyMintResponse": {
-        "type": "object",
+        },
         "required": [
           "created_at",
           "expires_at",
@@ -10647,58 +2683,21 @@
           "scopes",
           "secret"
         ],
-        "properties": {
-          "created_at": {
-            "type": "string"
-          },
-          "expires_at": {
-            "type": "string",
-            "example": "2026-08-20T08:30:00Z"
-          },
-          "id": {
-            "type": "string",
-            "example": "ask_a1b2c3d4e5f6g7h8"
-          },
-          "name": {
-            "type": "string"
-          },
-          "prefix": {
-            "type": "string",
-            "example": "ask_a1b2c3d4e5f6g7h8"
-          },
-          "scopes": {
-            "type": "array",
-            "items": {
-              "type": "string"
-            }
-          },
-          "secret": {
-            "type": "string",
-            "example": "ask_a1b2c3d4e5f6g7h8_X9y8Z7w6V5u4T3s2R1q0P9o8N7m6L5k4J3i2H1g0F9e8D7c6B5a4AbCdEf"
-          }
-        }
+        "type": "object"
       },
       "WorkspaceCreateRequest": {
-        "type": "object",
+        "properties": {
+          "name": {
+            "example": "My Workspace",
+            "type": "string"
+          }
+        },
         "required": [
           "name"
         ],
-        "properties": {
-          "name": {
-            "type": "string",
-            "example": "My Workspace"
-          }
-        }
+        "type": "object"
       },
       "WorkspaceDefaultsResponse": {
-        "type": "object",
-        "required": [
-          "current_sandboxes",
-          "max_idle_timeout",
-          "max_sandbox_cpu",
-          "max_sandbox_memory",
-          "max_sandboxes"
-        ],
         "properties": {
           "current_sandboxes": {
             "type": "integer"
@@ -10715,38 +2714,41 @@
           "max_sandboxes": {
             "type": "integer"
           }
-        }
+        },
+        "required": [
+          "current_sandboxes",
+          "max_idle_timeout",
+          "max_sandbox_cpu",
+          "max_sandbox_memory",
+          "max_sandboxes"
+        ],
+        "type": "object"
       },
       "WorkspaceMember": {
-        "type": "object",
-        "required": [
-          "email",
-          "role",
-          "user_id"
-        ],
         "properties": {
           "email": {
             "type": "string"
           },
           "picture": {
-            "type": "string",
-            "nullable": true
+            "nullable": true,
+            "type": "string"
           },
           "role": {
-            "type": "string",
-            "example": "developer"
+            "example": "developer",
+            "type": "string"
           },
           "user_id": {
             "type": "string"
           }
-        }
+        },
+        "required": [
+          "email",
+          "role",
+          "user_id"
+        ],
+        "type": "object"
       },
       "WorkspaceQuotaResponse": {
-        "type": "object",
-        "required": [
-          "current",
-          "max"
-        ],
         "properties": {
           "current": {
             "type": "integer"
@@ -10754,22 +2756,26 @@
           "max": {
             "type": "integer"
           }
-        }
+        },
+        "required": [
+          "current",
+          "max"
+        ],
+        "type": "object"
       },
       "WorkspaceRenameRequest": {
-        "type": "object",
+        "properties": {
+          "name": {
+            "example": "Renamed Workspace",
+            "type": "string"
+          }
+        },
         "required": [
           "name"
         ],
-        "properties": {
-          "name": {
-            "type": "string",
-            "example": "Renamed Workspace"
-          }
-        }
+        "type": "object"
       },
       "sdk.ConnectorEnv": {
-        "type": "object",
         "properties": {
           "is_default": {
             "type": "boolean"
@@ -10781,59 +2787,59 @@
             "type": "string"
           },
           "tools": {
-            "type": "array",
             "items": {
               "$ref": "#/components/schemas/sdk.ConnectorTool"
-            }
+            },
+            "type": "array"
           },
           "type": {
-            "type": "string",
-            "example": "executor"
+            "example": "executor",
+            "type": "string"
           }
-        }
+        },
+        "type": "object"
       },
       "sdk.ConnectorEnvsListResponse": {
-        "type": "object",
         "properties": {
           "envs": {
-            "type": "array",
             "items": {
               "$ref": "#/components/schemas/sdk.ConnectorEnv"
-            }
+            },
+            "type": "array"
           }
-        }
+        },
+        "type": "object"
       },
       "sdk.ConnectorErrorBody": {
-        "type": "object",
         "properties": {
           "code": {
-            "type": "string",
-            "example": "unknown_tool"
+            "example": "unknown_tool",
+            "type": "string"
           },
           "message": {
             "type": "string"
           }
-        }
+        },
+        "type": "object"
       },
       "sdk.ConnectorErrorResponse": {
-        "type": "object",
         "properties": {
           "error": {
             "$ref": "#/components/schemas/sdk.ConnectorErrorBody"
           }
-        }
+        },
+        "type": "object"
       },
       "sdk.ConnectorOKResponse": {
-        "type": "object",
         "properties": {
           "ok": {
-            "type": "boolean",
-            "example": true
+            "example": true,
+            "type": "boolean"
           }
-        }
+        },
+        "type": "object"
       },
       "sdk.ConnectorOutputChunk": {
-        "type": "object",
         "properties": {
           "data_b64": {
             "type": "string"
@@ -10842,26 +2848,26 @@
             "type": "integer"
           },
           "stream": {
-            "type": "string",
             "enum": [
               "stdout",
               "stderr"
-            ]
+            ],
+            "type": "string"
           }
-        }
+        },
+        "type": "object"
       },
       "sdk.ConnectorOutputResponse": {
-        "type": "object",
         "properties": {
           "chunks": {
-            "type": "array",
             "items": {
               "$ref": "#/components/schemas/sdk.ConnectorOutputChunk"
-            }
+            },
+            "type": "array"
           },
           "exit_code": {
-            "type": "integer",
-            "nullable": true
+            "nullable": true,
+            "type": "integer"
           },
           "lost_bytes": {
             "type": "integer"
@@ -10872,56 +2878,56 @@
           "truncated": {
             "type": "boolean"
           }
-        }
+        },
+        "type": "object"
       },
       "sdk.ConnectorStdinRequest": {
-        "type": "object",
         "properties": {
           "data_b64": {
-            "type": "string",
-            "example": "aGVsbG8="
+            "example": "aGVsbG8=",
+            "type": "string"
           }
-        }
+        },
+        "type": "object"
       },
       "sdk.ConnectorTool": {
-        "type": "object",
         "properties": {
           "description": {
             "type": "string"
           },
           "kind": {
-            "type": "string",
             "enum": [
               "core",
               "custom"
-            ]
+            ],
+            "type": "string"
           },
           "name": {
             "type": "string"
           }
-        }
+        },
+        "type": "object"
       },
       "sdk.ConnectorToolCallRequest": {
-        "type": "object",
         "properties": {
           "arguments": {
-            "type": "object",
-            "additionalProperties": {}
+            "additionalProperties": {},
+            "type": "object"
           },
           "tool": {
-            "type": "string",
-            "example": "shell"
+            "example": "shell",
+            "type": "string"
           }
-        }
+        },
+        "type": "object"
       },
       "tools.MCPCallToolResult": {
-        "type": "object",
         "properties": {
           "content": {
-            "type": "array",
             "items": {
               "$ref": "#/components/schemas/tools.MCPToolContent"
-            }
+            },
+            "type": "array"
           },
           "isError": {
             "type": "boolean"
@@ -10929,10 +2935,10 @@
           "structuredContent": {
             "type": "object"
           }
-        }
+        },
+        "type": "object"
       },
       "tools.MCPToolContent": {
-        "type": "object",
         "properties": {
           "text": {
             "type": "string"
@@ -10940,8 +2946,8008 @@
           "type": {
             "type": "string"
           }
-        }
+        },
+        "type": "object"
+      }
+    },
+    "securitySchemes": {
+      "BearerAuth": {
+        "description": "`Authorization: Bearer <token>` with an OAuth access token, a `proxy_token` from POST /api/agent/register, or a workspace API key (`wak_*`).",
+        "in": "header",
+        "name": "Authorization",
+        "type": "apiKey"
+      },
+      "CookieAuth": {
+        "description": "Session cookie set by POST /api/auth/login. All non-auth endpoints assume this cookie.",
+        "in": "cookie",
+        "name": "agentserver-token",
+        "type": "apiKey"
       }
     }
-  }
+  },
+  "info": {
+    "contact": {},
+    "description": "Public REST API for agentserver. Generated from\nGo handler annotations via swaggo/swag; see\ndocs/api/README.md for regeneration instructions.",
+    "title": "agentserver API",
+    "version": "0.1.0"
+  },
+  "openapi": "3.0.0",
+  "paths": {
+    "/api/admin/quotas/defaults": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminQuotaDefaultsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "admin role required"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Get system-wide quota defaults (admin)",
+        "tags": [
+          "Admin"
+        ]
+      },
+      "put": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminQuotaDefaultsUpdateRequest"
+              }
+            }
+          },
+          "description": "Quota fields to update (all optional)",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminQuotaDefaultsResponse"
+                }
+              }
+            },
+            "description": "Updated defaults"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "admin role required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Update system-wide quota defaults (admin)",
+        "tags": [
+          "Admin"
+        ]
+      }
+    },
+    "/api/admin/sandboxes": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AdminSandboxItem"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "admin role required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "List all sandboxes (admin)",
+        "tags": [
+          "Admin"
+        ]
+      }
+    },
+    "/api/admin/users": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AdminUserItem"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "admin role required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "List all users (admin)",
+        "tags": [
+          "Admin"
+        ]
+      }
+    },
+    "/api/admin/users/{id}/quota": {
+      "delete": {
+        "parameters": [
+          {
+            "description": "User ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "deleted"
+          },
+          "401": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "admin role required"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Delete per-user quota override (admin)",
+        "tags": [
+          "Admin"
+        ]
+      },
+      "get": {
+        "parameters": [
+          {
+            "description": "User ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminUserQuotaResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "admin role required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Get per-user quota override (admin)",
+        "tags": [
+          "Admin"
+        ]
+      },
+      "put": {
+        "parameters": [
+          {
+            "description": "User ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminSetUserQuotaRequest"
+              }
+            }
+          },
+          "description": "Quota overrides",
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "saved"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "bad request"
+          },
+          "401": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "admin role required"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Set per-user quota override (admin)",
+        "tags": [
+          "Admin"
+        ]
+      }
+    },
+    "/api/admin/users/{id}/role": {
+      "put": {
+        "parameters": [
+          {
+            "description": "User ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminUpdateUserRoleRequest"
+              }
+            }
+          },
+          "description": "New role (user or admin)",
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "updated"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "bad request / invalid role"
+          },
+          "401": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "admin role required"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Update a user's role (admin)",
+        "tags": [
+          "Admin"
+        ]
+      }
+    },
+    "/api/admin/workspaces": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AdminWorkspaceItem"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "admin role required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "List all workspaces (admin)",
+        "tags": [
+          "Admin"
+        ]
+      }
+    },
+    "/api/admin/workspaces/{id}/llm-quota": {
+      "delete": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "deleted"
+          },
+          "401": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "admin role required"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "llmproxy unavailable"
+          },
+          "503": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "llmproxy not configured"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Delete workspace LLM quota override (admin, proxied to llmproxy)",
+        "tags": [
+          "Admin"
+        ]
+      },
+      "get": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LLMQuotaResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "admin role required"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "llmproxy unavailable"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "llmproxy not configured"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Get workspace LLM quota (admin, proxied to llmproxy)",
+        "tags": [
+          "Admin"
+        ]
+      },
+      "put": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "saved"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "bad request"
+          },
+          "401": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "admin role required"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "llmproxy unavailable"
+          },
+          "503": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "llmproxy not configured"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Set workspace LLM quota override (admin, proxied to llmproxy)",
+        "tags": [
+          "Admin"
+        ]
+      }
+    },
+    "/api/admin/workspaces/{id}/quota": {
+      "delete": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "deleted"
+          },
+          "401": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "admin role required"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Delete workspace quota override (admin)",
+        "tags": [
+          "Admin"
+        ]
+      },
+      "get": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AdminWorkspaceQuotaResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "admin role required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Get workspace quota override (admin)",
+        "tags": [
+          "Admin"
+        ]
+      },
+      "put": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AdminSetWorkspaceQuotaRequest"
+              }
+            }
+          },
+          "description": "Quota overrides (all optional, merged with existing)",
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "saved"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "bad request"
+          },
+          "401": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "admin role required"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Set workspace quota override (admin)",
+        "tags": [
+          "Admin"
+        ]
+      }
+    },
+    "/api/agent/discovery/agents": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AgentCardItem"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "summary": "Discover agents in the calling agent's workspace (proxy_token auth)",
+        "tags": [
+          "Agent"
+        ]
+      }
+    },
+    "/api/agent/discovery/cards": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentCardRegisterRequest"
+              }
+            }
+          },
+          "description": "Agent card info",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentCardRegisterResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "summary": "Register or update an agent capability card",
+        "tags": [
+          "Agent"
+        ]
+      }
+    },
+    "/api/agent/mailbox/inbox": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Max messages to return (default 10)",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AgentMailboxMessage"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "summary": "Read messages from the calling agent's inbox",
+        "tags": [
+          "Agent"
+        ]
+      }
+    },
+    "/api/agent/mailbox/send": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentMailboxSendRequest"
+              }
+            }
+          },
+          "description": "Message payload",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentMailboxSendResponse"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "target not in same workspace"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "target agent not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "summary": "Send a message to another agent's mailbox",
+        "tags": [
+          "Agent"
+        ]
+      }
+    },
+    "/api/agent/register": {
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentRegisterRequest"
+              }
+            }
+          },
+          "description": "Agent registration info",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentRegisterResponse"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "no permission"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "summary": "Register an agent (obtain sandbox credentials)",
+        "tags": [
+          "Agent"
+        ]
+      }
+    },
+    "/api/agent/tasks": {
+      "post": {
+        "requestBody": {
+          "$ref": "#/components/requestBodies/AgentTaskCreateRequest"
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentTaskCreateResponse"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "target agent not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "summary": "Create a delegated task (proxy_token auth)",
+        "tags": [
+          "Agent"
+        ]
+      }
+    },
+    "/api/agent/tasks/poll": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Sandbox ID (defaults to token's sandbox)",
+            "in": "query",
+            "name": "sandbox_id",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AgentTaskPollItem"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "forbidden"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "summary": "Poll for pending tasks (proxy_token auth)",
+        "tags": [
+          "Agent"
+        ]
+      }
+    },
+    "/api/agent/tasks/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Task ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentTaskDetail"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "summary": "Get a task by ID (proxy_token auth)",
+        "tags": [
+          "Agent"
+        ]
+      }
+    },
+    "/api/agent/tasks/{id}/status": {
+      "put": {
+        "parameters": [
+          {
+            "description": "Task ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AgentTaskStatusRequest"
+              }
+            }
+          },
+          "description": "Status update",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "bad request"
+          },
+          "401": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "summary": "Update task status (proxy_token auth)",
+        "tags": [
+          "Agent"
+        ]
+      }
+    },
+    "/api/agent/whoami": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentWhoamiResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "identity not valid for this token (missing user binding or workspace membership)"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "summary": "Inspect the calling agent identity (proxy_token auth)",
+        "tags": [
+          "Agent"
+        ]
+      }
+    },
+    "/api/agents/{sandboxId}": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Sandbox ID",
+            "in": "path",
+            "name": "sandboxId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentCardItem"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a member"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Get a single agent card by sandbox ID",
+        "tags": [
+          "Agent"
+        ]
+      }
+    },
+    "/api/auth/check": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthStatusResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Check session validity",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/api/auth/login": {
+      "post": {
+        "description": "Validates credentials; on success sets the session cookie and returns {\"status\":\"ok\"}.",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/AuthCredentials"
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthStatusResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "invalid credentials"
+          }
+        },
+        "summary": "Log in with email + password",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/api/auth/logout": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthStatusResponse"
+                }
+              }
+            },
+            "description": "OK"
+          }
+        },
+        "summary": "Log out (clear session cookie)",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/api/auth/me": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthMeResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "user not found"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Get current user profile",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/api/auth/register": {
+      "post": {
+        "description": "On success returns the new user id. The first registered user becomes admin.",
+        "requestBody": {
+          "$ref": "#/components/requestBodies/AuthCredentials"
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthRegisterResponse"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "bad request / email and password required"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "email already taken"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error / failed to create user"
+          }
+        },
+        "summary": "Register a new user",
+        "tags": [
+          "Auth"
+        ]
+      }
+    },
+    "/api/codex/tokens": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "in": "query",
+            "name": "workspace_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Include revoked tokens (default false)",
+            "in": "query",
+            "name": "include_revoked",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/CodexTokenListItem"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "workspace_id required"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a member"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "List Codex tokens for a workspace",
+        "tags": [
+          "Codex Tokens"
+        ]
+      },
+      "post": {
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CodexTokenMintRequest"
+              }
+            }
+          },
+          "description": "Token parameters",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CodexTokenMintResponse"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "invalid JSON"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a member of this workspace"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "workspace_id and name are required / expires_at invalid"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Mint a Codex access token",
+        "tags": [
+          "Codex Tokens"
+        ]
+      }
+    },
+    "/api/codex/tokens/{id}": {
+      "delete": {
+        "parameters": [
+          {
+            "description": "Token id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "forbidden"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Revoke a Codex token",
+        "tags": [
+          "Codex Tokens"
+        ]
+      }
+    },
+    "/api/connectors/envs/list": {
+      "post": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sdk.ConnectorEnvsListResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
+                }
+              }
+            },
+            "description": "missing or invalid bearer token"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
+                }
+              }
+            },
+            "description": "registry_error"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "List connected executors for the calling workspace",
+        "tags": [
+          "Connectors"
+        ]
+      }
+    },
+    "/api/connectors/envs/{name}/tool/call": {
+      "post": {
+        "parameters": [
+          {
+            "description": "Connected environment name (from /envs/list)",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/sdk.ConnectorToolCallRequest"
+              }
+            }
+          },
+          "description": "Tool name and arguments. The gateway injects environment_id from the path; callers can omit it.",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/tools.MCPCallToolResult"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
+                }
+              }
+            },
+            "description": "bad_request | unknown_tool | bad_arguments"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
+                }
+              }
+            },
+            "description": "missing or invalid bearer token"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
+                }
+              }
+            },
+            "description": "workspace_init | tool_error"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Call an MCP tool on a connected executor",
+        "tags": [
+          "Connectors"
+        ]
+      }
+    },
+    "/api/connectors/processes/{sid}/output": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Session id returned by exec_command",
+            "in": "path",
+            "name": "sid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Highest seq already seen; only newer chunks are returned",
+            "in": "query",
+            "name": "since",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sdk.ConnectorOutputResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
+                }
+              }
+            },
+            "description": "missing or invalid bearer token"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
+                }
+              }
+            },
+            "description": "session belongs to a different workspace"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
+                }
+              }
+            },
+            "description": "session_not_found"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Poll a running process's stdout/stderr",
+        "tags": [
+          "Connectors"
+        ]
+      }
+    },
+    "/api/connectors/processes/{sid}/stdin": {
+      "post": {
+        "parameters": [
+          {
+            "description": "Session id returned by exec_command",
+            "in": "path",
+            "name": "sid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/sdk.ConnectorStdinRequest"
+              }
+            }
+          },
+          "description": "Base64-encoded stdin chunk",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sdk.ConnectorOKResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
+                }
+              }
+            },
+            "description": "bad_request | bad_base64"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
+                }
+              }
+            },
+            "description": "missing or invalid bearer token"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
+                }
+              }
+            },
+            "description": "session belongs to a different workspace"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
+                }
+              }
+            },
+            "description": "session_not_found"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Write to a running process's stdin",
+        "tags": [
+          "Connectors"
+        ]
+      }
+    },
+    "/api/connectors/processes/{sid}/terminate": {
+      "post": {
+        "parameters": [
+          {
+            "description": "Session id returned by exec_command",
+            "in": "path",
+            "name": "sid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sdk.ConnectorOKResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
+                }
+              }
+            },
+            "description": "missing or invalid bearer token"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
+                }
+              }
+            },
+            "description": "session belongs to a different workspace"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sdk.ConnectorErrorResponse"
+                }
+              }
+            },
+            "description": "session_not_found"
+          }
+        },
+        "security": [
+          {
+            "BearerAuth": []
+          }
+        ],
+        "summary": "Terminate a running process",
+        "tags": [
+          "Connectors"
+        ]
+      }
+    },
+    "/api/sandboxes/{id}": {
+      "delete": {
+        "parameters": [
+          {
+            "description": "Sandbox id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a member"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "sandbox not found"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Delete a sandbox",
+        "tags": [
+          "Sandboxes"
+        ]
+      },
+      "get": {
+        "parameters": [
+          {
+            "description": "Sandbox id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Sandbox"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a member"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "sandbox not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Get a sandbox by id",
+        "tags": [
+          "Sandboxes"
+        ]
+      },
+      "patch": {
+        "parameters": [
+          {
+            "description": "Sandbox id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SandboxRenameRequest"
+              }
+            }
+          },
+          "description": "New name",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Sandbox"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "name required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a member"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "sandbox not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Rename a sandbox",
+        "tags": [
+          "Sandboxes"
+        ]
+      }
+    },
+    "/api/sandboxes/{id}/im/bind": {
+      "delete": {
+        "parameters": [
+          {
+            "description": "Sandbox id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IMSandboxUnbindResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a member"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "sandbox not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Unbind a sandbox from its IM channel",
+        "tags": [
+          "IM Channels"
+        ]
+      },
+      "post": {
+        "parameters": [
+          {
+            "description": "Sandbox id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IMSandboxBindRequest"
+              }
+            }
+          },
+          "description": "Channel id",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IMSandboxBindResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "bad request"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a member"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "sandbox or channel not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Bind a sandbox to an IM channel",
+        "tags": [
+          "IM Channels"
+        ]
+      }
+    },
+    "/api/sandboxes/{id}/pause": {
+      "post": {
+        "description": "Initiates pause transition; returns {\"status\":\"pausing\"}. Final state lands asynchronously.",
+        "parameters": [
+          {
+            "description": "Sandbox id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SandboxLifecycleStatusResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "local sandbox cannot be paused"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a member"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "sandbox not found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "invalid state for pause"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Pause a sandbox (cloud sandboxes only)",
+        "tags": [
+          "Sandboxes"
+        ]
+      }
+    },
+    "/api/sandboxes/{id}/resume": {
+      "post": {
+        "description": "Initiates resume transition; returns {\"status\":\"resuming\"}. Final state lands asynchronously.",
+        "parameters": [
+          {
+            "description": "Sandbox id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SandboxLifecycleStatusResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "local sandbox cannot be resumed"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a member"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "sandbox not found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "invalid state for resume"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Resume a paused sandbox (cloud sandboxes only)",
+        "tags": [
+          "Sandboxes"
+        ]
+      }
+    },
+    "/api/sandboxes/{id}/traces": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Sandbox ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Max entries to return",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Pagination offset",
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TraceListResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a workspace member"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "sandbox not found"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "llmproxy not configured"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "List LLM traces for a sandbox",
+        "tags": [
+          "Misc"
+        ]
+      }
+    },
+    "/api/sandboxes/{id}/traces/{traceId}": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Sandbox ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Trace ID",
+            "in": "path",
+            "name": "traceId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TraceDetailResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a workspace member"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "sandbox not found"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "llmproxy not configured"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Get a single LLM trace for a sandbox",
+        "tags": [
+          "Misc"
+        ]
+      }
+    },
+    "/api/sandboxes/{id}/usage": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Sandbox id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SandboxUsage"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a member"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "sandbox not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Get sandbox usage stats",
+        "tags": [
+          "Sandboxes"
+        ]
+      }
+    },
+    "/api/tasks/{id}": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Task ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Include output events",
+            "in": "query",
+            "name": "include_output",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentTaskDetail"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Get a task by ID",
+        "tags": [
+          "Agent"
+        ]
+      }
+    },
+    "/api/tasks/{id}/cancel": {
+      "post": {
+        "parameters": [
+          {
+            "description": "Task ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentTaskCancelResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "task already finished"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Cancel a task",
+        "tags": [
+          "Agent"
+        ]
+      }
+    },
+    "/api/workspaces": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Workspace"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "List workspaces for the current user",
+        "tags": [
+          "Workspaces"
+        ]
+      },
+      "post": {
+        "description": "Creator is auto-added as owner. May fail with 403 if the per-user workspace quota is exceeded.",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkspaceCreateRequest"
+              }
+            }
+          },
+          "description": "Workspace name",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Workspace"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "bad request / empty name"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "workspace quota exceeded"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Create a new workspace",
+        "tags": [
+          "Workspaces"
+        ]
+      }
+    },
+    "/api/workspaces/quota": {
+      "get": {
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceQuotaResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Get per-user workspace quota",
+        "tags": [
+          "Workspaces"
+        ]
+      }
+    },
+    "/api/workspaces/{id}": {
+      "delete": {
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "owner only"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Delete a workspace (owner only; cascades to sandboxes + namespace)",
+        "tags": [
+          "Workspaces"
+        ]
+      },
+      "get": {
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Workspace"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a member"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "workspace not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Get a workspace by id",
+        "tags": [
+          "Workspaces"
+        ]
+      },
+      "patch": {
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkspaceRenameRequest"
+              }
+            }
+          },
+          "description": "New name",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Workspace"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "empty name"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "owner or maintainer required"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Rename a workspace",
+        "tags": [
+          "Workspaces"
+        ]
+      }
+    },
+    "/api/workspaces/{id}/credentials/{kind}": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Credential kind (e.g. kubernetes)",
+            "in": "path",
+            "name": "kind",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/CredentialBindingItem"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "List credential bindings for a workspace",
+        "tags": [
+          "Misc"
+        ]
+      },
+      "post": {
+        "description": "On success returns 201 with the new binding. When the provider requires OIDC device code authentication returns 202 with verification_uri and user_code; poll device-complete to finalize.",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Credential kind (e.g. kubernetes)",
+            "in": "path",
+            "name": "kind",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CredentialBindingCreateRequest"
+              }
+            }
+          },
+          "description": "Credential config",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CredentialBindingCreateResponse"
+                }
+              }
+            },
+            "description": "Binding created"
+          },
+          "202": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CredentialBindingCreateResponse"
+                }
+              }
+            },
+            "description": "OIDC device code flow initiated"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "duplicate display_name"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Create a credential binding for a workspace",
+        "tags": [
+          "Misc"
+        ]
+      }
+    },
+    "/api/workspaces/{id}/credentials/{kind}/{bindingId}": {
+      "delete": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Credential kind",
+            "in": "path",
+            "name": "kind",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Binding ID",
+            "in": "path",
+            "name": "bindingId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "deleted"
+          },
+          "401": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not found"
+          },
+          "409": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "cannot delete default binding while others exist"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Delete a credential binding",
+        "tags": [
+          "Misc"
+        ]
+      },
+      "patch": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Credential kind",
+            "in": "path",
+            "name": "kind",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Binding ID",
+            "in": "path",
+            "name": "bindingId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CredentialBindingPatchRequest"
+              }
+            }
+          },
+          "description": "Fields to update",
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "updated"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "bad request"
+          },
+          "401": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not found"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Patch a credential binding (rename)",
+        "tags": [
+          "Misc"
+        ]
+      }
+    },
+    "/api/workspaces/{id}/credentials/{kind}/{bindingId}/device-complete": {
+      "post": {
+        "description": "Long-polls until the user authorizes the device code. Returns 201 with the created binding on success.",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Credential kind",
+            "in": "path",
+            "name": "kind",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Pending binding ID",
+            "in": "path",
+            "name": "bindingId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CredentialBindingCreateResponse"
+                }
+              }
+            },
+            "description": "Binding created"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "device code authorization failed"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "no pending device code flow found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "duplicate display_name or flow already being completed"
+          },
+          "410": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "device code flow expired"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Complete an OIDC device code flow for a pending credential binding",
+        "tags": [
+          "Misc"
+        ]
+      }
+    },
+    "/api/workspaces/{id}/credentials/{kind}/{bindingId}/set-default": {
+      "post": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Credential kind",
+            "in": "path",
+            "name": "kind",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Binding ID",
+            "in": "path",
+            "name": "bindingId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "updated"
+          },
+          "401": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Set a credential binding as the default",
+        "tags": [
+          "Misc"
+        ]
+      }
+    },
+    "/api/workspaces/{id}/exec-audit/calls": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Session ID filter",
+            "in": "query",
+            "name": "session_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Executor ID filter",
+            "in": "query",
+            "name": "exe_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "User ID filter",
+            "in": "query",
+            "name": "user_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Source filter",
+            "in": "query",
+            "name": "source",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "RPC method filter",
+            "in": "query",
+            "name": "method",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "RFC3339 lower bound (started_at)",
+            "in": "query",
+            "name": "since",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "RFC3339 upper bound (started_at)",
+            "in": "query",
+            "name": "until",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Max rows (default 50)",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListAuditCallsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "List exec-audit calls (workspace-scoped)",
+        "tags": [
+          "Exec-Audit"
+        ]
+      }
+    },
+    "/api/workspaces/{id}/exec-audit/calls/{call_id}": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Call ID",
+            "in": "path",
+            "name": "call_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuditCallDetail"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Get exec-audit call (workspace-scoped)",
+        "tags": [
+          "Exec-Audit"
+        ]
+      }
+    },
+    "/api/workspaces/{id}/exec-audit/calls/{call_id}/payload": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Call ID",
+            "in": "path",
+            "name": "call_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "500": {
+            "content": {
+              "application/octet-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Get exec-audit call request payload (workspace-scoped)",
+        "tags": [
+          "Exec-Audit"
+        ]
+      }
+    },
+    "/api/workspaces/{id}/exec-audit/sessions": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Executor ID filter",
+            "in": "query",
+            "name": "exe_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "User ID filter",
+            "in": "query",
+            "name": "user_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Turn ID filter",
+            "in": "query",
+            "name": "turn_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "RFC3339 lower bound (opened_at)",
+            "in": "query",
+            "name": "since",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "RFC3339 upper bound (opened_at)",
+            "in": "query",
+            "name": "until",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Max rows (default 50)",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListAuditSessionsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "List exec-audit sessions (workspace-scoped)",
+        "tags": [
+          "Exec-Audit"
+        ]
+      }
+    },
+    "/api/workspaces/{id}/exec-audit/sessions/{session_id}": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Session ID",
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuditSessionDetail"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Get exec-audit session (workspace-scoped)",
+        "tags": [
+          "Exec-Audit"
+        ]
+      }
+    },
+    "/api/workspaces/{id}/im/channels": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IMChannelListResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a member"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "List IM channels in a workspace",
+        "tags": [
+          "IM Channels"
+        ]
+      }
+    },
+    "/api/workspaces/{id}/im/channels/{channelId}": {
+      "delete": {
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Channel id",
+            "in": "path",
+            "name": "channelId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a member"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "channel not found"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Delete an IM channel",
+        "tags": [
+          "IM Channels"
+        ]
+      },
+      "patch": {
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Channel id",
+            "in": "path",
+            "name": "channelId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IMChannelPatchRequest"
+              }
+            }
+          },
+          "description": "Settings patch",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IMChannelPatchResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "bad request"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a member"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "channel not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Update IM channel settings",
+        "tags": [
+          "IM Channels"
+        ]
+      }
+    },
+    "/api/workspaces/{id}/im/matrix/configure": {
+      "post": {
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IMMatrixConfigureRequest"
+              }
+            }
+          },
+          "description": "Matrix credentials",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IMMatrixConfigureResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "invalid credentials"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a member"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Bind a Matrix account to a workspace",
+        "tags": [
+          "IM Channels"
+        ]
+      }
+    },
+    "/api/workspaces/{id}/im/telegram/configure": {
+      "post": {
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/IMTelegramConfigureRequest"
+              }
+            }
+          },
+          "description": "Bot token",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IMTelegramConfigureResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "invalid bot token"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a member"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Bind a Telegram bot to a workspace",
+        "tags": [
+          "IM Channels"
+        ]
+      }
+    },
+    "/api/workspaces/{id}/im/weixin/qr-start": {
+      "post": {
+        "description": "Returns a QR code URL the user scans in WeChat. Client should then long-poll qr-wait until the channel is bound.",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IMWeixinQRStartResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a member"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "upstream error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Start WeChat QR-code bind for a workspace",
+        "tags": [
+          "IM Channels"
+        ]
+      }
+    },
+    "/api/workspaces/{id}/im/weixin/qr-wait": {
+      "post": {
+        "description": "Polls for QR scan progress. Returns status \"wait\", \"scaned\", \"confirmed\", \"expired\", or other terminal states. On \"confirmed\", bot_id is set. On \"expired\", qrcode_url contains a refreshed code.",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/IMWeixinQRWaitResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "no active session"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a member"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "upstream error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Long-poll WeChat QR-code scan for a workspace",
+        "tags": [
+          "IM Channels"
+        ]
+      }
+    },
+    "/api/workspaces/{id}/llm-config": {
+      "delete": {
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "insufficient role"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Delete workspace LLM config (owner/maintainer)",
+        "tags": [
+          "Workspaces"
+        ]
+      },
+      "get": {
+        "description": "The returned api_key is masked (first 3 + \"...\" + last 4). updated_at is null when no config is set.",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LLMConfigResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "insufficient role"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Get workspace LLM config (owner/maintainer)",
+        "tags": [
+          "Workspaces"
+        ]
+      },
+      "put": {
+        "description": "On update, omitting api_key retains the existing key.",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LLMConfigUpsertRequest"
+              }
+            }
+          },
+          "description": "Config payload",
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LLMConfigUpsertResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "validation error (invalid URL / missing field / too many models)"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "insufficient role"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Upsert workspace LLM config (owner/maintainer)",
+        "tags": [
+          "Workspaces"
+        ]
+      }
+    },
+    "/api/workspaces/{id}/llm-quota": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LLMQuotaResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "insufficient role"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Get the workspace's daily LLM request quota usage",
+        "tags": [
+          "Workspaces"
+        ]
+      }
+    },
+    "/api/workspaces/{id}/members": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/WorkspaceMember"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a member"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "List members of a workspace",
+        "tags": [
+          "Workspaces"
+        ]
+      },
+      "post": {
+        "description": "Looks up the user by email. Default role is \"developer\" if omitted.",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MemberAddRequest"
+              }
+            }
+          },
+          "description": "Email and optional role",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceMember"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "bad request"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "owner or maintainer required"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "user not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Add a member to a workspace",
+        "tags": [
+          "Workspaces"
+        ]
+      }
+    },
+    "/api/workspaces/{id}/members/{userId}": {
+      "delete": {
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "User id",
+            "in": "path",
+            "name": "userId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "owner only"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Remove a member (owner only)",
+        "tags": [
+          "Workspaces"
+        ]
+      },
+      "put": {
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "User id",
+            "in": "path",
+            "name": "userId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MemberRoleUpdateRequest"
+              }
+            }
+          },
+          "description": "New role",
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "empty role"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "owner only"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Change a member's role (owner only)",
+        "tags": [
+          "Workspaces"
+        ]
+      }
+    },
+    "/api/workspaces/{id}/modelserver/connect": {
+      "get": {
+        "description": "Redirects the browser to the ModelServer OAuth authorization URL. Returns 302.",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "302": {
+            "description": "redirect to ModelServer OAuth"
+          },
+          "401": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "insufficient role (owner/maintainer required)"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          },
+          "501": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "ModelServer OAuth not configured"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Initiate ModelServer OAuth connection for a workspace",
+        "tags": [
+          "Misc"
+        ]
+      }
+    },
+    "/api/workspaces/{id}/modelserver/disconnect": {
+      "delete": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "disconnected"
+          },
+          "401": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "insufficient role (owner/maintainer required)"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Disconnect ModelServer from a workspace",
+        "tags": [
+          "Misc"
+        ]
+      }
+    },
+    "/api/workspaces/{id}/modelserver/status": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ModelServerStatusResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a workspace member"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Get ModelServer connection status for a workspace",
+        "tags": [
+          "Misc"
+        ]
+      }
+    },
+    "/api/workspaces/{wid}/agent-interactions": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "wid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Max entries (1–200, default 50)",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Pagination offset",
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AgentInteractionItem"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a workspace member"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "List agent interaction audit trail for a workspace",
+        "tags": [
+          "Misc"
+        ]
+      }
+    },
+    "/api/workspaces/{wid}/agents": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "wid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AgentCardItem"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a member"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "List agent cards in a workspace",
+        "tags": [
+          "Agent"
+        ]
+      }
+    },
+    "/api/workspaces/{wid}/api-keys": {
+      "get": {
+        "description": "Returns prefix-only metadata. Secrets are never included.",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "in": "path",
+            "name": "wid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/WorkspaceAPIKey"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a member"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "List workspace API keys",
+        "tags": [
+          "Workspace API Keys"
+        ]
+      },
+      "post": {
+        "description": "Returns the secret ONCE in the response body. At least one Available scope must be provided.",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "in": "path",
+            "name": "wid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/WorkspaceAPIKeyMintRequest"
+              }
+            }
+          },
+          "description": "Key metadata",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceAPIKeyMintResponse"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "name required / scope not available / at least one scope required"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "owner or maintainer required"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "expires_at invalid (bad RFC3339 / in past / >365d in future)"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Mint a workspace API key",
+        "tags": [
+          "Workspace API Keys"
+        ]
+      }
+    },
+    "/api/workspaces/{wid}/api-keys/scopes": {
+      "get": {
+        "description": "Returns the catalog of scope names + descriptions. Available=false entries are placeholders shown greyed-out in the UI.",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "in": "path",
+            "name": "wid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/APIKeyScopeDescriptor"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a member"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "List available API key scopes",
+        "tags": [
+          "Workspace API Keys"
+        ]
+      }
+    },
+    "/api/workspaces/{wid}/api-keys/{id}": {
+      "delete": {
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "in": "path",
+            "name": "wid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Key id (= prefix)",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "owner or maintainer required"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Revoke a workspace API key",
+        "tags": [
+          "Workspace API Keys"
+        ]
+      }
+    },
+    "/api/workspaces/{wid}/browsers": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "in": "path",
+            "name": "wid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/CodexBrowserItem"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a member"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "List Codex browser sessions for a workspace",
+        "tags": [
+          "Codex Browser Sessions"
+        ]
+      }
+    },
+    "/api/workspaces/{wid}/defaults": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "wid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WorkspaceDefaultsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "insufficient role"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Get workspace quota defaults and current sandbox count",
+        "tags": [
+          "Misc"
+        ]
+      }
+    },
+    "/api/workspaces/{wid}/executors": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "wid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/ExecutorItem"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a workspace member"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "upstream gateway error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "List codex remote executors for a workspace",
+        "tags": [
+          "Misc"
+        ]
+      },
+      "post": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "wid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ExecutorRegisterRequest"
+              }
+            }
+          },
+          "description": "Executor registration payload",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExecutorRegisterResponse"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "bad request / invalid name"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "insufficient role (owner/maintainer required)"
+          },
+          "502": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "upstream gateway error"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "executors not configured"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Register a new codex remote executor for a workspace",
+        "tags": [
+          "Misc"
+        ]
+      }
+    },
+    "/api/workspaces/{wid}/executors/{exe_id}": {
+      "delete": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "wid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Executor ID",
+            "in": "path",
+            "name": "exe_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "removed"
+          },
+          "400": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "bad request"
+          },
+          "401": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "insufficient role (owner/maintainer required)"
+          },
+          "502": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "upstream gateway error"
+          },
+          "503": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "executors not configured"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Remove a codex remote executor from a workspace",
+        "tags": [
+          "Misc"
+        ]
+      }
+    },
+    "/api/workspaces/{wid}/mcp/pats": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "wid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/MCPPAT"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not authenticated"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not found (or not a member)"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "List MCP Personal Access Tokens for a workspace",
+        "tags": [
+          "MCP PATs"
+        ]
+      },
+      "post": {
+        "description": "Returns the secret ONCE in the response body. At least one scope must be provided. The PAT is bound to the URL's workspace; the body has no workspace field.",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "wid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MCPPATMintRequest"
+              }
+            }
+          },
+          "description": "PAT metadata",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MCPPATMintResponse"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "name required / scope not available"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not authenticated"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not found (or not a member of the workspace)"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "expires_at invalid"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Mint an MCP Personal Access Token for a workspace",
+        "tags": [
+          "MCP PATs"
+        ]
+      }
+    },
+    "/api/workspaces/{wid}/mcp/pats/scopes": {
+      "get": {
+        "description": "Static capability scopes (mcp:read, mcp:exec). No dynamic workspace scopes — workspace binding is implicit in the route's {wid}.",
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "wid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MCPPATScopesResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not authenticated"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not found (or not a member of the workspace)"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "List MCP PAT scope catalog for a workspace",
+        "tags": [
+          "MCP PATs"
+        ]
+      }
+    },
+    "/api/workspaces/{wid}/mcp/pats/{id}": {
+      "delete": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "wid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "PAT id (= prefix, e.g. agpat_a1b2...)",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "401": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not authenticated"
+          },
+          "404": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not found (or not a member of the workspace)"
+          },
+          "500": {
+            "content": {
+              "*/*": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Revoke an MCP Personal Access Token",
+        "tags": [
+          "MCP PATs"
+        ]
+      }
+    },
+    "/api/workspaces/{wid}/sandboxes": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "in": "path",
+            "name": "wid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/Sandbox"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a member"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "List sandboxes in a workspace",
+        "tags": [
+          "Sandboxes"
+        ]
+      },
+      "post": {
+        "description": "Validates type / CPU / memory / idle_timeout / quota / budget. Returns 201 immediately with status=\"provisioning\"; container starts asynchronously.",
+        "parameters": [
+          {
+            "description": "Workspace id",
+            "in": "path",
+            "name": "wid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SandboxCreateRequest"
+              }
+            }
+          },
+          "description": "Create payload",
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Sandbox"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "validation error (type/cpu/memory/idle_timeout)"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "insufficient role / quota / budget"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Create a sandbox in a workspace",
+        "tags": [
+          "Sandboxes"
+        ]
+      }
+    },
+    "/api/workspaces/{wid}/tasks": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "wid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/AgentTaskItem"
+                  },
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a member"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "List delegated tasks for a workspace",
+        "tags": [
+          "Agent"
+        ]
+      },
+      "post": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "wid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "$ref": "#/components/requestBodies/AgentTaskCreateRequest"
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentTaskCreateResponse"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "bad request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "target agent not found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "internal error"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Create a delegated task in a workspace",
+        "tags": [
+          "Agent"
+        ]
+      }
+    },
+    "/api/workspaces/{wid}/traces": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "wid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Max entries to return",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Pagination offset",
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TraceListResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a workspace member"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "llmproxy not configured"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "List LLM traces for a workspace",
+        "tags": [
+          "Misc"
+        ]
+      }
+    },
+    "/api/workspaces/{wid}/traces/{traceId}": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Workspace ID",
+            "in": "path",
+            "name": "wid",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Trace ID",
+            "in": "path",
+            "name": "traceId",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TraceDetailResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "unauthorized"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "not a workspace member"
+          },
+          "503": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "llmproxy not configured"
+          }
+        },
+        "security": [
+          {
+            "CookieAuth": []
+          }
+        ],
+        "summary": "Get a single LLM trace for a workspace",
+        "tags": [
+          "Misc"
+        ]
+      }
+    },
+    "/internal/exec-audit/batch": {
+      "post": {
+        "parameters": [
+          {
+            "description": "Shared secret",
+            "in": "header",
+            "name": "X-Internal-Secret",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExecAuditBatchAckResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Ingest a batch of exec-gateway audit records (internal)",
+        "tags": [
+          "Exec-Audit"
+        ]
+      }
+    },
+    "/internal/exec-audit/calls": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Shared secret",
+            "in": "header",
+            "name": "X-Internal-Secret",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Workspace ID",
+            "in": "query",
+            "name": "workspace_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Session ID filter",
+            "in": "query",
+            "name": "session_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Executor ID filter",
+            "in": "query",
+            "name": "exe_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "User ID filter",
+            "in": "query",
+            "name": "user_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Source filter (e.g. mcp_rpc, sse_event)",
+            "in": "query",
+            "name": "source",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "RPC method filter",
+            "in": "query",
+            "name": "method",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "RFC3339 lower bound (started_at)",
+            "in": "query",
+            "name": "since",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "RFC3339 upper bound (started_at)",
+            "in": "query",
+            "name": "until",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Max rows (default 50)",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListAuditCallsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "List exec-audit calls (internal)",
+        "tags": [
+          "Exec-Audit"
+        ]
+      }
+    },
+    "/internal/exec-audit/calls/{call_id}": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Shared secret",
+            "in": "header",
+            "name": "X-Internal-Secret",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Call ID",
+            "in": "path",
+            "name": "call_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuditCallDetail"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Get an exec-audit call detail (internal)",
+        "tags": [
+          "Exec-Audit"
+        ]
+      }
+    },
+    "/internal/exec-audit/sessions": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Shared secret",
+            "in": "header",
+            "name": "X-Internal-Secret",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Workspace ID",
+            "in": "query",
+            "name": "workspace_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Executor ID filter",
+            "in": "query",
+            "name": "exe_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "User ID filter",
+            "in": "query",
+            "name": "user_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Turn ID filter",
+            "in": "query",
+            "name": "turn_id",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "RFC3339 lower bound (opened_at)",
+            "in": "query",
+            "name": "since",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "RFC3339 upper bound (opened_at)",
+            "in": "query",
+            "name": "until",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Max rows (default 50)",
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ListAuditSessionsResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "List exec-audit sessions (internal)",
+        "tags": [
+          "Exec-Audit"
+        ]
+      }
+    },
+    "/internal/exec-audit/sessions/{session_id}": {
+      "get": {
+        "parameters": [
+          {
+            "description": "Shared secret",
+            "in": "header",
+            "name": "X-Internal-Secret",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Session ID",
+            "in": "path",
+            "name": "session_id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuditSessionDetail"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "401": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Unauthorized"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "500": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Internal Server Error"
+          }
+        },
+        "summary": "Get an exec-audit session detail (internal)",
+        "tags": [
+          "Exec-Audit"
+        ]
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "/"
+    }
+  ]
 }

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -961,7 +961,8 @@ paths:
               schema:
                 type: string
         "403":
-          description: forbidden
+          description: identity not valid for this token (missing user binding or
+            workspace membership)
           content:
             application/json:
               schema:
@@ -5495,6 +5496,15 @@ components:
         sandbox_id:
           example: sbx_456
           type: string
+        sandbox_status:
+          description: |-
+            SandboxStatus is the current sandboxes.status column verbatim —
+            one of creating / running / pausing / paused / resuming / offline /
+            deleting (see internal/sbxstore/state.go), or "" for legacy rows
+            where the field was never set. The server always populates this
+            field on 200 responses.
+          example: running
+          type: string
         short_id:
           example: alice-driver-01
           type: string
@@ -5511,6 +5521,7 @@ components:
         - display_name
         - role
         - sandbox_id
+        - sandbox_status
         - short_id
         - user_id
         - workspace_id

--- a/docs/api/reference/agent.md
+++ b/docs/api/reference/agent.md
@@ -265,7 +265,7 @@ Inspect the calling agent identity (proxy_token auth)
 |--------|-------------|--------|
 | `200` | OK | [`AgentWhoamiResponse`](#schema-agentwhoamiresponse) |
 | `401` | unauthorized | `string` |
-| `403` | forbidden | `string` |
+| `403` | identity not valid for this token (missing user binding or workspace membership) | `string` |
 | `500` | internal error | `string` |
 
 
@@ -629,6 +629,7 @@ Schema: [`AgentTaskCreateRequest`](#schema-agenttaskcreaterequest)
   display_name: string
   role: string
   sandbox_id: string
+  sandbox_status: string
   short_id: string
   user_id: string
   workspace_id: string

--- a/docs/plan/290-local-sandbox-whoami-403.md
+++ b/docs/plan/290-local-sandbox-whoami-403.md
@@ -1,0 +1,256 @@
+# Plan: `whoami` returns identity unconditionally + exposes runtime status
+
+Spec: `docs/spec/290-local-sandbox-whoami-403.md`
+Issue: https://github.com/agentserver/agentserver/issues/290 (see
+`@yzs15`'s second comment for the corrected analysis).
+
+## Decision summary
+
+`GET /api/agent/whoami` stops gating on `sandboxes.status`. Once the
+identity verification passes (proxy_token + non-null `user_id` +
+membership JOIN), the handler always returns **200** with the existing
+identity fields **plus** a new `sandbox_status` field carrying the
+current `sandboxes.status` value verbatim. Callers (observer-server,
+admin scripts, future SDK consumers) decide for themselves whether to
+gate on the runtime state.
+
+Three other behaviors are deliberately preserved unchanged:
+
+- 401 paths (missing/malformed/unknown/wrong-type bearer).
+- 403 paths for the two real identity failures
+  (`legacy_null_user`, `membership_removed`).
+- `Cache-Control: no-store` on every 200 response.
+
+The DB query (`internal/db/agent_whoami.go`) already returns
+`s.status` into `AgentWhoami.SandboxStatus` (line 51, line 66) — no
+SQL change, no new column read, no migration.
+
+## Code changes
+
+All paths relative to repo root.
+
+### 1. `internal/server/agent_whoami.go` — drop the status gate
+
+- Delete `activeWhoamiSandboxStatus` (lines 24-26).
+- In `handleAgentWhoami` (lines 39-76), remove the
+  `!activeWhoamiSandboxStatus(who.SandboxStatus)` branch (lines 60-63).
+  The remaining `who == nil` guard is dead code by construction (when
+  `state == AgentWhoamiOK`, `who` is non-nil) but the cheapest defense
+  is to keep a `who == nil` → 500 check; the spec already maps "I
+  couldn't tell" to 500, so this is consistent.
+- Pass `who.SandboxStatus` into the response (new field below).
+- Update the swaggo annotations on the handler doc-comment:
+  - Keep `@Success 200 {object} AgentWhoamiResponse`.
+  - Keep `@Failure 401 {string} string "unauthorized"`.
+  - Tighten `@Failure 403` description from generic "forbidden" to
+    something like
+    `"identity not valid for this token (missing user binding or workspace membership)"`
+    so the OpenAPI surface tells callers exactly what 403 means now.
+  - Keep `@Failure 500 {string} string "internal error"`.
+
+### 2. `internal/server/api_types.go` — add the new field
+
+In `AgentWhoamiResponse` (lines 329-339), append one field:
+
+```go
+SandboxStatus string `json:"sandbox_status" validate:"required" example:"running"`
+```
+
+Decisions:
+
+- **Name**: `sandbox_status` mirrors the existing `sandbox_id` /
+  `workspace_id` snake_case naming and avoids the ambiguous `status`.
+- **`validate:"required"`**: included so the OpenAPI surface marks the
+  field as always-present. The field is always populated by the
+  handler (every 200 response now carries it), so `required` is
+  accurate. Old SDK consumers decoding into the old struct silently
+  ignore unknown fields — they are unaffected.
+- **No `omitempty`**: we want the field present even when
+  `SandboxStatus == ""` (which can happen for some legacy rows; that
+  empty string is meaningful — it says "the row exists but has no
+  status set" — and hiding it loses information).
+- **Position**: at the end of the struct, after `Role`, so the
+  generated OpenAPI diff is minimal (no field re-ordering churn).
+- We do **not** add `is_local` or `last_heartbeat_at` in this PR.
+  Rationale: keep the contract change minimal. `last_heartbeat_at` is
+  seeded by `CreateLocalSandbox` at registration
+  (`internal/db/sandboxes.go:284`) and then only refreshed by the
+  tunnel keepalive at `internal/sandboxproxy/tunnel.go:102` —
+  meaning a non-tunneled `is_local` row carries its registration
+  timestamp forever and exposing it would advertise a misleading
+  half-truth. A future PR can add liveness fields if needed; this
+  one is just unblocking observer-server.
+
+### 3. `internal/server/agent_whoami_test.go` — rewrite assertions
+
+Existing tests and their new shape:
+
+- **`TestStrictBearerToken`** (lines 70-95) — unchanged. Pure helper
+  test, no whoami contract dependency.
+
+- **`TestActiveWhoamiSandboxStatus`** (lines 97-108) — **delete** the
+  whole function. The helper it tests is removed.
+
+- **`TestAgentWhoami_HappyPath`** (lines 110-130) — extend: after
+  decoding the response, assert
+  `out.SandboxStatus == "running"` (matches the seeded value).
+
+- **`TestAgentWhoami_UnauthorizedCases`** (lines 132-165) — unchanged.
+  The 401 paths are preserved exactly.
+
+- **`TestAgentWhoami_ForbiddenCases`** (lines 167-199) —
+  **split** into two table-driven tests:
+  - `TestAgentWhoami_ForbiddenIdentity` — keeps the two genuine
+    identity-failure sub-cases:
+    - `legacy_null_user` (seed with `withUser=false`) → 403, body
+      `"forbidden\n"`.
+    - `membership_removed` (seed normal, then delete the
+      `workspace_members` row) → 403, body `"forbidden\n"`.
+  - `TestAgentWhoami_RuntimeStatusReportedInBody` — the previously-403
+    statuses now flip to 200, table-driven over the full set defined
+    in `internal/sbxstore/state.go:5-12` (`creating`, `running`,
+    `pausing`, `paused`, `resuming`, `offline`, `deleting`) **plus**
+    the empty string `""` for completeness. For each seeded status,
+    run **two variants**: `is_local=FALSE` (cloud) and `is_local=TRUE`
+    (local). Both must return:
+    - HTTP 200.
+    - Decoded body with `out.SandboxStatus == <seeded>`.
+    - All existing identity fields populated.
+
+    The `is_local=TRUE, status='offline'` row is the spec's
+    headline scenario (success criterion #1) and must be covered
+    explicitly, not just implied by the table sweep.
+
+- **`TestAgentWhoami_DisplayNameFallsBackToSandboxName`** (lines
+  201-215) — extend: also assert `out.SandboxStatus == "running"`.
+
+**Helper change** — `seedWhoamiSandbox` (lines 24-57) currently does
+not expose `is_local`, so every seeded row is `is_local=FALSE`
+(default per `internal/db/migrations/001_initial.sql:81`). Extend its
+signature with a trailing `isLocal bool` parameter and pass it
+through the `INSERT INTO sandboxes` statement (add `is_local` to the
+column list at line 28 and to the value list at line 29). Update the
+six existing call sites (lines 112, 134, 171, 181, 190, 203) to pass
+`false` to preserve their current intent. New tests pass `true` or
+`false` per case.
+
+### 4. OpenAPI / docs regeneration
+
+After the Go changes, run:
+
+```bash
+make openapi    # regenerates docs/api/openapi.{yaml,json}
+make api-docs   # regenerates docs/api/reference/*.md from openapi.yaml
+```
+
+Both targets are wired to CI drift checks (`openapi-check`,
+`api-docs-check` — `Makefile:101, 119`); committing the Go change
+without re-running them fails CI. The diff in `docs/api/openapi.yaml`
+should be a one-field addition to the `AgentWhoami` schema definition
+plus the tightened 403 description on `/api/agent/whoami`. The diff in
+`docs/api/reference/agent.md` (or whichever per-tag file the whoami
+endpoint lands in) mirrors the same.
+
+No other files in `docs/` need manual editing.
+
+## Files touched
+
+- **Modified**: `internal/server/agent_whoami.go` — drop the
+  status-gate branch + helper; update swaggo `@Failure 403` text;
+  pass `SandboxStatus` into the response.
+- **Modified**: `internal/server/api_types.go` — add
+  `SandboxStatus` field to `AgentWhoamiResponse`.
+- **Modified**: `internal/server/agent_whoami_test.go` — delete
+  `TestActiveWhoamiSandboxStatus`; extend happy-path / display-name
+  tests; split forbidden tests as described.
+- **Regenerated** (via `make openapi` + `make api-docs`):
+  `docs/api/openapi.yaml`, `docs/api/openapi.json`,
+  `docs/api/reference/*.md` (one file at most).
+- **No new file**. No migration. No agentsdk SDK change in
+  `pkg/agentsdk/` (consumers there don't deserialize whoami
+  responses).
+
+## Reuse / pattern conformance
+
+- Use existing helpers (`newWhoamiTestServer`, `seedWorkspaceMember`,
+  `seedWhoamiSandbox`, `callWhoami`) — they already take all
+  parameters the new tests need.
+- Status constants come from `internal/sbxstore/state.go:5-12`. In
+  test code we can keep them as literal strings (matches the existing
+  test style in `agent_whoami_test.go:103, 168`) — no need to
+  import `sbxstore` from this test file.
+- The `Cache-Control: no-store` header pattern (existing line 66)
+  stays; we just emit it before `json.NewEncoder(w).Encode(...)`
+  exactly as today.
+- swaggo annotation style matches the existing handler doc-comment
+  format (no schema changes; just a string update).
+
+## Verification
+
+End-to-end, in order:
+
+1. **Unit tests**:
+   ```bash
+   go test ./internal/server -run AgentWhoami -count=1 -v
+   ```
+   Every new subtest must pass; no existing assertion regresses.
+   Then the broader package:
+   ```bash
+   go test ./internal/server -count=1
+   ```
+
+2. **Whole-module sweep** (matches CI):
+   ```bash
+   go test ./...
+   ```
+   No regressions anywhere.
+
+3. **OpenAPI drift check** (matches CI):
+   ```bash
+   make openapi
+   make api-docs
+   make openapi-check
+   make api-docs-check
+   ```
+   Both `-check` targets must report no drift after the regen step.
+
+4. **Live reproduction against `https://agent.cs.ac.cn`** using the
+   existing `/tmp/repro290/repro290` harness:
+   ```bash
+   /tmp/repro290/repro290              # register fresh non-tunneled sandbox
+   # then EITHER manually flip status to 'offline' via SQL,
+   # OR start serve-mcp and SIGTERM it (we already verified this
+   # path writes status=offline via tunnel.go:127).
+   /tmp/repro290/repro290 -resume <proxy_token> -count 3
+   ```
+   Before the fix: probes return 403.
+   After the fix: probes return 200 with `"sandbox_status":"offline"`
+   in the body.
+
+5. **Negative tests** (no DB writes, just curl-level):
+   - Bearer with unknown token → 401 (unchanged).
+   - Bearer with the workspace-token type → 401 (unchanged).
+   - Tunnel-token instead of proxy-token → 401 (unchanged).
+
+## Risk and rollback
+
+- **External callers** assuming a 403 for offline sandboxes now get
+  200. observer-server is the only known caller we care about;
+  reporter has already requested this behavior change. Other callers
+  in the wild (admin scripts, monitoring) that interpret 403 as
+  "sandbox unhealthy" are wrong by spec but may exist; the new
+  `sandbox_status` field gives them the exact value to gate on, so
+  they can migrate without ambiguity.
+- **Rollback** is a single revert of the three Go files plus the
+  regenerated docs.
+
+## Out of scope (deliberately not in this PR)
+
+- Changing `tunnel.go:127`'s behavior, the tunnel reconnect logic, or
+  any other status writer.
+- Adding `POST /api/agent/heartbeat` or any non-whoami liveness
+  endpoint.
+- Changing `commander.WSClient`'s 401-is-terminal handling in loom
+  (separate repo, separate PR).
+- Adding `is_local`, `last_heartbeat_at`, or other runtime
+  introspection to the whoami response.

--- a/docs/spec/290-local-sandbox-whoami-403.md
+++ b/docs/spec/290-local-sandbox-whoami-403.md
@@ -1,0 +1,208 @@
+# Spec: `whoami` should not gate identity on sandbox runtime status
+
+GitHub issue: https://github.com/agentserver/agentserver/issues/290 (see the
+**second** comment by `@yzs15` for the corrected root-cause analysis; the
+issue body itself is superseded).
+
+## Problem (corrected after reporter's second comment)
+
+`GET /api/agent/whoami` currently conflates two unrelated questions:
+
+1. **Identity** — "is this `proxy_token` a valid identity for some
+   (user, workspace, sandbox) tuple?"
+2. **Runtime liveness** — "is this sandbox's yamux tunnel currently
+   connected?"
+
+Today, whoami returns HTTP 403 unless **both** are true
+(`internal/server/agent_whoami.go:60`, `activeWhoamiSandboxStatus` only
+permits `creating`/`running`). The only writer of `sandboxes.status =
+'offline'` is `internal/sandboxproxy/tunnel.go:127`, which fires the
+**moment** the active tunnel's context is cancelled — i.e. the moment the
+agent process holding that tunnel exits or its WebSocket dies.
+
+This makes the contract leak into normal operation. The deadlock the
+reporter hits is reachable purely through the everyday `codex` lifecycle:
+
+| T | Action | `sandboxes.status` | `whoami` |
+|---|--------|--------------------|----------|
+| 0 | `driver-agent register` | `running` | 200 |
+| +Δ | `driver-agent serve-mcp` starts → `agentsdk.Client.Connect` opens tunnel → `tunnel.go:82` writes `running` | `running` | 200 |
+| +Δ | `serve-mcp` exits cleanly (codex CLI session ends, EOF on stdin) → `tunnel.go:127` writes `offline` within ms | `offline` | **403** within ms |
+| +Δ | `driver-agent serve-daemon` starts; observer-server validates the bearer via whoami → 403 → observer returns 401 to daemon → `commander.WSClient` treats 401 as non-retryable → daemon process exits within ~200 ms | `offline` | 403 |
+
+The asymmetry the reporter originally described — "tunneled agents
+self-heal, non-tunneled don't" — is in fact "agents whose long-lived
+process owns the tunnel self-heal (slave-agent's poller maintains its own
+tunnel forever); agents whose tunnel is owned by a short-lived child
+process (driver-agent serve-mcp under codex) do not, because the
+long-lived sibling (`serve-daemon`) cannot reach any agentserver endpoint
+that depends on whoami once the child has exited."
+
+`MarkStaleAgentCardsOffline` only touches `agent_cards.agent_status`
+(`internal/db/agent_cards.go:103-115`) and is unrelated. `last_heartbeat_at`
+staleness does **not** flip `sandboxes.status` anywhere in v0.69.9.
+
+## Root cause
+
+`whoami` is the only proxy_token-authed endpoint in the codebase that
+checks `sandboxes.status`. All other proxy_token-authed endpoints —
+`internal/server/agent_proxy_routes.go:21`,
+`internal/server/agent_discovery.go:127`,
+`internal/server/agent_mailbox.go:37, 119`,
+`internal/server/agent_tasks.go:272, 346` — authenticate via
+`GetSandboxByAnyToken` and do **not** gate on `sandboxes.status`. The
+`status` check inside whoami is therefore not enforcing a system-wide
+authorization rule; it is whoami-specific behavior that has become a
+de-facto liveness probe for callers (observer-server in particular).
+
+The runtime liveness signal — "is the tunnel up right now?" — is
+legitimate state, but it is **not** what whoami's name or its existing
+docstring promise (`internal/server/agent_whoami.go:28-38`: "returns the
+identity represented by a sandbox proxy_token"). Callers that need
+liveness should be able to ask for it; callers that need identity (e.g.
+auth gates that decide "is this caller anyone real?") should be able to
+get identity without runtime status getting in the way.
+
+## Goal
+
+Make `GET /api/agent/whoami` answer the identity question alone, and
+expose the runtime sandbox status as additional data so callers that
+want to gate on it still can:
+
+1. Whoami returns **200** for any `proxy_token` that resolves to a valid
+   `(user, workspace, sandbox)` tuple where the user has workspace
+   membership — regardless of the sandbox's current `status` — and the
+   response body includes the current `sandboxes.status` as a new
+   field so observer-server (and any other caller) can decide for
+   itself whether to treat `offline` as actionable.
+2. Whoami continues to return:
+   - **401** for unknown / malformed bearer (no proxy_token row found,
+     wrong token_type, no sandbox_id binding).
+   - **403** for the existing identity failures: NULL/empty `user_id`
+     (`internal/db/agent_whoami.go:38-39`,
+     `TestAgentWhoami_ForbiddenCases/legacy_null_user`) and JOIN-miss
+     (membership removed, etc.;
+     `TestAgentWhoami_ForbiddenCases/membership_removed`).
+3. The fix changes the contract of one endpoint (whoami) and one
+   response struct (`AgentWhoamiResponse`). No other server behavior
+   changes. observer-server is free to upgrade at its own pace; until
+   it does, it will simply stop receiving 403 for offline sandboxes
+   and instead receive 200 with the offline status in the body — which
+   it can ignore, log, or gate on as it wishes.
+
+## Non-goals
+
+- Not changing `sbxstore.StatusOffline`, `tunnel.go:127`, the tunnel
+  reconnect path, or any other status writer. `sandboxes.status='offline'`
+  is the correct signal when the active tunnel drops; we are not
+  hiding it, just stopping whoami from interpreting it as a 403.
+- Not changing observer-server (it's in a separate repo). The fix
+  must work whether observer-server is ever updated or not.
+- Not changing `commander.WSClient`'s 401-is-terminal behavior (also
+  out-of-tree).
+- Not changing other proxy_token-authed endpoints. They already don't
+  gate on status; they stay as-is.
+- Not changing `MarkStaleAgentCardsOffline` or `agent_cards.agent_status`.
+- Not adding a `POST /api/agent/heartbeat` endpoint or otherwise giving
+  agents a way to mark themselves running — that's the original
+  (now-superseded) direction and is unnecessary once whoami stops
+  gating on status.
+- Not introducing a new schema migration; no new columns on
+  `proxy_tokens` or `sandboxes`.
+
+## Constraints
+
+- **Identity gating must not weaken.** The current 401 paths
+  (`TestAgentWhoami_UnauthorizedCases`: missing/malformed bearer, empty
+  bearer, unknown token, workspace token, tunnel token) and the
+  remaining 403 paths (`legacy_null_user`, `membership_removed`) must
+  still trip the same status codes with the same response bodies.
+- **Response contract change must be additive.** Existing fields
+  (`UserID`, `WorkspaceID`, `WorkspaceName`, `SandboxID`, `ShortID`,
+  `DisplayName`, `Role` in
+  `internal/server/api_types.go:329-339`) must keep their names,
+  types, JSON tags, and `validate:"required"` shape. The new field is
+  added at the end of the struct.
+- **No-cache header preserved.** `Cache-Control: no-store` on the
+  response (`internal/server/agent_whoami.go:66`) must stay; status
+  can change instantaneously when a tunnel connects/disconnects, so
+  the response is never cacheable.
+- **Swagger / generated docs must update.** The struct is annotated
+  `// @name AgentWhoamiResponse`; the OpenAPI surface (consumed by
+  `docs/` swagger output) must reflect the new field, including
+  example value. The Failure 403 doc annotation
+  (`internal/server/agent_whoami.go:36`) must drop "forbidden" from
+  the "sandbox status not active" implication — only the
+  identity-failure cases (`legacy_null_user`, `membership_removed`)
+  remain.
+- **Backward-compatible JSON.** A caller that decodes the response
+  into the old struct (without the new field) continues to work — the
+  new field is just ignored. A caller that decodes into the new
+  struct against an old server (without the new field) sees the
+  Go zero-value (`""`). If that caller chooses to enforce
+  validation (the field is tagged `validate:"required"` because the
+  new server always populates it), it will reject the old-server
+  response — that's the desired signal that they're talking to a
+  server that predates this change.
+
+## Success criteria
+
+1. **A token whose sandbox is `offline` returns 200**, with body
+   containing the existing identity fields **plus** the new
+   `sandbox_status: "offline"` field. Specifically: seed an
+   `is_local=TRUE` sandbox with `status='offline'` and a valid
+   `proxy_token` whose `user_id` is set; call whoami; observe 200 and
+   `sandbox_status == "offline"` in the body. Same for
+   `is_local=FALSE`.
+2. **A token whose sandbox is in any other non-active state returns
+   200 too**, with `sandbox_status` set to whatever the row says. The
+   table-driven `TestAgentWhoami_ForbiddenCases` "status_*" sub-cases
+   that previously asserted 403 for `paused`, `pausing`, `deleting`
+   (and the additional `resuming` state defined in
+   `internal/sbxstore/state.go:25` but not previously covered) now
+   assert 200 with `sandbox_status` matching the seeded value.
+   Rationale: identity is identity; runtime state is runtime state.
+   The caller decides what to do with `paused`/`deleting`/etc.
+   The helper `activeWhoamiSandboxStatus` and its dedicated test
+   `TestActiveWhoamiSandboxStatus`
+   (`internal/server/agent_whoami_test.go:97`) encode the old
+   contract; both are removed when the handler stops gating on
+   status.
+3. **Identity failures still return 403.**
+   `TestAgentWhoami_ForbiddenCases/legacy_null_user` and
+   `/membership_removed` continue to return 403 with body
+   `"forbidden\n"`, unchanged.
+4. **Unauthorized failures still return 401.**
+   `TestAgentWhoami_UnauthorizedCases` continues to pass unchanged.
+5. **Happy-path responses include the new field.**
+   `TestAgentWhoami_HappyPath` and
+   `TestAgentWhoami_DisplayNameFallsBackToSandboxName` both observe a
+   non-empty `sandbox_status` field whose value matches the seeded
+   row (`"running"` in both cases).
+6. **`Cache-Control: no-store` still present** on every 200 response.
+7. **End-to-end deadlock is gone**: replaying the reporter's exact
+   sequence (`register` → `serve-mcp` → SIGTERM → curl whoami) returns
+   HTTP 200 with `sandbox_status: "offline"` instead of 403. Verified
+   by the reproduction harness (the `repro290` script we already have
+   on disk works; we just re-run it after the fix and observe the
+   different result).
+8. The OpenAPI output regenerated from the struct annotations shows
+   the new field. Manual: run `make openapi` (which updates
+   `docs/api/openapi.yaml` and `docs/api/openapi.json` —
+   `Makefile:91`) and `make api-docs` (which updates the reference
+   markdown — `Makefile:114`), then grep both for `sandbox_status`.
+
+## Open design questions (resolved in the plan)
+
+- Exact JSON name for the new field. Candidates: `sandbox_status`
+  (mirrors existing `sandbox_id` style — recommended) vs `status`
+  (shorter but collides with the more general "this whole response's
+  status"). Plan picks one and applies it consistently.
+- Whether to also expose `is_local` and `last_heartbeat_at` in the
+  same response, to give callers richer liveness signal without
+  another round trip. Plan picks (yes/no) and justifies.
+- Where the `status` value should come from when the JOIN's
+  `s.status` column is read: today `GetAgentWhoamiByProxyToken`
+  already returns it as `out.SandboxStatus`
+  (`internal/db/agent_whoami.go:51, 66`), so the wiring is trivial —
+  the plan just confirms no new DB query is needed.

--- a/internal/server/agent_whoami.go
+++ b/internal/server/agent_whoami.go
@@ -21,11 +21,20 @@ func strictBearerToken(r *http.Request) (string, bool) {
 	return token, true
 }
 
-func activeWhoamiSandboxStatus(status string) bool {
-	return status == "creating" || status == "running"
-}
-
 // handleAgentWhoami returns the identity represented by a sandbox proxy_token.
+//
+// The endpoint verifies identity only: a valid proxy_token whose
+// user_id is non-null and whose user is still a workspace member
+// returns 200. The sandbox's current runtime status (creating / running /
+// pausing / paused / resuming / offline / deleting) is reported in the
+// response body as SandboxStatus, but it does NOT influence the HTTP
+// status code. See issue #290 for the rationale: callers (notably
+// observer-server) were treating whoami as a liveness probe, which
+// turned every routine tunnel disconnect into a hard auth failure
+// for the next caller — a deadlock reachable through ordinary
+// `serve-mcp` exit. Identity is identity; runtime state belongs in
+// the body.
+//
 // GET /api/agent/whoami
 //
 //	@Summary   Inspect the calling agent identity (proxy_token auth)
@@ -33,7 +42,7 @@ func activeWhoamiSandboxStatus(status string) bool {
 //	@Produce   json
 //	@Success   200  {object}  AgentWhoamiResponse
 //	@Failure   401  {string}  string  "unauthorized"
-//	@Failure   403  {string}  string  "forbidden"
+//	@Failure   403  {string}  string  "identity not valid for this token (missing user binding or workspace membership)"
 //	@Failure   500  {string}  string  "internal error"
 //	@Router    /api/agent/whoami [get]
 func (s *Server) handleAgentWhoami(w http.ResponseWriter, r *http.Request) {
@@ -57,8 +66,11 @@ func (s *Server) handleAgentWhoami(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "forbidden", http.StatusForbidden)
 		return
 	}
-	if who == nil || !activeWhoamiSandboxStatus(who.SandboxStatus) {
-		http.Error(w, "forbidden", http.StatusForbidden)
+	if who == nil {
+		// Defensive: AgentWhoamiOK guarantees a non-nil row, but if the
+		// invariant ever changes we'd rather 500 than panic on nil deref.
+		log.Printf("agent whoami: nil identity with state=ok")
+		http.Error(w, "internal error", http.StatusInternalServerError)
 		return
 	}
 
@@ -72,5 +84,6 @@ func (s *Server) handleAgentWhoami(w http.ResponseWriter, r *http.Request) {
 		ShortID:       who.ShortID,
 		DisplayName:   who.DisplayName,
 		Role:          who.Role,
+		SandboxStatus: who.SandboxStatus,
 	})
 }

--- a/internal/server/agent_whoami_test.go
+++ b/internal/server/agent_whoami_test.go
@@ -21,14 +21,14 @@ func newWhoamiTestServer(t *testing.T) *Server {
 	return &Server{DB: d}
 }
 
-func seedWhoamiSandbox(t *testing.T, srv *Server, token, tunnelToken, status, role, displayName string, withUser bool) {
+func seedWhoamiSandbox(t *testing.T, srv *Server, token, tunnelToken, status, role, displayName string, withUser, isLocal bool) {
 	t.Helper()
 	seedWorkspaceMember(t, srv.DB, "ws_whoami", "u_whoami", role)
 	if _, err := srv.DB.Exec(
-		`INSERT INTO sandboxes (id, workspace_id, name, type, status, proxy_token, tunnel_token, short_id)
-		 VALUES ('sbx_whoami', 'ws_whoami', 'Sandbox Name', 'custom', $1, $2, $3, 'short-whoami')
-		 ON CONFLICT (id) DO UPDATE SET status = EXCLUDED.status, proxy_token = EXCLUDED.proxy_token, tunnel_token = EXCLUDED.tunnel_token`,
-		status, token, tunnelToken,
+		`INSERT INTO sandboxes (id, workspace_id, name, type, status, is_local, proxy_token, tunnel_token, short_id)
+		 VALUES ('sbx_whoami', 'ws_whoami', 'Sandbox Name', 'custom', $1, $2, $3, $4, 'short-whoami')
+		 ON CONFLICT (id) DO UPDATE SET status = EXCLUDED.status, is_local = EXCLUDED.is_local, proxy_token = EXCLUDED.proxy_token, tunnel_token = EXCLUDED.tunnel_token`,
+		status, isLocal, token, tunnelToken,
 	); err != nil {
 		t.Fatalf("insert sandbox: %v", err)
 	}
@@ -94,22 +94,9 @@ func TestStrictBearerToken(t *testing.T) {
 	}
 }
 
-func TestActiveWhoamiSandboxStatus(t *testing.T) {
-	for _, status := range []string{"creating", "running"} {
-		if !activeWhoamiSandboxStatus(status) {
-			t.Fatalf("%q should be active", status)
-		}
-	}
-	for _, status := range []string{"paused", "offline", "deleting", "pausing", ""} {
-		if activeWhoamiSandboxStatus(status) {
-			t.Fatalf("%q should not be active", status)
-		}
-	}
-}
-
 func TestAgentWhoami_HappyPath(t *testing.T) {
 	srv := newWhoamiTestServer(t)
-	seedWhoamiSandbox(t, srv, "proxy-good", "tunnel-good", "running", "developer", "Display Agent", true)
+	seedWhoamiSandbox(t, srv, "proxy-good", "tunnel-good", "running", "developer", "Display Agent", true, false)
 
 	rr := callWhoami(t, srv, "Bearer proxy-good")
 	if rr.Code != http.StatusOK {
@@ -127,11 +114,14 @@ func TestAgentWhoami_HappyPath(t *testing.T) {
 		out.DisplayName != "Display Agent" || out.Role != "developer" {
 		t.Fatalf("unexpected response: %+v", out)
 	}
+	if out.SandboxStatus != "running" {
+		t.Fatalf("sandbox_status = %q, want %q", out.SandboxStatus, "running")
+	}
 }
 
 func TestAgentWhoami_UnauthorizedCases(t *testing.T) {
 	srv := newWhoamiTestServer(t)
-	seedWhoamiSandbox(t, srv, "proxy-good", "tunnel-good", "running", "developer", "", true)
+	seedWhoamiSandbox(t, srv, "proxy-good", "tunnel-good", "running", "developer", "", true, false)
 	if _, err := srv.DB.Exec(
 		`INSERT INTO proxy_tokens (token, token_type, workspace_id)
 		 VALUES ('workspace-token', 'workspace', 'ws_whoami')
@@ -164,30 +154,31 @@ func TestAgentWhoami_UnauthorizedCases(t *testing.T) {
 	}
 }
 
-func TestAgentWhoami_ForbiddenCases(t *testing.T) {
-	for _, status := range []string{"paused", "offline", "deleting", "pausing"} {
-		t.Run("status_"+status, func(t *testing.T) {
-			srv := newWhoamiTestServer(t)
-			seedWhoamiSandbox(t, srv, "proxy-forbidden", "tunnel-forbidden", status, "developer", "", true)
-			rr := callWhoami(t, srv, "Bearer proxy-forbidden")
-			if rr.Code != http.StatusForbidden {
-				t.Fatalf("want 403, got %d: %s", rr.Code, rr.Body.String())
-			}
-		})
-	}
-
+// TestAgentWhoami_ForbiddenIdentity covers the two cases that legitimately
+// fail identity verification and must continue to return 403:
+//
+//   - legacy_null_user: a proxy_tokens row whose user_id is NULL (predates
+//     migration 034). The handler short-circuits in
+//     internal/db/agent_whoami.go:38.
+//   - membership_removed: the user was removed from the workspace after the
+//     token was issued, so the JOIN against workspace_members returns no
+//     rows. The handler short-circuits in internal/db/agent_whoami.go:67.
+func TestAgentWhoami_ForbiddenIdentity(t *testing.T) {
 	t.Run("legacy_null_user", func(t *testing.T) {
 		srv := newWhoamiTestServer(t)
-		seedWhoamiSandbox(t, srv, "proxy-legacy", "tunnel-legacy", "running", "developer", "", false)
+		seedWhoamiSandbox(t, srv, "proxy-legacy", "tunnel-legacy", "running", "developer", "", false, false)
 		rr := callWhoami(t, srv, "Bearer proxy-legacy")
 		if rr.Code != http.StatusForbidden {
 			t.Fatalf("want 403, got %d: %s", rr.Code, rr.Body.String())
+		}
+		if rr.Body.String() != "forbidden\n" {
+			t.Fatalf("body = %q", rr.Body.String())
 		}
 	})
 
 	t.Run("membership_removed", func(t *testing.T) {
 		srv := newWhoamiTestServer(t)
-		seedWhoamiSandbox(t, srv, "proxy-removed", "tunnel-removed", "running", "developer", "", true)
+		seedWhoamiSandbox(t, srv, "proxy-removed", "tunnel-removed", "running", "developer", "", true, false)
 		if _, err := srv.DB.Exec(`DELETE FROM workspace_members WHERE workspace_id = 'ws_whoami' AND user_id = 'u_whoami'`); err != nil {
 			t.Fatalf("delete membership: %v", err)
 		}
@@ -195,12 +186,62 @@ func TestAgentWhoami_ForbiddenCases(t *testing.T) {
 		if rr.Code != http.StatusForbidden {
 			t.Fatalf("want 403, got %d: %s", rr.Code, rr.Body.String())
 		}
+		if rr.Body.String() != "forbidden\n" {
+			t.Fatalf("body = %q", rr.Body.String())
+		}
 	})
+}
+
+// TestAgentWhoami_RuntimeStatusReportedInBody asserts the post-#290 contract:
+// once identity verification passes, whoami returns 200 regardless of the
+// sandbox's current runtime status, and the status appears verbatim in the
+// response body so callers (observer-server etc.) can decide how to react.
+// Previously paused/pausing/resuming/offline/deleting all returned 403.
+func TestAgentWhoami_RuntimeStatusReportedInBody(t *testing.T) {
+	// Status values from internal/sbxstore/state.go:5-12, plus the empty
+	// string to pin behavior for legacy rows where status is unset.
+	statuses := []string{"creating", "running", "pausing", "paused", "resuming", "offline", "deleting", ""}
+	for _, status := range statuses {
+		for _, isLocal := range []bool{false, true} {
+			name := "status_" + status
+			if status == "" {
+				name = "status_empty"
+			}
+			if isLocal {
+				name += "_local"
+			} else {
+				name += "_cloud"
+			}
+			t.Run(name, func(t *testing.T) {
+				srv := newWhoamiTestServer(t)
+				seedWhoamiSandbox(t, srv, "proxy-rt", "tunnel-rt", status, "developer", "", true, isLocal)
+				rr := callWhoami(t, srv, "Bearer proxy-rt")
+				if rr.Code != http.StatusOK {
+					t.Fatalf("want 200, got %d: %s", rr.Code, rr.Body.String())
+				}
+				if rr.Header().Get("Cache-Control") != "no-store" {
+					t.Fatalf("Cache-Control = %q, want no-store", rr.Header().Get("Cache-Control"))
+				}
+				var out AgentWhoamiResponse
+				if err := json.NewDecoder(rr.Body).Decode(&out); err != nil {
+					t.Fatalf("decode: %v", err)
+				}
+				if out.SandboxStatus != status {
+					t.Fatalf("sandbox_status = %q, want %q", out.SandboxStatus, status)
+				}
+				// Identity fields must still be populated.
+				if out.UserID != "u_whoami" || out.WorkspaceID != "ws_whoami" ||
+					out.SandboxID != "sbx_whoami" || out.Role != "developer" {
+					t.Fatalf("identity fields missing in response: %+v", out)
+				}
+			})
+		}
+	}
 }
 
 func TestAgentWhoami_DisplayNameFallsBackToSandboxName(t *testing.T) {
 	srv := newWhoamiTestServer(t)
-	seedWhoamiSandbox(t, srv, "proxy-fallback", "tunnel-fallback", "running", "developer", "", true)
+	seedWhoamiSandbox(t, srv, "proxy-fallback", "tunnel-fallback", "running", "developer", "", true, false)
 	rr := callWhoami(t, srv, "Bearer proxy-fallback")
 	if rr.Code != http.StatusOK {
 		t.Fatalf("want 200, got %d: %s", rr.Code, rr.Body.String())
@@ -211,5 +252,8 @@ func TestAgentWhoami_DisplayNameFallsBackToSandboxName(t *testing.T) {
 	}
 	if out.DisplayName != "Sandbox Name" {
 		t.Fatalf("display_name = %q, want Sandbox Name", out.DisplayName)
+	}
+	if out.SandboxStatus != "running" {
+		t.Fatalf("sandbox_status = %q, want %q", out.SandboxStatus, "running")
 	}
 }

--- a/internal/server/api_types.go
+++ b/internal/server/api_types.go
@@ -327,7 +327,13 @@ type AgentRegisterResponse struct {
 } // @name AgentRegisterResponse
 
 // AgentWhoamiResponse is returned by GET /api/agent/whoami.
-// It contains the full public identity contract for a sandbox proxy token.
+// It contains the full public identity contract for a sandbox proxy token,
+// plus the sandbox's current runtime status as advisory information.
+//
+// The endpoint does not gate on SandboxStatus — any valid identity returns
+// 200, regardless of whether the sandbox is creating / running / paused /
+// offline / etc. Callers that want to refuse offline sandboxes should
+// inspect this field themselves; see issue #290 for the rationale.
 type AgentWhoamiResponse struct {
 	UserID        string `json:"user_id" validate:"required" example:"u_abc123"`
 	WorkspaceID   string `json:"workspace_id" validate:"required" example:"ws_xyz789"`
@@ -336,6 +342,12 @@ type AgentWhoamiResponse struct {
 	ShortID       string `json:"short_id" validate:"required" example:"alice-driver-01"`
 	DisplayName   string `json:"display_name" validate:"required" example:"Alice Driver"`
 	Role          string `json:"role" validate:"required" example:"developer"`
+	// SandboxStatus is the current sandboxes.status column verbatim —
+	// one of creating / running / pausing / paused / resuming / offline /
+	// deleting (see internal/sbxstore/state.go), or "" for legacy rows
+	// where the field was never set. The server always populates this
+	// field on 200 responses.
+	SandboxStatus string `json:"sandbox_status" validate:"required" example:"running"`
 } // @name AgentWhoamiResponse
 
 // AgentCardRegisterRequest is the body for POST /api/agent/discovery/cards.


### PR DESCRIPTION
## Summary

- **Decouples identity verification from sandbox runtime status in `GET /api/agent/whoami`.** Identity-valid tokens now return **200** regardless of sandbox status; the previous status gate (only `creating`/`running` allowed through) returned 403 for every other state and was creating a deadlock through the ordinary `codex → serve-mcp → exit` lifecycle.
- **Adds `sandbox_status` to `AgentWhoamiResponse`** so callers that genuinely want to gate on runtime state (notably observer-server) can inspect the value themselves. The DB helper already selected `s.status`; this PR just exposes it.
- **Preserves all existing 401 paths** (unknown/wrong-type/malformed bearer) and the two genuine **403 identity-failure paths** (`legacy_null_user`, `membership_removed`). The only behavior change is that runtime statuses `paused`, `pausing`, `resuming`, `offline`, `deleting` flip from `403 forbidden` to `200` with the status reported in the body.

Closes #290 — see the reporter's [second comment](https://github.com/agentserver/agentserver/issues/290#issuecomment-) for the corrected reproduction (the deadlock is reachable through the normal `codex` lifecycle, not requiring `serve-daemon`).

## Root cause

`whoami` is the only proxy_token-authed endpoint in the codebase that gates on `sandboxes.status`. All others (`agent_proxy_routes.go:21`, `agent_discovery.go:127`, `agent_mailbox.go:37,119`, `agent_tasks.go:272,346`) authenticate via `GetSandboxByAnyToken` without checking status. The whoami gate is therefore not enforcing a system-wide authorization rule — it had quietly become a liveness probe for observer-server's startup handshake.

The runtime "tunnel is up?" signal is legitimate state, but it's not what whoami's name promises (identity inspection). Conflating them made the contract leak into normal operation:

| T | Action | `sandboxes.status` | `whoami` |
|---|--------|--------------------|----------|
| 0 | `register` | `running` | 200 |
| +Δ | `serve-mcp` opens tunnel → `tunnel.go:82` writes `running` | `running` | 200 |
| +Δ | `serve-mcp` exits cleanly → `tunnel.go:127` writes `offline` within ms | `offline` | **403** within ms |
| +Δ | `serve-daemon` starts → observer validates bearer → 403 → daemon dies in ~200ms | `offline` | 403 |

## Design

See `docs/spec/290-local-sandbox-whoami-403.md` and `docs/plan/290-local-sandbox-whoami-403.md` for the full analysis (~460 lines covering: every in-tree writer of `sandboxes.status` enumerated, the three 403 branches in `agent_whoami.go`, why other proxy_token endpoints don't need this gate, and the chosen fix direction). The plan was reviewed by codex twice (spec) and twice (plan) before implementation.

## Test plan

- [x] `TestStrictBearerToken` — unchanged, passes
- [x] `TestAgentWhoami_HappyPath` — extended to assert new `sandbox_status` field
- [x] `TestAgentWhoami_UnauthorizedCases` — 6 subcases, unchanged behavior
- [x] `TestAgentWhoami_ForbiddenIdentity` — new, covers `legacy_null_user` + `membership_removed` (both still 403)
- [x] `TestAgentWhoami_RuntimeStatusReportedInBody` — new, **16 subcases** = 8 statuses (`creating`/`running`/`pausing`/`paused`/`resuming`/`offline`/`deleting`/`""`) × 2 `is_local` variants. All return 200 with `sandbox_status` matching the seeded value.
- [x] `TestAgentWhoami_DisplayNameFallsBackToSandboxName` — extended to assert new field
- [x] `go vet ./...` clean
- [x] `make openapi-check` passes (regenerated `openapi.yaml`/`openapi.json`)
- [x] `make api-docs-check` passes (regenerated `reference/agent.md`)
- [x] End-to-end local verification: started agentserver against fresh PostgreSQL, seeded an `is_local=TRUE, status='offline'` sandbox, observed whoami return `HTTP 200` with `{..., "sandbox_status": "offline"}`. Identity-failure cases (membership removed, NULL user_id) still return 403; unknown bearer still 401.

## Out of scope (deliberately separate PRs)

- Changing `tunnel.go:127`'s offline-on-disconnect behavior — that's the correct signal, just not whoami's concern.
- Adding `POST /api/agent/heartbeat` or other liveness endpoints — unnecessary once whoami stops gating on status.
- Changing `commander.WSClient`'s 401-is-terminal behavior in loom (separate repo).
- Adding `is_local`/`last_heartbeat_at` to the whoami response — `last_heartbeat_at` is unreliable for non-tunneled local sandboxes (only refreshed by `tunnel.go:102`), so exposing it now would advertise a misleading half-truth. Future PR if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)