### PR TITLE
fix(v2): type managed sandbox reservation TTLs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,6 +16,20 @@ permissions:
 jobs:
   v2-unit:
     runs-on: k8s-sg
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: test
+          POSTGRES_PASSWORD: test
+          POSTGRES_DB: test
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     steps:
       - uses: actions/checkout@v6
 
@@ -67,6 +81,16 @@ jobs:
 
       - name: Verify v2 module boundary and unit tests
         run: make -C v2 check
+
+      - name: Managed sandbox PostgreSQL reservation regression test
+        working-directory: v2
+        env:
+          AGENTSERVER_RUN_POSTGRES_TESTS: "1"
+          AGENTSERVER_V2_TEST_DATABASE_URL: postgres://test:test@localhost:5432/test?sslmode=disable
+        run: >-
+          go test ./internal/coredb
+          -run '^TestPostgreSQLManagedSandboxReservationPersistsTypedTTLs$'
+          -count=1 -timeout 2m -v
 
   test:
     needs: [v2-unit]

--- a/v2/internal/coredb/state_managed_sandbox_postgres_integration_test.go
+++ b/v2/internal/coredb/state_managed_sandbox_postgres_integration_test.go
@@ -10,6 +10,40 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
+func TestPostgreSQLManagedSandboxReservationPersistsTypedTTLs(t *testing.T) {
+	store, pool, schema := newPostgresStateStore(t)
+	running := startExecutionTestRun(t, store, pool, schema, 800_000)
+	reserve := managedSandboxTestReserve(801_000, running)
+
+	beforeReserve := time.Now().UTC()
+	result, err := store.ReserveManagedSandbox(t.Context(), reserve)
+	afterReserve := time.Now().UTC()
+	if err != nil {
+		t.Fatalf("ReserveManagedSandbox() error = %v", err)
+	}
+	if !result.Created {
+		t.Fatal("ReserveManagedSandbox() did not create the initial reservation")
+	}
+	if result.Sandbox.RequestedTTL != reserve.RequestedTTL || result.Sandbox.IdleTTL != reserve.RequestedIdleTTL {
+		t.Fatalf(
+			"reserved TTLs = (%s, %s), want (%s, %s)",
+			result.Sandbox.RequestedTTL, result.Sandbox.IdleTTL,
+			reserve.RequestedTTL, reserve.RequestedIdleTTL,
+		)
+	}
+	if result.Sandbox.IdleExpiresAt == nil {
+		t.Fatal("reserved sandbox has no idle expiry")
+	}
+	wantEarliestExpiry := beforeReserve.Add(reserve.RequestedIdleTTL)
+	wantLatestExpiry := afterReserve.Add(reserve.RequestedIdleTTL)
+	if result.Sandbox.IdleExpiresAt.Before(wantEarliestExpiry) || result.Sandbox.IdleExpiresAt.After(wantLatestExpiry) {
+		t.Fatalf(
+			"reserved idle expiry = %s, want between %s and %s",
+			result.Sandbox.IdleExpiresAt, wantEarliestExpiry, wantLatestExpiry,
+		)
+	}
+}
+
 func TestPostgreSQLManagedSandboxLifecycleActivityAndTAEDispatch(t *testing.T) {
 	store, pool, schema := newPostgresStateStore(t)
 	running := startExecutionTestRun(t, store, pool, schema, 810_000)

--- a/v2/internal/coredb/state_managed_sandboxes.go
+++ b/v2/internal/coredb/state_managed_sandboxes.go
@@ -74,8 +74,8 @@ INSERT INTO %s
      requested_ttl_seconds, idle_ttl_seconds, idle_expires_at)
 VALUES
     ($1, $2, $3, $4, 'tae', $5, 'ready', 'reserved',
-     $6, $7, $8, $9, $10, $11, $12, $13,
-     pg_catalog.clock_timestamp() + ($13 * interval '1 second'))
+     $6, $7, $8, $9, $10, $11, $12::bigint, $13::bigint,
+     pg_catalog.clock_timestamp() + ($13::bigint * interval '1 second'))
 RETURNING %s`, s.table("managed_sandboxes"), managedSandboxColumns(""))
 		sandbox, err := scanManagedSandbox(transaction.QueryRow(ctx, insertQuery,
 			command.SandboxID, command.WorkspaceID, command.SessionID, command.EnvironmentID,


### PR DESCRIPTION
Fix the production managed-sandbox reservation failure caused by PostgreSQL inferring parameter 13 as both bigint and double precision. Explicitly type TTL parameters and add a focused PostgreSQL 15 regression test to the SG self-hosted CI job.\n\nValidation: make -C v2 check