### PR TITLE
fix(v2): recover TAE create metadata via fast release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
+    paths-ignore:
+      - "v2/**"
+      - ".github/workflows/v2-production.yml"
+      - ".github/workflows/self-hosted-runner-check.yml"
   workflow_dispatch:
 
 env:

--- a/.github/workflows/self-hosted-runner-check.yml
+++ b/.github/workflows/self-hosted-runner-check.yml
@@ -20,12 +20,8 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
-
-      - name: Install build tools
-        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends make libatomic1
-
-      - name: Verify runner Docker access
-        run: docker version
+        with:
+          fetch-depth: 2
 
       - uses: actions/setup-go@v6
         with:
@@ -53,22 +49,39 @@ jobs:
             'GIT_TERMINAL_PROMPT=0' \
             'GOPRIVATE=code.byted.org' \
             'GONOSUMDB=code.byted.org' >>"${GITHUB_ENV}"
-          GIT_TERMINAL_PROMPT=0 git ls-remote --exit-code \
-            https://code.byted.org/security/zti-jwt-golang.git HEAD >/dev/null
 
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 11.18.0
-          run_install: false
-
-      - uses: actions/setup-node@v6
-        with:
-          node-version-file: v2/.node-version
-          cache: pnpm
-          cache-dependency-path: v2/pnpm-lock.yaml
-
-      - name: Install v2 web dependencies
-        run: pnpm --dir v2 install --frozen-lockfile
-
-      - name: Verify v2 module boundary and unit tests
-        run: make -C v2 check
+      - name: Test only changed Go packages
+        shell: bash
+        run: |
+          set -euo pipefail
+          if git rev-parse --verify HEAD^ >/dev/null 2>&1; then
+            changed=$(git diff --name-only HEAD^ HEAD)
+          else
+            changed=$(git diff-tree --no-commit-id --name-only -r HEAD)
+          fi
+          declare -A root_packages=()
+          declare -A tae_packages=()
+          while IFS= read -r file; do
+            case "${file}" in
+              v2/providers/tae/*.go)
+                directory=$(dirname "${file#v2/providers/tae/}")
+                tae_packages["./${directory}"]=1
+                ;;
+              v2/*.go)
+                directory=$(dirname "${file#v2/}")
+                root_packages["./${directory}"]=1
+                ;;
+              *.sh)
+                sh -n "${file}"
+                ;;
+            esac
+          done <<<"${changed}"
+          if ((${#root_packages[@]})); then
+            go -C v2 test "${!root_packages[@]}" -count=1
+          fi
+          if ((${#tae_packages[@]})); then
+            go -C v2/providers/tae test "${!tae_packages[@]}" -count=1
+          fi
+          if ((!${#root_packages[@]} && !${#tae_packages[@]})); then
+            echo 'No changed Go package; development gate completed without a repository-wide rebuild.'
+          fi

--- a/.github/workflows/v2-production.yml
+++ b/.github/workflows/v2-production.yml
@@ -8,6 +8,14 @@ on:
       - ".github/workflows/v2-production.yml"
   workflow_dispatch:
     inputs:
+      release_mode:
+        description: Developer service-only release reuses the active harness, managed sandbox, Hydra, and TAE evidence
+        required: false
+        default: service_only
+        type: choice
+        options:
+          - full
+          - service_only
       active_chart_only:
         description: Promote the already-probed evidence-bound active Chart without rebuilding images
         required: false
@@ -42,7 +50,7 @@ env:
 
 jobs:
   publish-linux-amd64:
-    if: ${{ !inputs.active_chart_only }}
+    if: ${{ github.event_name == 'workflow_dispatch' && !inputs.active_chart_only && inputs.release_mode == 'full' }}
     runs-on: k8s-sg
     timeout-minutes: 90
     steps:
@@ -418,6 +426,131 @@ jobs:
             ${{ runner.temp }}/agentserver-v2-image-evidence/*-image-manifest.json
             ${{ steps.chart.outputs.release_dir }}/production.json
             ${{ steps.chart.outputs.release_dir }}/managed-release-verification.txt
+            ${{ steps.chart.outputs.release_dir }}/agentserver-v2-*.tgz
+
+  publish-service-only:
+    if: ${{ !inputs.active_chart_only && (github.event_name == 'push' || inputs.release_mode == 'service_only') }}
+    runs-on: k8s-sg
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: v2/go.mod
+          cache-dependency-path: |
+            v2/go.sum
+            v2/providers/tae/go.sum
+
+      - name: Configure code.byted.org read access
+        env:
+          CODE_BYTED_USERNAME: ${{ secrets.CODE_BYTED_USERNAME }}
+          CODE_BYTED_TOKEN: ${{ secrets.CODE_BYTED_TOKEN }}
+        run: |
+          set -euo pipefail
+          test -n "${CODE_BYTED_USERNAME}" && test -n "${CODE_BYTED_TOKEN}"
+          credential_file="${RUNNER_TEMP}/code-byted.credentials"
+          umask 077
+          git config --global credential.helper "store --file=${credential_file}"
+          printf 'protocol=https\nhost=code.byted.org\nusername=%s\npassword=%s\n\n' \
+            "${CODE_BYTED_USERNAME}" "${CODE_BYTED_TOKEN}" | git credential approve
+          printf '%s\n' \
+            'GIT_TERMINAL_PROMPT=0' \
+            'GOPRIVATE=code.byted.org' \
+            'GONOSUMDB=code.byted.org' >>"${GITHUB_ENV}"
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: azure/setup-helm@v4
+        with:
+          version: v3.18.4
+
+      - name: Build and publish only the service image
+        id: service
+        run: |
+          set -euo pipefail
+          evidence="${RUNNER_TEMP}/agentserver-v2-service-evidence"
+          ./v2/deploy/production/build-service-image.sh \
+            --platform=linux-amd64 \
+            --service-image="${SERVICE_REPOSITORY}:sha-${GITHUB_SHA}" \
+            --cache=gha \
+            --output-dir="${evidence}"
+          service_digest=$(tr -d '\n' <"${evidence}/service-image-digest.txt")
+          test "${#service_digest}" = 71
+          printf 'service_digest=%s\n' "${service_digest}" >>"${GITHUB_OUTPUT}"
+
+      - name: Generate active chart with reused runtime artifacts
+        id: chart
+        env:
+          SERVICE_DIGEST: ${{ steps.service.outputs.service_digest }}
+          SG_PRODUCTION_CONFIG_B64: ${{ secrets.V2_SG_PRODUCTION_CONFIG_B64 }}
+        run: |
+          set -euo pipefail
+          test -n "${SG_PRODUCTION_CONFIG_B64:-}"
+          release_dir="${RUNNER_TEMP}/agentserver-v2-service-release"
+          chart_dir="${release_dir}/agentserver-v2"
+          install -d -m 0700 "${release_dir}"
+          umask 077
+          active_config="${release_dir}/sg-active.json"
+          printf '%s' "${SG_PRODUCTION_CONFIG_B64}" | base64 --decode >"${active_config}"
+          chmod 0600 "${active_config}"
+          test "$(jq -r '.managedExecutor.stage' "${active_config}")" = active
+          go -C v2 build -o "${release_dir}/agentserver-deploy" ./cmd/agentserver-deploy
+          "${release_dir}/agentserver-deploy" lock-developer-service \
+            --config="${active_config}" \
+            --output="${release_dir}/production.json" \
+            --service-image="registry-sg.byted.cs.ac.cn/ghcr/agentserver/v2-service@${SERVICE_DIGEST}"
+          # Prove that the fast path changed only images.service. The selected
+          # harness, managed sandbox, Hydra, and all TAE evidence remain the
+          # already-probed active production authority.
+          jq --sort-keys 'del(.images.service)' "${active_config}" >"${release_dir}/before.json"
+          jq --sort-keys 'del(.images.service)' "${release_dir}/production.json" >"${release_dir}/after.json"
+          cmp "${release_dir}/before.json" "${release_dir}/after.json"
+          "${release_dir}/agentserver-deploy" chart \
+            --config="${release_dir}/production.json" \
+            --output="${chart_dir}"
+          helm lint --strict --namespace agentserver "${chart_dir}"
+          deployment_sha=$(sed -n 's/^deploymentConfigSHA256: "\([0-9a-f]\{64\}\)"$/\1/p' "${chart_dir}/values.yaml")
+          chart_version=$(sed -n 's/^version: \([^[:space:]]*\)$/\1/p' "${chart_dir}/Chart.yaml")
+          test "${#deployment_sha}" = 64
+          test "${chart_version}" = "0.1.0-config.d$(printf '%s' "${deployment_sha}" | cut -c1-12)"
+          helm package "${chart_dir}" --destination "${release_dir}"
+          printf '%s' "${{ secrets.GITHUB_TOKEN }}" | \
+            helm registry login ghcr.io --username "${GITHUB_ACTOR}" --password-stdin
+          helm push "${release_dir}/agentserver-v2-${chart_version}.tgz" oci://ghcr.io/agentserver
+          printf 'deployment_sha=%s\n' "${deployment_sha}" >>"${GITHUB_OUTPUT}"
+          printf 'version=%s\n' "${chart_version}" >>"${GITHUB_OUTPUT}"
+          printf 'release_dir=%s\n' "${release_dir}" >>"${GITHUB_OUTPUT}"
+
+      - name: Record service-only development release
+        env:
+          SERVICE_DIGEST: ${{ steps.service.outputs.service_digest }}
+          CHART_VERSION: ${{ steps.chart.outputs.version }}
+          DEPLOYMENT_SHA: ${{ steps.chart.outputs.deployment_sha }}
+        run: |
+          {
+            printf '## AgentServer v2 service-only development release\n\n'
+            printf -- '- Service: `%s@%s`\n' "${SERVICE_REPOSITORY}" "${SERVICE_DIGEST}"
+            printf -- '- Chart: `oci://%s:%s`\n' "${CHART_REPOSITORY}" "${CHART_VERSION}"
+            printf -- '- Deployment config SHA-256: `%s`\n' "${DEPLOYMENT_SHA}"
+            printf -- '- Reused: active harness, managed sandbox, Hydra, runtime/pack locks, and TAE evidence\n'
+            printf -- '- Skipped: web dependency install, full repository check, Codex/bwrap/Lark downloads, and unchanged image builds\n'
+          } >>"${GITHUB_STEP_SUMMARY}"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: agentserver-v2-service-only-${{ github.sha }}
+          if-no-files-found: error
+          retention-days: 7
+          path: |
+            ${{ runner.temp }}/agentserver-v2-service-evidence/service-image-manifest.json
+            ${{ steps.chart.outputs.release_dir }}/production.json
             ${{ steps.chart.outputs.release_dir }}/agentserver-v2-*.tgz
 
   promote-active-chart:

--- a/v2/cmd/agentserver-deploy/main.go
+++ b/v2/cmd/agentserver-deploy/main.go
@@ -16,6 +16,7 @@ type deployCommands struct {
 	chart                   func(productiondeploy.LoadedConfig) (productiondeploy.HelmChart, error)
 	writeChart              func(productiondeploy.HelmChart, string) error
 	lock                    func(productiondeploy.LoadedConfig, productiondeploy.ReleaseLock) ([]byte, error)
+	lockDeveloperService    func(productiondeploy.LoadedConfig, string) ([]byte, error)
 	writeLock               func([]byte, string) error
 	preparePolicyBootstrap  func(string, string) error
 	pinManagedTerminal      func(string, string, string, string) error
@@ -26,7 +27,8 @@ func main() {
 	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr, deployCommands{
 		load: productiondeploy.LoadConfig, render: productiondeploy.Render, write: productiondeploy.WriteBundle,
 		chart: productiondeploy.RenderHelmChart, writeChart: productiondeploy.WriteHelmChart,
-		lock: productiondeploy.LockRelease, writeLock: productiondeploy.WriteReleaseConfig,
+		lock: productiondeploy.LockRelease, lockDeveloperService: productiondeploy.LockDeveloperServiceRelease,
+		writeLock:               productiondeploy.WriteReleaseConfig,
 		preparePolicyBootstrap:  productiondeploy.PreparePolicyBootstrapFile,
 		pinManagedTerminal:      productiondeploy.PinManagedTerminalRevisionFile,
 		activateManagedExecutor: productiondeploy.ActivateManagedExecutorFile,
@@ -120,6 +122,31 @@ func run(arguments []string, stdout, stderr io.Writer, commands deployCommands) 
 			return 1
 		}
 		fmt.Fprintf(stdout, "agentserver-deploy lock-release: wrote locked production config to %s\n", values["output"])
+		return 0
+	case "lock-developer-service":
+		values, ok := exactArguments(arguments[1:], "config", "output", "service-image")
+		if !ok {
+			writeUsage(stderr)
+			return 2
+		}
+		if commands.load == nil || commands.lockDeveloperService == nil || commands.writeLock == nil {
+			fmt.Fprintln(stderr, "agentserver-deploy lock-developer-service: command is unavailable")
+			return 1
+		}
+		config, err := commands.load(values["config"])
+		if err != nil {
+			fmt.Fprintf(stderr, "agentserver-deploy lock-developer-service: %v\n", err)
+			return 1
+		}
+		raw, err := commands.lockDeveloperService(config, values["service-image"])
+		if err == nil {
+			err = commands.writeLock(raw, values["output"])
+		}
+		if err != nil {
+			fmt.Fprintf(stderr, "agentserver-deploy lock-developer-service: %v\n", err)
+			return 1
+		}
+		fmt.Fprintf(stdout, "agentserver-deploy lock-developer-service: wrote service-only development config to %s\n", values["output"])
 		return 0
 	case "validate":
 		values, ok := exactArguments(arguments[1:], "config")
@@ -232,6 +259,7 @@ func writeUsage(writer io.Writer) {
 	fmt.Fprintln(writer, "usage: agentserver-deploy prepare-policy-bootstrap --config=/absolute/active-template.json --output=/absolute/new-bootstrap.json")
 	fmt.Fprintln(writer, "usage: agentserver-deploy pin-terminal-revision --config=/absolute/bootstrap.json --output=/absolute/new-bootstrap.json --sandbox-id=<expected-sandbox-id> --revision-id=<published-terminal-revision-id>")
 	fmt.Fprintln(writer, "usage: agentserver-deploy lock-release --config=/absolute/template.json --output=/absolute/new-production.json --service-image=IMAGE@sha256:DIGEST --harness-image=IMAGE@sha256:DIGEST --hydra-image=IMAGE@sha256:DIGEST --managed-sandbox-image=IMAGE@sha256:DIGEST --lark-cli-sha256=DIGEST --lark-skill-sha256=DIGEST")
+	fmt.Fprintln(writer, "       agentserver-deploy lock-developer-service --config=/absolute/active.json --output=/absolute/new-production.json --service-image=registry-sg.byted.cs.ac.cn/ghcr/agentserver/v2-service@sha256:DIGEST")
 	fmt.Fprintln(writer, "       agentserver-deploy validate --config=/absolute/path")
 	fmt.Fprintln(writer, "       agentserver-deploy render --config=/absolute/path --output=/absolute/directory")
 	fmt.Fprintln(writer, "       agentserver-deploy chart --config=/absolute/path --output=/absolute/new-chart")

--- a/v2/cmd/agentserver-deploy/main_test.go
+++ b/v2/cmd/agentserver-deploy/main_test.go
@@ -139,6 +139,38 @@ func TestRunLockReleasePassesExactAuthorityAndWritesOnce(t *testing.T) {
 	}
 }
 
+func TestRunLockDeveloperServicePassesOnlyServiceAuthority(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	called := []string{}
+	wantRaw := []byte("locked\n")
+	digest := strings.Repeat("a", 64)
+	exitCode := run([]string{
+		"lock-developer-service", "--config=/absolute/active.json", "--output=/absolute/production.json",
+		"--service-image=registry/service@sha256:" + digest,
+	}, &stdout, &stderr, deployCommands{
+		load: func(path string) (productiondeploy.LoadedConfig, error) {
+			called = append(called, "load:"+path)
+			return productiondeploy.LoadedConfig{}, nil
+		},
+		lockDeveloperService: func(_ productiondeploy.LoadedConfig, image string) ([]byte, error) {
+			called = append(called, "lock:"+image)
+			return wantRaw, nil
+		},
+		writeLock: func(raw []byte, path string) error {
+			if !bytes.Equal(raw, wantRaw) {
+				t.Fatalf("locked bytes = %q", raw)
+			}
+			called = append(called, "write:"+path)
+			return nil
+		},
+	})
+	if exitCode != 0 || stderr.Len() != 0 || strings.Join(called, ",") !=
+		"load:/absolute/active.json,lock:registry/service@sha256:"+digest+",write:/absolute/production.json" ||
+		!strings.Contains(stdout.String(), "service-only development config") {
+		t.Fatalf("run = %d, calls %v, stdout %q, stderr %q", exitCode, called, stdout.String(), stderr.String())
+	}
+}
+
 func TestRunRejectsDuplicateUnknownAndMissingArguments(t *testing.T) {
 	for _, arguments := range [][]string{
 		{}, {"render"},

--- a/v2/deploy/production/build-service-image.sh
+++ b/v2/deploy/production/build-service-image.sh
@@ -1,0 +1,161 @@
+#!/bin/sh
+set -eu
+
+umask 077
+
+script_dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd -P)
+v2_root=$(CDPATH= cd -- "${script_dir}/../.." && pwd -P)
+repository_root=$(CDPATH= cd -- "${v2_root}/.." && pwd -P)
+
+platform=""
+service_image=""
+output_directory=""
+cache="none"
+
+usage() {
+    printf '%s\n' \
+        'usage: build-service-image.sh --platform=linux-amd64|linux-arm64' \
+        '                              --service-image=registry/name:tag' \
+        '                              --output-dir=/absolute/new-directory' \
+        '                              [--cache=none|gha]'
+}
+
+fail() {
+    printf '%s\n' "build-service-image.sh: $*" >&2
+    exit 1
+}
+
+for argument in "$@"; do
+    case "${argument}" in
+        --platform=*) platform=${argument#--platform=} ;;
+        --service-image=*) service_image=${argument#--service-image=} ;;
+        --output-dir=*) output_directory=${argument#--output-dir=} ;;
+        --cache=*) cache=${argument#--cache=} ;;
+        --help|-h) usage; exit 0 ;;
+        *) usage >&2; exit 2 ;;
+    esac
+done
+
+case "${platform}" in
+    linux-amd64) goarch=amd64 ;;
+    linux-arm64) goarch=arm64 ;;
+    *) usage >&2; exit 2 ;;
+esac
+oci_platform="linux/${goarch}"
+
+[ -n "${service_image}" ] || { usage >&2; exit 2; }
+case "${output_directory}" in /*) ;; *) usage >&2; exit 2 ;; esac
+case "${cache}" in none|gha) ;; *) usage >&2; exit 2 ;; esac
+[ ! -e "${output_directory}" ] || fail "output directory already exists"
+[ -d "$(dirname -- "${output_directory}")" ] || fail "output parent is not a directory"
+
+command -v docker >/dev/null 2>&1 || fail "Docker CLI is required"
+command -v git >/dev/null 2>&1 || fail "git is required"
+command -v go >/dev/null 2>&1 || fail "go is required"
+command -v jq >/dev/null 2>&1 || fail "jq is required"
+command -v tar >/dev/null 2>&1 || fail "tar is required"
+docker buildx version >/dev/null 2>&1 || fail "Docker buildx is required"
+[ "$(go env GOVERSION)" = "go1.26.5" ] || fail "exact Go toolchain go1.26.5 is required"
+[ "$(uname -s)" = "Linux" ] || fail "developer service releases run only on Linux"
+
+git -C "${repository_root}" diff --quiet HEAD -- v2 || fail "tracked v2 source differs from HEAD; commit before publishing"
+untracked_v2=$(git -C "${repository_root}" ls-files --others --exclude-standard -- v2)
+[ -z "${untracked_v2}" ] || fail "untracked v2 source exists; commit or remove it before publishing"
+source_revision=$(git -C "${repository_root}" rev-parse --verify HEAD)
+[ "${#source_revision}" -eq 40 ] || fail "HEAD is not a canonical 40-character Git SHA"
+case "${source_revision}" in *[!0-9a-f]*) fail "HEAD is not a canonical 40-character Git SHA" ;; esac
+
+work_directory=$(mktemp -d "${TMPDIR:-/tmp}/agentserver-v2-service-image.XXXXXX")
+work_directory=$(CDPATH= cd -- "${work_directory}" && pwd -P)
+
+cleanup() {
+    status=$?
+    trap - EXIT INT TERM
+    chmod -R u+w "${work_directory}" >/dev/null 2>&1 || true
+    rm -rf -- "${work_directory}"
+    exit "${status}"
+}
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+mkdir -m 0700 \
+    "${work_directory}/service-bin" \
+    "${work_directory}/service-context"
+
+printf '%s\n' 'build-service-image.sh: compiling root service binaries in one Go build'
+(
+    cd "${v2_root}"
+    env CGO_ENABLED=0 GOOS=linux GOARCH="${goarch}" GOBIN="${work_directory}/service-bin" \
+        go install -buildvcs=false -trimpath -ldflags='-s -w -buildid=' \
+        ./cmd/agentserver-core \
+        ./cmd/agentserver-probe \
+        ./cmd/platform-gateway \
+        ./cmd/browser-gateway \
+        ./cmd/executor-gateway \
+        ./cmd/egress-authorizer \
+        ./cmd/llmproxy
+)
+printf '%s\n' 'build-service-image.sh: compiling sandbox-gateway'
+(
+    cd "${v2_root}/providers/tae"
+    env CGO_ENABLED=0 GOOS=linux GOARCH="${goarch}" \
+        go build -buildvcs=false -trimpath -ldflags='-s -w -buildid=' \
+        -o "${work_directory}/service-bin/sandbox-gateway" ./cmd/sandbox-gateway
+)
+chmod 0555 "${work_directory}/service-bin"/*
+
+printf '%s\n' 'build-service-image.sh: preparing the closed-world service rootfs'
+(
+    cd "${v2_root}"
+    go build -buildvcs=false -trimpath -o "${work_directory}/agentserver-image" ./cmd/agentserver-image
+)
+chmod 0500 "${work_directory}/agentserver-image"
+"${work_directory}/agentserver-image" prepare \
+    --kind=service \
+    --platform="${platform}" \
+    --source-revision="${source_revision}" \
+    --binary-dir="${work_directory}/service-bin" \
+    --output="${work_directory}/service-payload"
+
+tar --format=ustar --no-xattrs -cf "${work_directory}/service-context/rootfs.tar" \
+    -C "${work_directory}/service-payload/rootfs" .
+cp "${script_dir}/service.Containerfile" "${work_directory}/service-context/Dockerfile"
+chmod 0444 \
+    "${work_directory}/service-context/Dockerfile" \
+    "${work_directory}/service-context/rootfs.tar"
+
+set -- docker buildx build \
+    --platform "${oci_platform}" \
+    --progress plain \
+    --provenance=false \
+    --sbom=false \
+    --build-arg "SOURCE_REVISION=${source_revision}" \
+    --tag "${service_image}" \
+    --push \
+    --metadata-file "${work_directory}/build-metadata.json"
+if [ "${cache}" = "gha" ]; then
+    set -- "$@" \
+        --cache-from "type=gha,scope=agentserver-v2-service-${platform}" \
+        --cache-to "type=gha,mode=max,scope=agentserver-v2-service-${platform}"
+fi
+set -- "$@" "${work_directory}/service-context"
+
+printf '%s\n' "build-service-image.sh: building and publishing ${service_image}"
+"$@"
+service_digest=$(jq -er '."containerimage.digest"' "${work_directory}/build-metadata.json")
+[ "${#service_digest}" -eq 71 ] || fail "BuildKit did not return a canonical service manifest digest"
+case "${service_digest}" in sha256:*) ;; *) fail "BuildKit did not return a canonical service manifest digest" ;; esac
+case "${service_digest#sha256:}" in *[!0-9a-f]*) fail "BuildKit did not return a canonical service manifest digest" ;; esac
+docker buildx imagetools inspect "${service_image}@${service_digest}" >/dev/null
+
+mkdir -m 0700 "${output_directory}"
+cp "${work_directory}/service-payload/image-manifest.json" "${output_directory}/service-image-manifest.json"
+printf '%s\n' "${service_digest}" >"${output_directory}/service-image-digest.txt"
+chmod 0444 "${output_directory}"/*
+
+printf '%s\n' \
+    'build-service-image.sh: developer service image published' \
+    "  platform=${platform}" \
+    "  image=${service_image}@${service_digest}" \
+    "  source_revision=${source_revision}"

--- a/v2/docs/PRODUCTION_DEPLOYMENT.md
+++ b/v2/docs/PRODUCTION_DEPLOYMENT.md
@@ -330,6 +330,13 @@ keyring。不得用伪造 `published=true` 或模板 evidence 绕过这个阶段
 8. 在 workflow summary 和 artifact 中记录四个镜像 digest、Chart version、完整
    `deploymentConfigSHA256`、生产配置和镜像验证报告。
 
+开发阶段的 service-only 变更使用同一个 workflow 的 `service_only` 通道（`main` 上的 v2 push 默认走
+该通道）。它只运行改动包测试并重建 service 镜像，复用当前 active 配置中已经发布和验证过的
+harness、managed-sandbox、Hydra、runtime/pack lock 与 TAE evidence；不会安装 pnpm、下载
+Codex/bwrap/Lark 或重建未变化镜像。service 构建使用 GHA BuildKit cache。该通道只允许修改
+`images.service`，并在发布 Chart 前对删除该字段后的 JSON 做逐字节比较。最终生产晋级仍需通过
+`workflow_dispatch(release_mode=full)` 执行上述完整 closed-world 门禁。
+
 SG 配置始终引用 mirror 路径：
 
 ```text

--- a/v2/internal/productiondeploy/release_lock.go
+++ b/v2/internal/productiondeploy/release_lock.go
@@ -64,6 +64,50 @@ func LockRelease(base LoadedConfig, lock ReleaseLock) ([]byte, error) {
 	return raw, nil
 }
 
+// LockDeveloperServiceRelease changes only the Kubernetes service image in an
+// active release. It intentionally keeps the existing harness, managed
+// sandbox, Hydra, runtime, pack, and TAE evidence locks byte-for-byte intact.
+// Final production promotion still uses LockRelease and its full verification.
+func LockDeveloperServiceRelease(base LoadedConfig, serviceImage string) ([]byte, error) {
+	document := base.Document
+	if err := validateManagedReleaseEvidence(document); err != nil {
+		return nil, err
+	}
+	if !managedExecutionActive(document.Managed) {
+		return nil, errors.New("developer service release requires an active managed executor configuration")
+	}
+	if !imagePattern.MatchString(serviceImage) || !strings.HasPrefix(serviceImage, ProductionServiceImage+"@sha256:") {
+		return nil, errors.New("developer service release requires a digest-pinned SG service mirror image")
+	}
+	harnessImage := document.Images.Harness
+	hydraImage := document.Images.Hydra
+	managedSandboxImage := document.Images.ManagedSandbox
+	runtimeProfileSHA256 := document.Managed.Environment.RuntimeProfileSHA256
+	packSetSHA256 := document.Managed.Environment.PackSetSHA256
+	networkBindingSHA256 := document.Managed.TAE.NetworkEvidence.BindingSHA256
+	document.Images.Service = serviceImage
+	loaded, err := ValidateConfig(document)
+	if err != nil {
+		return nil, fmt.Errorf("validate developer service release: %w", err)
+	}
+	if loaded.Document.Images.Harness != harnessImage || loaded.Document.Images.Hydra != hydraImage ||
+		loaded.Document.Images.ManagedSandbox != managedSandboxImage ||
+		loaded.Document.Managed.Environment.RuntimeProfileSHA256 != runtimeProfileSHA256 ||
+		loaded.Document.Managed.Environment.PackSetSHA256 != packSetSHA256 ||
+		loaded.Document.Managed.TAE.NetworkEvidence.BindingSHA256 != networkBindingSHA256 {
+		return nil, errors.New("developer service release changed a TAE runtime, pack, or network evidence lock")
+	}
+	raw, err := json.MarshalIndent(loaded.Document, "", "  ")
+	if err != nil {
+		return nil, fmt.Errorf("encode developer service release: %w", err)
+	}
+	raw = append(raw, '\n')
+	if _, err := ParseConfig(raw); err != nil {
+		return nil, fmt.Errorf("verify developer service release: %w", err)
+	}
+	return raw, nil
+}
+
 func releaseLockMatches(document ConfigDocument, lock ReleaseLock) bool {
 	return document.Images.Service == lock.ServiceImage &&
 		document.Images.Harness == lock.HarnessImage &&

--- a/v2/internal/productiondeploy/release_lock_test.go
+++ b/v2/internal/productiondeploy/release_lock_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -76,6 +77,54 @@ func TestLockReleaseRejectsEvidenceBoundActiveArtifactDrift(t *testing.T) {
 			_, err := LockRelease(base, lock)
 			if err == nil || !strings.Contains(err.Error(), "active managed executor artifacts are immutable") {
 				t.Fatalf("active artifact drift error = %v", err)
+			}
+		})
+	}
+}
+
+func TestLockDeveloperServiceReleaseChangesOnlyServiceImage(t *testing.T) {
+	base, err := ValidateConfig(validConfigDocument())
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantImage := ProductionServiceImage + "@sha256:" + releaseDigest("a")
+	raw, err := LockDeveloperServiceRelease(base, wantImage)
+	if err != nil {
+		t.Fatal(err)
+	}
+	locked, err := ParseConfig(raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := base.Document
+	want.Images.Service = wantImage
+	if !reflect.DeepEqual(locked.Document, want) {
+		t.Fatal("developer service release changed facts outside images.service")
+	}
+}
+
+func TestLockDeveloperServiceReleaseFailsClosed(t *testing.T) {
+	active, err := ValidateConfig(validConfigDocument())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for name, testCase := range map[string]struct {
+		config LoadedConfig
+		image  string
+	}{
+		"mutable image": {active, ProductionServiceImage + ":main"},
+		"wrong mirror":  {active, "ghcr.io/agentserver/v2-service@sha256:" + releaseDigest("a")},
+		"bootstrap stage": {func() LoadedConfig {
+			loaded, loadErr := ValidateConfig(policyBootstrapConfigDocument())
+			if loadErr != nil {
+				t.Fatal(loadErr)
+			}
+			return loaded
+		}(), ProductionServiceImage + "@sha256:" + releaseDigest("a")},
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, lockErr := LockDeveloperServiceRelease(testCase.config, testCase.image); lockErr == nil {
+				t.Fatal("unsafe developer service release was accepted")
 			}
 		})
 	}

--- a/v2/internal/productionimage/release_workflow_test.go
+++ b/v2/internal/productionimage/release_workflow_test.go
@@ -66,3 +66,41 @@ func TestProductionWorkflowPublishesAndLocksManagedSandbox(t *testing.T) {
 		t.Fatal("managed sandbox Containerfile must not inherit the official terminal_faas image")
 	}
 }
+
+func TestProductionWorkflowHasBoundedServiceOnlyDevelopmentPath(t *testing.T) {
+	_, source, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("locate production workflow contract test")
+	}
+	v2Root := filepath.Clean(filepath.Join(filepath.Dir(source), "..", ".."))
+	workflow, err := os.ReadFile(filepath.Join(v2Root, "..", ".github", "workflows", "v2-production.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	fastPath := string(workflow)
+	start := strings.Index(fastPath, "  publish-service-only:")
+	end := strings.Index(fastPath, "  promote-active-chart:")
+	if start < 0 || end <= start {
+		t.Fatal("production workflow is missing the service-only job boundary")
+	}
+	fastPath = fastPath[start:end]
+	for _, required := range []string{
+		"build-service-image.sh",
+		"--cache=gha",
+		"lock-developer-service",
+		"del(.images.service)",
+		"cmp \"${release_dir}/before.json\" \"${release_dir}/after.json\"",
+	} {
+		if !strings.Contains(fastPath, required) {
+			t.Fatalf("service-only workflow is missing fast-path contract %q", required)
+		}
+	}
+	for _, forbidden := range []string{
+		"pnpm", "make -C v2 check", "CODEX_URL", "LARK_CLI_URL",
+		"build-images.sh", "MANAGED_SANDBOX_REPOSITORY", "HARNESS_REPOSITORY",
+	} {
+		if strings.Contains(fastPath, forbidden) {
+			t.Fatalf("service-only workflow retained redundant work %q", forbidden)
+		}
+	}
+}

--- a/v2/providers/tae/adapter/sdk_controlplane.go
+++ b/v2/providers/tae/adapter/sdk_controlplane.go
@@ -214,6 +214,14 @@ func (control *SDKControlPlane) Create(ctx context.Context, input CreateInput) (
 	if err != nil {
 		return ControlSession{}, &RequestError{WroteRequest: true, Code: "invalid_response", Cause: err}
 	}
+	// bytedai-go v1.1.63 sends Metadata in the Terminal create request but
+	// drops result.Data.Metadata while constructing the returned Session's
+	// AdvancedInfo. Preserve the exact sent identity only when the SDK reports
+	// no metadata at all. A non-empty partial/conflicting provider value is
+	// deliberately left untouched and remains fail-closed in Provider.
+	if len(converted.Metadata) == 0 {
+		converted.Metadata = cloneStrings(input.Metadata)
+	}
 	return converted, nil
 }
 

--- a/v2/providers/tae/adapter/sdk_controlplane_test.go
+++ b/v2/providers/tae/adapter/sdk_controlplane_test.go
@@ -121,6 +121,90 @@ func TestSDKControlPlaneCreatePinsRevisionAndOmitsTerminalOverrides(t *testing.T
 	}
 }
 
+func TestSDKControlPlaneCreateRestoresMetadataOmittedFromResponse(t *testing.T) {
+	metadata := map[string]string{MetadataSandboxID: "managed-sandbox-1"}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/sandboxes/psm.agentserver.tae", func(response http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(response).Encode(sandbox.SandboxMetaResponse{
+			Code: 0,
+			Data: &sandbox.SandboxMeta{SandboxID: "sandbox-1", SandboxType: sandbox.SandboxTypeTerminal,
+				Name: "agentserver", Psm: "psm.agentserver.tae"},
+		})
+	})
+	mux.HandleFunc("/api/v1/sandboxes/sandbox-1/sessions", func(response http.ResponseWriter, request *http.Request) {
+		var payload sandbox.CreateSessionRequest
+		if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+			t.Fatal(err)
+		}
+		if !reflect.DeepEqual(payload.Metadata, metadata) {
+			t.Fatalf("create metadata = %#v, want %#v", payload.Metadata, metadata)
+		}
+		_ = json.NewEncoder(response).Encode(sandbox.CreateSessionResponse{
+			Code: 0,
+			Data: &sandbox.CreateSessionResponseData{SessionInfoResponseData: sandbox.SessionInfoResponseData{
+				SessionID: "session-1", Status: "running", ExpiresAt: "2026-08-06T21:00:00Z",
+				SandboxdEnabled: true,
+			}},
+		})
+	})
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+	control, err := NewSGSDKControlPlane(t.Context(), SDKControlPlaneConfig{
+		PSM: "psm.agentserver.tae", SandboxID: "sandbox-1", RevisionID: "revision-1",
+		HTTPClient: server.Client(), Headers: staticJWTSource(),
+		ControlPlaneURL: server.URL, RequestTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := control.Create(t.Context(), CreateInput{TTL: time.Minute, Metadata: metadata})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if created.ID != "session-1" || !reflect.DeepEqual(created.Metadata, metadata) {
+		t.Fatalf("created Terminal Session = %+v", created)
+	}
+}
+
+func TestSDKControlPlaneCreateDoesNotReplaceConflictingMetadata(t *testing.T) {
+	want := map[string]string{MetadataSandboxID: "managed-sandbox-1"}
+	got := map[string]string{MetadataSandboxID: "different"}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v1/sandboxes/psm.agentserver.tae", func(response http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(response).Encode(sandbox.SandboxMetaResponse{
+			Code: 0,
+			Data: &sandbox.SandboxMeta{SandboxID: "sandbox-1", SandboxType: sandbox.SandboxTypeTerminal,
+				Name: "agentserver", Psm: "psm.agentserver.tae"},
+		})
+	})
+	mux.HandleFunc("/api/v1/sandboxes/sandbox-1/sessions", func(response http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(response).Encode(sandbox.CreateSessionResponse{
+			Code: 0,
+			Data: &sandbox.CreateSessionResponseData{SessionInfoResponseData: sandbox.SessionInfoResponseData{
+				SessionID: "session-1", Status: "running", ExpiresAt: "2026-08-06T21:00:00Z",
+				SandboxdEnabled: true, Metadata: got,
+			}},
+		})
+	})
+	server := httptest.NewTLSServer(mux)
+	defer server.Close()
+	control, err := NewSGSDKControlPlane(t.Context(), SDKControlPlaneConfig{
+		PSM: "psm.agentserver.tae", SandboxID: "sandbox-1", RevisionID: "revision-1",
+		HTTPClient: server.Client(), Headers: staticJWTSource(),
+		ControlPlaneURL: server.URL, RequestTimeout: time.Second,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	created, err := control.Create(t.Context(), CreateInput{TTL: time.Minute, Metadata: want})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(created.Metadata, got) {
+		t.Fatalf("created metadata = %#v, want provider value %#v", created.Metadata, got)
+	}
+}
+
 func TestSDKControlPlaneFailsClosedWhenPSMResolvesToDifferentSandboxID(t *testing.T) {
 	requests := 0
 	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {


### PR DESCRIPTION
Fix the bytedai-go Create response metadata omission without weakening non-empty mismatch checks. Add a service-only development release path that reuses the active harness, managed sandbox, Hydra, and TAE evidence; defaults v2 pushes to that path and keeps the complete gate as explicit full promotion.\n\nTargeted validation: productionimage/productiondeploy/deploy-command tests, TAE SDK control-plane regression tests, YAML parse, shell syntax, diff check.