### PR TITLE
fix(v2): pin TAE terminal sandbox revision

### DIFF
--- a/v2/api/schema/production-deployment.schema.json
+++ b/v2/api/schema/production-deployment.schema.json
@@ -25,7 +25,7 @@
     "resources"
   ],
   "properties": {
-    "version": {"const": 3},
+    "version": {"const": 4},
     "region": {"const": "sg"},
     "namespace": {"const": "agentserver"},
     "clusterDomain": {"$ref": "#/$defs/dnsName"},
@@ -357,10 +357,12 @@
     "managedTAE": {
       "type": "object",
       "additionalProperties": false,
-      "required": ["region", "psm", "policy", "networkEvidence"],
+      "required": ["region", "psm", "sandboxId", "sandboxRevisionId", "policy", "networkEvidence"],
       "properties": {
         "region": {"const": "sg"},
         "psm": {"type": "string", "minLength": 1, "maxLength": 256, "pattern": "^[^ /:@]+$"},
+        "sandboxId": {"$ref": "#/$defs/dnsLabel"},
+        "sandboxRevisionId": {"$ref": "#/$defs/dnsLabel"},
         "policy": {"$ref": "#/$defs/managedTAEPolicy"},
         "networkEvidence": {"$ref": "#/$defs/managedTAENetworkEvidence"}
       }
@@ -370,7 +372,7 @@
       "additionalProperties": false,
       "required": ["version", "reportSha256", "bindingSha256", "evidenceRef"],
       "properties": {
-        "version": {"type": "integer", "minimum": 0, "maximum": 3},
+        "version": {"type": "integer", "minimum": 0, "maximum": 4},
         "reportSha256": {"$ref": "#/$defs/optionalSha256"},
         "bindingSha256": {"$ref": "#/$defs/optionalSha256"},
         "evidenceRef": {"type": "string", "maxLength": 1024}
@@ -493,7 +495,7 @@
                   },
                   "networkEvidence": {
                     "properties": {
-                      "version": {"const": 3},
+                      "version": {"const": 4},
                       "reportSha256": {"$ref": "#/$defs/sha256"},
                       "bindingSha256": {"$ref": "#/$defs/sha256"},
                       "evidenceRef": {"type": "string", "minLength": 1, "maxLength": 1024}

--- a/v2/api/schema/tae-network-report.schema.json
+++ b/v2/api/schema/tae-network-report.schema.json
@@ -16,7 +16,7 @@
     "checks"
   ],
   "properties": {
-    "schemaVersion": { "const": 2 },
+    "schemaVersion": { "const": 3 },
     "kind": { "const": "agentserver.tae.sg-network-report" },
     "startedAt": { "type": "string", "format": "date-time" },
     "finishedAt": { "type": "string", "format": "date-time" },
@@ -71,6 +71,8 @@
         "controlPlaneHost",
         "dataPlaneDomainSuffix",
         "sandboxImage",
+        "sandboxId",
+        "sandboxRevisionId",
         "larkCliVersion",
         "larkCliSha256",
         "larkSkillSha256",
@@ -91,12 +93,20 @@
           "type": "string",
           "pattern": "^[^\\s@]+:sha256-[0-9a-f]{64}$"
         },
+        "sandboxId": { "$ref": "#/$defs/taeIdentity" },
+        "sandboxRevisionId": { "$ref": "#/$defs/taeIdentity" },
         "larkCliVersion": { "$ref": "#/$defs/boundedText" },
         "larkCliSha256": { "$ref": "#/$defs/digest" },
         "larkSkillSha256": { "$ref": "#/$defs/digest" },
         "connectivityAttempts": { "type": "integer", "minimum": 1, "maximum": 100 },
         "lifecycleAttempts": { "type": "integer", "minimum": 1, "maximum": 5 }
       }
+    },
+    "taeIdentity": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 63,
+      "pattern": "^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$"
     },
     "check": {
       "type": "object",

--- a/v2/deploy/production/config.example.json
+++ b/v2/deploy/production/config.example.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 4,
   "region": "sg",
   "namespace": "agentserver",
   "clusterDomain": "cluster.local",
@@ -103,8 +103,8 @@
         "codexCommit": "e363b08c9175ac1cbe5893615dd2cb9ddf95043b",
         "codexSha256": "2e863156ed35ecc5253b1e2f907a9143077b9f7cb51942070c61996471ff6e04"
       },
-      "runtimeProfileSha256": "7e7c97546b2e5f9a7d712ba44a55b6030db1595ffa72dfaf304e5e1321f7d702",
-      "packSetSha256": "d12de65e35ce74bbd3fbf88035c501caebeb4bd8dd8f4d4072d0c607fa4ee6b5",
+      "runtimeProfileSha256": "36e18c077b06a581a5d51253b39afa85ac69d8f3ef553a910b8201fafb0c2123",
+      "packSetSha256": "7d9cdca22f02d52912411b2ee1b0d0e08b60b8208ec075f39ff7c9a0c0cf8957",
       "sandboxTtl": "30m",
       "activityTtl": "5m",
       "idleTtl": "5m"
@@ -112,6 +112,8 @@
     "tae": {
       "region": "sg",
       "psm": "bytedance.sandbox.agentserver",
+      "sandboxId": "orbiryz0",
+      "sandboxRevisionId": "049daew1i5",
       "policy": {
         "version": 1,
         "revision": "lark-readonly-v1",
@@ -129,9 +131,9 @@
         "evidenceRef": "REPLACE_WITH_TAE_CHANGE_OR_SECURITY_TICKET"
       },
       "networkEvidence": {
-        "version": 3,
+        "version": 4,
         "reportSha256": "47d34822e5249f822ebb4b3d26d39e1704917fc39403c4ff94e77722626c4008",
-        "bindingSha256": "b490570eefd9012d4c171b9684bf1fbe56761d157241f777eb1fe61b204e622c",
+        "bindingSha256": "ec793ef26d8429af0f30c3b6e5bfc5e1e95aeefb07b905dcec643f9d9e41cfb3",
         "evidenceRef": "REPLACE_WITH_SG_NETWORK_TEST_REPORT"
       }
     },

--- a/v2/internal/productiondeploy/config.go
+++ b/v2/internal/productiondeploy/config.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	CurrentVersion                     = 3
+	CurrentVersion                     = 4
 	ProductionRegion                   = "sg"
 	ProductionNamespace                = "agentserver"
 	ProductionTrustDomain              = "agentserver.byted.bps.dev"

--- a/v2/internal/productiondeploy/config_test.go
+++ b/v2/internal/productiondeploy/config_test.go
@@ -162,6 +162,8 @@ func TestValidateConfigRejectsUnsafeProductionShapes(t *testing.T) {
 		"manifest key mismatch":       func(value *ConfigDocument) { value.Runtime.ManifestSigningKeyID = "other" },
 		"runtime allowlist drift":     func(value *ConfigDocument) { value.Runtime.CheckpointAllowlistVersion++ },
 		"shared secret":               func(value *ConfigDocument) { value.Secrets.HarnessWorker = value.Secrets.HarnessPool },
+		"missing TAE sandbox ID":      func(value *ConfigDocument) { value.Managed.TAE.SandboxID = "" },
+		"uppercase TAE revision ID":   func(value *ConfigDocument) { value.Managed.TAE.RevisionID = "Revision-1" },
 	} {
 		t.Run(name, func(t *testing.T) {
 			document := validConfigDocument()
@@ -210,6 +212,9 @@ func TestValidateConfigBindsManagedNetworkEvidenceToNormalizedFacts(t *testing.T
 		},
 		"report digest": func(value *ConfigDocument) {
 			value.Managed.TAE.NetworkEvidence.ReportSHA256 = canonicalDigest("different-report")
+		},
+		"terminal sandbox revision": func(value *ConfigDocument) {
+			value.Managed.TAE.RevisionID = "revision-2"
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
@@ -388,6 +393,7 @@ func validActivationNetworkReport(document ConfigDocument, revision string) taen
 			PolicyRevision: revision, ByteCloudSite: "i18n-tt", JWTEndpoint: ProductionByteCloudJWTEndpoint,
 			ProxyURL: ProductionTAEProxyURL, ControlPlaneHost: ProductionTAEControlPlaneHost,
 			DataPlaneDomainSuffix: ProductionTAEDataPlaneSuffix, SandboxImage: taeSandboxImage,
+			SandboxID: document.Managed.TAE.SandboxID, SandboxRevisionID: document.Managed.TAE.RevisionID,
 			LarkCLIVersion: productionimage.ManagedLarkCLIVersion, LarkCLISHA256: document.Managed.Lark.CLISHA256,
 			LarkSkillSHA256:      document.Managed.Lark.SkillSHA256,
 			ConnectivityAttempts: connectivityAttempts, LifecycleAttempts: lifecycleAttempts,
@@ -480,6 +486,7 @@ func validConfigDocument() ConfigDocument {
 			},
 			TAE: ManagedTAEDocument{
 				Region: ProductionRegion, PSM: ProductionTAEPSM,
+				SandboxID: "sandbox-1", RevisionID: "revision-1",
 				Policy: ManagedTAEPolicyDocument{
 					Version: 1, Revision: "lark-readonly-v1",
 					PolicySHA256: larkegresspolicy.SHA256Hex(),

--- a/v2/internal/productiondeploy/managed_config.go
+++ b/v2/internal/productiondeploy/managed_config.go
@@ -25,7 +25,7 @@ const (
 	managedLarkCLIPath             = "/usr/local/bin/lark-cli"
 	managedLarkSkillPath           = "/opt/agentserver/packs/lark-readonly/SKILL.md"
 	managedSandboxRootPath         = "/workspace"
-	managedNetworkEvidenceVersion  = 3
+	managedNetworkEvidenceVersion  = 4
 	ProductionTAEPSM               = "bytedance.sandbox.agentserver"
 	ProductionByteCloudJWTEndpoint = "https://cloud-i18n-sg.bytedance.net"
 	ProductionTAEControlPlaneHost  = "controlplane.sg.ai-sandbox-i18n.byted.org"
@@ -87,6 +87,8 @@ type ManagedCompatibilityRuntimeDocument struct {
 type ManagedTAEDocument struct {
 	Region          string                            `json:"region"`
 	PSM             string                            `json:"psm"`
+	SandboxID       string                            `json:"sandboxId"`
+	RevisionID      string                            `json:"sandboxRevisionId"`
 	Policy          ManagedTAEPolicyDocument          `json:"policy"`
 	NetworkEvidence ManagedTAENetworkEvidenceDocument `json:"networkEvidence"`
 }
@@ -304,6 +306,8 @@ func validateTAENetworkReportForActivation(document ConfigDocument, policyRevisi
 		"controlPlaneHost":       {configuration.ControlPlaneHost, ProductionTAEControlPlaneHost},
 		"dataPlaneDomainSuffix":  {configuration.DataPlaneDomainSuffix, ProductionTAEDataPlaneSuffix},
 		"sandboxImage":           {configuration.SandboxImage, taeSandboxImage},
+		"sandboxId":              {configuration.SandboxID, document.Managed.TAE.SandboxID},
+		"sandboxRevisionId":      {configuration.SandboxRevisionID, document.Managed.TAE.RevisionID},
 		"larkCliVersion":         {configuration.LarkCLIVersion, productionimage.ManagedLarkCLIVersion},
 		"larkCliSha256":          {configuration.LarkCLISHA256, document.Managed.Lark.CLISHA256},
 		"larkSkillSha256":        {configuration.LarkSkillSHA256, document.Managed.Lark.SkillSHA256},
@@ -424,6 +428,12 @@ func validateManagedExecutor(managed ManagedExecutorDocument, document ConfigDoc
 	}
 	if managed.TAE.PSM != ProductionTAEPSM {
 		return LoadedConfig{}, fmt.Errorf("managedExecutor.tae.psm must be exactly %s", ProductionTAEPSM)
+	}
+	if !dnsLabelPattern.MatchString(managed.TAE.SandboxID) {
+		return LoadedConfig{}, errors.New("managedExecutor.tae.sandboxId must be a canonical lowercase TAE identity")
+	}
+	if !dnsLabelPattern.MatchString(managed.TAE.RevisionID) {
+		return LoadedConfig{}, errors.New("managedExecutor.tae.sandboxRevisionId must be a canonical lowercase TAE identity")
 	}
 	if !validUUID(managed.Environment.EnvironmentID) {
 		return LoadedConfig{}, errors.New("managedExecutor.environment.environmentId must be a non-zero canonical lowercase UUID")
@@ -619,8 +629,10 @@ func managedRuntimeProfileDigest(document ConfigDocument, managed ManagedExecuto
 		TAEPolicyBindingSHA256  string `json:"taePolicyBindingSha256"`
 		TAENetworkBindingSHA256 string `json:"taeNetworkBindingSha256"`
 		TAEPolicyRevision       string `json:"taePolicyRevision"`
+		TAESandboxID            string `json:"taeSandboxId"`
+		TAESandboxRevisionID    string `json:"taeSandboxRevisionId"`
 	}{
-		Version: 4, Platform: document.Platform, Image: document.Images.ManagedSandbox,
+		Version: 5, Platform: document.Platform, Image: document.Images.ManagedSandbox,
 		Root: managed.Environment.Root.Path, KeeperCommand: managedruntime.ExecutablePath,
 		CodexRelease: managed.Environment.Compatibility.CodexRelease,
 		CodexCommit:  managed.Environment.Compatibility.CodexCommit, CodexSHA256: managed.Environment.Compatibility.CodexSHA256,
@@ -640,6 +652,7 @@ func managedRuntimeProfileDigest(document ConfigDocument, managed ManagedExecuto
 		PolicySHA256:           managed.TAE.Policy.PolicySHA256,
 		TAEPolicyBindingSHA256: managed.TAE.Policy.BindingSHA256, TAEPolicyRevision: managed.TAE.Policy.Revision,
 		TAENetworkBindingSHA256: managed.TAE.NetworkEvidence.BindingSHA256,
+		TAESandboxID:            managed.TAE.SandboxID, TAESandboxRevisionID: managed.TAE.RevisionID,
 	}
 	return canonicalDigest(lock)
 }
@@ -720,6 +733,8 @@ func managedTAENetworkEvidenceDigest(document ConfigDocument) string {
 		Version                          int                  `json:"version"`
 		Region                           string               `json:"region"`
 		SandboxPSM                       string               `json:"sandboxPsm"`
+		SandboxID                        string               `json:"sandboxId"`
+		SandboxRevisionID                string               `json:"sandboxRevisionId"`
 		ClusterDomain                    string               `json:"clusterDomain"`
 		DNSClusterIP                     string               `json:"dnsClusterIp"`
 		DNSNamespace                     string               `json:"dnsNamespace"`
@@ -746,6 +761,7 @@ func managedTAENetworkEvidenceDigest(document ConfigDocument) string {
 		EvidenceRef                      string               `json:"evidenceRef"`
 	}{
 		Version: evidence.Version, Region: managed.TAE.Region, SandboxPSM: managed.TAE.PSM,
+		SandboxID: managed.TAE.SandboxID, SandboxRevisionID: managed.TAE.RevisionID,
 		ClusterDomain: document.ClusterDomain, DNSClusterIP: document.Network.DNSClusterIP,
 		DNSNamespace: document.Network.DNSNamespace, DNSPodSelector: document.Network.DNSPodSelector,
 		SandboxServiceClusterIP:          document.Services.SandboxGateway.ClusterIP,

--- a/v2/internal/productiondeploy/render_test.go
+++ b/v2/internal/productiondeploy/render_test.go
@@ -416,7 +416,9 @@ func TestRenderLocksProductionTopologyAndSecurityShape(t *testing.T) {
 	}
 	if sandboxConfig.ProviderRegion != "sg" || sandboxConfig.ProviderPSM != loaded.Document.Managed.TAE.PSM ||
 		len(sandboxConfig.WorkspaceAllowlist) != len(loaded.Document.Managed.WorkspaceAllowlist) ||
-		sandboxEnvironment("AGENTSERVER_V2_TAE_SANDBOX_IMAGE") != wantTAEImage {
+		sandboxEnvironment("AGENTSERVER_V2_TAE_SANDBOX_IMAGE") != wantTAEImage ||
+		sandboxEnvironment("AGENTSERVER_V2_TAE_SANDBOX_ID") != loaded.Document.Managed.TAE.SandboxID ||
+		sandboxEnvironment("AGENTSERVER_V2_TAE_SANDBOX_REVISION_ID") != loaded.Document.Managed.TAE.RevisionID {
 		t.Fatalf("rendered sandbox-gateway authority = %+v", sandboxConfig)
 	}
 	for name, want := range map[string]string{

--- a/v2/internal/productiondeploy/tae_network_probe.go
+++ b/v2/internal/productiondeploy/tae_network_probe.go
@@ -44,6 +44,8 @@ func taeNetworkProbeResources(config LoadedConfig) ([]kubeObject, error) {
 	}
 	environment := []any{
 		valueEnvironment("AGENTSERVER_V2_TAE_SANDBOX_IMAGE", taeSandboxImage),
+		valueEnvironment("AGENTSERVER_V2_TAE_SANDBOX_ID", document.Managed.TAE.SandboxID),
+		valueEnvironment("AGENTSERVER_V2_TAE_SANDBOX_REVISION_ID", document.Managed.TAE.RevisionID),
 		valueEnvironment("AGENTSERVER_V2_TAE_AUTH_MODE", "bytecloud-app-aksk-v1"),
 		valueEnvironment("AGENTSERVER_V2_TAE_BYTECLOUD_SITE", "i18n-tt"),
 		valueEnvironment("AGENTSERVER_V2_TAE_BYTECLOUD_JWT_ENDPOINT", ProductionByteCloudJWTEndpoint),

--- a/v2/internal/productiondeploy/tae_network_probe_test.go
+++ b/v2/internal/productiondeploy/tae_network_probe_test.go
@@ -62,6 +62,8 @@ func TestTAENetworkProbeResourcesAreOneShotClosedWorldAuthority(t *testing.T) {
 	}
 	for name, want := range map[string]string{
 		"AGENTSERVER_V2_TAE_SANDBOX_IMAGE":                    wantTAEImage,
+		"AGENTSERVER_V2_TAE_SANDBOX_ID":                       loaded.Document.Managed.TAE.SandboxID,
+		"AGENTSERVER_V2_TAE_SANDBOX_REVISION_ID":              loaded.Document.Managed.TAE.RevisionID,
 		"AGENTSERVER_V2_TAE_PROXY_URL":                        ProductionTAEProxyURL,
 		"AGENTSERVER_V2_TAE_BYTECLOUD_JWT_ENDPOINT":           ProductionByteCloudJWTEndpoint,
 		"AGENTSERVER_V2_TAE_PROBE_DEPLOYMENT_CONFIG_SHA256":   canonicalDigest(loaded.Document),

--- a/v2/internal/productiondeploy/workloads.go
+++ b/v2/internal/productiondeploy/workloads.go
@@ -610,6 +610,8 @@ func renderSandboxDeployment(context renderContext) (kubeObject, error) {
 		valueEnvironment("AGENTSERVER_V2_TAE_REGION", document.Managed.TAE.Region),
 		valueEnvironment("AGENTSERVER_V2_TAE_PSM", document.Managed.TAE.PSM),
 		valueEnvironment("AGENTSERVER_V2_TAE_SANDBOX_IMAGE", taeSandboxImage),
+		valueEnvironment("AGENTSERVER_V2_TAE_SANDBOX_ID", document.Managed.TAE.SandboxID),
+		valueEnvironment("AGENTSERVER_V2_TAE_SANDBOX_REVISION_ID", document.Managed.TAE.RevisionID),
 		valueEnvironment("AGENTSERVER_V2_TAE_AUTH_MODE", "bytecloud-app-aksk-v1"),
 		valueEnvironment("AGENTSERVER_V2_TAE_BYTECLOUD_SITE", "i18n-tt"),
 		valueEnvironment("AGENTSERVER_V2_TAE_BYTECLOUD_JWT_ENDPOINT", ProductionByteCloudJWTEndpoint),

--- a/v2/internal/taenetworkreport/report.go
+++ b/v2/internal/taenetworkreport/report.go
@@ -22,7 +22,7 @@ import (
 )
 
 const (
-	CurrentVersion = 2
+	CurrentVersion = 3
 	Kind           = "agentserver.tae.sg-network-report"
 	maximumBytes   = int64(256 * 1024)
 )
@@ -32,6 +32,7 @@ var (
 	checkNamePattern = regexp.MustCompile(`^[a-z][a-z0-9_]{0,63}$`)
 	errorCodePattern = regexp.MustCompile(`^[a-z][a-z0-9_]{0,63}$`)
 	podUIDPattern    = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`)
+	taeIDPattern     = regexp.MustCompile(`^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$`)
 )
 
 type Report struct {
@@ -65,6 +66,8 @@ type Configuration struct {
 	ControlPlaneHost       string `json:"controlPlaneHost"`
 	DataPlaneDomainSuffix  string `json:"dataPlaneDomainSuffix"`
 	SandboxImage           string `json:"sandboxImage"`
+	SandboxID              string `json:"sandboxId"`
+	SandboxRevisionID      string `json:"sandboxRevisionId"`
 	LarkCLIVersion         string `json:"larkCliVersion"`
 	LarkCLISHA256          string `json:"larkCliSha256"`
 	LarkSkillSHA256        string `json:"larkSkillSha256"`
@@ -199,6 +202,12 @@ func Validate(report Report) error {
 	}
 	if err := taeimage.ValidateContentTag(report.Configuration.SandboxImage); err != nil {
 		return fmt.Errorf("TAE network report configuration.sandboxImage: %w", err)
+	}
+	if !taeIDPattern.MatchString(report.Configuration.SandboxID) {
+		return errors.New("TAE network report configuration.sandboxId must be a canonical lowercase TAE identity")
+	}
+	if !taeIDPattern.MatchString(report.Configuration.SandboxRevisionID) {
+		return errors.New("TAE network report configuration.sandboxRevisionId must be a canonical lowercase TAE identity")
 	}
 	if report.Configuration.ConnectivityAttempts < 1 || report.Configuration.ConnectivityAttempts > 100 ||
 		report.Configuration.LifecycleAttempts < 1 || report.Configuration.LifecycleAttempts > 5 {

--- a/v2/internal/taenetworkreport/report_test.go
+++ b/v2/internal/taenetworkreport/report_test.go
@@ -19,7 +19,7 @@ func TestReportCanonicalRoundTripAndDigest(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if bytes.Count(raw, []byte{'\n'}) != 1 || raw[len(raw)-1] != '\n' || !bytes.HasPrefix(raw, []byte(`{"schemaVersion":2,"kind":"agentserver.tae.sg-network-report"`)) {
+	if bytes.Count(raw, []byte{'\n'}) != 1 || raw[len(raw)-1] != '\n' || !bytes.HasPrefix(raw, []byte(`{"schemaVersion":3,"kind":"agentserver.tae.sg-network-report"`)) {
 		t.Fatalf("report is not one canonical line: %q", raw)
 	}
 	parsed, err := Parse(raw)
@@ -53,6 +53,12 @@ func TestValidateRejectsInconsistentEvidence(t *testing.T) {
 			value.Configuration.DeploymentConfigSHA256 = strings.Repeat("0", 64)
 		},
 		"mutable image": func(value *Report) { value.Configuration.SandboxImage = "sandbox:latest" },
+		"invalid sandbox ID": func(value *Report) {
+			value.Configuration.SandboxID = "Sandbox-1"
+		},
+		"missing sandbox revision ID": func(value *Report) {
+			value.Configuration.SandboxRevisionID = ""
+		},
 	} {
 		t.Run(name, func(t *testing.T) {
 			report := validReport()
@@ -132,6 +138,7 @@ func validReport() Report {
 			PolicyRevision: "revision-1", ByteCloudSite: "i18n-tt", JWTEndpoint: "https://cloud-i18n-sg.bytedance.net",
 			ProxyURL: "socks5h://proxy.example:1080", ControlPlaneHost: "controlplane.sg.example",
 			DataPlaneDomainSuffix: "sg.example", SandboxImage: "registry.example/sandbox:sha256-" + strings.Repeat("2", 64),
+			SandboxID: "sandbox-1", SandboxRevisionID: "revision-1",
 			LarkCLIVersion: "1.0.69", LarkCLISHA256: strings.Repeat("3", 64), LarkSkillSHA256: strings.Repeat("4", 64),
 			ConnectivityAttempts: 2, LifecycleAttempts: 1,
 		},

--- a/v2/providers/tae/adapter/contracts.go
+++ b/v2/providers/tae/adapter/contracts.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/agentserver/agentserver/v2/internal/managedruntime"
@@ -23,18 +24,21 @@ type ControlSession struct {
 }
 
 // RuntimeCommandConflicts reports an authoritative provider conflict. TAE's
-// Session create/get/search responses do not consistently echo the optional
-// command field, so an empty value means "not reported" rather than "the
-// process started without a command". The SDK adapter separately rejects any
-// create request that does not carry the exact managed runtime executable.
+// Session create/get/search responses do not consistently echo the command
+// fixed by the Terminal Sandbox revision, so an empty value means "not
+// reported" rather than "the process started without a command". Session
+// creation deliberately cannot supply a command override.
 func RuntimeCommandConflicts(command string) bool {
 	return command != "" && command != managedruntime.ExecutablePath
+}
+
+func ValidTerminalIdentity(value string) bool {
+	return sessionDNSLabelPattern.MatchString(value) && strings.ToLower(value) == value
 }
 
 type CreateInput struct {
 	TTL      time.Duration
 	Metadata map[string]string
-	Command  string
 }
 
 type SearchInput struct {

--- a/v2/providers/tae/adapter/provider.go
+++ b/v2/providers/tae/adapter/provider.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/agentserver/agentserver/v2/internal/executionbackend"
 	"github.com/agentserver/agentserver/v2/internal/larkegresspolicy"
-	"github.com/agentserver/agentserver/v2/internal/managedruntime"
 	"github.com/agentserver/agentserver/v2/internal/sandboxgateway"
 	"github.com/agentserver/agentserver/v2/internal/taepolicy"
 )
@@ -149,11 +148,11 @@ func (provider *Provider) CreateSandbox(ctx context.Context, request sandboxgate
 		}
 		return provider.providerSandbox(existing)
 	}
-	// Terminal Sandbox images are fixed by the published Sandbox version. The
-	// Session API must not receive an image override; that field is only valid
-	// for image-collection sandboxes.
+	// Terminal Sandbox images and startup commands are fixed by the pinned TAE
+	// Sandbox revision. The Session API must not receive image or command
+	// overrides; those fields are not the release boundary for Terminal.
 	session, err := provider.control.Create(ctx, CreateInput{
-		TTL: request.TTL, Metadata: metadata, Command: managedruntime.ExecutablePath,
+		TTL: request.TTL, Metadata: metadata,
 	})
 	if err != nil {
 		return sandboxgateway.ProviderSandbox{}, provider.createError(err)

--- a/v2/providers/tae/adapter/provider_test.go
+++ b/v2/providers/tae/adapter/provider_test.go
@@ -140,8 +140,7 @@ func TestProviderLifecycleUsesProviderAssignedIdentityAndExactMetadata(t *testin
 	want := provider.createMetadata(request.SandboxID, request.IdempotencyKey, request.WorkspaceID, request.SessionID,
 		request.EnvironmentID, request.RuntimeProfileSHA256, request.PackSetSHA256)
 	if !metadataEqual(captured.Metadata, want) || len(captured.Metadata) != 8 ||
-		captured.Metadata[MetadataTAEPolicySHA256] != provider.policy.BindingSHA256 ||
-		captured.Command != managedruntime.ExecutablePath {
+		captured.Metadata[MetadataTAEPolicySHA256] != provider.policy.BindingSHA256 {
 		t.Fatalf("create metadata = %#v, want %#v", captured.Metadata, want)
 	}
 

--- a/v2/providers/tae/adapter/sdk_controlplane.go
+++ b/v2/providers/tae/adapter/sdk_controlplane.go
@@ -14,13 +14,14 @@ import (
 
 	"code.byted.org/inf/bytedai-go/region"
 	"code.byted.org/inf/bytedai-go/sandbox"
-	"github.com/agentserver/agentserver/v2/internal/managedruntime"
 )
 
 const defaultControlRequestTimeout = 45 * time.Second
 
 type SDKControlPlaneConfig struct {
 	PSM             string
+	SandboxID       string
+	RevisionID      string
 	HTTPClient      *http.Client
 	Headers         HeaderSource
 	ControlPlaneURL string
@@ -32,6 +33,8 @@ type SDKControlPlane struct {
 	identityClient *http.Client
 	metadataURL    string
 	psm            string
+	sandboxID      string
+	revisionID     string
 	requestTimeout time.Duration
 }
 
@@ -49,6 +52,12 @@ func NewSGSDKControlPlane(ctx context.Context, config SDKControlPlaneConfig) (*S
 	}
 	if strings.TrimSpace(config.PSM) != config.PSM || config.PSM == "" || len(config.PSM) > 256 {
 		return nil, errors.New("TAE SDK PSM is invalid")
+	}
+	if !ValidTerminalIdentity(config.SandboxID) {
+		return nil, errors.New("TAE SDK terminal sandbox ID is invalid")
+	}
+	if !ValidTerminalIdentity(config.RevisionID) {
+		return nil, errors.New("TAE SDK terminal sandbox revision ID is invalid")
 	}
 	if config.RequestTimeout == 0 {
 		config.RequestTimeout = defaultControlRequestTimeout
@@ -73,8 +82,12 @@ func NewSGSDKControlPlane(ctx context.Context, config SDKControlPlaneConfig) (*S
 	if err != nil {
 		return nil, fmt.Errorf("configure TAE SDK identity transport: %w", err)
 	}
+	identityClient, err = newTerminalSandboxControlClient(identityClient, config.PSM, config.SandboxID)
+	if err != nil {
+		return nil, fmt.Errorf("scope TAE SDK terminal sandbox transport: %w", err)
+	}
 	client, err := sandbox.NewSandboxClientWithOptions(
-		ctx, config.PSM, "", region.AIPaaSGatewayRegionI18nProd,
+		ctx, config.PSM, config.SandboxID, region.AIPaaSGatewayRegionI18nProd,
 		&sandbox.SandboxClientOptions{LegacyHTTPClient: identityClient, ControlPlaneURL: config.ControlPlaneURL}, false,
 	)
 	if err != nil {
@@ -83,8 +96,45 @@ func NewSGSDKControlPlane(ctx context.Context, config SDKControlPlaneConfig) (*S
 	metadataURL := controlPlaneOrigin + "/api/v1/sandboxes/" + url.PathEscape(config.PSM)
 	return &SDKControlPlane{
 		client: client, identityClient: identityClient, metadataURL: metadataURL,
-		psm: config.PSM, requestTimeout: config.RequestTimeout,
+		psm: config.PSM, sandboxID: config.SandboxID, revisionID: config.RevisionID,
+		requestTimeout: config.RequestTimeout,
 	}, nil
+}
+
+// newTerminalSandboxControlClient prevents the SDK's internal PSM lookup from
+// redirecting lifecycle operations to a different Sandbox resource. The SDK
+// still resolves the Terminal type through the metadata endpoint, but every
+// session request is constrained to the configured immutable Sandbox ID.
+func newTerminalSandboxControlClient(client *http.Client, psm, sandboxID string) (*http.Client, error) {
+	if client == nil || client.Transport == nil || psm == "" || sandboxID == "" {
+		return nil, errors.New("TAE terminal sandbox control scope is incomplete")
+	}
+	clone := *client
+	clone.Transport = &terminalSandboxControlRoundTripper{
+		base:         client.Transport,
+		metadataPath: "/api/v1/sandboxes/" + url.PathEscape(psm),
+		sessionsPath: "/api/v1/sandboxes/" + url.PathEscape(sandboxID) + "/sessions",
+	}
+	return &clone, nil
+}
+
+type terminalSandboxControlRoundTripper struct {
+	base         http.RoundTripper
+	metadataPath string
+	sessionsPath string
+}
+
+func (transport *terminalSandboxControlRoundTripper) RoundTrip(request *http.Request) (*http.Response, error) {
+	if transport == nil || transport.base == nil || request == nil || request.URL == nil {
+		return nil, errors.New("TAE terminal sandbox control transport is unavailable")
+	}
+	requestPath := request.URL.EscapedPath()
+	metadataRequest := request.Method == http.MethodGet && requestPath == transport.metadataPath
+	sessionRequest := requestPath == transport.sessionsPath || strings.HasPrefix(requestPath, transport.sessionsPath+"/")
+	if !metadataRequest && !sessionRequest {
+		return nil, errors.New("TAE terminal sandbox control request is outside the configured Sandbox ID")
+	}
+	return transport.base.RoundTrip(request)
 }
 
 // DescribeSandbox resolves the immutable management-plane identity needed by
@@ -92,7 +142,8 @@ func NewSGSDKControlPlane(ctx context.Context, config SDKControlPlaneConfig) (*S
 // pinned control-plane client and provider identity as lifecycle operations;
 // callers cannot supply an alternate authority or sandbox ID.
 func (control *SDKControlPlane) DescribeSandbox(ctx context.Context) (SandboxDescriptor, error) {
-	if control == nil || control.identityClient == nil || control.metadataURL == "" || control.psm == "" {
+	if control == nil || control.identityClient == nil || control.metadataURL == "" || control.psm == "" ||
+		control.sandboxID == "" || control.revisionID == "" {
 		return SandboxDescriptor{}, &RequestError{Code: "provider_unavailable", Cause: errors.New("TAE sandbox descriptor client is unavailable")}
 	}
 	if ctx == nil {
@@ -136,8 +187,7 @@ func (control *SDKControlPlane) DescribeSandbox(ctx context.Context) (SandboxDes
 		}
 	}
 	if envelope.Code != 0 || envelope.Data == nil || envelope.Data.Psm != control.psm ||
-		envelope.Data.SandboxType != sandbox.SandboxTypeTerminal ||
-		!sessionDNSLabelPattern.MatchString(envelope.Data.SandboxID) || strings.ToLower(envelope.Data.SandboxID) != envelope.Data.SandboxID {
+		envelope.Data.SandboxType != sandbox.SandboxTypeTerminal || envelope.Data.SandboxID != control.sandboxID {
 		return SandboxDescriptor{}, &RequestError{
 			WroteRequest: true, StatusCode: response.StatusCode, Code: "invalid_response",
 			RequestID: providerRequestID(response.Header), Cause: errors.New("TAE sandbox descriptor did not match the configured terminal PSM"),
@@ -147,16 +197,14 @@ func (control *SDKControlPlane) DescribeSandbox(ctx context.Context) (SandboxDes
 }
 
 func (control *SDKControlPlane) Create(ctx context.Context, input CreateInput) (ControlSession, error) {
-	if input.Command != managedruntime.ExecutablePath {
-		return ControlSession{}, &RequestError{Code: "bad_request", Cause: errors.New("TAE session command differs from the managed runtime contract")}
-	}
 	seconds, err := wholeSeconds(input.TTL)
 	if err != nil {
 		return ControlSession{}, &RequestError{Code: "bad_request", Cause: err}
 	}
 	traced, wrote := traceRequest(ctx)
+	revisionID := control.revisionID
 	session, err := control.client.CreateSessionWithOpts(traced, &sandbox.CreateSessionOpts{
-		TTL: seconds, Metadata: cloneStrings(input.Metadata), Command: input.Command,
+		TTL: seconds, Metadata: cloneStrings(input.Metadata), RevisionID: &revisionID,
 		Timeout: control.requestTimeout,
 	})
 	if err != nil {

--- a/v2/providers/tae/adapter/sdk_controlplane_test.go
+++ b/v2/providers/tae/adapter/sdk_controlplane_test.go
@@ -45,7 +45,8 @@ func TestSDKControlPlaneInjectsApplicationJWTIntoEveryControlRequest(t *testing.
 	server := httptest.NewTLSServer(mux)
 	defer server.Close()
 	control, err := NewSGSDKControlPlane(context.Background(), SDKControlPlaneConfig{
-		PSM: "psm.agentserver.tae", HTTPClient: server.Client(), Headers: staticJWTSource(),
+		PSM: "psm.agentserver.tae", SandboxID: "sandbox-1", RevisionID: "revision-1",
+		HTTPClient: server.Client(), Headers: staticJWTSource(),
 		ControlPlaneURL: server.URL, RequestTimeout: time.Second,
 	})
 	if err != nil {
@@ -64,7 +65,7 @@ func TestSDKControlPlaneInjectsApplicationJWTIntoEveryControlRequest(t *testing.
 	}
 }
 
-func TestSDKControlPlaneCreateSelectsManagedRuntimeAndOmitsTerminalSessionImage(t *testing.T) {
+func TestSDKControlPlaneCreatePinsRevisionAndOmitsTerminalOverrides(t *testing.T) {
 	metadata := map[string]string{MetadataSandboxID: "managed-sandbox-1"}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/api/v1/sandboxes/psm.agentserver.tae", func(response http.ResponseWriter, _ *http.Request) {
@@ -85,9 +86,12 @@ func TestSDKControlPlaneCreateSelectsManagedRuntimeAndOmitsTerminalSessionImage(
 		if _, present := payload["image"]; present {
 			t.Fatalf("Terminal Session create carried forbidden image override: %s", payload["image"])
 		}
-		var command string
-		if err := json.Unmarshal(payload["command"], &command); err != nil || command != managedruntime.ExecutablePath {
-			t.Fatalf("Terminal Session create command = %q, %v", command, err)
+		if _, present := payload["command"]; present {
+			t.Fatalf("Terminal Session create carried forbidden command override: %s", payload["command"])
+		}
+		var revisionID string
+		if err := json.Unmarshal(payload["revision_id"], &revisionID); err != nil || revisionID != "revision-1" {
+			t.Fatalf("Terminal Session create revision_id = %q, %v", revisionID, err)
 		}
 		_ = json.NewEncoder(response).Encode(sandbox.CreateSessionResponse{
 			Code: 0,
@@ -100,15 +104,14 @@ func TestSDKControlPlaneCreateSelectsManagedRuntimeAndOmitsTerminalSessionImage(
 	server := httptest.NewTLSServer(mux)
 	defer server.Close()
 	control, err := NewSGSDKControlPlane(t.Context(), SDKControlPlaneConfig{
-		PSM: "psm.agentserver.tae", HTTPClient: server.Client(), Headers: staticJWTSource(),
+		PSM: "psm.agentserver.tae", SandboxID: "sandbox-1", RevisionID: "revision-1",
+		HTTPClient: server.Client(), Headers: staticJWTSource(),
 		ControlPlaneURL: server.URL, RequestTimeout: time.Second,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	created, err := control.Create(t.Context(), CreateInput{
-		TTL: time.Minute, Metadata: metadata, Command: managedruntime.ExecutablePath,
-	})
+	created, err := control.Create(t.Context(), CreateInput{TTL: time.Minute, Metadata: metadata})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,9 +119,34 @@ func TestSDKControlPlaneCreateSelectsManagedRuntimeAndOmitsTerminalSessionImage(
 		!reflect.DeepEqual(created.Metadata, metadata) {
 		t.Fatalf("created Terminal Session = %+v", created)
 	}
-	if _, err := control.Create(t.Context(), CreateInput{TTL: time.Minute, Metadata: metadata}); err == nil ||
-		!strings.Contains(err.Error(), "session command differs") {
-		t.Fatalf("missing managed runtime command error = %v", err)
+}
+
+func TestSDKControlPlaneFailsClosedWhenPSMResolvesToDifferentSandboxID(t *testing.T) {
+	requests := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		requests++
+		if request.URL.Path != "/api/v1/sandboxes/psm.agentserver.tae" {
+			t.Fatalf("unexpected request escaped configured Sandbox ID scope: %s", request.URL.Path)
+		}
+		_ = json.NewEncoder(response).Encode(sandbox.SandboxMetaResponse{
+			Code: 0,
+			Data: &sandbox.SandboxMeta{SandboxID: "sandbox-2", SandboxType: sandbox.SandboxTypeTerminal,
+				Name: "drifted", Psm: "psm.agentserver.tae"},
+		})
+	}))
+	defer server.Close()
+	control, err := NewSGSDKControlPlane(t.Context(), SDKControlPlaneConfig{
+		PSM: "psm.agentserver.tae", SandboxID: "sandbox-1", RevisionID: "revision-1",
+		HTTPClient: server.Client(), Headers: staticJWTSource(),
+		ControlPlaneURL: server.URL, RequestTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = control.Create(t.Context(), CreateInput{TTL: time.Minute})
+	var requestError *RequestError
+	if !errors.As(err, &requestError) || requestError.Code != "provider_unavailable" || requests != 1 {
+		t.Fatalf("Create() with drifted Sandbox ID error=%#v requests=%d", err, requests)
 	}
 }
 
@@ -133,7 +161,8 @@ func TestDescribeSandboxRejectsTrailingOrOversizedJSON(t *testing.T) {
 			}))
 			defer server.Close()
 			control, err := NewSGSDKControlPlane(t.Context(), SDKControlPlaneConfig{
-				PSM: "psm.agentserver.tae", HTTPClient: server.Client(), Headers: staticJWTSource(),
+				PSM: "psm.agentserver.tae", SandboxID: "sandbox-1", RevisionID: "revision-1",
+				HTTPClient: server.Client(), Headers: staticJWTSource(),
 				ControlPlaneURL: server.URL, RequestTimeout: time.Second,
 			})
 			if err != nil {

--- a/v2/providers/tae/cmd/sandbox-gateway/main.go
+++ b/v2/providers/tae/cmd/sandbox-gateway/main.go
@@ -26,6 +26,8 @@ const (
 	signalTimeoutEnvironment        = "AGENTSERVER_V2_TAE_SIGNAL_TIMEOUT"
 	maxReadBytesEnvironment         = "AGENTSERVER_V2_TAE_MAX_READ_SOURCE_BYTES"
 	sandboxImageEnvironment         = "AGENTSERVER_V2_TAE_SANDBOX_IMAGE"
+	sandboxIDEnvironment            = "AGENTSERVER_V2_TAE_SANDBOX_ID"
+	sandboxRevisionIDEnvironment    = "AGENTSERVER_V2_TAE_SANDBOX_REVISION_ID"
 	authModeEnvironment             = "AGENTSERVER_V2_TAE_AUTH_MODE"
 	byteCloudSiteEnvironment        = "AGENTSERVER_V2_TAE_BYTECLOUD_SITE"
 	byteCloudAccessKeyEnvironment   = "AGENTSERVER_V2_TAE_BYTECLOUD_ACCESS_KEY_ID_FILE"
@@ -48,6 +50,8 @@ type providerConfig struct {
 	signalTimeout     time.Duration
 	maxReadBytes      int64
 	sandboxImage      string
+	sandboxID         string
+	sandboxRevisionID string
 	authMode          string
 	byteCloudSite     string
 	accessKeyFile     string
@@ -186,6 +190,14 @@ func loadProviderConfig(getenv func(string) string) (providerConfig, error) {
 	if err := taeimage.ValidateContentTag(sandboxImage); err != nil {
 		return providerConfig{}, fmt.Errorf("%s: %w", sandboxImageEnvironment, err)
 	}
+	sandboxID := getenv(sandboxIDEnvironment)
+	if !adapter.ValidTerminalIdentity(sandboxID) {
+		return providerConfig{}, fmt.Errorf("%s must be a canonical lowercase TAE identity", sandboxIDEnvironment)
+	}
+	sandboxRevisionID := getenv(sandboxRevisionIDEnvironment)
+	if !adapter.ValidTerminalIdentity(sandboxRevisionID) {
+		return providerConfig{}, fmt.Errorf("%s must be a canonical lowercase TAE identity", sandboxRevisionIDEnvironment)
+	}
 	controlTimeout, err := optionalDuration(getenv(controlTimeoutEnvironment), 45*time.Second, time.Second, time.Minute, controlTimeoutEnvironment)
 	if err != nil {
 		return providerConfig{}, err
@@ -218,6 +230,7 @@ func loadProviderConfig(getenv func(string) string) (providerConfig, error) {
 		controlTimeout: controlTimeout, headerTimeout: headerTimeout, streamGrace: streamGrace,
 		reconnectAttempts: reconnectAttempts, reconnectDelay: reconnectDelay,
 		signalTimeout: signalTimeout, maxReadBytes: maxReadBytes, sandboxImage: sandboxImage,
+		sandboxID: sandboxID, sandboxRevisionID: sandboxRevisionID,
 		authMode: byteCloudAppAKSKAuthMode, byteCloudSite: byteCloudSite,
 		accessKeyFile: accessKeyFile, secretKeyFile: secretKeyFile,
 		jwtEndpoint: jwtEndpoint, proxyURL: proxyURL, jwtRequestTimeout: jwtRequestTimeout,

--- a/v2/providers/tae/cmd/sandbox-gateway/main_test.go
+++ b/v2/providers/tae/cmd/sandbox-gateway/main_test.go
@@ -54,6 +54,11 @@ func TestLoadProviderConfigFailsClosedOnUnsafeRuntime(t *testing.T) {
 		"unbounded-file":       {maxReadBytesEnvironment: "999999999"},
 		"digest-image":         {sandboxImageEnvironment: "registry.example/sandbox@sha256:" + strings.Repeat("a", 64)},
 		"mutable-image":        {sandboxImageEnvironment: "registry.example/sandbox:latest"},
+		"missing-sandbox-id":   {sandboxIDEnvironment: ""},
+		"padded-sandbox-id":    {sandboxIDEnvironment: " sandbox-1"},
+		"uppercase-sandbox-id": {sandboxIDEnvironment: "Sandbox-1"},
+		"missing-revision-id":  {sandboxRevisionIDEnvironment: ""},
+		"invalid-revision-id":  {sandboxRevisionIDEnvironment: "revision_1"},
 	} {
 		t.Run(name, func(t *testing.T) {
 			values := validProviderEnvironment()
@@ -75,7 +80,8 @@ func TestLoadProviderConfigDefaultsAreBounded(t *testing.T) {
 	}
 	if config.controlTimeout != 45*time.Second || config.headerTimeout != 15*time.Second ||
 		config.streamGrace != 30*time.Second || config.reconnectAttempts != 2 ||
-		config.signalTimeout != 3*time.Second || config.maxReadBytes != 8*1024*1024 || config.sandboxImage == "" {
+		config.signalTimeout != 3*time.Second || config.maxReadBytes != 8*1024*1024 || config.sandboxImage == "" ||
+		config.sandboxID != "sandbox-1" || config.sandboxRevisionID != "revision-1" {
 		t.Fatalf("defaults = %+v", config)
 	}
 	if config.authMode != byteCloudAppAKSKAuthMode || config.byteCloudSite != adapter.ByteCloudSiteI18NTT ||
@@ -88,6 +94,8 @@ func TestLoadProviderConfigDefaultsAreBounded(t *testing.T) {
 func validProviderEnvironment() map[string]string {
 	return map[string]string{
 		sandboxImageEnvironment:         "aliyun-sin-hub.byted.org/agentserver/tae-sandbox:sha256-" + strings.Repeat("a", 64),
+		sandboxIDEnvironment:            "sandbox-1",
+		sandboxRevisionIDEnvironment:    "revision-1",
 		authModeEnvironment:             byteCloudAppAKSKAuthMode,
 		byteCloudSiteEnvironment:        adapter.ByteCloudSiteI18NTT,
 		byteCloudJWTEndpointEnvironment: adapter.ByteCloudJWTEndpointSG,

--- a/v2/providers/tae/cmd/sandbox-gateway/network_probe.go
+++ b/v2/providers/tae/cmd/sandbox-gateway/network_probe.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/agentserver/agentserver/v2/internal/managedruntime"
 	"github.com/agentserver/agentserver/v2/internal/productionimage"
 	"github.com/agentserver/agentserver/v2/internal/taenetworkreport"
 	"github.com/agentserver/agentserver/v2/providers/tae/adapter"
@@ -213,7 +212,8 @@ func executeNetworkProbe(ctx context.Context, config networkProbeConfig, clients
 			PolicyRevision: config.policyRevision, ByteCloudSite: adapter.ByteCloudSiteI18NTT,
 			JWTEndpoint: adapter.ByteCloudJWTEndpointSG, ProxyURL: adapter.TAEProxyURLSG,
 			ControlPlaneHost: adapter.SGTAEControlPlaneHost, DataPlaneDomainSuffix: domainSuffix,
-			SandboxImage: config.provider.sandboxImage, LarkCLIVersion: config.larkCLIVersion,
+			SandboxImage: config.provider.sandboxImage, SandboxID: config.provider.sandboxID,
+			SandboxRevisionID: config.provider.sandboxRevisionID, LarkCLIVersion: config.larkCLIVersion,
 			LarkCLISHA256: config.larkCLISHA256, LarkSkillSHA256: config.larkSkillSHA256,
 			ConnectivityAttempts: config.connectivityAttempts, LifecycleAttempts: config.lifecycleAttempts,
 		},
@@ -232,7 +232,7 @@ func runProbeLifecycle(ctx context.Context, config networkProbeConfig, clients *
 		requestContext, cancel := context.WithTimeout(ctx, config.provider.controlTimeout)
 		defer cancel()
 		created, err := clients.control.Create(requestContext, adapter.CreateInput{
-			TTL: probeSessionTTL, Metadata: metadata, Command: managedruntime.ExecutablePath,
+			TTL: probeSessionTTL, Metadata: metadata,
 		})
 		if err != nil {
 			return err

--- a/v2/providers/tae/cmd/sandbox-gateway/network_probe_test.go
+++ b/v2/providers/tae/cmd/sandbox-gateway/network_probe_test.go
@@ -150,6 +150,7 @@ func testNetworkProbeConfig(cli, skill []byte) networkProbeConfig {
 		provider: providerConfig{
 			controlTimeout: time.Second, jwtRequestTimeout: time.Second,
 			sandboxImage: "registry.example/sandbox:sha256-" + strings.Repeat("1", 64),
+			sandboxID:    "sandbox-1", sandboxRevisionID: "revision-1",
 		},
 		deploymentSHA256: strings.Repeat("2", 64), policyRevision: "revision-1",
 		larkCLIVersion: "test", larkCLISHA256: digest(cli), larkCLISize: int64(len(cli)),
@@ -206,11 +207,8 @@ func (control *probeControl) Create(_ context.Context, input adapter.CreateInput
 	if control.createError != nil {
 		return adapter.ControlSession{}, control.createError
 	}
-	if input.Command != managedruntime.ExecutablePath {
-		return adapter.ControlSession{}, &adapter.RequestError{Code: "bad_request", Cause: errors.New("unexpected managed runtime command")}
-	}
 	control.deleted = false
-	command := input.Command
+	command := managedruntime.ExecutablePath
 	if control.omitCommand {
 		command = ""
 	}

--- a/v2/providers/tae/cmd/sandbox-gateway/tae_clients.go
+++ b/v2/providers/tae/cmd/sandbox-gateway/tae_clients.go
@@ -43,7 +43,8 @@ func newTAEClients(ctx context.Context, config providerConfig, psm string) (*tae
 		return nil, fmt.Errorf("configure ByteCloud application identity: %w", err)
 	}
 	control, err := adapter.NewSGSDKControlPlane(ctx, adapter.SDKControlPlaneConfig{
-		PSM: psm, HTTPClient: controlHTTPClient, Headers: headerSource,
+		PSM: psm, SandboxID: config.sandboxID, RevisionID: config.sandboxRevisionID,
+		HTTPClient: controlHTTPClient, Headers: headerSource,
 		RequestTimeout: config.controlTimeout,
 	})
 	if err != nil {

--- a/v2/providers/tae/cmd/terminal-probe/main.go
+++ b/v2/providers/tae/cmd/terminal-probe/main.go
@@ -14,7 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/agentserver/agentserver/v2/internal/managedruntime"
 	"github.com/agentserver/agentserver/v2/providers/tae/adapter"
 )
 
@@ -23,6 +22,8 @@ const (
 	serviceAccount = "sa_g_eadce90936c71c1e"
 	accessPath     = "/var/run/agentserver/material/bytecloud-access-key-id"
 	secretPath     = "/var/run/agentserver/material/bytecloud-secret-access-key"
+	sandboxIDEnv   = "AGENTSERVER_V2_TAE_SANDBOX_ID"
+	revisionIDEnv  = "AGENTSERVER_V2_TAE_SANDBOX_REVISION_ID"
 )
 
 type report struct {
@@ -33,7 +34,10 @@ type report struct {
 	Passed                                bool      `json:"passed"`
 	Region                                string    `json:"region"`
 	PSM                                   string    `json:"psm"`
+	SandboxID                             string    `json:"sandboxId"`
+	SandboxRevisionID                     string    `json:"sandboxRevisionId"`
 	ImageOmitted                          bool      `json:"imageOmitted"`
+	CommandOmitted                        bool      `json:"commandOmitted"`
 	SessionID                             string    `json:"sessionId,omitempty"`
 	Created                               bool      `json:"created"`
 	Ready                                 bool      `json:"ready"`
@@ -60,12 +64,13 @@ func main() {
 
 func run() (result report) {
 	result = report{
-		SchemaVersion: 1,
-		Kind:          "agentserver.tae.sg-terminal-probe",
-		StartedAt:     time.Now().UTC(),
-		Region:        "sg",
-		PSM:           psm,
-		ImageOmitted:  true,
+		SchemaVersion:  1,
+		Kind:           "agentserver.tae.sg-terminal-probe",
+		StartedAt:      time.Now().UTC(),
+		Region:         "sg",
+		PSM:            psm,
+		ImageOmitted:   true,
+		CommandOmitted: true,
 	}
 	defer func() { result.FinishedAt = time.Now().UTC() }()
 
@@ -81,6 +86,18 @@ func run() (result report) {
 		result.Error = "load ByteCloud application secret key"
 		return result
 	}
+	sandboxID := os.Getenv(sandboxIDEnv)
+	if !adapter.ValidTerminalIdentity(sandboxID) {
+		result.Error = sandboxIDEnv + " is invalid"
+		return result
+	}
+	revisionID := os.Getenv(revisionIDEnv)
+	if !adapter.ValidTerminalIdentity(revisionID) {
+		result.Error = revisionIDEnv + " is invalid"
+		return result
+	}
+	result.SandboxID = sandboxID
+	result.SandboxRevisionID = revisionID
 
 	controlHTTP, err := adapter.NewSGTAEControlHTTPClient(adapter.StrictHTTPClientConfig{
 		TotalTimeout: 60 * time.Second, ResponseHeaderTimeout: 30 * time.Second,
@@ -107,7 +124,8 @@ func run() (result report) {
 		return result
 	}
 	control, err := adapter.NewSGSDKControlPlane(ctx, adapter.SDKControlPlaneConfig{
-		PSM: psm, HTTPClient: controlHTTP, Headers: headerSource, RequestTimeout: 60 * time.Second,
+		PSM: psm, SandboxID: sandboxID, RevisionID: revisionID,
+		HTTPClient: controlHTTP, Headers: headerSource, RequestTimeout: 60 * time.Second,
 	})
 	if err != nil {
 		result.Error = err.Error()
@@ -128,9 +146,7 @@ func run() (result report) {
 	}
 	metadata := map[string]string{adapter.MetadataSandboxID: "agentserver-tae-terminal-probe-" + id}
 	createContext, cancelCreate := context.WithTimeout(ctx, 60*time.Second)
-	session, err := control.Create(createContext, adapter.CreateInput{
-		TTL: 15 * time.Minute, Metadata: metadata, Command: managedruntime.ExecutablePath,
-	})
+	session, err := control.Create(createContext, adapter.CreateInput{TTL: 15 * time.Minute, Metadata: metadata})
 	cancelCreate()
 	if err != nil {
 		result.Error = err.Error()


### PR DESCRIPTION
Use the published TAE Terminal Sandbox revision as the runtime release boundary. Session creation now pins revision_id and omits dynamic image and command overrides.\n\nThe production config and network evidence bind sandboxId plus sandboxRevisionId, and rendered sandbox-gateway/probe workloads receive both identities. Outbound SDK lifecycle paths fail closed if the PSM resolves to another Sandbox ID.\n\nValidated with make check in v2, including the nested private-SDK provider module, web checks, schemas, and contract tests.