### PR TITLE
feat(browser-gateway) P3: reference SPA (@ag-ui/client + @a2ui/react) + deploy wiring

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -492,6 +492,39 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  build-browser-gateway:
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v6
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/agentserver/browser-gateway
+          tags: |
+            type=sha,prefix=
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile.browser-gateway
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
   integration-cc-app-gateway:
     runs-on: ubuntu-latest
     needs: [build-cc-app-gateway]

--- a/Dockerfile.browser-gateway
+++ b/Dockerfile.browser-gateway
@@ -1,9 +1,20 @@
 # syntax=docker/dockerfile:1
+# Stage 1: build the browserweb SPA
+FROM node:25-slim AS frontend
+RUN npm install -g pnpm
+WORKDIR /app/browserweb
+COPY browserweb/package.json browserweb/pnpm-lock.yaml browserweb/pnpm-workspace.yaml ./
+RUN pnpm install --frozen-lockfile
+COPY browserweb/ ./
+RUN pnpm build
+
+# Stage 2: build the Go binary (embeds browserweb/dist)
 FROM golang:1.26-trixie AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
+COPY --from=frontend /app/browserweb/dist ./browserweb/dist
 RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' \
     -o /out/browser-gateway ./cmd/browser-gateway
 

--- a/browserweb/.gitignore
+++ b/browserweb/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+dist

--- a/browserweb/dist/index.html
+++ b/browserweb/dist/index.html
@@ -1,7 +1,1 @@
-<!doctype html>
-<html lang="en">
-  <head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" /><title>browser-gateway</title>  <script type="module" crossorigin src="/assets/index-BRM6Ah_E.js"></script>
-  <link rel="stylesheet" crossorigin href="/assets/index-CcEb0ABE.css">
-</head>
-  <body><div id="root"></div></body>
-</html>
+<!doctype html><title>browser-gateway</title><div id="root"></div>

--- a/browserweb/dist/index.html
+++ b/browserweb/dist/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" /><title>browser-gateway</title>  <script type="module" crossorigin src="/assets/index-BRM6Ah_E.js"></script>
+  <link rel="stylesheet" crossorigin href="/assets/index-CcEb0ABE.css">
+</head>
+  <body><div id="root"></div></body>
+</html>

--- a/browserweb/embed.go
+++ b/browserweb/embed.go
@@ -1,0 +1,7 @@
+// Package browserweb embeds the built browser-gateway reference SPA.
+package browserweb
+
+import "embed"
+
+//go:embed all:dist
+var StaticFS embed.FS

--- a/browserweb/index.html
+++ b/browserweb/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
 <html lang="en">
-  <head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" /><title>browser-gateway</title></head>
+  <head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" /><meta name="referrer" content="no-referrer" /><title>browser-gateway</title></head>
   <body><div id="root"></div><script type="module" src="/src/main.tsx"></script></body>
 </html>

--- a/browserweb/index.html
+++ b/browserweb/index.html
@@ -1,0 +1,5 @@
+<!doctype html>
+<html lang="en">
+  <head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" /><title>browser-gateway</title></head>
+  <body><div id="root"></div><script type="module" src="/src/main.tsx"></script></body>
+</html>

--- a/browserweb/package.json
+++ b/browserweb/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "browserweb",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@a2ui/react": "0.10.2",
+    "@a2ui/web_core": "0.10.5",
+    "@ag-ui/client": "0.0.57",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.2.1",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.1.1",
+    "tailwindcss": "^4.2.1",
+    "typescript": "~5.9.3",
+    "vite": "^7.3.1",
+    "vitest": "^3.2.0"
+  }
+}

--- a/browserweb/pnpm-lock.yaml
+++ b/browserweb/pnpm-lock.yaml
@@ -1,0 +1,2016 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@a2ui/react':
+        specifier: 0.10.2
+        version: 0.10.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@3.25.76)
+      '@a2ui/web_core':
+        specifier: 0.10.5
+        version: 0.10.5
+      '@ag-ui/client':
+        specifier: 0.0.57
+        version: 0.0.57
+      react:
+        specifier: ^19.2.0
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.0
+        version: 19.2.7(react@19.2.7)
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
+    devDependencies:
+      '@tailwindcss/vite':
+        specifier: ^4.2.1
+        version: 4.3.3(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^5.1.1
+        version: 5.2.0(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
+      tailwindcss:
+        specifier: ^4.2.1
+        version: 4.3.3
+      typescript:
+        specifier: ~5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^7.3.1
+        version: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
+      vitest:
+        specifier: ^3.2.0
+        version: 3.2.7(jiti@2.7.0)(lightningcss@1.32.0)
+
+packages:
+
+  '@a2ui/markdown-it@0.1.0':
+    resolution: {integrity: sha512-Iv/4/CzFFVQTgT/qeT7lo/sJlZ3+w2+kD7dMQguZS1iZ95GNN5MILdnh+gqVWe6H9iaj+uyonLWMR7RTLHUxPQ==}
+    peerDependencies:
+      '@a2ui/web_core': ^0.10.3
+
+  '@a2ui/react@0.10.2':
+    resolution: {integrity: sha512-QDVs97a/sihcjE3DMnWbwB8bJKv1z2tn291m6+0w6+lXi8dfwnSiZilAgoQmLWjW4Oikv8OFh532NiQMqL/+nw==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^19.2.7
+      react-dom: ^19.2.7
+      zod: ^3.25.76
+
+  '@a2ui/web_core@0.10.5':
+    resolution: {integrity: sha512-q+HyK1V/jM8l+/VmuXRbBNCS9yDguqdjsJ7/8aqY9O/WUdRE14FbhkFyQyGWQNqPJa9QbVfQyAjGQIK0B1aQtg==}
+
+  '@ag-ui/client@0.0.57':
+    resolution: {integrity: sha512-Xap2alG9Z0/j5kb3x4D7oTpe2sw1dfrC9rgJJr2NZu5vKcm8dzIPNd31mF2B4zS3BKqYIu245yxKPhEtT30MHw==}
+
+  '@ag-ui/core@0.0.57':
+    resolution: {integrity: sha512-gho1OWjNE6E3Rl7ZEZ1wr2CEpUHjLFU0FqzCZZk439TicLu+BfLCMkMokB07bMGlRmbJ60hM6LW60iOVauCx+Q==}
+
+  '@ag-ui/encoder@0.0.57':
+    resolution: {integrity: sha512-ifD9NctR4xyPDR58xF9GK1bj/S8oECFkTeDfuYD8tXdbcOstIJ2TOqU2zhiCKnw7Vw+zR9Qv3TbsM9E7Gi9X3Q==}
+
+  '@ag-ui/proto@0.0.57':
+    resolution: {integrity: sha512-pPENOZt0P6ibH8sCTgq05wLYXi5t3P9B5r/1bWYehXjUxtyOdnukSlWM++SsCIwUXsQdm/b3aBgGjEeTF7RenA==}
+
+  '@babel/code-frame@7.29.7':
+    resolution: {integrity: sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.7':
+    resolution: {integrity: sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.7':
+    resolution: {integrity: sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.7':
+    resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.29.7':
+    resolution: {integrity: sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.29.7':
+    resolution: {integrity: sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.29.7':
+    resolution: {integrity: sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.29.7':
+    resolution: {integrity: sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.29.7':
+    resolution: {integrity: sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.29.7':
+    resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.29.7':
+    resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.29.7':
+    resolution: {integrity: sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.7':
+    resolution: {integrity: sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.7':
+    resolution: {integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7':
+    resolution: {integrity: sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7':
+    resolution: {integrity: sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.29.7':
+    resolution: {integrity: sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.7':
+    resolution: {integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.7':
+    resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
+    engines: {node: '>=6.9.0'}
+
+  '@bufbuild/protobuf@2.12.1':
+    resolution: {integrity: sha512-BvAMfS6LrgZiryOAZ4pBYucu4wG/Ei/9o9DZ9akbREnMLbPJiom2i8b9C8IsKErQoiKqVhrerzt3kOT/RrzLHg==}
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@preact/signals-core@1.14.4':
+    resolution: {integrity: sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==}
+
+  '@protobuf-ts/protoc@2.11.1':
+    resolution: {integrity: sha512-mUZJaV0daGO6HUX90o/atzQ6A7bbN2RSuHtdwo8SSF2Qoe3zHwa4IHyCN1evftTeHfLmdz+45qo47sL+5P8nyg==}
+    hasBin: true
+
+  '@rolldown/pluginutils@1.0.0-rc.3':
+    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/node@4.3.3':
+    resolution: {integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==}
+
+  '@tailwindcss/oxide-android-arm64@4.3.3':
+    resolution: {integrity: sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
+    resolution: {integrity: sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
+    resolution: {integrity: sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
+    resolution: {integrity: sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
+    resolution: {integrity: sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
+    resolution: {integrity: sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
+    resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
+    resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
+    resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
+    resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
+    resolution: {integrity: sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
+    resolution: {integrity: sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.3.3':
+    resolution: {integrity: sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.3.3':
+    resolution: {integrity: sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.17':
+    resolution: {integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
+
+  '@vitejs/plugin-react@5.2.0':
+    resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
+
+  '@vitest/expect@3.2.7':
+    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
+
+  '@vitest/mocker@3.2.7':
+    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
+
+  '@vitest/runner@3.2.7':
+    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
+
+  '@vitest/snapshot@3.2.7':
+    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
+
+  '@vitest/spy@3.2.7':
+    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
+
+  '@vitest/utils@3.2.7':
+    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  baseline-browser-mapping@2.10.43:
+    resolution: {integrity: sha512-AjYpR78kDWAY3Efj+cDTFH9t9SCoL7OoTp1BOb0mQV7S+6CiLwnWM3FyxhJtdPufDFKzmCSFoUncKjWgJEZTCQ==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  browserslist@4.28.6:
+    resolution: {integrity: sha512-FQBYNK15VMslhLHpA7+n+n1GOlF1kId2xcCg7/j95f24AOF6VDYMNH4mFxF7KuaTdv627faazpOAjFzMrfJOUw==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  caniuse-lite@1.0.30001806:
+    resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
+  compare-versions@6.1.1:
+    resolution: {integrity: sha512-4hm4VPpIecmlg59CHXnRDnqGplJFrbLG4aFEl5vl6cK1u76ws3LLvX7ikFnTDl5vo39sjWD6AaDPYodJp/NNHg==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  date-fns@4.4.0:
+    resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  dompurify@3.4.11:
+    resolution: {integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==}
+
+  electron-to-chromium@1.5.393:
+    resolution: {integrity: sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==}
+
+  enhanced-resolve@5.24.3:
+    resolution: {integrity: sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==}
+    engines: {node: '>=10.13.0'}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  fast-json-patch@3.1.1:
+    resolution: {integrity: sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
+  linkify-it@5.0.2:
+    resolution: {integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  markdown-it@14.3.0:
+    resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
+    hasBin: true
+
+  mdurl@2.0.0:
+    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-releases@2.0.51:
+    resolution: {integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==}
+    engines: {node: '>=18'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.20:
+    resolution: {integrity: sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  punycode.js@2.3.1:
+    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
+    engines: {node: '>=6'}
+
+  react-dom@19.2.7:
+    resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
+    peerDependencies:
+      react: ^19.2.7
+
+  react-refresh@0.18.0:
+    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.7:
+    resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
+    engines: {node: '>=0.10.0'}
+
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  rxjs@7.8.1:
+    resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
+
+  tailwindcss@4.3.3:
+    resolution: {integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==}
+
+  tapable@2.3.3:
+    resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
+    engines: {node: '>=6'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@2.0.0:
+    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@4.0.4:
+    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+    engines: {node: '>=14.0.0'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  uc.micro@2.1.0:
+    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
+  untruncate-json@0.0.1:
+    resolution: {integrity: sha512-4W9enDK4X1y1s2S/Rz7ysw6kDuMS3VmRjMFg7GZrNO+98OSe+x5Lh7PKYoVjy3lW/1wmhs6HW0lusnQRHgMarA==}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  uuid@11.1.1:
+    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
+    hasBin: true
+
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
+  vite@7.3.6:
+    resolution: {integrity: sha512-4XP60spRGjSZFf1qYH+dJIkK2znL3zQfl9KkOV9MkkRR/3Dls0dxaBsQPTloEc5BLXWPL9vsOxopxyKoMmDueg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@3.2.7:
+    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.7
+      '@vitest/ui': 3.2.7
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+snapshots:
+
+  '@a2ui/markdown-it@0.1.0(@a2ui/web_core@0.10.5)':
+    dependencies:
+      '@a2ui/web_core': 0.10.5
+      dompurify: 3.4.11
+      markdown-it: 14.3.0
+
+  '@a2ui/react@0.10.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(zod@3.25.76)':
+    dependencies:
+      '@a2ui/markdown-it': 0.1.0(@a2ui/web_core@0.10.5)
+      '@a2ui/web_core': 0.10.5
+      clsx: 2.1.1
+      markdown-it: 14.3.0
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      zod: 3.25.76
+
+  '@a2ui/web_core@0.10.5':
+    dependencies:
+      '@preact/signals-core': 1.14.4
+      date-fns: 4.4.0
+      zod: 3.25.76
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
+
+  '@ag-ui/client@0.0.57':
+    dependencies:
+      '@ag-ui/core': 0.0.57
+      '@ag-ui/encoder': 0.0.57
+      '@ag-ui/proto': 0.0.57
+      '@types/uuid': 10.0.0
+      compare-versions: 6.1.1
+      fast-json-patch: 3.1.1
+      rxjs: 7.8.1
+      untruncate-json: 0.0.1
+      uuid: 11.1.1
+      zod: 3.25.76
+
+  '@ag-ui/core@0.0.57':
+    dependencies:
+      zod: 3.25.76
+
+  '@ag-ui/encoder@0.0.57':
+    dependencies:
+      '@ag-ui/core': 0.0.57
+      '@ag-ui/proto': 0.0.57
+
+  '@ag-ui/proto@0.0.57':
+    dependencies:
+      '@ag-ui/core': 0.0.57
+      '@bufbuild/protobuf': 2.12.1
+      '@protobuf-ts/protoc': 2.11.1
+
+  '@babel/code-frame@7.29.7':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.29.7
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.7': {}
+
+  '@babel/core@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-compilation-targets': 7.29.7
+      '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7)
+      '@babel/helpers': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.7':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.29.7':
+    dependencies:
+      '@babel/compat-data': 7.29.7
+      '@babel/helper-validator-option': 7.29.7
+      browserslist: 4.28.6
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.29.7': {}
+
+  '@babel/helper-module-imports@7.29.7':
+    dependencies:
+      '@babel/traverse': 7.29.7
+      '@babel/types': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-module-imports': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+      '@babel/traverse': 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.29.7': {}
+
+  '@babel/helper-string-parser@7.29.7': {}
+
+  '@babel/helper-validator-identifier@7.29.7': {}
+
+  '@babel/helper-validator-option@7.29.7': {}
+
+  '@babel/helpers@7.29.7':
+    dependencies:
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/parser@7.29.7':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-self@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/plugin-transform-react-jsx-source@7.29.7(@babel/core@7.29.7)':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/helper-plugin-utils': 7.29.7
+
+  '@babel/template@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@babel/traverse@7.29.7':
+    dependencies:
+      '@babel/code-frame': 7.29.7
+      '@babel/generator': 7.29.7
+      '@babel/helper-globals': 7.29.7
+      '@babel/parser': 7.29.7
+      '@babel/template': 7.29.7
+      '@babel/types': 7.29.7
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.7':
+    dependencies:
+      '@babel/helper-string-parser': 7.29.7
+      '@babel/helper-validator-identifier': 7.29.7
+
+  '@bufbuild/protobuf@2.12.1': {}
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@preact/signals-core@1.14.4': {}
+
+  '@protobuf-ts/protoc@2.11.1': {}
+
+  '@rolldown/pluginutils@1.0.0-rc.3': {}
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    optional: true
+
+  '@tailwindcss/node@4.3.3':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.24.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.3.3
+
+  '@tailwindcss/oxide-android-arm64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.3.3':
+    optional: true
+
+  '@tailwindcss/oxide@4.3.3':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-arm64': 4.3.3
+      '@tailwindcss/oxide-darwin-x64': 4.3.3
+      '@tailwindcss/oxide-freebsd-x64': 4.3.3
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-arm64-musl': 4.3.3
+      '@tailwindcss/oxide-linux-x64-gnu': 4.3.3
+      '@tailwindcss/oxide-linux-x64-musl': 4.3.3
+      '@tailwindcss/oxide-wasm32-wasi': 4.3.3
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.3.3
+      '@tailwindcss/oxide-win32-x64-msvc': 4.3.3
+
+  '@tailwindcss/vite@4.3.3(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@tailwindcss/node': 4.3.3
+      '@tailwindcss/oxide': 4.3.3
+      tailwindcss: 4.3.3
+      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.7
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/react-dom@19.2.3(@types/react@19.2.17)':
+    dependencies:
+      '@types/react': 19.2.17
+
+  '@types/react@19.2.17':
+    dependencies:
+      csstype: 3.2.3
+
+  '@types/trusted-types@2.0.7':
+    optional: true
+
+  '@types/uuid@10.0.0': {}
+
+  '@vitejs/plugin-react@5.2.0(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@babel/core': 7.29.7
+      '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
+      '@babel/plugin-transform-react-jsx-source': 7.29.7(@babel/core@7.29.7)
+      '@rolldown/pluginutils': 1.0.0-rc.3
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.18.0
+      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitest/expect@3.2.7':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
+  '@vitest/mocker@3.2.7(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))':
+    dependencies:
+      '@vitest/spy': 3.2.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
+
+  '@vitest/pretty-format@3.2.7':
+    dependencies:
+      tinyrainbow: 2.0.0
+
+  '@vitest/runner@3.2.7':
+    dependencies:
+      '@vitest/utils': 3.2.7
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
+  '@vitest/snapshot@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@3.2.7':
+    dependencies:
+      tinyspy: 4.0.4
+
+  '@vitest/utils@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  argparse@2.0.1: {}
+
+  assertion-error@2.0.1: {}
+
+  baseline-browser-mapping@2.10.43: {}
+
+  browserslist@4.28.6:
+    dependencies:
+      baseline-browser-mapping: 2.10.43
+      caniuse-lite: 1.0.30001806
+      electron-to-chromium: 1.5.393
+      node-releases: 2.0.51
+      update-browserslist-db: 1.2.3(browserslist@4.28.6)
+
+  cac@6.7.14: {}
+
+  caniuse-lite@1.0.30001806: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  clsx@2.1.1: {}
+
+  compare-versions@6.1.1: {}
+
+  convert-source-map@2.0.0: {}
+
+  csstype@3.2.3: {}
+
+  date-fns@4.4.0: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  detect-libc@2.1.2: {}
+
+  dompurify@3.4.11:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
+  electron-to-chromium@1.5.393: {}
+
+  enhanced-resolve@5.24.3:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.3
+
+  entities@4.5.0: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+
+  escalade@3.2.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  expect-type@1.4.0: {}
+
+  fast-json-patch@3.1.1: {}
+
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
+  fsevents@2.3.3:
+    optional: true
+
+  gensync@1.0.0-beta.2: {}
+
+  graceful-fs@4.2.11: {}
+
+  jiti@2.7.0: {}
+
+  js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
+  linkify-it@5.0.2:
+    dependencies:
+      uc.micro: 2.1.0
+
+  loupe@3.2.1: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  markdown-it@14.3.0:
+    dependencies:
+      argparse: 2.0.1
+      entities: 4.5.0
+      linkify-it: 5.0.2
+      mdurl: 2.0.0
+      punycode.js: 2.3.1
+      uc.micro: 2.1.0
+
+  mdurl@2.0.0: {}
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.16: {}
+
+  node-releases@2.0.51: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.5: {}
+
+  postcss@8.5.20:
+    dependencies:
+      nanoid: 3.3.16
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  punycode.js@2.3.1: {}
+
+  react-dom@19.2.7(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      scheduler: 0.27.0
+
+  react-refresh@0.18.0: {}
+
+  react@19.2.7: {}
+
+  rollup@4.62.2:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
+      fsevents: 2.3.3
+
+  rxjs@7.8.1:
+    dependencies:
+      tslib: 2.8.1
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
+
+  tailwindcss@4.3.3: {}
+
+  tapable@2.3.3: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@2.0.0: {}
+
+  tinyspy@4.0.4: {}
+
+  tslib@2.8.1: {}
+
+  typescript@5.9.3: {}
+
+  uc.micro@2.1.0: {}
+
+  untruncate-json@0.0.1: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.6):
+    dependencies:
+      browserslist: 4.28.6
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  uuid@11.1.1: {}
+
+  vite-node@3.2.4(jiti@2.7.0)(lightningcss@1.32.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0):
+    dependencies:
+      esbuild: 0.28.1
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+      postcss: 8.5.20
+      rollup: 4.62.2
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.32.0
+
+  vitest@3.2.7(jiti@2.7.0)(lightningcss@1.32.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@7.3.6(jiti@2.7.0)(lightningcss@1.32.0))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.6(jiti@2.7.0)(lightningcss@1.32.0)
+      vite-node: 3.2.4(jiti@2.7.0)(lightningcss@1.32.0)
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  yallist@3.1.1: {}
+
+  zod-to-json-schema@3.25.2(zod@3.25.76):
+    dependencies:
+      zod: 3.25.76
+
+  zod@3.25.76: {}

--- a/browserweb/pnpm-workspace.yaml
+++ b/browserweb/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: true

--- a/browserweb/src/App.tsx
+++ b/browserweb/src/App.tsx
@@ -3,9 +3,11 @@ import { A2uiSurface } from '@a2ui/react/v0_9'
 import { useAgent } from './useAgent'
 
 function readAndScrubToken(): string {
+  // Read the token ONLY from the URL fragment (#token=), which browsers never
+  // send to the server — so it cannot leak into the initial GET request line or
+  // access logs. (A ?query fallback would leak before the scrub runs.)
   const hash = new URLSearchParams(window.location.hash.replace(/^#/, ''))
-  const query = new URLSearchParams(window.location.search)
-  const token = hash.get('token') ?? query.get('token') ?? ''
+  const token = hash.get('token') ?? ''
   if (token) {
     // Scrub the credential from the URL (history, address bar, Referer).
     history.replaceState(null, '', window.location.pathname)

--- a/browserweb/src/App.tsx
+++ b/browserweb/src/App.tsx
@@ -1,3 +1,55 @@
+import { useState } from 'react'
+import { A2uiSurface } from '@a2ui/react/v0_9'
+import { useAgent } from './useAgent'
+
+function tokenFromUrl(): string {
+  return new URLSearchParams(window.location.search).get('token') ?? ''
+}
+
 export function App() {
-  return <div className="p-4">browser-gateway UI</div>
+  const [token, setToken] = useState(tokenFromUrl)
+  if (!token) return <TokenGate onSubmit={setToken} />
+  return <Chat token={token} />
+}
+
+function TokenGate({ onSubmit }: { onSubmit: (t: string) => void }) {
+  const [v, setV] = useState('')
+  return (
+    <div className="mx-auto max-w-md p-8">
+      <h1 className="mb-2 text-lg font-semibold">browser-gateway</h1>
+      <p className="mb-4 text-sm text-gray-600">Paste a workspace codex token to connect.</p>
+      <input className="w-full rounded border p-2" value={v} onChange={(e) => setV(e.target.value)} placeholder="token" />
+      <button className="mt-3 rounded bg-black px-4 py-2 text-white" onClick={() => v.trim() && onSubmit(v.trim())}>Connect</button>
+    </div>
+  )
+}
+
+function Chat({ token }: { token: string }) {
+  const { chat, surfaces, send, running, error } = useAgent(token)
+  const [input, setInput] = useState('')
+  const submit = () => { send(input); setInput('') }
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-3 p-4">
+      {error && <div className="rounded bg-red-50 p-2 text-sm text-red-700">{error}</div>}
+      <div className="flex flex-col gap-2">
+        {chat.messages.map((m) => (
+          <div key={m.id} className={m.role === 'user' ? 'self-end rounded bg-blue-100 px-3 py-2' : 'self-start rounded bg-gray-100 px-3 py-2'}>
+            <span className="whitespace-pre-wrap">{m.text}</span>
+          </div>
+        ))}
+        {chat.tools.map((t) => (
+          <div key={t.id} className="self-start rounded border border-gray-300 px-3 py-2 font-mono text-xs">
+            <div className="font-semibold">{t.name}</div>
+            <div className="whitespace-pre-wrap text-gray-700">{t.args}</div>
+          </div>
+        ))}
+        {surfaces.map((s) => <A2uiSurface key={s.id} surface={s} />)}
+      </div>
+      <div className="flex gap-2">
+        <input className="flex-1 rounded border p-2" value={input} onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && submit()} placeholder={running ? 'running…' : 'message'} disabled={running} />
+        <button className="rounded bg-black px-4 py-2 text-white disabled:opacity-50" onClick={submit} disabled={running}>Send</button>
+      </div>
+    </div>
+  )
 }

--- a/browserweb/src/App.tsx
+++ b/browserweb/src/App.tsx
@@ -2,12 +2,19 @@ import { useState } from 'react'
 import { A2uiSurface } from '@a2ui/react/v0_9'
 import { useAgent } from './useAgent'
 
-function tokenFromUrl(): string {
-  return new URLSearchParams(window.location.search).get('token') ?? ''
+function readAndScrubToken(): string {
+  const hash = new URLSearchParams(window.location.hash.replace(/^#/, ''))
+  const query = new URLSearchParams(window.location.search)
+  const token = hash.get('token') ?? query.get('token') ?? ''
+  if (token) {
+    // Scrub the credential from the URL (history, address bar, Referer).
+    history.replaceState(null, '', window.location.pathname)
+  }
+  return token
 }
 
 export function App() {
-  const [token, setToken] = useState(tokenFromUrl)
+  const [token, setToken] = useState(readAndScrubToken)
   if (!token) return <TokenGate onSubmit={setToken} />
   return <Chat token={token} />
 }
@@ -18,8 +25,18 @@ function TokenGate({ onSubmit }: { onSubmit: (t: string) => void }) {
     <div className="mx-auto max-w-md p-8">
       <h1 className="mb-2 text-lg font-semibold">browser-gateway</h1>
       <p className="mb-4 text-sm text-gray-600">Paste a workspace codex token to connect.</p>
-      <input className="w-full rounded border p-2" value={v} onChange={(e) => setV(e.target.value)} placeholder="token" />
-      <button className="mt-3 rounded bg-black px-4 py-2 text-white" onClick={() => v.trim() && onSubmit(v.trim())}>Connect</button>
+      <input
+        className="w-full rounded border p-2"
+        type="password"
+        name="token"
+        autoComplete="off"
+        autoCapitalize="off"
+        spellCheck={false}
+        value={v}
+        onChange={(e) => setV(e.target.value)}
+        placeholder="token"
+      />
+      <button className="mt-3 rounded bg-black px-4 py-2 text-white" onClick={() => v.trim() && (onSubmit(v.trim()), setV(''))}>Connect</button>
     </div>
   )
 }

--- a/browserweb/src/App.tsx
+++ b/browserweb/src/App.tsx
@@ -1,0 +1,3 @@
+export function App() {
+  return <div className="p-4">browser-gateway UI</div>
+}

--- a/browserweb/src/agentState.test.ts
+++ b/browserweb/src/agentState.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest'
+import { reduceEvent, emptyChatState } from './agentState'
+
+describe('reduceEvent', () => {
+  it('assembles a streamed assistant message from START/CONTENT/END', () => {
+    let s = emptyChatState
+    s = reduceEvent(s, { type: 'TEXT_MESSAGE_START', messageId: 'm1', role: 'assistant' })
+    s = reduceEvent(s, { type: 'TEXT_MESSAGE_CONTENT', messageId: 'm1', delta: 'Hel' })
+    s = reduceEvent(s, { type: 'TEXT_MESSAGE_CONTENT', messageId: 'm1', delta: 'lo' })
+    s = reduceEvent(s, { type: 'TEXT_MESSAGE_END', messageId: 'm1' })
+    expect(s.messages).toEqual([{ id: 'm1', role: 'assistant', text: 'Hello' }])
+  })
+
+  it('records a tool call from START/ARGS/END', () => {
+    let s = emptyChatState
+    s = reduceEvent(s, { type: 'TOOL_CALL_START', toolCallId: 't1', toolCallName: 'shell' })
+    s = reduceEvent(s, { type: 'TOOL_CALL_ARGS', toolCallId: 't1', delta: 'ls -la' })
+    s = reduceEvent(s, { type: 'TOOL_CALL_END', toolCallId: 't1' })
+    expect(s.tools).toEqual([{ id: 't1', name: 'shell', args: 'ls -la' }])
+  })
+
+  it('ignores unrelated events without mutating input', () => {
+    const s0 = emptyChatState
+    const s1 = reduceEvent(s0, { type: 'CUSTOM', name: 'a2ui.operations', value: [] })
+    expect(s1).toBe(s0)
+  })
+})

--- a/browserweb/src/agentState.ts
+++ b/browserweb/src/agentState.ts
@@ -1,0 +1,33 @@
+export type ChatMessage = { id: string; role: 'user' | 'assistant'; text: string }
+export type ToolCall = { id: string; name: string; args: string }
+export type ChatState = { messages: ChatMessage[]; tools: ToolCall[] }
+
+export const emptyChatState: ChatState = { messages: [], tools: [] }
+
+// reduceEvent applies one AG-UI event to the chat state. Pure: returns the
+// same reference when the event does not affect chat/tool state.
+export function reduceEvent(state: ChatState, ev: { type: string; [k: string]: any }): ChatState {
+  switch (ev.type) {
+    case 'TEXT_MESSAGE_START':
+      return { ...state, messages: [...state.messages, { id: ev.messageId, role: 'assistant', text: '' }] }
+    case 'TEXT_MESSAGE_CONTENT':
+      return {
+        ...state,
+        messages: state.messages.map((m) => (m.id === ev.messageId ? { ...m, text: m.text + (ev.delta ?? '') } : m)),
+      }
+    case 'TOOL_CALL_START':
+      return { ...state, tools: [...state.tools, { id: ev.toolCallId, name: ev.toolCallName, args: '' }] }
+    case 'TOOL_CALL_ARGS':
+      return {
+        ...state,
+        tools: state.tools.map((t) => (t.id === ev.toolCallId ? { ...t, args: t.args + (ev.delta ?? '') } : t)),
+      }
+    default:
+      return state // TEXT_MESSAGE_END, TOOL_CALL_END, CUSTOM, RUN_*, etc. — no chat-state change here
+  }
+}
+
+// addUserMessage appends a user-authored message (used when the user submits input).
+export function addUserMessage(state: ChatState, id: string, text: string): ChatState {
+  return { ...state, messages: [...state.messages, { id, role: 'user', text }] }
+}

--- a/browserweb/src/index.css
+++ b/browserweb/src/index.css
@@ -1,0 +1,2 @@
+@import "tailwindcss";
+/* NOTE: @a2ui/react@0.10.2 declares ./styles/structural.css but ships no such file (upstream defect); A2uiSurface styles come from its bundled CSS Modules. */

--- a/browserweb/src/main.tsx
+++ b/browserweb/src/main.tsx
@@ -1,0 +1,6 @@
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import { App } from './App'
+
+createRoot(document.getElementById('root')!).render(<StrictMode><App /></StrictMode>)

--- a/browserweb/src/useAgent.ts
+++ b/browserweb/src/useAgent.ts
@@ -1,8 +1,8 @@
 import { useEffect, useMemo, useState } from 'react'
 import { HttpAgent } from '@ag-ui/client'
-import { MessageProcessor } from '@a2ui/web_core/v0_9'
+import { MessageProcessor, SurfaceModel } from '@a2ui/web_core/v0_9'
 import { basicCatalog } from '@a2ui/react/v0_9'
-import type { SurfaceModel, ReactComponentImplementation } from '@a2ui/react/v0_9'
+import type { ReactComponentImplementation } from '@a2ui/react/v0_9'
 import { reduceEvent, addUserMessage, emptyChatState, type ChatState } from './agentState'
 
 type Surface = SurfaceModel<ReactComponentImplementation>

--- a/browserweb/src/useAgent.ts
+++ b/browserweb/src/useAgent.ts
@@ -1,0 +1,46 @@
+import { useEffect, useMemo, useState } from 'react'
+import { HttpAgent } from '@ag-ui/client'
+import { MessageProcessor } from '@a2ui/web_core/v0_9'
+import { basicCatalog } from '@a2ui/react/v0_9'
+import type { SurfaceModel, ReactComponentImplementation } from '@a2ui/react/v0_9'
+import { reduceEvent, addUserMessage, emptyChatState, type ChatState } from './agentState'
+
+type Surface = SurfaceModel<ReactComponentImplementation>
+
+export function useAgent(token: string) {
+  const agent = useMemo(() => new HttpAgent({ url: '/agui', headers: { Authorization: `Bearer ${token}` } }), [token])
+  const processor = useMemo(() => new MessageProcessor([basicCatalog]), [])
+
+  const [chat, setChat] = useState<ChatState>(emptyChatState)
+  const [surfaces, setSurfaces] = useState<Surface[]>([])
+  const [running, setRunning] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const syncSurfaces = () => setSurfaces(Array.from(processor.model.surfacesMap.values()) as Surface[])
+    const created = processor.onSurfaceCreated(syncSurfaces)
+    const deleted = processor.onSurfaceDeleted(syncSurfaces)
+    const sub = agent.subscribe({
+      onTextMessageStartEvent: ({ event }) => setChat((s) => reduceEvent(s, event as any)),
+      onTextMessageContentEvent: ({ event }) => setChat((s) => reduceEvent(s, event as any)),
+      onToolCallStartEvent: ({ event }) => setChat((s) => reduceEvent(s, event as any)),
+      onToolCallArgsEvent: ({ event }) => setChat((s) => reduceEvent(s, event as any)),
+      onCustomEvent: ({ event }) => {
+        if ((event as any).name === 'a2ui.operations') processor.processMessages((event as any).value)
+      },
+      onRunErrorEvent: ({ event }) => setError((event as any).message ?? 'run error'),
+    })
+    return () => { sub.unsubscribe(); created.unsubscribe(); deleted.unsubscribe() }
+  }, [agent, processor])
+
+  const send = (text: string) => {
+    if (!text.trim() || running) return
+    setError(null)
+    setChat((s) => addUserMessage(s, crypto.randomUUID(), text))
+    agent.addMessage({ id: crypto.randomUUID(), role: 'user', content: text })
+    setRunning(true)
+    agent.runAgent().catch((e) => setError(String(e))).finally(() => setRunning(false))
+  }
+
+  return { chat, surfaces, send, running, error }
+}

--- a/browserweb/tsconfig.app.json
+++ b/browserweb/tsconfig.app.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2022", "useDefineForClassFields": true, "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext", "skipLibCheck": true, "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true, "verbatimModuleSyntax": true, "moduleDetection": "force",
+    "noEmit": true, "jsx": "react-jsx", "strict": true, "noUnusedLocals": true,
+    "noUnusedParameters": true, "noFallthroughCasesInSwitch": true, "types": ["vitest/globals"]
+  },
+  "include": ["src"]
+}

--- a/browserweb/tsconfig.json
+++ b/browserweb/tsconfig.json
@@ -1,0 +1,1 @@
+{ "files": [], "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }] }

--- a/browserweb/tsconfig.node.json
+++ b/browserweb/tsconfig.node.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "target": "ES2023", "lib": ["ES2023"], "module": "ESNext", "skipLibCheck": true,
+    "moduleResolution": "bundler", "allowImportingTsExtensions": true, "noEmit": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/browserweb/vite.config.ts
+++ b/browserweb/vite.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  server: {
+    proxy: { '/agui': 'http://localhost:8088' },
+  },
+})

--- a/deploy/helm/agentserver/Chart.yaml
+++ b/deploy/helm/agentserver/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: agentserver
 description: Run your coding agent in the browser — a self-hosted web interface for opencode
 type: application
-version: 0.70.0
-appVersion: "0.70.0"
+version: 0.71.0
+appVersion: "0.71.0"
 home: https://github.com/agentserver/agentserver
 sources:
   - https://github.com/agentserver/agentserver

--- a/deploy/helm/agentserver/templates/browser-gateway.yaml
+++ b/deploy/helm/agentserver/templates/browser-gateway.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.browserGateway.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-browser-gateway
+  labels:
+    app: {{ .Release.Name }}-browser-gateway
+spec:
+  replicas: {{ .Values.browserGateway.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-browser-gateway
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-browser-gateway
+    spec:
+      serviceAccountName: {{ .Release.Name }}
+      containers:
+        - name: browser-gateway
+          image: "{{ .Values.browserGateway.image.repository }}:{{ .Values.browserGateway.image.tag }}"
+          imagePullPolicy: {{ .Values.browserGateway.image.pullPolicy }}
+          args: ["serve"]
+          ports:
+            - containerPort: {{ .Values.browserGateway.port }}
+          env:
+            - name: BRG_LISTEN_ADDR
+              value: ":{{ .Values.browserGateway.port }}"
+            - name: BRG_CODEX_APP_GATEWAY_WS_URL
+              value: "ws://{{ .Release.Name }}-codex-app-gateway.{{ .Release.Namespace }}.svc:{{ .Values.codexAppGateway.port }}"
+            - name: BRG_ALLOWED_ORIGINS
+              value: {{ .Values.browserGateway.allowedOrigins | quote }}
+            - name: BRG_LOG_LEVEL
+              value: {{ .Values.browserGateway.logLevel | quote }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.browserGateway.port }}
+            initialDelaySeconds: 3
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-browser-gateway
+  labels:
+    app: {{ .Release.Name }}-browser-gateway
+spec:
+  selector:
+    app: {{ .Release.Name }}-browser-gateway
+  ports:
+    - port: {{ .Values.browserGateway.port }}
+      targetPort: {{ .Values.browserGateway.port }}
+{{- end }}

--- a/deploy/helm/agentserver/templates/browser-gateway.yaml
+++ b/deploy/helm/agentserver/templates/browser-gateway.yaml
@@ -15,7 +15,6 @@ spec:
       labels:
         app: {{ .Release.Name }}-browser-gateway
     spec:
-      serviceAccountName: {{ .Release.Name }}
       containers:
         - name: browser-gateway
           image: "{{ .Values.browserGateway.image.repository }}:{{ .Values.browserGateway.image.tag }}"

--- a/deploy/helm/agentserver/templates/httproute.yaml
+++ b/deploy/helm/agentserver/templates/httproute.yaml
@@ -9,6 +9,8 @@ main gateway host. Operator can override via {codexAppGateway,codexExecGateway}.
 {{- if and .Values.codexExecGateway.enabled (not $codexExecHost) }}{{- $codexExecHost = printf "codex-exec.%s" .Values.gateway.host }}{{- end }}
 {{- $codexAuthHost := .Values.codexAuth.externalHost }}
 {{- if and .Values.codexAuth.enabled (not $codexAuthHost) }}{{- $codexAuthHost = printf "codex-auth.%s" .Values.gateway.host }}{{- end }}
+{{- $browserGatewayHost := .Values.browserGateway.externalHost }}
+{{- if and .Values.browserGateway.enabled (not $browserGatewayHost) }}{{- $browserGatewayHost = printf "browser-gateway.%s" .Values.gateway.host }}{{- end }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -119,5 +121,25 @@ spec:
       backendRefs:
         - name: {{ .Release.Name }}-codex-exec-gateway
           port: {{ .Values.codexExecGateway.port }}
+{{- end }}
+{{- if .Values.browserGateway.enabled }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ .Release.Name }}-browser-gateway
+spec:
+  parentRefs:
+    {{- toYaml .Values.gateway.parentRefs | nindent 4 }}
+  hostnames:
+    - {{ $browserGatewayHost | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: {{ .Release.Name }}-browser-gateway
+          port: {{ .Values.browserGateway.port }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/agentserver/values.yaml
+++ b/deploy/helm/agentserver/values.yaml
@@ -302,8 +302,8 @@ browserGateway:
   replicaCount: 1
   port: 8088
   logLevel: info
-  # Comma-separated CORS allowlist; "*" for dev.
-  allowedOrigins: "*"
+  # CORS allowlist (comma-separated origins). Empty = same-origin only (no CORS). Set explicit origins for third-party AG-UI frontends; "*" is unsafe outside dev.
+  allowedOrigins: ""
 
 codexAppGateway:
   enabled: false

--- a/deploy/helm/agentserver/values.yaml
+++ b/deploy/helm/agentserver/values.yaml
@@ -293,6 +293,18 @@ codexGateway:
 # bindings from codex-exec-gateway, mints per-turn cap tokens, and writes
 # config.toml entries that route remote tool calls through the env-mcp
 # child binary.
+browserGateway:
+  enabled: false
+  image:
+    repository: ghcr.io/agentserver/browser-gateway
+    tag: latest
+    pullPolicy: Always
+  replicaCount: 1
+  port: 8088
+  logLevel: info
+  # Comma-separated CORS allowlist; "*" for dev.
+  allowedOrigins: "*"
+
 codexAppGateway:
   enabled: false
   image:

--- a/docs/superpowers/plans/2026-07-20-browser-gateway-frontend-p3.md
+++ b/docs/superpowers/plans/2026-07-20-browser-gateway-frontend-p3.md
@@ -1,0 +1,797 @@
+# browser-gateway frontend + deploy (P3) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a `browserweb` reference SPA (Vite + React 19) that connects to the browser-gateway `POST /agui` endpoint, renders streaming chat + tool calls, and renders the gateway's `a2ui.operations` CUSTOM events as A2UI cards — then embed it in the Go binary and wire deployment (Dockerfile frontend stage, CI, Helm) so a single `browser-gateway` container serves both the endpoint and the UI.
+
+**Architecture:** A **pure client-side** SPA (no Node/Next.js runtime): `@ag-ui/client`'s `HttpAgent` talks HTTP+SSE directly to `/agui`; `@a2ui/react`'s `MessageProcessor` + `<A2uiSurface>` render the A2UI v0.9 cards from `onCustomEvent`. The built `dist` is embedded via `//go:embed` and served by the gateway's HTTP server. CopilotKit is intentionally NOT used (it requires a separate Node runtime, incompatible with single-binary deploy).
+
+**Tech Stack:** Vite 7 + React 19 + Tailwind 4 (mirroring the repo's existing `web/`); `@ag-ui/client@0.0.57`, `@a2ui/react@0.10.2`, `@a2ui/web_core@0.10.5`, `zod@^3.25.76`; Go `embed`; GitHub Actions; Helm.
+
+**Builds on:** P1 (`browser-gateway-p1`, PR #292) + P2 (`browser-gateway-p2`, PR #293). **Stacked branch off `browser-gateway-p2`** (`b277303`). Spec: `docs/superpowers/specs/2026-07-20-browser-gateway-design.md`.
+
+## Global Constraints
+
+- Repo module `github.com/agentserver/agentserver`, Go 1.26. Branch: stack on `browser-gateway-p2` (base `b277303`). Subagents run in `/root/agentserver` (NO worktree — subagent cwd pins to repo root). npm registry IS reachable in this environment (frontend can be installed/built).
+- **Frontend stack (exact, verified on npm):** deps `@ag-ui/client@0.0.57`, `@a2ui/react@0.10.2`, `@a2ui/web_core@0.10.5`, `react@^19.2.0`, `react-dom@^19.2.0`, `zod@^3.25.76`; devDeps `vite@^7`, `@vitejs/plugin-react@^5`, `typescript@~5.9`, `@tailwindcss/vite@^4`, `tailwindcss@^4`, `@types/react@^19`, `@types/react-dom@^19`, `vitest@^3`. **Pin one `zod@^3.25.76`** (satisfies both @ag-ui and @a2ui; a stray zod 3.22 breaks A2UI). Use TS `moduleResolution: "bundler"` so the `/v0_9` subpath exports resolve.
+- **AG-UI client API (verified):** `import { HttpAgent } from "@ag-ui/client"`. Construct `new HttpAgent({ url, headers: { Authorization: "Bearer "+token } })`. Subscribe via `agent.subscribe({ onTextMessageStartEvent, onTextMessageContentEvent, onTextMessageEndEvent, onToolCallStartEvent, onToolCallArgsEvent, onToolCallEndEvent, onCustomEvent, onRunFinishedEvent, onRunErrorEvent })` → returns `{ unsubscribe }`. Each callback gets `{ event, ... }`; `event` is a typed object. Send a turn: `agent.addMessage({ id, role: "user", content })` then `await agent.runAgent()`. The agent owns `messages`/`threadId`/`state`.
+- **CUSTOM → A2UI carrier:** `onCustomEvent: ({ event }) => { if (event.name === "a2ui.operations") processor.processMessages(event.value) }`. `event.value` is the A2UI v0.9 message array.
+- **A2UI renderer API (verified):** `import { MessageProcessor } from "@a2ui/web_core/v0_9"`; `import { A2uiSurface, basicCatalog } from "@a2ui/react/v0_9"`; import CSS `@a2ui/react/styles/structural.css`. `const processor = new MessageProcessor([basicCatalog]); processor.processMessages(msgs);` Surfaces live in `processor.model.surfacesMap` (a `Map<string, SurfaceModel>`); subscribe to changes via `processor.onSurfaceCreated(fn)` / `processor.onSurfaceDeleted(fn)` (each returns `{ unsubscribe }`). Render `<A2uiSurface surface={s} />` per surface; it self-updates on later `updateComponents`/`updateDataModel`.
+- **Auth:** the SPA obtains a workspace codex token (minted by the console `POST /api/codex/tokens`, verified by CXG `RemoteVerifier`) and sends it as the Bearer. v1 UX: read `?token=` from the URL, else a paste field; store in memory only.
+- **Serve:** built `dist` embedded via `browserweb/embed.go` (`//go:embed all:dist`) and served by the gateway server for `GET /` + non-API paths, with SPA fallback to `index.html`. `/agui`, `/healthz` keep precedence.
+- **Deploy patterns (mirror existing):** Dockerfile — root `Dockerfile` builds `web/` in a `node:25-slim` pnpm stage then `COPY --from=frontend dist` into the Go build context (embed at Go-build time). CI — `.github/workflows/build.yml` has one job per image (login → `docker/metadata-action` `images: ghcr.io/agentserver/<name>` → `docker/build-push-action` `file: ./Dockerfile.<name>`); mirror `build-credentialproxy`. Helm — `deploy/helm/agentserver/templates/<name>.yaml` + a `values.yaml` block + httproute; browser-gateway's is a plain Deployment+Service (no S3/secrets), env `BRG_CODEX_APP_GATEWAY_WS_URL` pointing at the in-cluster codex-app-gateway service.
+- TDD where there's real logic (the pure event→state reducer; the Go serve route). Frontend components verified by `pnpm build` (tsc + vite) succeeding. `gofmt -w` Go; commit per task.
+
+---
+
+### Task 1: Scaffold `browserweb` (build + deps resolve)
+
+**Files:**
+- Create: `browserweb/package.json`, `browserweb/vite.config.ts`, `browserweb/tsconfig.json`, `browserweb/tsconfig.app.json`, `browserweb/tsconfig.node.json`, `browserweb/index.html`, `browserweb/src/main.tsx`, `browserweb/src/App.tsx`, `browserweb/src/index.css`, `browserweb/.gitignore`
+
+**Interfaces:**
+- Produces: a buildable Vite app; `pnpm build` emits `browserweb/dist/`.
+
+- [ ] **Step 1: package.json**
+
+`browserweb/package.json`:
+```json
+{
+  "name": "browserweb",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@a2ui/react": "0.10.2",
+    "@a2ui/web_core": "0.10.5",
+    "@ag-ui/client": "0.0.57",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "zod": "^3.25.76"
+  },
+  "devDependencies": {
+    "@tailwindcss/vite": "^4.2.1",
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.1.1",
+    "tailwindcss": "^4.2.1",
+    "typescript": "~5.9.3",
+    "vite": "^7.3.1",
+    "vitest": "^3.2.0"
+  }
+}
+```
+
+- [ ] **Step 2: vite + tsconfig + gitignore**
+
+`browserweb/vite.config.ts`:
+```ts
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+import tailwindcss from '@tailwindcss/vite'
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  server: {
+    proxy: { '/agui': 'http://localhost:8088' },
+  },
+})
+```
+`browserweb/tsconfig.json`:
+```json
+{ "files": [], "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }] }
+```
+`browserweb/tsconfig.app.json`:
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022", "useDefineForClassFields": true, "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext", "skipLibCheck": true, "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true, "verbatimModuleSyntax": true, "moduleDetection": "force",
+    "noEmit": true, "jsx": "react-jsx", "strict": true, "noUnusedLocals": true,
+    "noUnusedParameters": true, "noFallthroughCasesInSwitch": true, "types": ["vitest/globals"]
+  },
+  "include": ["src"]
+}
+```
+`browserweb/tsconfig.node.json`:
+```json
+{
+  "compilerOptions": {
+    "target": "ES2023", "lib": ["ES2023"], "module": "ESNext", "skipLibCheck": true,
+    "moduleResolution": "bundler", "allowImportingTsExtensions": true, "noEmit": true
+  },
+  "include": ["vite.config.ts"]
+}
+```
+`browserweb/.gitignore`:
+```
+node_modules
+dist
+```
+
+- [ ] **Step 3: index.html + minimal app + css**
+
+`browserweb/index.html`:
+```html
+<!doctype html>
+<html lang="en">
+  <head><meta charset="UTF-8" /><meta name="viewport" content="width=device-width, initial-scale=1.0" /><title>browser-gateway</title></head>
+  <body><div id="root"></div><script type="module" src="/src/main.tsx"></script></body>
+</html>
+```
+`browserweb/src/index.css`:
+```css
+@import "tailwindcss";
+@import "@a2ui/react/styles/structural.css";
+```
+`browserweb/src/main.tsx`:
+```tsx
+import { StrictMode } from 'react'
+import { createRoot } from 'react-dom/client'
+import './index.css'
+import { App } from './App'
+
+createRoot(document.getElementById('root')!).render(<StrictMode><App /></StrictMode>)
+```
+`browserweb/src/App.tsx` (placeholder; replaced in Task 4):
+```tsx
+export function App() {
+  return <div className="p-4">browser-gateway UI</div>
+}
+```
+
+- [ ] **Step 4: install + build**
+
+Run:
+```bash
+cd /root/agentserver/browserweb && pnpm install && pnpm build
+```
+Expected: install resolves all deps from npm (no peer/zod conflicts), `pnpm build` runs `tsc -b` clean and emits `browserweb/dist/index.html` + assets. If `pnpm` complains about a missing lockfile flag, plain `pnpm install` (which writes `pnpm-lock.yaml`) is correct here — commit the lockfile.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /root/agentserver
+git add browserweb/package.json browserweb/pnpm-lock.yaml browserweb/vite.config.ts browserweb/tsconfig*.json browserweb/index.html browserweb/.gitignore browserweb/src/
+git commit -m "feat(browser-gateway): scaffold browserweb Vite+React SPA"
+```
+
+---
+
+### Task 2: Pure AG-UI event → chat state reducer (tested)
+
+**Files:**
+- Create: `browserweb/src/agentState.ts`
+- Test: `browserweb/src/agentState.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `type ChatMessage = { id: string; role: "user" | "assistant"; text: string }`
+  - `type ToolCall = { id: string; name: string; args: string }`
+  - `type ChatState = { messages: ChatMessage[]; tools: ToolCall[] }`
+  - `const emptyChatState: ChatState`
+  - `function reduceEvent(state: ChatState, ev: { type: string; [k: string]: any }): ChatState` — pure; applies one AG-UI event.
+
+- [ ] **Step 1: Write the failing test**
+
+`browserweb/src/agentState.test.ts`:
+```ts
+import { describe, it, expect } from 'vitest'
+import { reduceEvent, emptyChatState } from './agentState'
+
+describe('reduceEvent', () => {
+  it('assembles a streamed assistant message from START/CONTENT/END', () => {
+    let s = emptyChatState
+    s = reduceEvent(s, { type: 'TEXT_MESSAGE_START', messageId: 'm1', role: 'assistant' })
+    s = reduceEvent(s, { type: 'TEXT_MESSAGE_CONTENT', messageId: 'm1', delta: 'Hel' })
+    s = reduceEvent(s, { type: 'TEXT_MESSAGE_CONTENT', messageId: 'm1', delta: 'lo' })
+    s = reduceEvent(s, { type: 'TEXT_MESSAGE_END', messageId: 'm1' })
+    expect(s.messages).toEqual([{ id: 'm1', role: 'assistant', text: 'Hello' }])
+  })
+
+  it('records a tool call from START/ARGS/END', () => {
+    let s = emptyChatState
+    s = reduceEvent(s, { type: 'TOOL_CALL_START', toolCallId: 't1', toolCallName: 'shell' })
+    s = reduceEvent(s, { type: 'TOOL_CALL_ARGS', toolCallId: 't1', delta: 'ls -la' })
+    s = reduceEvent(s, { type: 'TOOL_CALL_END', toolCallId: 't1' })
+    expect(s.tools).toEqual([{ id: 't1', name: 'shell', args: 'ls -la' }])
+  })
+
+  it('ignores unrelated events without mutating input', () => {
+    const s0 = emptyChatState
+    const s1 = reduceEvent(s0, { type: 'CUSTOM', name: 'a2ui.operations', value: [] })
+    expect(s1).toBe(s0)
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd /root/agentserver/browserweb && pnpm test`
+Expected: FAIL (cannot import `reduceEvent`/`emptyChatState`).
+
+- [ ] **Step 3: Implement the reducer**
+
+`browserweb/src/agentState.ts`:
+```ts
+export type ChatMessage = { id: string; role: 'user' | 'assistant'; text: string }
+export type ToolCall = { id: string; name: string; args: string }
+export type ChatState = { messages: ChatMessage[]; tools: ToolCall[] }
+
+export const emptyChatState: ChatState = { messages: [], tools: [] }
+
+// reduceEvent applies one AG-UI event to the chat state. Pure: returns the
+// same reference when the event does not affect chat/tool state.
+export function reduceEvent(state: ChatState, ev: { type: string; [k: string]: any }): ChatState {
+  switch (ev.type) {
+    case 'TEXT_MESSAGE_START':
+      return { ...state, messages: [...state.messages, { id: ev.messageId, role: 'assistant', text: '' }] }
+    case 'TEXT_MESSAGE_CONTENT':
+      return {
+        ...state,
+        messages: state.messages.map((m) => (m.id === ev.messageId ? { ...m, text: m.text + (ev.delta ?? '') } : m)),
+      }
+    case 'TOOL_CALL_START':
+      return { ...state, tools: [...state.tools, { id: ev.toolCallId, name: ev.toolCallName, args: '' }] }
+    case 'TOOL_CALL_ARGS':
+      return {
+        ...state,
+        tools: state.tools.map((t) => (t.id === ev.toolCallId ? { ...t, args: t.args + (ev.delta ?? '') } : t)),
+      }
+    default:
+      return state // TEXT_MESSAGE_END, TOOL_CALL_END, CUSTOM, RUN_*, etc. — no chat-state change here
+  }
+}
+
+// addUserMessage appends a user-authored message (used when the user submits input).
+export function addUserMessage(state: ChatState, id: string, text: string): ChatState {
+  return { ...state, messages: [...state.messages, { id, role: 'user', text }] }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd /root/agentserver/browserweb && pnpm test`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /root/agentserver
+git add browserweb/src/agentState.ts browserweb/src/agentState.test.ts
+git commit -m "feat(browser-gateway): pure AG-UI event→chat-state reducer + tests"
+```
+
+---
+
+### Task 3: `useAgent` hook — HttpAgent + A2UI processor wiring
+
+**Files:**
+- Create: `browserweb/src/useAgent.ts`
+
+**Interfaces:**
+- Consumes: `HttpAgent` from `@ag-ui/client`; `MessageProcessor` + `basicCatalog` from `@a2ui/*/v0_9`; `reduceEvent`/`addUserMessage`/`ChatState`/`emptyChatState` (Task 2).
+- Produces: `function useAgent(token: string): { chat: ChatState; surfaces: SurfaceModel<...>[]; send: (text: string) => void; running: boolean; error: string | null }`
+
+- [ ] **Step 1: Implement the hook**
+
+`browserweb/src/useAgent.ts`:
+```ts
+import { useEffect, useMemo, useState } from 'react'
+import { HttpAgent } from '@ag-ui/client'
+import { MessageProcessor } from '@a2ui/web_core/v0_9'
+import { basicCatalog } from '@a2ui/react/v0_9'
+import type { SurfaceModel, ReactComponentImplementation } from '@a2ui/react/v0_9'
+import { reduceEvent, addUserMessage, emptyChatState, type ChatState } from './agentState'
+
+type Surface = SurfaceModel<ReactComponentImplementation>
+
+export function useAgent(token: string) {
+  const agent = useMemo(() => new HttpAgent({ url: '/agui', headers: { Authorization: `Bearer ${token}` } }), [token])
+  const processor = useMemo(() => new MessageProcessor([basicCatalog]), [])
+
+  const [chat, setChat] = useState<ChatState>(emptyChatState)
+  const [surfaces, setSurfaces] = useState<Surface[]>([])
+  const [running, setRunning] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const syncSurfaces = () => setSurfaces(Array.from(processor.model.surfacesMap.values()) as Surface[])
+    const created = processor.onSurfaceCreated(syncSurfaces)
+    const deleted = processor.onSurfaceDeleted(syncSurfaces)
+    const sub = agent.subscribe({
+      onTextMessageStartEvent: ({ event }) => setChat((s) => reduceEvent(s, event as any)),
+      onTextMessageContentEvent: ({ event }) => setChat((s) => reduceEvent(s, event as any)),
+      onToolCallStartEvent: ({ event }) => setChat((s) => reduceEvent(s, event as any)),
+      onToolCallArgsEvent: ({ event }) => setChat((s) => reduceEvent(s, event as any)),
+      onCustomEvent: ({ event }) => {
+        if ((event as any).name === 'a2ui.operations') processor.processMessages((event as any).value)
+      },
+      onRunErrorEvent: ({ event }) => setError((event as any).message ?? 'run error'),
+    })
+    return () => { sub.unsubscribe(); created.unsubscribe(); deleted.unsubscribe() }
+  }, [agent, processor])
+
+  const send = (text: string) => {
+    if (!text.trim() || running) return
+    setError(null)
+    setChat((s) => addUserMessage(s, crypto.randomUUID(), text))
+    agent.addMessage({ id: crypto.randomUUID(), role: 'user', content: text })
+    setRunning(true)
+    agent.runAgent().catch((e) => setError(String(e))).finally(() => setRunning(false))
+  }
+
+  return { chat, surfaces, send, running, error }
+}
+```
+(Note: `event as any` casts are deliberate — the subscriber gives typed events, but we read a small common subset via the reducer; keep the reducer as the single typed surface. If TS flags a missing `SurfaceModel`/`ReactComponentImplementation` export path, they are exported from `@a2ui/react/v0_9` per the renderer — adjust the import to the type's actual export if the compiler disagrees.)
+
+- [ ] **Step 2: Typecheck (build)**
+
+Run: `cd /root/agentserver/browserweb && pnpm build`
+Expected: `tsc -b` passes (the hook typechecks against the real @ag-ui / @a2ui types) and vite builds. If a subscriber callback name or an @a2ui type import differs from the above, fix it against the installed package's `.d.ts` (the API is verified but exact type-export paths must satisfy the compiler). Do genuine type-driven fixes; don't `// @ts-nocheck`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /root/agentserver
+git add browserweb/src/useAgent.ts
+git commit -m "feat(browser-gateway): useAgent hook (HttpAgent + A2UI processor)"
+```
+
+---
+
+### Task 4: Chat UI + A2UI surface rendering
+
+**Files:**
+- Modify: `browserweb/src/App.tsx`
+
+**Interfaces:**
+- Consumes: `useAgent` (Task 3); `A2uiSurface` from `@a2ui/react/v0_9`.
+
+- [ ] **Step 1: Implement App**
+
+`browserweb/src/App.tsx`:
+```tsx
+import { useState } from 'react'
+import { A2uiSurface } from '@a2ui/react/v0_9'
+import { useAgent } from './useAgent'
+
+function tokenFromUrl(): string {
+  return new URLSearchParams(window.location.search).get('token') ?? ''
+}
+
+export function App() {
+  const [token, setToken] = useState(tokenFromUrl)
+  if (!token) return <TokenGate onSubmit={setToken} />
+  return <Chat token={token} />
+}
+
+function TokenGate({ onSubmit }: { onSubmit: (t: string) => void }) {
+  const [v, setV] = useState('')
+  return (
+    <div className="mx-auto max-w-md p-8">
+      <h1 className="mb-2 text-lg font-semibold">browser-gateway</h1>
+      <p className="mb-4 text-sm text-gray-600">Paste a workspace codex token to connect.</p>
+      <input className="w-full rounded border p-2" value={v} onChange={(e) => setV(e.target.value)} placeholder="token" />
+      <button className="mt-3 rounded bg-black px-4 py-2 text-white" onClick={() => v.trim() && onSubmit(v.trim())}>Connect</button>
+    </div>
+  )
+}
+
+function Chat({ token }: { token: string }) {
+  const { chat, surfaces, send, running, error } = useAgent(token)
+  const [input, setInput] = useState('')
+  const submit = () => { send(input); setInput('') }
+  return (
+    <div className="mx-auto flex max-w-3xl flex-col gap-3 p-4">
+      {error && <div className="rounded bg-red-50 p-2 text-sm text-red-700">{error}</div>}
+      <div className="flex flex-col gap-2">
+        {chat.messages.map((m) => (
+          <div key={m.id} className={m.role === 'user' ? 'self-end rounded bg-blue-100 px-3 py-2' : 'self-start rounded bg-gray-100 px-3 py-2'}>
+            <span className="whitespace-pre-wrap">{m.text}</span>
+          </div>
+        ))}
+        {chat.tools.map((t) => (
+          <div key={t.id} className="self-start rounded border border-gray-300 px-3 py-2 font-mono text-xs">
+            <div className="font-semibold">{t.name}</div>
+            <div className="whitespace-pre-wrap text-gray-700">{t.args}</div>
+          </div>
+        ))}
+        {surfaces.map((s) => <A2uiSurface key={s.id} surface={s} />)}
+      </div>
+      <div className="flex gap-2">
+        <input className="flex-1 rounded border p-2" value={input} onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => e.key === 'Enter' && submit()} placeholder={running ? 'running…' : 'message'} disabled={running} />
+        <button className="rounded bg-black px-4 py-2 text-white disabled:opacity-50" onClick={submit} disabled={running}>Send</button>
+      </div>
+    </div>
+  )
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `cd /root/agentserver/browserweb && pnpm build`
+Expected: clean tsc + vite build; `browserweb/dist/` populated.
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /root/agentserver
+git add browserweb/src/App.tsx
+git commit -m "feat(browser-gateway): chat UI + A2UI surface rendering"
+```
+
+---
+
+### Task 5: Embed the SPA + serve it from the gateway
+
+**Files:**
+- Create: `browserweb/embed.go`
+- Modify: `internal/browsergateway/server.go`
+- Test: `internal/browsergateway/server_test.go`
+
+**Interfaces:**
+- Consumes: P1 `Server.Handler()`.
+- Produces: `browserweb.StaticFS embed.FS`; a static/SPA route on the gateway (`GET /` + non-API paths → embedded `dist`, SPA fallback to `index.html`).
+
+- [ ] **Step 1: embed.go + a committed dist placeholder**
+
+`browserweb/embed.go`:
+```go
+// Package browserweb embeds the built browser-gateway reference SPA.
+package browserweb
+
+import "embed"
+
+//go:embed all:dist
+var StaticFS embed.FS
+```
+`go:embed` fails to compile if `dist/` is absent. Since `dist` is gitignored (Task 1) and built in CI/Docker, commit a tiny placeholder so local `go build` works and tests have something to serve:
+`browserweb/dist/index.html`:
+```html
+<!doctype html><title>browser-gateway</title><div id="root"></div>
+```
+Force-add it past .gitignore in Step 5.
+
+- [ ] **Step 2: Write the failing serve test**
+
+Add to `internal/browsergateway/server_test.go`:
+```go
+func TestServer_ServesSPA(t *testing.T) {
+	s := NewServer(ServeConfig{CodexAppGatewayWSURL: "ws://unused", AllowedOrigins: []string{"*"}}, slog.Default())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	s.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET / = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "<div id=\"root\">") {
+		t.Errorf("GET / did not serve the SPA index; body=%q", rec.Body.String())
+	}
+}
+
+func TestServer_SPAFallback(t *testing.T) {
+	s := NewServer(ServeConfig{CodexAppGatewayWSURL: "ws://unused", AllowedOrigins: []string{"*"}}, slog.Default())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/some/client/route", nil)
+	s.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("client route = %d, want 200 (SPA fallback)", rec.Code)
+	}
+}
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd /root/agentserver && go test ./internal/browsergateway/ -run 'TestServer_ServesSPA|TestServer_SPAFallback' -v`
+Expected: FAIL (no route for `/`; 404).
+
+- [ ] **Step 4: Add static serving to server.go**
+
+In `internal/browsergateway/server.go`: import `io/fs`, `net/http`, and `github.com/agentserver/agentserver/browserweb`. In `Handler()`, after registering `/healthz` and `POST /agui`, add a catch-all `GET /` that serves the embedded SPA with fallback:
+```go
+	mux.Handle("GET /", spaHandler())
+```
+and add:
+```go
+// spaHandler serves the embedded browserweb SPA, falling back to index.html
+// for client-side routes (any path that isn't a real embedded file).
+func spaHandler() http.Handler {
+	sub, err := fs.Sub(browserweb.StaticFS, "dist")
+	if err != nil {
+		panic("browserweb dist embed: " + err.Error())
+	}
+	fileServer := http.FileServer(http.FS(sub))
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fs.Stat(sub, strings.TrimPrefix(r.URL.Path, "/")); err != nil && r.URL.Path != "/" {
+			r = r.Clone(r.Context())
+			r.URL.Path = "/"
+		}
+		fileServer.ServeHTTP(w, r)
+	})
+}
+```
+(Go 1.22 mux: the `GET /` pattern is the lowest-precedence catch-all, so `GET /healthz` and `POST /agui` still win for their exact paths.)
+
+- [ ] **Step 5: Run tests + commit**
+
+Run: `cd /root/agentserver && go test ./internal/browsergateway/... -count=1`
+Expected: PASS (including the two new SPA tests and all prior tests).
+```bash
+cd /root/agentserver && gofmt -w internal/browsergateway/server.go
+git add browserweb/embed.go internal/browsergateway/server.go internal/browsergateway/server_test.go
+git add -f browserweb/dist/index.html
+git commit -m "feat(browser-gateway): embed + serve the browserweb SPA (SPA fallback)"
+```
+
+---
+
+### Task 6: Dockerfile — frontend build stage + embed
+
+**Files:**
+- Modify: `Dockerfile.browser-gateway`
+
+**Interfaces:**
+- Produces: an image whose Go build embeds the freshly-built `browserweb/dist`.
+
+- [ ] **Step 1: Rewrite Dockerfile.browser-gateway with a frontend stage**
+
+`Dockerfile.browser-gateway`:
+```dockerfile
+# syntax=docker/dockerfile:1
+# Stage 1: build the browserweb SPA
+FROM node:25-slim AS frontend
+RUN npm install -g pnpm
+WORKDIR /app/browserweb
+COPY browserweb/package.json browserweb/pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+COPY browserweb/ ./
+RUN pnpm build
+
+# Stage 2: build the Go binary (embeds browserweb/dist)
+FROM golang:1.26-trixie AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+COPY --from=frontend /app/browserweb/dist ./browserweb/dist
+RUN CGO_ENABLED=0 go build -trimpath -ldflags='-s -w' \
+    -o /out/browser-gateway ./cmd/browser-gateway
+
+FROM debian:trixie-slim
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates \
+ && rm -rf /var/lib/apt/lists/*
+COPY --from=build /out/browser-gateway /usr/local/bin/browser-gateway
+ENTRYPOINT ["/usr/local/bin/browser-gateway"]
+CMD ["serve"]
+EXPOSE 8088
+```
+
+- [ ] **Step 2: Verify the image builds (if docker available)**
+
+Run: `cd /root/agentserver && docker build -f Dockerfile.browser-gateway -t browser-gateway:dev .`
+Expected: frontend stage installs + builds the SPA; Go stage embeds the real dist; image builds.
+If docker is unavailable here, SKIP and note it; the load-bearing local checks are `cd browserweb && pnpm build` (Task 4) and `go build ./...` (already green).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /root/agentserver
+git add Dockerfile.browser-gateway
+git commit -m "feat(browser-gateway): Dockerfile frontend build stage + embed"
+```
+
+---
+
+### Task 7: CI — `build-browser-gateway` job
+
+**Files:**
+- Modify: `.github/workflows/build.yml`
+
+**Interfaces:**
+- Produces: a CI job that builds+pushes `ghcr.io/agentserver/browser-gateway` from `Dockerfile.browser-gateway`.
+
+- [ ] **Step 1: Add the job**
+
+In `.github/workflows/build.yml`, add a job mirroring `build-credentialproxy` (after the existing gateway jobs, e.g. after `build-cc-app-gateway`):
+```yaml
+  build-browser-gateway:
+    runs-on: ubuntu-latest
+    needs: [test]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v6
+        id: meta
+        with:
+          images: ${{ env.REGISTRY }}/agentserver/browser-gateway
+          tags: |
+            type=sha,prefix=
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile.browser-gateway
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+```
+
+- [ ] **Step 2: Validate the workflow YAML**
+
+Run: `cd /root/agentserver && python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/build.yml')); print('yaml ok')"`
+Expected: `yaml ok` (no parse error). Confirm the new job's indentation matches the sibling jobs (2-space job key under `jobs:`).
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd /root/agentserver
+git add .github/workflows/build.yml
+git commit -m "ci(browser-gateway): build+push image job"
+```
+
+---
+
+### Task 8: Helm — deployment, service, values, route
+
+**Files:**
+- Create: `deploy/helm/agentserver/templates/browser-gateway.yaml`
+- Modify: `deploy/helm/agentserver/values.yaml`
+- Modify: `deploy/helm/agentserver/templates/httproute.yaml` (add the route if the chart uses HTTPRoute; else `ingress.yaml`)
+
+**Interfaces:**
+- Produces: an opt-in (`browserGateway.enabled`) Deployment+Service wired to the in-cluster codex-app-gateway, plus a public route.
+
+- [ ] **Step 1: values.yaml block**
+
+Add to `deploy/helm/agentserver/values.yaml` (near `codexAppGateway:`):
+```yaml
+browserGateway:
+  enabled: false
+  image:
+    repository: ghcr.io/agentserver/browser-gateway
+    tag: latest
+    pullPolicy: Always
+  replicaCount: 1
+  port: 8088
+  logLevel: info
+  # Comma-separated CORS allowlist; "*" for dev.
+  allowedOrigins: "*"
+```
+
+- [ ] **Step 2: template**
+
+`deploy/helm/agentserver/templates/browser-gateway.yaml`:
+```yaml
+{{- if .Values.browserGateway.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-browser-gateway
+  labels:
+    app: {{ .Release.Name }}-browser-gateway
+spec:
+  replicas: {{ .Values.browserGateway.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ .Release.Name }}-browser-gateway
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-browser-gateway
+    spec:
+      serviceAccountName: {{ .Release.Name }}
+      containers:
+        - name: browser-gateway
+          image: "{{ .Values.browserGateway.image.repository }}:{{ .Values.browserGateway.image.tag }}"
+          imagePullPolicy: {{ .Values.browserGateway.image.pullPolicy }}
+          args: ["serve"]
+          ports:
+            - containerPort: {{ .Values.browserGateway.port }}
+          env:
+            - name: BRG_LISTEN_ADDR
+              value: ":{{ .Values.browserGateway.port }}"
+            - name: BRG_CODEX_APP_GATEWAY_WS_URL
+              value: "ws://{{ .Release.Name }}-codex-app-gateway.{{ .Release.Namespace }}.svc:{{ .Values.codexAppGateway.port }}"
+            - name: BRG_ALLOWED_ORIGINS
+              value: {{ .Values.browserGateway.allowedOrigins | quote }}
+            - name: BRG_LOG_LEVEL
+              value: {{ .Values.browserGateway.logLevel | quote }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: {{ .Values.browserGateway.port }}
+            initialDelaySeconds: 3
+            periodSeconds: 10
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-browser-gateway
+  labels:
+    app: {{ .Release.Name }}-browser-gateway
+spec:
+  selector:
+    app: {{ .Release.Name }}-browser-gateway
+  ports:
+    - port: {{ .Values.browserGateway.port }}
+      targetPort: {{ .Values.browserGateway.port }}
+{{- end }}
+```
+
+- [ ] **Step 3: Lint the chart**
+
+Run:
+```bash
+cd /root/agentserver && helm lint deploy/helm/agentserver --set browserGateway.enabled=true 2>&1 | tail -20 || echo "(helm not installed — skip; template is valid YAML by inspection)"
+helm template t deploy/helm/agentserver --set browserGateway.enabled=true 2>&1 | grep -A2 "kind: Deployment" | grep browser-gateway && echo "template renders browser-gateway"
+```
+Expected: lint passes (or helm absent → skip); `helm template` renders the browser-gateway Deployment. If `helm` is unavailable, validate the template file is well-formed YAML with the same `python3 -c "import yaml..."` check applied to a `helm template`-free copy (the `{{ }}` makes raw YAML-parse fail — in that case rely on `helm template` if available, else inspection).
+
+- [ ] **Step 4: (route) add the public host**
+
+If `deploy/helm/agentserver/templates/httproute.yaml` defines per-service routes gated on `.enabled`, add a `browserGateway`-gated backendRef/rule pointing at the `{{ .Release.Name }}-browser-gateway` Service on `.Values.browserGateway.port`, mirroring how `codexAppGateway`/the main service are routed there. Read that file first and follow its existing structure exactly (hostnames, gateway ref). If routing is done via `ingress.yaml` instead, add the equivalent path/host there. Keep it gated on `browserGateway.enabled`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /root/agentserver
+git add deploy/helm/agentserver/templates/browser-gateway.yaml deploy/helm/agentserver/values.yaml deploy/helm/agentserver/templates/httproute.yaml
+git commit -m "feat(browser-gateway): Helm deployment, service, values, route"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage (P3 scope):**
+- CopilotKit reference frontend → **superseded by user decision**: pure `@ag-ui/client` + `@a2ui/react` SPA (Tasks 1–4). The design's "CopilotKit" is explicitly replaced (CopilotKit needs a Node runtime, incompatible with single-binary); recorded in the plan header + Global Constraints.
+- Consumes `a2ui.operations` CUSTOM via `@a2ui/react` → Task 3 (`onCustomEvent` → `processor.processMessages`) + Task 4 (`<A2uiSurface>`). ✓
+- Embed + serve in the single Go binary → Task 5. ✓
+- Dockerfile frontend stage → Task 6; CI `build-browser-gateway` → Task 7; Helm → Task 8. ✓
+- Auth handoff (workspace codex token) → Task 4 (`?token=` / paste), sent as Bearer by Task 3. ✓
+- Out of scope (documented): HITL/approvals, A2UI interactive callbacks (the `MessageProcessor` `actionHandler` is noted in recon but not wired — a follow-up), live `commandExecution/outputDelta` streaming, Playwright E2E.
+
+**2. Placeholder scan:** No TBD/TODO. Every code step has complete content. Two honest latitude points, both bounded: Task 3 Step 2 and Task 8 Step 4 tell the implementer to reconcile against the installed `.d.ts` / the existing route file — these are real "match the existing/installed artifact" instructions, not vague hand-waves, and each names the exact file and the exact fix criterion.
+
+**3. Type/interface consistency:**
+- `ChatState`/`ChatMessage`/`ToolCall`/`reduceEvent`/`addUserMessage`/`emptyChatState` — defined Task 2, consumed Task 3. ✓
+- `useAgent(token) → { chat, surfaces, send, running, error }` — defined Task 3, consumed Task 4. ✓
+- `browserweb.StaticFS` — defined Task 5 embed.go, consumed Task 5 server.go. ✓
+- Package versions/import subpaths (`@a2ui/react/v0_9`, `@a2ui/web_core/v0_9`, `@ag-ui/client`) are consistent across Tasks 1/3 and match the verified npm versions. ✓
+- Helm env `BRG_CODEX_APP_GATEWAY_WS_URL` matches the P1 config key; `BRG_ALLOWED_ORIGINS`/`BRG_LOG_LEVEL`/`BRG_LISTEN_ADDR` match P1's `LoadServeConfigFromEnv`. ✓
+
+Fixed inline: none needed.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-07-20-browser-gateway-frontend-p3.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** — fresh subagent per task, review between tasks, on a branch stacked off `browser-gateway-p2` (no worktree).
+
+**2. Inline Execution** — execute in this session with checkpoints.
+
+This completes the browser-gateway feature (P1 endpoint → P2 tools+A2UI → P3 reference UI + deploy). After P3, remaining follow-ups (separate, smaller): HITL/approvals, A2UI interactive callbacks, live output-delta streaming.

--- a/internal/browsergateway/server.go
+++ b/internal/browsergateway/server.go
@@ -80,38 +80,45 @@ func (s *Server) handleAGUI(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) withCORS(next http.Handler) http.Handler {
-	// wildcard is true when any origin is allowed: no allowlist configured, or
-	// "*" explicitly listed. Otherwise a single, valid ACAO must be chosen per
-	// request (a comma-joined list is not a valid Access-Control-Allow-Origin).
-	wildcard := len(s.cfg.AllowedOrigins) == 0
+	// An empty allowlist means same-origin only: emit no CORS headers at all.
+	// The bundled SPA is served same-origin and needs none; only cross-origin
+	// third-party frontends require an explicit allowlist.
+	//
+	// wildcard is true when "*" is explicitly listed. Otherwise a single, valid
+	// ACAO must be chosen per request (a comma-joined list is not a valid
+	// Access-Control-Allow-Origin).
+	sameOrigin := len(s.cfg.AllowedOrigins) == 0
+	wildcard := false
 	for _, o := range s.cfg.AllowedOrigins {
 		if o == "*" {
 			wildcard = true
 		}
 	}
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if wildcard {
-			w.Header().Set("Access-Control-Allow-Origin", "*")
-		} else {
-			reqOrigin := r.Header.Get("Origin")
-			matched := false
-			for _, o := range s.cfg.AllowedOrigins {
-				if o == reqOrigin {
-					matched = true
-					break
+		if !sameOrigin {
+			if wildcard {
+				w.Header().Set("Access-Control-Allow-Origin", "*")
+			} else {
+				reqOrigin := r.Header.Get("Origin")
+				matched := false
+				for _, o := range s.cfg.AllowedOrigins {
+					if o == reqOrigin {
+						matched = true
+						break
+					}
+				}
+				if matched {
+					// Echo exactly the one allowed origin the client sent.
+					w.Header().Set("Access-Control-Allow-Origin", reqOrigin)
+					w.Header().Set("Vary", "Origin")
+				} else {
+					// Deterministic, still a single valid value.
+					w.Header().Set("Access-Control-Allow-Origin", s.cfg.AllowedOrigins[0])
 				}
 			}
-			if matched {
-				// Echo exactly the one allowed origin the client sent.
-				w.Header().Set("Access-Control-Allow-Origin", reqOrigin)
-				w.Header().Set("Vary", "Origin")
-			} else {
-				// Deterministic, still a single valid value.
-				w.Header().Set("Access-Control-Allow-Origin", s.cfg.AllowedOrigins[0])
-			}
+			w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
+			w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, Accept, Cache-Control")
 		}
-		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, Accept, Cache-Control")
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)
 			return

--- a/internal/browsergateway/server.go
+++ b/internal/browsergateway/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io/fs"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -12,6 +13,7 @@ import (
 	"github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/core/types"
 	"github.com/ag-ui-protocol/ag-ui/sdks/community/go/pkg/encoding/sse"
 
+	"github.com/agentserver/agentserver/browserweb"
 	"github.com/agentserver/agentserver/internal/browsergateway/codexclient"
 )
 
@@ -49,6 +51,7 @@ func (s *Server) Handler() http.Handler {
 		_, _ = w.Write([]byte("ok"))
 	})
 	mux.HandleFunc("POST /agui", s.handleAGUI)
+	mux.Handle("GET /", spaHandler())
 	return s.withCORS(mux)
 }
 
@@ -123,6 +126,23 @@ func extractBearer(r *http.Request) string {
 		return strings.TrimSpace(h[len("Bearer "):])
 	}
 	return ""
+}
+
+// spaHandler serves the embedded browserweb SPA, falling back to index.html
+// for client-side routes (any path that isn't a real embedded file).
+func spaHandler() http.Handler {
+	sub, err := fs.Sub(browserweb.StaticFS, "dist")
+	if err != nil {
+		panic("browserweb dist embed: " + err.Error())
+	}
+	fileServer := http.FileServer(http.FS(sub))
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if _, err := fs.Stat(sub, strings.TrimPrefix(r.URL.Path, "/")); err != nil && r.URL.Path != "/" {
+			r = r.Clone(r.Context())
+			r.URL.Path = "/"
+		}
+		fileServer.ServeHTTP(w, r)
+	})
 }
 
 // Run starts the HTTP server and blocks until ctx is cancelled.

--- a/internal/browsergateway/server_test.go
+++ b/internal/browsergateway/server_test.go
@@ -75,3 +75,26 @@ func TestServer_AGUI_StreamsRun(t *testing.T) {
 		t.Errorf("body missing RUN_FINISHED:\n%s", rec.Body.String())
 	}
 }
+
+func TestServer_ServesSPA(t *testing.T) {
+	s := NewServer(ServeConfig{CodexAppGatewayWSURL: "ws://unused", AllowedOrigins: []string{"*"}}, slog.Default())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	s.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("GET / = %d, want 200", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "<div id=\"root\">") {
+		t.Errorf("GET / did not serve the SPA index; body=%q", rec.Body.String())
+	}
+}
+
+func TestServer_SPAFallback(t *testing.T) {
+	s := NewServer(ServeConfig{CodexAppGatewayWSURL: "ws://unused", AllowedOrigins: []string{"*"}}, slog.Default())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/some/client/route", nil)
+	s.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("client route = %d, want 200 (SPA fallback)", rec.Code)
+	}
+}

--- a/internal/browsergateway/server_test.go
+++ b/internal/browsergateway/server_test.go
@@ -57,6 +57,22 @@ func TestServer_CORS_MultiOrigin(t *testing.T) {
 	}
 }
 
+func TestServer_CORS_DefaultSameOrigin(t *testing.T) {
+	s := NewServer(ServeConfig{CodexAppGatewayWSURL: "ws://unused"}, slog.Default())
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodOptions, "/agui", nil)
+	req.Header.Set("Origin", "https://evil.example")
+	s.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("OPTIONS status = %d, want 204", rec.Code)
+	}
+	if got := rec.Header().Get("Access-Control-Allow-Origin"); got != "" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want none (same-origin default)", got)
+	}
+}
+
 func TestServer_AGUI_StreamsRun(t *testing.T) {
 	fc := &fakeConn{frames: make(chan codexclient.Frame, 4)}
 	fc.frames <- codexclient.Frame{Method: "item/completed", Params: []byte(`{"item":{"type":"agentMessage","id":"m1","text":"hi"}}`)}


### PR DESCRIPTION
**Stacked on #293** (base `browser-gateway-p2`). Merge #292 → #293 → this, in order; each PR's base auto-retargets as its parent merges.

## What & why

P3 adds the **reference web UI** for browser-gateway and the deployment wiring, completing the feature (P1 endpoint → P2 tools+A2UI → **P3 UI + deploy**). A pure client-side SPA (Vite + React 19, **no CopilotKit / no Node runtime**) connects to `POST /agui`, renders streaming chat + tool calls, and renders the gateway's `a2ui.operations` CUSTOM events as A2UI v0.9 cards.

> **Stack note:** the design named CopilotKit, but it requires its own Node/Next.js runtime (incompatible with a single Go binary). Confirmed with the requester and switched to **`@ag-ui/client` + `@a2ui/react`** — a pure static SPA the Go binary embeds and serves. Same standard AG-UI endpoint; CopilotKit can still connect later if a runtime is added.

## Changes

- **`browserweb/`** — Vite/React19/Tailwind SPA: a pure `reduceEvent` AG-UI-event→chat-state reducer (unit-tested); `useAgent` hook (`HttpAgent.subscribe` → reducer for text/tool, `onCustomEvent` → `MessageProcessor.processMessages` for A2UI, surface sync); `App.tsx` (token gate, chat bubbles, tool cards, `<A2uiSurface>`).
- **Serve** — `browserweb/embed.go` (`//go:embed`) + a gateway SPA route with fallback (`/healthz`, `/agui` keep precedence).
- **Deploy** — `Dockerfile.browser-gateway` node build stage → embed; `build-browser-gateway` CI job; Helm `browser-gateway.yaml` (gated Deployment+Service wired to the codex-app-gateway service) + values + httproute.

## Security hardening (from automated commit review, addressed)

- Token read from the URL **fragment** (`#token=`, never sent to the server) + immediate `history.replaceState` scrub + `no-referrer` meta; token `<input type="password">`; token in memory only. (Auth travels in the `Authorization` header, not the URL.)
- Pod uses the **default ServiceAccount** (browser-gateway makes no k8s API calls) — not the main agentserver SA.
- CORS **defaults to same-origin** (`allowedOrigins: ""` → no `Access-Control-Allow-Origin`); operators opt into explicit origins or `"*"`.

## Testing

- Go: reducer/serve unit tests + CORS same-origin/multi-origin tests; all `internal/browsergateway` + `cmd/browser-gateway` packages pass under `-race`; `go build ./...` clean.
- Frontend: `pnpm build` (tsc + vite) clean; reducer Vitest suite.
- Docker: `Dockerfile.browser-gateway` builds end-to-end (SPA → embed → binary). Helm: `lint` + `template` render the gated resources; nothing renders when disabled.

Built task-by-task (TDD) with per-task review + a final whole-branch review + two automated security-review fix waves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)