### PR TITLE
fix(v2): stop managed sandbox runs from hanging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,14 +82,14 @@ jobs:
       - name: Verify v2 module boundary and unit tests
         run: make -C v2 check
 
-      - name: Managed sandbox PostgreSQL reservation regression test
+      - name: V2 production PostgreSQL regressions
         working-directory: v2
         env:
           AGENTSERVER_RUN_POSTGRES_TESTS: "1"
           AGENTSERVER_V2_TEST_DATABASE_URL: postgres://test:test@localhost:5432/test?sslmode=disable
         run: >-
           go test ./internal/coredb
-          -run '^TestPostgreSQLManagedSandboxReservationPersistsTypedTTLs$'
+          -run '^TestPostgreSQL(ManagedSandboxReservationPersistsTypedTTLs|PreTurnAbandonmentAtomicallyArbitratesCancellation)$'
           -count=1 -timeout 2m -v
 
   test:

--- a/v2/cmd/harness-pool/serve.go
+++ b/v2/cmd/harness-pool/serve.go
@@ -253,7 +253,7 @@ func serveHarnessPool(
 	if managedSandboxLifecycle != nil {
 		managedDescription = "managed sandbox lifecycle enabled"
 	}
-	fmt.Fprintf(stdout, "harness-pool serve: %s; %s; %s; holder %s; control %s; max attempts %d\n",
+	fmt.Fprintf(stdout, "harness-pool serve: %s; %s; %s; holder %s; control %s; max concurrent attempts %d\n",
 		authorityDescription, objectStoreDescription, managedDescription, poolInstanceID, callbackEndpoint, config.maxConcurrent)
 	return runHarnessPoolServices(ctx, pool, controls, server, tls.NewListener(listener, controlTLS), readiness)
 }

--- a/v2/internal/coredb/state_managed_sandbox_postgres_integration_test.go
+++ b/v2/internal/coredb/state_managed_sandbox_postgres_integration_test.go
@@ -14,6 +14,11 @@ func TestPostgreSQLManagedSandboxReservationPersistsTypedTTLs(t *testing.T) {
 	store, pool, schema := newPostgresStateStore(t)
 	running := startExecutionTestRun(t, store, pool, schema, 800_000)
 	reserve := managedSandboxTestReserve(801_000, running)
+	// The gateway does not know the provider session reference until after
+	// provider create. Production reservations therefore carry the Go zero
+	// value, which must be persisted as SQL NULL to satisfy the bounded-ref
+	// constraint and scan back as an empty string.
+	reserve.ProviderSessionRef = ""
 
 	beforeReserve := time.Now().UTC()
 	result, err := store.ReserveManagedSandbox(t.Context(), reserve)
@@ -23,6 +28,9 @@ func TestPostgreSQLManagedSandboxReservationPersistsTypedTTLs(t *testing.T) {
 	}
 	if !result.Created {
 		t.Fatal("ReserveManagedSandbox() did not create the initial reservation")
+	}
+	if result.Sandbox.ProviderSessionRef != "" {
+		t.Fatalf("reserved provider session ref = %q, want empty", result.Sandbox.ProviderSessionRef)
 	}
 	if result.Sandbox.RequestedTTL != reserve.RequestedTTL || result.Sandbox.IdleTTL != reserve.RequestedIdleTTL {
 		t.Fatalf(

--- a/v2/internal/coredb/state_managed_sandboxes.go
+++ b/v2/internal/coredb/state_managed_sandboxes.go
@@ -74,7 +74,7 @@ INSERT INTO %s
      requested_ttl_seconds, idle_ttl_seconds, idle_expires_at)
 VALUES
     ($1, $2, $3, $4, 'tae', $5, 'ready', 'reserved',
-     $6, $7, $8, $9, $10, $11, $12::bigint, $13::bigint,
+     $6, $7, NULLIF($8, ''), $9, $10, $11, $12::bigint, $13::bigint,
      pg_catalog.clock_timestamp() + ($13::bigint * interval '1 second'))
 RETURNING %s`, s.table("managed_sandboxes"), managedSandboxColumns(""))
 		sandbox, err := scanManagedSandbox(transaction.QueryRow(ctx, insertQuery,

--- a/v2/internal/coredb/state_run_cancellation.go
+++ b/v2/internal/coredb/state_run_cancellation.go
@@ -9,13 +9,20 @@ import (
 )
 
 const (
-	cancelReasonUser       = "cancelled"
-	cancelCodeUser         = "user_cancelled"
-	cancelMessage          = "the run was cancelled by a workspace member"
-	abandonReasonStartup   = "startup_failed"
-	abandonCodeStartup     = "attempt_startup_failed"
-	abandonMessage         = "the attempt stopped before accepting a turn and will be retried"
-	abandonTerminalMessage = "the attempt was rejected before accepting a turn and will not be retried"
+	cancelReasonUser        = "cancelled"
+	cancelCodeUser          = "user_cancelled"
+	cancelMessage           = "the run was cancelled by a workspace member"
+	abandonReasonStartup    = "startup_failed"
+	abandonCodeStartup      = "attempt_startup_failed"
+	abandonMessage          = "the attempt stopped before accepting a turn and will be retried"
+	abandonTerminalMessage  = "the attempt was rejected before accepting a turn and will not be retried"
+	abandonExhaustedCode    = "attempt_startup_retry_exhausted"
+	abandonExhaustedMessage = "the attempt stopped before accepting a turn after the maximum startup attempts and will not be retried"
+
+	// The generation is durable on the run, so this retry budget survives
+	// harness restarts and ownership changes. Four means one initial attempt
+	// plus at most three pre-turn retries.
+	maximumPreTurnStartupAttempts int64 = 4
 
 	AbandonDispositionRequeued            = "requeued"
 	AbandonDispositionFailed              = "failed"
@@ -461,11 +468,16 @@ func (s *StateStore) AbandonAttempt(ctx context.Context, command AbandonAttemptC
 		code := abandonCodeStartup
 		message := abandonMessage
 		disposition := AbandonDispositionRequeued
-		if command.Terminal {
+		terminal := command.Terminal || attempt.Generation >= maximumPreTurnStartupAttempts
+		if terminal {
 			runStatus = RunStatusFailed
 			kind = "run.failed"
 			message = abandonTerminalMessage
 			disposition = AbandonDispositionFailed
+		}
+		if !command.Terminal && attempt.Generation >= maximumPreTurnStartupAttempts {
+			code = abandonExhaustedCode
+			message = abandonExhaustedMessage
 		}
 		if run.Status == RunStatusCancelling {
 			attemptStatus = AttemptStatusInterrupted

--- a/v2/internal/coredb/state_run_cancellation_postgres_integration_test.go
+++ b/v2/internal/coredb/state_run_cancellation_postgres_integration_test.go
@@ -335,6 +335,59 @@ func TestPostgreSQLPreTurnAbandonmentAtomicallyArbitratesCancellation(t *testing
 		)
 	})
 
+	t.Run("startup retry budget is durable", func(t *testing.T) {
+		store, pool, schema := newPostgresStateStore(t)
+		workspaceID := stateTestUUID(157_000)
+		sessionID := stateTestUUID(157_001)
+		insertStateTestSession(t, pool, schema, workspaceID, sessionID)
+		created := mustCreateStateRun(t, store, stateCreateRunCommand(157_010, workspaceID, sessionID, "startup-retry-budget"))
+		currentRun := created.Run
+
+		for generation := int64(1); generation <= maximumPreTurnStartupAttempts; generation++ {
+			seed := 157_020 + int(generation)*10
+			claim := mustClaimStateRun(t, store, stateClaimRunCommand(seed, currentRun.ID, currentRun.Version, fmt.Sprintf("retry-holder-%d", generation)))
+			if claim.Attempt.Generation != generation {
+				t.Fatalf("attempt generation = %d, want %d", claim.Attempt.Generation, generation)
+			}
+			command := AbandonAttemptCommand{
+				RunID: currentRun.ID, AttemptID: claim.Attempt.ID, HolderID: claim.Attempt.HolderID,
+				Generation: generation, Reason: abandonReasonStartup, Record: stateTransitionRecord(seed + 1),
+			}
+			abandoned, err := store.AbandonAttempt(t.Context(), command)
+			if err != nil {
+				t.Fatalf("generation %d AbandonAttempt() error = %v", generation, err)
+			}
+			if generation < maximumPreTurnStartupAttempts {
+				if abandoned.Disposition != AbandonDispositionRequeued || abandoned.Run.Status != RunStatusQueued {
+					t.Fatalf("generation %d abandonment = %+v, want requeued", generation, abandoned)
+				}
+			} else {
+				if abandoned.Disposition != AbandonDispositionFailed || abandoned.Run.Status != RunStatusFailed {
+					t.Fatalf("generation %d abandonment = %+v, want failed", generation, abandoned)
+				}
+				assertAttemptAbandonmentTransition(
+					t, pool, schema, command.Record, currentRun.ID, claim.Attempt,
+					"run.failed", abandonExhaustedCode, abandonExhaustedMessage,
+					1+maximumPreTurnStartupAttempts*2,
+				)
+			}
+			currentRun = abandoned.Run
+		}
+
+		var attempts int
+		attemptCountQuery := fmt.Sprintf("SELECT pg_catalog.count(*) FROM %s.run_attempts WHERE run_id = $1", quoteIdentifier(schema))
+		if err := pool.QueryRow(t.Context(), attemptCountQuery, currentRun.ID).Scan(&attempts); err != nil {
+			t.Fatal(err)
+		}
+		if attempts != int(maximumPreTurnStartupAttempts) {
+			t.Fatalf("persisted attempts = %d, want %d", attempts, maximumPreTurnStartupAttempts)
+		}
+		assertCancellationAggregate(
+			t, pool, schema, currentRun.ID, sessionID, RunStatusFailed,
+			currentRun.Version, currentRun.NextEventSeq, false, 0, 0,
+		)
+	})
+
 	t.Run("cancel then abandon", func(t *testing.T) {
 		store, pool, schema := newPostgresStateStore(t)
 		workspaceID := stateTestUUID(154_000)


### PR DESCRIPTION
Fixes the production managed-sandbox reservation failure and unbounded pre-turn retry loop.\n\n- persist an unknown provider session reference as SQL NULL\n- cover the production empty-ref reservation with PostgreSQL\n- fail a run after four durable pre-turn startup attempts\n- run both production PostgreSQL regressions in CI\n- clarify the startup log reports concurrency, not retry budget\n\nLocal verification: make -C v2 check