### PR TITLE
fix(v2): expose credentials before managed activation

### DIFF
--- a/v2/cmd/agentserver-core/serve.go
+++ b/v2/cmd/agentserver-core/serve.go
@@ -96,6 +96,10 @@ type coreProductionEnrollmentConfig struct {
 	ttl    time.Duration
 }
 
+func workspaceCredentialControlPlaneEnabled(mode coreServeMode, managedExecutorEnabled bool) bool {
+	return mode == coreServeProduction || managedExecutorEnabled
+}
+
 func serveCore(ctx context.Context, getenv func(string) string, stdout, stderr io.Writer, mode coreServeMode) error {
 	if mode != coreServeProduction && mode != coreServeInsecureDevelopment {
 		return errors.New("Core serve mode is invalid")
@@ -430,27 +434,22 @@ func serveCore(ctx context.Context, getenv func(string) string, stdout, stderr i
 	var workspaceCredentialAuthorizationHandler *coreserver.WorkspaceCredentialAuthorizationHandler
 	var egressCredentialHandler *coreserver.EgressCredentialHandler
 	var executionCredentialHandler *coreserver.ExecutionCredentialHandler
-	if managedExecutorEnabled {
+	var credentialRegistry *corecredentials.ProviderRegistry
+	var credentialSealer *corecredentials.Keyring
+	// Workspace credential configuration is a production control-plane feature:
+	// owners must be able to authorize providers before managed execution is
+	// activated. The managed-executor flag remains the kill switch for runtime
+	// resolution and sandbox authority only.
+	if workspaceCredentialControlPlaneEnabled(mode, managedExecutorEnabled) {
 		sealingKeyringFile, sealingErr := requiredConfiguration(getenv, coreCredentialSealingKeyringEnvironment)
 		if sealingErr != nil {
 			return sealingErr
-		}
-		placeholderKeyringFile, keyringErr := requiredConfiguration(getenv, coreEgressPlaceholderKeyringEnvironment)
-		if keyringErr != nil {
-			return keyringErr
-		}
-		placeholderVerifier, loadErr := egresscapability.LoadVerifier(placeholderKeyringFile)
-		if loadErr != nil {
-			return fmt.Errorf("configure v2 egress placeholder verifier: %w", loadErr)
-		}
-		capabilityVerifier, adapterErr := egressgateway.NewCapabilityPlaceholderVerifier(placeholderVerifier)
-		if adapterErr != nil {
-			return adapterErr
 		}
 		sealer, loadErr := corecredentials.LoadKeyring(sealingKeyringFile)
 		if loadErr != nil {
 			return fmt.Errorf("configure v2 workspace credential sealing keyring: %w", loadErr)
 		}
+		credentialSealer = sealer
 		publicProviderHTTPClient, clientErr := publichttps.NewClient(publichttps.ClientConfig{
 			Timeout: 25 * time.Second, ResponseHeaderTimeout: 15 * time.Second,
 			MaxIdleConns: 32, MaxIdleConnsPerHost: 8,
@@ -488,6 +487,7 @@ func serveCore(ctx context.Context, getenv func(string) string, stdout, stderr i
 		if registryErr != nil {
 			return fmt.Errorf("configure v2 workspace credential providers: %w", registryErr)
 		}
+		credentialRegistry = registry
 		credentialCommands := coreserver.StateStoreWorkspaceCredentialCommands{
 			Store: store, Registry: registry, Sealer: sealer, Now: time.Now, Logger: logger,
 		}
@@ -499,12 +499,28 @@ func serveCore(ctx context.Context, getenv func(string) string, stdout, stderr i
 		if err != nil {
 			return err
 		}
-		credentialRefresher, refreshErr := coreserver.NewWorkspaceCredentialRefresher(store, registry, sealer, time.Now)
+	}
+	if managedExecutorEnabled {
+		placeholderKeyringFile, keyringErr := requiredConfiguration(getenv, coreEgressPlaceholderKeyringEnvironment)
+		if keyringErr != nil {
+			return keyringErr
+		}
+		placeholderVerifier, loadErr := egresscapability.LoadVerifier(placeholderKeyringFile)
+		if loadErr != nil {
+			return fmt.Errorf("configure v2 egress placeholder verifier: %w", loadErr)
+		}
+		capabilityVerifier, adapterErr := egressgateway.NewCapabilityPlaceholderVerifier(placeholderVerifier)
+		if adapterErr != nil {
+			return adapterErr
+		}
+		credentialRefresher, refreshErr := coreserver.NewWorkspaceCredentialRefresher(
+			store, credentialRegistry, credentialSealer, time.Now,
+		)
 		if refreshErr != nil {
 			return fmt.Errorf("configure v2 workspace credential refresh: %w", refreshErr)
 		}
 		egressCredentialService, serviceErr := coreserver.NewEgressCredentialService(coreserver.EgressCredentialServiceConfig{
-			Store: store, Registry: registry, Sealer: sealer, Placeholders: capabilityVerifier,
+			Store: store, Registry: credentialRegistry, Sealer: credentialSealer, Placeholders: capabilityVerifier,
 			ProcessProofs: placeholderVerifier, ProcessEnvironmentTAEPSM: managedTAEPSM, Now: time.Now,
 			CredentialRefresher: credentialRefresher,
 		})

--- a/v2/cmd/agentserver-core/serve_test.go
+++ b/v2/cmd/agentserver-core/serve_test.go
@@ -75,6 +75,27 @@ func TestConfigureCoreLarkDeviceApplicationRequiresProductionIdentity(t *testing
 	}
 }
 
+func TestWorkspaceCredentialControlPlanePrecedesManagedExecutionActivation(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    coreServeMode
+		managed bool
+		want    bool
+	}{
+		{name: "production policy bootstrap", mode: coreServeProduction, managed: false, want: true},
+		{name: "production active", mode: coreServeProduction, managed: true, want: true},
+		{name: "development disabled", mode: coreServeInsecureDevelopment, managed: false, want: false},
+		{name: "development managed", mode: coreServeInsecureDevelopment, managed: true, want: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := workspaceCredentialControlPlaneEnabled(test.mode, test.managed); got != test.want {
+				t.Fatalf("workspace credential control plane enabled = %t, want %t", got, test.want)
+			}
+		})
+	}
+}
+
 func TestConfigureCoreByteCloudDeviceAPISeparatesFixedInternalProvider(t *testing.T) {
 	configuration := map[string]string{}
 	getenv := func(name string) string { return configuration[name] }

--- a/v2/internal/productiondeploy/kubernetes.go
+++ b/v2/internal/productiondeploy/kubernetes.go
@@ -110,7 +110,7 @@ var materialProfileFiles = map[string][]string{
 	materialProfileCore: {
 		"ca.crt", "tls.crt", "tls.key", "run-capability.key",
 		"run-capability-keyring.json", "executor-enrollment.key",
-		"llm-gateway-sealing-keyring.json",
+		"llm-gateway-sealing-keyring.json", "credential-sealing-keyring.json",
 	},
 	materialProfilePlatformGateway: {"ca.crt", "tls.crt", "tls.key"},
 	materialProfileBrowserGateway:  {"ca.crt", "tls.crt", "tls.key"},

--- a/v2/internal/productiondeploy/render_test.go
+++ b/v2/internal/productiondeploy/render_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/agentserver/agentserver/v2/internal/corecontract"
+	"github.com/agentserver/agentserver/v2/internal/corecredentials"
 	"github.com/agentserver/agentserver/v2/internal/executorgateway"
 	"github.com/agentserver/agentserver/v2/internal/sandboxgatewayapp"
 	"github.com/agentserver/agentserver/v2/internal/taeimage"
@@ -206,6 +207,20 @@ func TestRenderPolicyBootstrapExposesOnlyDenyWebhook(t *testing.T) {
 	if literalEnvironment(t, coreContainer, "AGENTSERVER_V2_MANAGED_EXECUTOR_ENABLED") != "false" {
 		t.Fatal("policy bootstrap activated managed execution in Core")
 	}
+	if got := literalEnvironment(t, coreContainer, "AGENTSERVER_V2_CREDENTIAL_SEALING_KEYRING_FILE"); got != serviceMaterialPath("credential-sealing-keyring.json") {
+		t.Fatalf("policy bootstrap credential sealing keyring = %q", got)
+	}
+	if got := literalEnvironment(t, coreContainer, "AGENTSERVER_V2_LARK_DEVICE_SCOPES"); got != corecredentials.DefaultManagedLarkScopes {
+		t.Fatalf("policy bootstrap Lark device scopes = %q", got)
+	}
+	if got := literalEnvironment(t, coreContainer, "AGENTSERVER_V2_BYTECLOUD_DEVICE_API_BASE_URL"); got != corecredentials.DefaultByteCloudDeviceAPIBaseURL {
+		t.Fatalf("policy bootstrap ByteCloud device API = %q", got)
+	}
+	assertSecretEnvironment(t, coreContainer, "AGENTSERVER_V2_LARK_DEVICE_APP_ID", loaded.Document.Secrets.Core, "lark-device-app-id")
+	assertSecretEnvironment(t, coreContainer, "AGENTSERVER_V2_LARK_DEVICE_APP_SECRET", loaded.Document.Secrets.Core, "lark-device-app-secret")
+	assertSecretMaterialMounts(t, core, "material", loaded.Document.Secrets.Core,
+		"/var/run/agentserver/material", groupReadableSecretMode,
+		[]string{"ca.crt", "tls.crt", "tls.key", "run-capability.key", "run-capability-keyring.json", "executor-enrollment.key", "llm-gateway-sealing-keyring.json", "credential-sealing-keyring.json"})
 }
 
 func TestRenderManagedExecutorWithoutLarkToolPackKeepsTAE(t *testing.T) {

--- a/v2/internal/productiondeploy/workloads.go
+++ b/v2/internal/productiondeploy/workloads.go
@@ -278,16 +278,16 @@ func renderCoreDeployment(context renderContext) (kubeObject, error) {
 		valueEnvironment("AGENTSERVER_V2_EXECUTOR_ENROLLMENT_TOKEN_KEY_FILE", serviceMaterialPath("executor-enrollment.key")),
 		valueEnvironment("AGENTSERVER_V2_EXECUTOR_ENROLLMENT_TOKEN_TTL", document.Runtime.EnrollmentTokenTTL),
 		valueEnvironment("AGENTSERVER_V2_MANAGED_EXECUTOR_ENABLED", strconv.FormatBool(managedExecutionActive(document.Managed))),
+		valueEnvironment("AGENTSERVER_V2_CREDENTIAL_SEALING_KEYRING_FILE", serviceMaterialPath("credential-sealing-keyring.json")),
+		secretEnvironment("AGENTSERVER_V2_LARK_DEVICE_APP_ID", document.Secrets.Core, "lark-device-app-id"),
+		secretEnvironment("AGENTSERVER_V2_LARK_DEVICE_APP_SECRET", document.Secrets.Core, "lark-device-app-secret"),
+		valueEnvironment("AGENTSERVER_V2_LARK_DEVICE_SCOPES", corecredentials.DefaultManagedLarkScopes),
+		valueEnvironment("AGENTSERVER_V2_BYTECLOUD_DEVICE_API_BASE_URL", corecredentials.DefaultByteCloudDeviceAPIBaseURL),
 	}
 	if managedExecutionActive(document.Managed) {
 		environment = append(environment,
 			valueEnvironment("AGENTSERVER_V2_SANDBOX_GATEWAY_SPIFFE_ID", spiffeIdentity(config, sandboxComponent)),
-			valueEnvironment("AGENTSERVER_V2_CREDENTIAL_SEALING_KEYRING_FILE", serviceMaterialPath("credential-sealing-keyring.json")),
 			valueEnvironment("AGENTSERVER_V2_MANAGED_TAE_PSM", document.Managed.TAE.PSM),
-			secretEnvironment("AGENTSERVER_V2_LARK_DEVICE_APP_ID", document.Secrets.Core, "lark-device-app-id"),
-			secretEnvironment("AGENTSERVER_V2_LARK_DEVICE_APP_SECRET", document.Secrets.Core, "lark-device-app-secret"),
-			valueEnvironment("AGENTSERVER_V2_LARK_DEVICE_SCOPES", corecredentials.DefaultManagedLarkScopes),
-			valueEnvironment("AGENTSERVER_V2_BYTECLOUD_DEVICE_API_BASE_URL", corecredentials.DefaultByteCloudDeviceAPIBaseURL),
 			valueEnvironment("AGENTSERVER_V2_EGRESS_AUTHORIZER_SPIFFE_ID", spiffeIdentity(config, egressComponent)),
 			valueEnvironment("AGENTSERVER_V2_EGRESS_PLACEHOLDER_KEYRING_FILE", serviceMaterialPath("egress-placeholder-keyring.json")),
 		)


### PR DESCRIPTION
Fixes the production 502 on GET /v2/credential-providers during policy-bootstrap.

The workspace credential control plane is now initialized in production independently of the managed-executor runtime kill switch. Policy-bootstrap mounts only the credential sealing material and provider application configuration; sandbox and egress credential resolution remain disabled until managed activation.

Verification:
- make check
- policy-bootstrap renderer regression covers Lark, ByteCloud, and sealing material
- Core mode regression covers production bootstrap versus active state